### PR TITLE
Send correct amount of parameters for Filter instance

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
@@ -22,6 +22,8 @@ import javax.el.MapELResolver;
 import javax.el.PropertyNotFoundException;
 import javax.el.ResourceBundleELResolver;
 
+import com.hubspot.jinjava.lib.filter.Filter;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -84,6 +86,14 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
       }
     } catch (IllegalArgumentException e) {
       // failed to access property, continue with method calls
+    }
+
+    if(base instanceof Filter && params.length < 3) {
+        // make sure we send at least 3 parameters so that the method call can be executed.
+        // parameters is only 2 long when no parameters are passed to the filter from the Hubl script
+        for(int i = params.length; i < 3; i++) {
+          params = ArrayUtils.add(params, null);
+        }
     }
 
     // TODO map named params to special arg in fn to invoke


### PR DESCRIPTION
Filters being called with no parameters were trying to execute the java method with 2 parameters which is not found on the Filter implementation.  There needs to be at least 3 parameters sent.

https://github.com/HubSpot/jinjava/issues/39
https://github.com/HubSpot/jinjava/issues/43

Previously, this expression was failing

`{{ boot_attributes_map|xmlattr }}`

but could be worked around by passing an empty parameter

`{{ boot_attributes_map|xmlattr('') }}`

This change ads the 3rd parameter as a null if none was sent from the filter expression.