### PR TITLE
add range function

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/FunctionLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/FunctionLibrary.java
@@ -13,6 +13,7 @@ public class FunctionLibrary extends SimpleLibrary<ELFunctionDefinition> {
   protected void registerDefaults() {
     register(new ELFunctionDefinition("", "datetimeformat", Functions.class, "dateTimeFormat", Object.class, String[].class));
     register(new ELFunctionDefinition("", "truncate", Functions.class, "truncate", Object.class, Object[].class));
+    register(new ELFunctionDefinition("", "range", Functions.class, "range", Object.class, Object[].class));
 
     register(new ELFunctionDefinition("", "super", Functions.class, "renderSuperBlock"));
 

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -148,8 +148,8 @@ public class Functions {
     return pointer + 1;
   }
 
-  @JinjavaDoc(value = "<p>Return a list containing an arithmetic progression of integers. " +
-      " With one parameter, range will return a list from 0 up to or down to the value. " +
+  @JinjavaDoc(value = "<p>Return a list containing an arithmetic progression of integers.</p>" +
+      "<p>With one parameter, range will return a list from 0 up to or down to the value. " +
       " With two parameters, the range will start at the first value and end at the second value. " +
       " The third parameter specifies the step increment.</p> <p>All values can be negative.</p>" +
       "<p>Ranges can generate a maximum of " + RANGE_LIMIT + " values.</p>",

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -149,9 +149,9 @@ public class Functions {
   }
 
   @JinjavaDoc(value = "<p>Return a list containing an arithmetic progression of integers.</p>" +
-      "<p>With one parameter, range will return a list from 0 up to or down to the value. " +
-      " With two parameters, the range will start at the first value and end at the second value. " +
-      " The third parameter specifies the step increment.</p> <p>All values can be negative.</p>" +
+      "<p>With one parameter, range will return a list from 0 up to (but not including) the value. " +
+      " With two parameters, the range will start at the first value and increment by 1 up to (but not including) the second value. " +
+      " The third parameter specifies the step increment.</p> <p>All values can be negative. Impossible ranges will return an empty list.</p>" +
       "<p>Ranges can generate a maximum of " + RANGE_LIMIT + " values.</p>",
       params = {
           @JinjavaParam(value = "start", type = "number", defaultValue = "0"),

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -5,6 +5,7 @@ import static com.hubspot.jinjava.util.Logging.ENGINE_LOG;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -24,6 +25,8 @@ import com.hubspot.jinjava.objects.date.StrftimeFormatter;
 import com.hubspot.jinjava.tree.Node;
 
 public class Functions {
+
+  public static final int RANGE_LIMIT = 1000;
 
   @JinjavaDoc(value = "Only usable within blocks, will render the contents of the parent block by calling super.", snippets = {
       @JinjavaSnippet(desc = "This gives back the results of the parent block", code = "{% block sidebar %}\n" +
@@ -145,4 +148,59 @@ public class Functions {
     return pointer + 1;
   }
 
+  @JinjavaDoc(value = "<p>Return a list containing an arithmetic progression of integers. " +
+      " With one parameter, range will return a list from 0 up to or down to the value. " +
+      " With two parameters, the range will start at the first value and end at the second value. " +
+      " The third parameter specifies the step increment.</p> <p>All values can be negative.</p>" +
+      "<p>Ranges can generate a maximum of " + RANGE_LIMIT + " values.</p>",
+      params = {
+          @JinjavaParam(value = "start", type = "number", defaultValue = "0"),
+          @JinjavaParam(value = "end", type = "number"),
+          @JinjavaParam(value = "step", type = "number", defaultValue = "1")})
+  public static List<Integer> range(Object arg1, Object... args) {
+
+    List<Integer> result = new ArrayList<>();
+
+    int start = 0;
+    int end;
+    int step = 1;
+
+    switch (args.length) {
+      case 0:
+        end = Integer.parseInt(arg1.toString());
+        break;
+      case 1:
+        start = Integer.parseInt(arg1.toString());
+        end = Integer.parseInt(args[0].toString());
+        break;
+      default:
+        start = Integer.parseInt(arg1.toString());
+        end = Integer.parseInt(args[0].toString());
+        step = Integer.parseInt(args[1].toString());
+    }
+
+    if (start < end) {
+      for (int i = start; i < end; i += step) {
+        if (result.size() >= RANGE_LIMIT) {
+          break;
+        }
+        result.add(i);
+      }
+    } else {
+
+      // make sure we're decrementing
+      if (step > 0) {
+        step = step * -1;
+      }
+
+      for (int i = start; i > end; i += step) {
+        if (result.size() >= RANGE_LIMIT) {
+          break;
+        }
+        result.add(i);
+      }
+    }
+
+    return result;
+  }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -179,7 +179,16 @@ public class Functions {
         step = Integer.parseInt(args[1].toString());
     }
 
+    if (step == 0) {
+      return result;
+    }
+
     if (start < end) {
+
+      if (step < 0) {
+        return result;
+      }
+
       for (int i = start; i < end; i += step) {
         if (result.size() >= RANGE_LIMIT) {
           break;
@@ -188,9 +197,8 @@ public class Functions {
       }
     } else {
 
-      // make sure we're decrementing
       if (step > 0) {
-        step = step * -1;
+        return result;
       }
 
       for (int i = start; i > end; i += step) {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/ListFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/ListFilterTest.java
@@ -40,6 +40,7 @@ public class ListFilterTest {
   public void itConvertsStringToListOfChars() {
     List o = (List)filter.filter("hello", null);
     assertThat(o).isEqualTo(Lists.newArrayList('h', 'e', 'l', 'l', 'o'));
+    assertThat(o.get(0)).isEqualTo('h');
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/fn/RangeFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/RangeFunctionTest.java
@@ -13,21 +13,32 @@ public class RangeFunctionTest {
     assertThat(Functions.range(1)).isEqualTo(Arrays.asList(0));
     assertThat(Functions.range(2)).isEqualTo(Arrays.asList(0, 1));
     assertThat(Functions.range(2, 4)).isEqualTo(Arrays.asList(2, 3));
+    assertThat(Functions.range("2", "4")).isEqualTo(Arrays.asList(2, 3));
     assertThat(Functions.range(2, 8, 2)).isEqualTo(Arrays.asList(2, 4, 6));
   }
 
   @Test
   public void itGeneratesBackwardsRanges() {
-    assertThat(Functions.range(-2)).isEqualTo(Arrays.asList(0, -1));
-    assertThat(Functions.range(2, -1)).isEqualTo(Arrays.asList(2, 1, 0));
+    assertThat(Functions.range(2, -1, -1)).isEqualTo(Arrays.asList(2, 1, 0));
     assertThat(Functions.range(8, 2, -2)).isEqualTo(Arrays.asList(8, 6, 4));
+    assertThat(Functions.range(2, -1, "-1")).isEqualTo(Arrays.asList(2, 1, 0));
   }
 
   @Test
   public void itHandlesBadRanges() {
-    assertThat(Functions.range(2, 2)).isEqualTo(Arrays.asList());
-    assertThat(Functions.range(2, 2000, -5).size()).isEqualTo(Functions.RANGE_LIMIT);
+    assertThat(Functions.range(-2)).isEmpty();
+    assertThat(Functions.range(-2, -4)).isEmpty();
+    assertThat(Functions.range(-2, -2)).isEmpty();
+    assertThat(Functions.range(2, 2)).isEmpty();
+    assertThat(Functions.range(2, 2000, 0)).isEmpty();
+    assertThat(Functions.range(2, 2000, -5)).isEmpty();
   }
+
+  @Test
+  public void itHandlesBadValues() {
+    assertThat(Functions.range(2, "f")).isEmpty();
+  }
+
 
   @Test
   public void itTruncatesHugeRanges() {

--- a/src/test/java/com/hubspot/jinjava/lib/fn/RangeFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/RangeFunctionTest.java
@@ -1,0 +1,37 @@
+package com.hubspot.jinjava.lib.fn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+public class RangeFunctionTest {
+
+  @Test
+  public void itGeneratesSimpleRanges() {
+    assertThat(Functions.range(1)).isEqualTo(Arrays.asList(0));
+    assertThat(Functions.range(2)).isEqualTo(Arrays.asList(0, 1));
+    assertThat(Functions.range(2, 4)).isEqualTo(Arrays.asList(2, 3));
+    assertThat(Functions.range(2, 8, 2)).isEqualTo(Arrays.asList(2, 4, 6));
+  }
+
+  @Test
+  public void itGeneratesBackwardsRanges() {
+    assertThat(Functions.range(-2)).isEqualTo(Arrays.asList(0, -1));
+    assertThat(Functions.range(2, -1)).isEqualTo(Arrays.asList(2, 1, 0));
+    assertThat(Functions.range(8, 2, -2)).isEqualTo(Arrays.asList(8, 6, 4));
+  }
+
+  @Test
+  public void itHandlesBadRanges() {
+    assertThat(Functions.range(2, 2)).isEqualTo(Arrays.asList());
+    assertThat(Functions.range(2, 2000, -5).size()).isEqualTo(Functions.RANGE_LIMIT);
+  }
+
+  @Test
+  public void itTruncatesHugeRanges() {
+    assertThat(Functions.range(2, 200000000).size()).isEqualTo(Functions.RANGE_LIMIT);
+  }
+
+}

--- a/src/test/java/com/hubspot/jinjava/lib/fn/RangeFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/RangeFunctionTest.java
@@ -34,7 +34,7 @@ public class RangeFunctionTest {
     assertThat(Functions.range(2, 2000, -5)).isEmpty();
   }
 
-  @Test
+  @Test(expected = NumberFormatException.class)
   public void itHandlesBadValues() {
     assertThat(Functions.range(2, "f")).isEmpty();
   }


### PR DESCRIPTION
Implements `range()` ala Jinja2: http://jinja.pocoo.org/docs/dev/templates/

Fixes #49

Examples: 

` System.out.println(jinjava.render("| {% for num in range(2) %} {{ num }}, {% endfor %}|", context));`
`|  0,  1, |`
`System.out.println(jinjava.render("| {% for num in range(2, 8, 2) %} {{ num }}, {% endfor %}|", context));`
`|  2,  4,  6, |` 
`System.out.println(jinjava.render("| {% for num in range(2, -4, -2) %} {{ num }}, {% endfor %}|", context));`
`|  2,  0,  -2, |`
