### PR TITLE
Add ErrorItem type

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -66,7 +66,7 @@ public class ExpressionResolver {
       return result;
 
     } catch (PropertyNotFoundException e) {
-      interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.UNKNOWN, ErrorItem.OTHER, e.getMessage(), "", interpreter.getLineNumber(), e));
+      interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.UNKNOWN, ErrorItem.PROPERTY, e.getMessage(), "", interpreter.getLineNumber(), e));
     } catch (TreeBuilderException e) {
       interpreter.addError(TemplateError.fromException(new TemplateSyntaxException(expression,
           "Error parsing '" + expression + "': " + StringUtils.substringAfter(e.getMessage(), "': "), interpreter.getLineNumber(), e)));

--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -9,6 +9,7 @@ import javax.el.ExpressionFactory;
 import javax.el.PropertyNotFoundException;
 import javax.el.ValueExpression;
 
+import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import org.apache.commons.lang3.StringUtils;
 
 import com.hubspot.jinjava.el.ext.NamedParameter;
@@ -65,7 +66,7 @@ public class ExpressionResolver {
       return result;
 
     } catch (PropertyNotFoundException e) {
-      interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.UNKNOWN, e.getMessage(), "", interpreter.getLineNumber(), e));
+      interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.UNKNOWN, ErrorItem.OTHER, e.getMessage(), "", interpreter.getLineNumber(), e));
     } catch (TreeBuilderException e) {
       interpreter.addError(TemplateError.fromException(new TemplateSyntaxException(expression,
           "Error parsing '" + expression + "': " + StringUtils.substringAfter(e.getMessage(), "': "), interpreter.getLineNumber(), e)));

--- a/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
@@ -21,6 +21,7 @@ import javax.el.MapELResolver;
 import javax.el.PropertyNotFoundException;
 import javax.el.ResourceBundleELResolver;
 
+import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -174,7 +175,7 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
       try {
         return StrftimeFormatter.formatter(d.getFormat(), interpreter.getConfig().getLocale());
       } catch (IllegalArgumentException e) {
-        interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.SYNTAX_ERROR, e.getMessage(), null, interpreter.getLineNumber(), null));
+        interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.SYNTAX_ERROR, ErrorItem.OTHER, e.getMessage(), null, interpreter.getLineNumber(), null));
       }
     }
 
@@ -186,7 +187,7 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
       try {
         return LocaleUtils.toLocale(d.getLanguage());
       } catch (IllegalArgumentException e) {
-        interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.SYNTAX_ERROR, e.getMessage(), null, interpreter.getLineNumber(), null));
+        interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.SYNTAX_ERROR, ErrorItem.OTHER, e.getMessage(), null, interpreter.getLineNumber(), null));
       }
     }
 

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -18,7 +18,6 @@ public class TemplateError {
     BAD_URL,
     EXCEPTION,
     MISSING,
-    MISSING_TEMPLATE,
     OTHER
   }
 

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -18,11 +18,20 @@ public class TemplateError {
     BAD_URL,
     EXCEPTION,
     MISSING,
+    MISSING_TEMPLATE,
     OTHER
+  }
+
+  public enum ErrorItem {
+    TEMPLATE,
+    TOKEN,
+    FUNCTION,
+    OTHER;
   }
 
   private final ErrorType severity;
   private final ErrorReason reason;
+  private final ErrorItem item;
   private final String message;
   private final String fieldName;
   private final int lineno;
@@ -30,11 +39,11 @@ public class TemplateError {
   private final Exception exception;
 
   public static TemplateError fromSyntaxError(InterpretException ex) {
-    return new TemplateError(ErrorType.FATAL, ErrorReason.SYNTAX_ERROR, ExceptionUtils.getMessage(ex), null, ex.getLineNumber(), ex);
+    return new TemplateError(ErrorType.FATAL, ErrorReason.SYNTAX_ERROR, ErrorItem.OTHER, ExceptionUtils.getMessage(ex), null, ex.getLineNumber(), ex);
   }
 
   public static TemplateError fromException(TemplateSyntaxException ex) {
-    return new TemplateError(ErrorType.FATAL, ErrorReason.SYNTAX_ERROR, ExceptionUtils.getMessage(ex), null, ex.getLineNumber(), ex);
+    return new TemplateError(ErrorType.FATAL, ErrorReason.SYNTAX_ERROR, ErrorItem.OTHER, ExceptionUtils.getMessage(ex), null, ex.getLineNumber(), ex);
   }
 
   public static TemplateError fromException(Exception ex) {
@@ -44,15 +53,15 @@ public class TemplateError {
       lineNumber = ((InterpretException) ex).getLineNumber();
     }
 
-    return new TemplateError(ErrorType.FATAL, ErrorReason.EXCEPTION, ExceptionUtils.getMessage(ex), null, lineNumber, ex);
+    return new TemplateError(ErrorType.FATAL, ErrorReason.EXCEPTION, ErrorItem.OTHER, ExceptionUtils.getMessage(ex), null, lineNumber, ex);
   }
 
   public static TemplateError fromException(Exception ex, int lineNumber) {
-    return new TemplateError(ErrorType.FATAL, ErrorReason.EXCEPTION, ExceptionUtils.getMessage(ex), null, lineNumber, ex);
+    return new TemplateError(ErrorType.FATAL, ErrorReason.EXCEPTION, ErrorItem.OTHER, ExceptionUtils.getMessage(ex), null, lineNumber, ex);
   }
 
   public static TemplateError fromUnknownProperty(Object base, String variable, int lineNumber) {
-    return new TemplateError(ErrorType.WARNING, ErrorReason.UNKNOWN, String.format("Cannot resolve property '%s' in '%s'", variable, friendlyObjectToString(base)),
+    return new TemplateError(ErrorType.WARNING, ErrorReason.UNKNOWN, ErrorItem.OTHER, String.format("Cannot resolve property '%s' in '%s'", variable, friendlyObjectToString(base)),
         variable, lineNumber, null);
   }
 
@@ -71,17 +80,18 @@ public class TemplateError {
     return c.getSimpleName();
   }
 
-  // java.lang.Object@7852e922
   private static final Pattern GENERIC_TOSTRING_PATTERN = Pattern.compile("@[0-9a-z]{4,}$");
 
   public TemplateError(ErrorType severity,
                        ErrorReason reason,
+                       ErrorItem item,
                        String message,
                        String fieldName,
                        int lineno,
                        Exception exception) {
     this.severity = severity;
     this.reason = reason;
+    this.item = item;
     this.message = message;
     this.fieldName = fieldName;
     this.lineno = lineno;
@@ -94,6 +104,10 @@ public class TemplateError {
 
   public ErrorReason getReason() {
     return reason;
+  }
+
+  public ErrorItem getItem() {
+    return item;
   }
 
   public String getMessage() {
@@ -113,7 +127,7 @@ public class TemplateError {
   }
 
   public TemplateError serializable() {
-    return new TemplateError(severity, reason, message, fieldName, lineno, null);
+    return new TemplateError(severity, reason, item, message, fieldName, lineno, null);
   }
 
   @Override
@@ -124,6 +138,7 @@ public class TemplateError {
         .add("message", message)
         .add("fieldName", fieldName)
         .add("lineno", lineno)
+        .add("item", item)
         .toString();
   }
 

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -25,6 +25,7 @@ public class TemplateError {
   public enum ErrorItem {
     TEMPLATE,
     TOKEN,
+    TAG,
     FUNCTION,
     OTHER;
   }

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -26,6 +26,7 @@ public class TemplateError {
     TOKEN,
     TAG,
     FUNCTION,
+    PROPERTY,
     OTHER
   }
 
@@ -61,7 +62,7 @@ public class TemplateError {
   }
 
   public static TemplateError fromUnknownProperty(Object base, String variable, int lineNumber) {
-    return new TemplateError(ErrorType.WARNING, ErrorReason.UNKNOWN, ErrorItem.OTHER, String.format("Cannot resolve property '%s' in '%s'", variable, friendlyObjectToString(base)),
+    return new TemplateError(ErrorType.WARNING, ErrorReason.UNKNOWN, ErrorItem.PROPERTY, String.format("Cannot resolve property '%s' in '%s'", variable, friendlyObjectToString(base)),
         variable, lineNumber, null);
   }
 

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -26,7 +26,7 @@ public class TemplateError {
     TOKEN,
     TAG,
     FUNCTION,
-    OTHER;
+    OTHER
   }
 
   private final ErrorType severity;

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import org.apache.commons.lang3.StringUtils;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
@@ -76,7 +77,7 @@ public class ImportTag implements Tag {
     try {
       interpreter.getContext().pushImportPath(path, tagNode.getLineNumber());
     } catch (ImportTagCycleException e) {
-      interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.EXCEPTION,
+      interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.EXCEPTION, ErrorItem.TOKEN,
           "Import cycle detected for path: '" + path + "'", null, tagNode.getLineNumber(), e));
       return "";
     }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -77,7 +77,7 @@ public class ImportTag implements Tag {
     try {
       interpreter.getContext().pushImportPath(path, tagNode.getLineNumber());
     } catch (ImportTagCycleException e) {
-      interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.EXCEPTION, ErrorItem.TOKEN,
+      interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.EXCEPTION, ErrorItem.TAG,
           "Import cycle detected for path: '" + path + "'", null, tagNode.getLineNumber(), e));
       return "";
     }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IncludeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IncludeTag.java
@@ -60,7 +60,7 @@ public class IncludeTag implements Tag {
     try {
       interpreter.getContext().pushIncludePath(templateFile, tagNode.getLineNumber());
     } catch (IncludeTagCycleException e) {
-      interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.EXCEPTION, ErrorItem.TOKEN,
+      interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.EXCEPTION, ErrorItem.TAG,
           "Include cycle detected for path: '" + templateFile + "'", null, tagNode.getLineNumber(), e));
       return "";
     }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IncludeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IncludeTag.java
@@ -17,6 +17,7 @@ package com.hubspot.jinjava.lib.tag;
 
 import java.io.IOException;
 
+import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import org.apache.commons.lang3.StringUtils;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
@@ -59,7 +60,7 @@ public class IncludeTag implements Tag {
     try {
       interpreter.getContext().pushIncludePath(templateFile, tagNode.getLineNumber());
     } catch (IncludeTagCycleException e) {
-      interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.EXCEPTION,
+      interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.EXCEPTION, ErrorItem.TOKEN,
           "Include cycle detected for path: '" + templateFile + "'", null, tagNode.getLineNumber(), e));
       return "";
     }


### PR DESCRIPTION
@jaredstehler

Add an `ErrorItem` enum to `TemplateError` so we can specify what type of object is causing a given error. In a perfect world this would be called `ErrorType` and `ErrorType` would be renamed `ErrorSeverity`. Sadly this is not a perfect world.

Let me know if I missed any possible 'types' or have too many.