### PR TITLE
Don't include caller in macro stack

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/AstMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstMacroFunction.java
@@ -30,20 +30,22 @@ public class AstMacroFunction extends AstFunction {
     MacroFunction macroFunction = interpreter.getContext().getGlobalMacro(getName());
     if (macroFunction != null) {
 
-      try {
-        interpreter.getContext().getMacroStack().push(getName(), -1);
-      } catch (MacroTagCycleException e) {
-        interpreter.addError(new TemplateError(TemplateError.ErrorType.WARNING,
-                                               TemplateError.ErrorReason.EXCEPTION,
-                                               TemplateError.ErrorItem.TAG,
-                                               "Cycle detected for macro '" + getName() + "'",
-                                               null,
-                                               -1,
-                                               e,
-                                               BasicTemplateErrorCategory.CYCLE_DETECTED,
-                                               ImmutableMap.of("name", getName())));
+      if (!macroFunction.isCaller()) {
+        try {
+          interpreter.getContext().getMacroStack().push(getName(), -1);
+        } catch (MacroTagCycleException e) {
+          interpreter.addError(new TemplateError(TemplateError.ErrorType.WARNING,
+                                                 TemplateError.ErrorReason.EXCEPTION,
+                                                 TemplateError.ErrorItem.TAG,
+                                                 "Cycle detected for macro '" + getName() + "'",
+                                                 null,
+                                                 -1,
+                                                 e,
+                                                 BasicTemplateErrorCategory.CYCLE_DETECTED,
+                                                 ImmutableMap.of("name", getName())));
 
-        return "";
+          return "";
+        }
       }
 
       try {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
@@ -130,6 +130,13 @@ public class MacroTagTest {
     assertThat(interpreter.getErrors().get(0).getMessage()).contains("Cycle detected for macro 'goodbye'");
   }
 
+  @Test
+  public void itAllowsMacrosCallingMacrosUsingCall() throws IOException {
+    String template = Resources.toString(Resources.getResource("tags/macrotag/macros-calling-macros.jinja"), StandardCharsets.UTF_8);
+    String out = interpreter.render(template);
+    assertThat(out).contains("Hello World One");
+    assertThat(out).contains("Hello World Two");
+  }
 
   private Node snippet(String jinja) {
     return new TreeParser(interpreter, jinja).buildTree().getChildren().getFirst();

--- a/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
@@ -134,6 +134,7 @@ public class MacroTagTest {
   public void itAllowsMacrosCallingMacrosUsingCall() throws IOException {
     String template = Resources.toString(Resources.getResource("tags/macrotag/macros-calling-macros.jinja"), StandardCharsets.UTF_8);
     String out = interpreter.render(template);
+    assertThat(interpreter.getErrors()).isEmpty();
     assertThat(out).contains("Hello World One");
     assertThat(out).contains("Hello World Two");
   }

--- a/src/test/resources/tags/macrotag/macros-calling-macros.jinja
+++ b/src/test/resources/tags/macrotag/macros-calling-macros.jinja
@@ -1,0 +1,26 @@
+{% macro render_dialog_one(title, class) %}
+<div class="{{ class }}">
+    <h2>{{ title }}</h2>
+    <div class="contents">
+        {{ caller() }}
+    </div>
+</div>
+{% endmacro %}
+
+{% macro render_dialog_two(title, class) %}
+<div class="{{ class }}">
+    <h2>{{ title }}</h2>
+    <div class="contents">
+        {{ caller() }}
+    </div>
+</div>
+{% endmacro %}
+
+{% call render_dialog_one('Hello World One', 'greeting 1') %}
+   <p>1) This is render_dialog_one</p>
+
+   {% call render_dialog_two('Hello World Two', 'greeting 2') %}
+       <p>2) This is render_dialog_two</p>
+   {% endcall %}
+
+{% endcall %}


### PR DESCRIPTION
When looking for recursive calls, don't include caller as a macro.