### PR TITLE
update to use all the same context level

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -319,29 +319,11 @@ public class Context extends ScopeMap<String, Object> {
   }
 
   public void addDependency(String type, String identification) {
-    Context highestParentContext = getHighestParentContext();
-    highestParentContext.dependencies.get(type).add(identification);
+    this.dependencies.get(type).add(identification);
   }
 
   public SetMultimap<String, String> getDependencies() {
-    Context highestParentContext = getHighestParentContext();
-    return highestParentContext.dependencies;
-  }
-
-  private Context getHighestParentContext() {
-    Context highestParentContext = parent != null ? parent : this;
-    Context currentParentContext = highestParentContext.getParent();
-
-    while (currentParentContext != null) {
-      if (currentParentContext.equals(currentParentContext.getParent())) {
-        return highestParentContext;
-      }
-
-      highestParentContext = highestParentContext.getParent();
-      currentParentContext = highestParentContext.getParent();
-
-    }
-    return highestParentContext;
+    return this.dependencies;
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ExtendsTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ExtendsTag.java
@@ -91,8 +91,8 @@ public class ExtendsTag implements Tag {
     try {
       String template = interpreter.getResource(path);
       Node node = interpreter.parse(template);
-      JinjavaInterpreter child = new JinjavaInterpreter(interpreter);
-      child.getContext().addDependency("coded_files", path);
+      JinjavaInterpreter currentInterpreter = JinjavaInterpreter.getCurrent();
+      currentInterpreter.getContext().addDependency("coded_files", path);
       interpreter.addExtendParentRoot(node);
       return "";
     } catch (IOException e) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IncludeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IncludeTag.java
@@ -67,8 +67,11 @@ public class IncludeTag implements Tag {
     try {
       String template = interpreter.getResource(templateFile);
       Node node = interpreter.parse(template);
-      JinjavaInterpreter child = new JinjavaInterpreter(interpreter);
-      child.getContext().addDependency("coded_files", templateFile);
+
+      JinjavaInterpreter currentInterpreter = JinjavaInterpreter.getCurrent();
+      JinjavaInterpreter child = new JinjavaInterpreter(currentInterpreter);
+
+      currentInterpreter.getContext().addDependency("coded_files", templateFile);
 
       String result = child.render(node);
       interpreter.getErrors().addAll(child.getErrors());


### PR DESCRIPTION
@jaredstehler 

The previous change no longer grabbed all the dependencies in memory, but went too far down the context level so it wasn't grabbing any dependencies. (aka goldilocks). I think the main problem was the `ExtendsTag` and `IncludesTag` were adding dependencies at a different level than the rest of the tags, so it wasn't possible to grab all dependencies across tags without changing those two files.