### PR TITLE
Escape string representation of objects too

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/EscapeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/EscapeFilter.java
@@ -15,6 +15,7 @@ limitations under the License.
  **********************************************************************/
 package com.hubspot.jinjava.lib.filter;
 
+import com.hubspot.jinjava.util.ObjectValue;
 import org.apache.commons.lang3.StringUtils;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
@@ -58,10 +59,7 @@ public class EscapeFilter implements Filter {
 
   @Override
   public Object filter(Object object, JinjavaInterpreter interpreter, String... arg) {
-    if (object instanceof String) {
-      return escapeHtmlEntities((String) object);
-    }
-    return object;
+    return escapeHtmlEntities(ObjectValue.printable(object));
   }
 
   @Override

--- a/src/test/java/com/hubspot/jinjava/lib/filter/EscapeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/EscapeFilterTest.java
@@ -24,12 +24,7 @@ public class EscapeFilterTest {
     assertThat(f.filter("", interpreter)).isEqualTo("");
     assertThat(f.filter("me & you", interpreter)).isEqualTo("me &amp; you");
     assertThat(f.filter("jared's & ted's bogus journey", interpreter)).isEqualTo("jared&#39;s &amp; ted&#39;s bogus journey");
-  }
-
-  @Test
-  public void itDoesntAffectNonStrings() {
-    Integer i = Integer.valueOf(123);
-    assertThat(f.filter(i, interpreter)).isSameAs(i);
+    assertThat(f.filter(1, interpreter)).isEqualTo("1");
   }
 
 }


### PR DESCRIPTION
String representations of objects are not escaped, if requested. This patch computes the string representation of all objects like ExpressionNode does and escapes it.

I think, if someone explicitly applies this filter, it is OK to convert any object to a string.