### PR TITLE
Stop iterating too high up the Context

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -319,29 +319,10 @@ public class Context extends ScopeMap<String, Object> {
   }
 
   public void addDependency(String type, String identification) {
-    Context highestParentContext = getHighestParentContext();
-    highestParentContext.dependencies.get(type).add(identification);
+    this.dependencies.get(type).add(identification);
   }
 
   public SetMultimap<String, String> getDependencies() {
-    Context highestParentContext = getHighestParentContext();
-    return highestParentContext.dependencies;
+    return this.dependencies;
   }
-
-  private Context getHighestParentContext() {
-    Context highestParentContext = parent != null ? parent : this;
-    Context currentParentContext = highestParentContext.getParent();
-
-    while (currentParentContext != null) {
-      if (currentParentContext.equals(currentParentContext.getParent())) {
-        return highestParentContext;
-      }
-
-      highestParentContext = highestParentContext.getParent();
-      currentParentContext = highestParentContext.getParent();
-
-    }
-    return highestParentContext;
-  }
-
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -319,7 +319,7 @@ public class Context extends ScopeMap<String, Object> {
   }
 
   public void addDependency(String type, String identification) {
-    this.dependencies.get(type).add(identification);
+    this.getParent().dependencies.get(type).add(identification);
   }
 
   public SetMultimap<String, String> getDependencies() {


### PR DESCRIPTION
@jaredstehler 

It was definitely going up to the very top parent context, this should keep it within the correct context scope