### PR TITLE
Prevent Macro Cycles

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/AstMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstMacroFunction.java
@@ -6,6 +6,8 @@ import javax.el.ELContext;
 import javax.el.ELException;
 
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.MacroTagCycleException;
+import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
 
 import de.odysseus.el.misc.LocalMessages;
@@ -25,12 +27,28 @@ public class AstMacroFunction extends AstFunction {
 
     MacroFunction macroFunction = interpreter.getContext().getGlobalMacro(getName());
     if (macroFunction != null) {
+
+      try {
+        interpreter.getContext().getMacroStack().push(getName(), -1);
+      } catch (MacroTagCycleException e) {
+        interpreter.addError(new TemplateError(TemplateError.ErrorType.WARNING,
+                                               TemplateError.ErrorReason.EXCEPTION,
+                                               TemplateError.ErrorItem.TAG,
+                                               "Cycle detected for macro '" + getName() + "'",
+                                               null,
+                                               -1,
+                                               e));
+        return "";
+      }
+
       try {
         return super.invoke(bindings, context, macroFunction, AbstractCallableMethod.EVAL_METHOD);
       } catch (IllegalAccessException e) {
         throw new ELException(LocalMessages.get("error.function.access", getName()), e);
       } catch (InvocationTargetException e) {
         throw new ELException(LocalMessages.get("error.function.invocation", getName()), e.getCause());
+      } finally {
+        interpreter.getContext().getMacroStack().pop();
       }
     }
 

--- a/src/main/java/com/hubspot/jinjava/interpret/CallStack.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/CallStack.java
@@ -1,0 +1,47 @@
+package com.hubspot.jinjava.interpret;
+
+import java.util.Optional;
+import java.util.Stack;
+
+public class CallStack {
+
+  private final CallStack parent;
+  private final Class<? extends TagCycleException> exceptionClass;
+  private final Stack<String> stack = new Stack<>();
+
+  public CallStack(CallStack parent, Class<? extends TagCycleException> exceptionClass) {
+    this.parent = parent;
+    this.exceptionClass = exceptionClass;
+  }
+
+  public boolean contains(String path) {
+    if (stack.contains(path)) {
+      return true;
+    }
+
+    if (parent != null) {
+      return parent.contains(path);
+    }
+
+    return false;
+  }
+
+  public void push(String path, int lineNumber) {
+    if (contains(path)) {
+      throw TagCycleException.create(exceptionClass, path, Optional.of(lineNumber));
+    }
+
+    stack.push(path);
+  }
+
+  public Optional<String> pop() {
+    if (stack.isEmpty()) {
+      if (parent != null) {
+        return parent.pop();
+      }
+      return Optional.empty();
+    }
+
+    return Optional.of(stack.pop());
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -191,7 +191,7 @@ public class JinjavaInterpreter {
           output.addNode(node.render(this));
         }
 
-        context.popExtendPath();
+        context.getExtendPathStack().pop();
       }
     }
 

--- a/src/main/java/com/hubspot/jinjava/interpret/MacroTagCycleException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/MacroTagCycleException.java
@@ -1,0 +1,11 @@
+package com.hubspot.jinjava.interpret;
+
+public class MacroTagCycleException extends TagCycleException {
+
+  private static final long serialVersionUID = -7552850581260771832L;
+
+  public MacroTagCycleException(String path, int lineNumber) {
+    super("Macro", path, lineNumber);
+  }
+
+}

--- a/src/main/java/com/hubspot/jinjava/interpret/TagCycleException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TagCycleException.java
@@ -1,5 +1,7 @@
 package com.hubspot.jinjava.interpret;
 
+import java.util.Optional;
+
 public class TagCycleException extends TemplateStateException {
   private static final long serialVersionUID = -3058494056577268723L;
 
@@ -7,7 +9,7 @@ public class TagCycleException extends TemplateStateException {
   private final String tagName;
 
   public TagCycleException(String tagName, String path, int lineNumber) {
-    super(tagName + " tag cycle for path '" + path + "'", lineNumber);
+    super(tagName + " tag cycle for '" + path + "'", lineNumber);
 
     this.path = path;
     this.tagName = tagName;
@@ -19,6 +21,25 @@ public class TagCycleException extends TemplateStateException {
 
   public String getTagName() {
     return tagName;
+  }
+
+  public static TagCycleException create(Class<? extends TagCycleException> clazz, String path, Optional<Integer> linenumber) {
+
+    final Integer line = linenumber.orElse(-1);
+
+    if (clazz != null) {
+      if (clazz.equals(ExtendsTagCycleException.class)) {
+        return new ExtendsTagCycleException(path, line);
+      } else if (clazz.equals(ImportTagCycleException.class)) {
+        return new ImportTagCycleException(path, line);
+      } else if (clazz.equals(IncludeTagCycleException.class)) {
+        return new IncludeTagCycleException(path, line);
+      } else if (clazz.equals(MacroTagCycleException.class)) {
+        return new MacroTagCycleException(path, line);
+      }
+    }
+
+    return new TagCycleException("", path, line);
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ExtendsTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ExtendsTag.java
@@ -86,7 +86,7 @@ public class ExtendsTag implements Tag {
     }
 
     String path = interpreter.resolveString(tokenizer.next(), tagNode.getLineNumber());
-    interpreter.getContext().pushExtendPath(path, tagNode.getLineNumber());
+    interpreter.getContext().getExtendPathStack().push(path, tagNode.getLineNumber());
 
     try {
       String template = interpreter.getResource(path);

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import org.apache.commons.lang3.StringUtils;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
@@ -15,6 +14,7 @@ import com.hubspot.jinjava.interpret.ImportTagCycleException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateError;
+import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
@@ -75,7 +75,7 @@ public class ImportTag implements Tag {
     String path = StringUtils.trimToEmpty(helper.get(0));
 
     try {
-      interpreter.getContext().pushImportPath(path, tagNode.getLineNumber());
+      interpreter.getContext().getImportPathStack().push(path, tagNode.getLineNumber());
     } catch (ImportTagCycleException e) {
       interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.EXCEPTION, ErrorItem.TAG,
           "Import cycle detected for path: '" + path + "'", null, tagNode.getLineNumber(), e));

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IncludeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IncludeTag.java
@@ -17,7 +17,6 @@ package com.hubspot.jinjava.lib.tag;
 
 import java.io.IOException;
 
-import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import org.apache.commons.lang3.StringUtils;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
@@ -27,6 +26,7 @@ import com.hubspot.jinjava.interpret.IncludeTagCycleException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateError;
+import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
@@ -58,7 +58,7 @@ public class IncludeTag implements Tag {
     String templateFile = interpreter.resolveString(path, tagNode.getLineNumber());
 
     try {
-      interpreter.getContext().pushIncludePath(templateFile, tagNode.getLineNumber());
+      interpreter.getContext().getIncludePathStack().push(templateFile, tagNode.getLineNumber());
     } catch (IncludeTagCycleException e) {
       interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.EXCEPTION, ErrorItem.TAG,
           "Include cycle detected for path: '" + templateFile + "'", null, tagNode.getLineNumber(), e));
@@ -81,7 +81,7 @@ public class IncludeTag implements Tag {
     } catch (IOException e) {
       throw new InterpretException(e.getMessage(), e, tagNode.getLineNumber());
     } finally {
-      interpreter.getContext().popIncludePath();
+      interpreter.getContext().getIncludePathStack().pop();
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
@@ -49,6 +49,9 @@ public class MacroTag implements Tag {
 
   private static final long serialVersionUID = 8397609322126956077L;
 
+  private static final Pattern MACRO_PATTERN = Pattern.compile("([a-zA-Z_][\\w_]*)[^\\(]*\\(([^\\)]*)\\)");
+  private static final Splitter ARGS_SPLITTER = Splitter.on(',').omitEmptyStrings().trimResults();
+
   @Override
   public String getName() {
     return "macro";
@@ -103,8 +106,4 @@ public class MacroTag implements Tag {
 
     return "";
   }
-
-  private static final Pattern MACRO_PATTERN = Pattern.compile("([a-zA-Z_][\\w_]*)[^\\(]*\\(([^\\)]*)\\)");
-  private static final Splitter ARGS_SPLITTER = Splitter.on(',').omitEmptyStrings().trimResults();
-
 }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
@@ -116,6 +116,21 @@ public class MacroTagTest {
     assertThat(tabs.select(".tools__description").get(3).text()).isEqualTo("body4");
   }
 
+  @Test
+  public void itPreventsDirectMacroRecursion() throws IOException {
+    String template = Resources.toString(Resources.getResource("tags/macrotag/recursion.jinja"), StandardCharsets.UTF_8);
+    interpreter.render(template);
+    assertThat(interpreter.getErrors().get(0).getMessage()).contains("Cycle detected for macro 'hello'");
+  }
+
+  @Test
+  public void itPreventsIndirectMacroRecursion() throws IOException {
+    String template = Resources.toString(Resources.getResource("tags/macrotag/recursion_indirect.jinja"), StandardCharsets.UTF_8);
+    interpreter.render(template);
+    assertThat(interpreter.getErrors().get(0).getMessage()).contains("Cycle detected for macro 'goodbye'");
+  }
+
+
   private Node snippet(String jinja) {
     return new TreeParser(interpreter, jinja).buildTree().getChildren().getFirst();
   }

--- a/src/test/resources/tags/macrotag/recursion.jinja
+++ b/src/test/resources/tags/macrotag/recursion.jinja
@@ -1,0 +1,5 @@
+{% macro hello() -%}
+  Hello {{ hello() }}
+{%- endmacro %}
+
+{{ hello() }}

--- a/src/test/resources/tags/macrotag/recursion_indirect.jinja
+++ b/src/test/resources/tags/macrotag/recursion_indirect.jinja
@@ -1,0 +1,9 @@
+{% macro hello() -%}
+  Hello, {{ goodbye() }}
+{%- endmacro %}
+
+{% macro goodbye() -%}
+  Goodbye, {{ hello() }}
+{%- endmacro %}
+
+{{ goodbye() }}


### PR DESCRIPTION
It's currently possible to define a macro that calls itself, either directly or indirectly and that can lead to a cycle.

This prevents cycles (and any recursion) in macros. 

I also refactored the other call stacks used for include and import cycle detection.