### PR TITLE
track resolved expressions and values

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -9,13 +9,13 @@ import javax.el.ExpressionFactory;
 import javax.el.PropertyNotFoundException;
 import javax.el.ValueExpression;
 
-import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import org.apache.commons.lang3.StringUtils;
 
 import com.hubspot.jinjava.el.ext.NamedParameter;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateError;
+import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
@@ -55,6 +55,8 @@ public class ExpressionResolver {
     if (StringUtils.isBlank(expression)) {
       return "";
     }
+
+    interpreter.getContext().addResolvedExpression(expression.trim());
 
     try {
       String elExpression = "#{" + expression.trim() + "}";

--- a/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
@@ -105,6 +105,8 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
     String propertyName = Objects.toString(property, "");
     Object value = null;
 
+    interpreter.getContext().addResolvedValue(propertyName);
+
     if (ExtendedParser.INTERPRETER.equals(property)) {
       value = interpreter;
     } else if (propertyName.startsWith(ExtendedParser.FILTER_PREFIX)) {

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -51,6 +51,7 @@ public class Context extends ScopeMap<String, Object> {
   private final Stack<String> includePathStack = new Stack<>();
 
   private final Set<String> resolvedExpressions = new HashSet<>();
+  private final Set<String> resolvedValues = new HashSet<>();
 
   private final ExpTestLibrary expTestLibrary;
   private final FilterLibrary filterLibrary;
@@ -149,6 +150,18 @@ public class Context extends ScopeMap<String, Object> {
 
   public boolean wasExpressionResolved(String expression) {
     return resolvedExpressions.contains(expression);
+  }
+
+  public void addResolvedValue(String value) {
+    resolvedValues.add(value);
+  }
+
+  public Set<String> getResolvedValues() {
+    return ImmutableSet.copyOf(resolvedValues);
+  }
+
+  public boolean wasValueResolved(String value) {
+    return resolvedValues.contains(value);
   }
 
   public List<? extends Node> getSuperBlock() {

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -18,12 +18,15 @@ package com.hubspot.jinjava.interpret;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.Stack;
 
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;
 import com.hubspot.jinjava.lib.Importable;
 import com.hubspot.jinjava.lib.exptest.ExpTest;
@@ -46,6 +49,8 @@ public class Context extends ScopeMap<String, Object> {
   private final Stack<String> extendPathStack = new Stack<>();
   private final Stack<String> importPathStack = new Stack<>();
   private final Stack<String> includePathStack = new Stack<>();
+
+  private final Set<String> resolvedExpressions = new HashSet<>();
 
   private final ExpTestLibrary expTestLibrary;
   private final FilterLibrary filterLibrary;
@@ -132,6 +137,18 @@ public class Context extends ScopeMap<String, Object> {
 
   public void setAutoEscape(Boolean autoEscape) {
     this.autoEscape = autoEscape;
+  }
+
+  public void addResolvedExpression(String expression) {
+    resolvedExpressions.add(expression);
+  }
+
+  public Set<String> getResolvedExpressions() {
+    return ImmutableSet.copyOf(resolvedExpressions);
+  }
+
+  public boolean wasExpressionResolved(String expression) {
+    return resolvedExpressions.contains(expression);
   }
 
   public List<? extends Node> getSuperBlock() {

--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.el;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.math.BigDecimal;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -75,6 +76,7 @@ public class ExpressionResolverTest {
     context.put("i_am_seven", 7L);
     Object val = interpreter.resolveELExpression("(i_am_seven * 2 + 1)/3", -1);
     assertThat(val).isEqualTo(5.0);
+    assertThat(interpreter.getContext().wasValueResolved("i_am_seven")).isTrue();
   }
 
   @Test
@@ -144,6 +146,13 @@ public class ExpressionResolverTest {
     public int getTotalCount() {
       return list.size();
     }
+  }
+
+  @Test
+  public void itRecordsFilterNames() throws Exception {
+    Object val = interpreter.resolveELExpression("2.3 | round", -1);
+    assertThat(val).isEqualTo(new BigDecimal(2));
+    assertThat(interpreter.getContext().wasValueResolved("filter:round")).isTrue();
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
@@ -67,6 +67,7 @@ public class ExpressionResolverTest {
     context.put("foo", "bar");
     Object val = interpreter.resolveELExpression("  foo ", -1);
     assertThat(val).isEqualTo("bar");
+    assertThat(interpreter.getContext().wasExpressionResolved("foo")).isTrue();
   }
 
   @Test
@@ -91,6 +92,7 @@ public class ExpressionResolverTest {
 
     Object val = interpreter.resolveELExpression("thedict['foo']", -1);
     assertThat(val).isEqualTo("bar");
+    assertThat(interpreter.getContext().wasExpressionResolved("thedict['foo']")).isTrue();
   }
 
   @Test
@@ -101,6 +103,7 @@ public class ExpressionResolverTest {
 
     Object val = interpreter.resolveELExpression("thedict.foo", -1);
     assertThat(val).isEqualTo("bar");
+    assertThat(interpreter.getContext().wasExpressionResolved("thedict.foo")).isTrue();
   }
 
   @Test


### PR DESCRIPTION
It's sometimes useful to see which expressions and values were evalulated by the interpreter. This stores them in sets for later analysis.