### PR TITLE
add second constructor to default to ErrorItem.OTHER

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -99,6 +99,21 @@ public class TemplateError {
     this.exception = exception;
   }
 
+  public TemplateError(ErrorType severity,
+                       ErrorReason reason,
+                       String message,
+                       String fieldName,
+                       int lineno,
+                       Exception exception) {
+    this.severity = severity;
+    this.reason = reason;
+    this.item = ErrorItem.OTHER;
+    this.message = message;
+    this.fieldName = fieldName;
+    this.lineno = lineno;
+    this.exception = exception;
+  }
+
   public ErrorType getSeverity() {
     return severity;
   }


### PR DESCRIPTION
@jaredstehler 

Adding another constructor for backwards compatibility. If we don't want this feel free to close.