### PR TITLE
Initialise the default locale

### DIFF
--- a/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
+import java.util.Locale;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -22,6 +24,7 @@ public class DateTimeFormatFilterTest {
   
   @Before
   public void setup() {
+    Locale.setDefault(Locale.ENGLISH);
     interpreter = new Jinjava().newInterpreter();
     filter = new  DateTimeFormatFilter();
     d = ZonedDateTime.parse("2013-11-06T14:22:00.000+00:00[UTC]");

--- a/src/test/java/com/hubspot/jinjava/lib/filter/FileSizeFormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FileSizeFormatFilterTest.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
+import java.util.Locale;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -16,6 +17,7 @@ public class FileSizeFormatFilterTest {
   
   @Before
   public void setup() {
+    Locale.setDefault(Locale.ENGLISH);
     jinjava = new Jinjava();
   }
   

--- a/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
@@ -15,6 +15,7 @@ public class StrftimeFormatterTest {
   
   @Before
   public void setup() {
+    Locale.setDefault(Locale.ENGLISH);
     d = ZonedDateTime.parse("2013-11-06T14:22:00.000+00:00");
   }
   


### PR DESCRIPTION
In non-English default locales, the tests fail because the target
strings expect filters to use English.