### PR TITLE
add support for multi-variable assignment using 'set'

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
@@ -24,11 +24,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.tree.TagNode;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 


### PR DESCRIPTION
I had to add this code to support parsing Jinja written like this:
```
{% set myvar1, myvar2, myvar3, myvar4 =
  'foo',
  'bar',
  '(hello, world, asdf, ooooo, fffff)',
  'yoooooo'
%}
```
which needs to result in assigning all 4 variables to all corresponding values
