### PR TITLE
Update macro tag to allow for included macros

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
@@ -102,8 +102,8 @@ public class MacroTag implements Tag {
 
     MacroFunction macro = new MacroFunction(tagNode.getChildren(), name, argNamesWithDefaults,
         catchKwargs, catchVarargs, caller, interpreter.getContext());
-    interpreter.getContext().addGlobalMacro(macro);
-
+//    interpreter.getContext().addGlobalMacro(macro);
+    JinjavaInterpreter.getCurrent().getContext().addGlobalMacro(macro);
     return "";
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
@@ -102,7 +102,6 @@ public class MacroTag implements Tag {
 
     MacroFunction macro = new MacroFunction(tagNode.getChildren(), name, argNamesWithDefaults,
         catchKwargs, catchVarargs, caller, interpreter.getContext());
-//    interpreter.getContext().addGlobalMacro(macro);
     JinjavaInterpreter.getCurrent().getContext().addGlobalMacro(macro);
     return "";
   }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
@@ -142,6 +142,7 @@ public class MacroTagTest {
   @Test
   public void itCanAccessMacrosAcrossFiles() throws IOException {
     String template = Resources.toString(Resources.getResource("tags/macrotag/include-another-macro.jinja"), StandardCharsets.UTF_8);
+    interpreter.render(template);
     assertThat(interpreter.getErrors()).isEmpty();
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
@@ -139,6 +139,12 @@ public class MacroTagTest {
     assertThat(out).contains("Hello World Two");
   }
 
+  @Test
+  public void itCanAccessMacrosAcrossFiles() throws IOException {
+    String template = Resources.toString(Resources.getResource("tags/macrotag/include-another-macro.jinja"), StandardCharsets.UTF_8);
+    assertThat(interpreter.getErrors()).isEmpty();
+  }
+
   private Node snippet(String jinja) {
     return new TreeParser(interpreter, jinja).buildTree().getChildren().getFirst();
   }
@@ -150,5 +156,4 @@ public class MacroTagTest {
       throw Throwables.propagate(e);
     }
   }
-
 }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
@@ -146,7 +146,6 @@ public class MacroTagTest {
     String output = interpreter.render(template);
     assertThat(interpreter.getErrors()).isEmpty();
     assertThat(output).isEqualTo(macroResult);
-
   }
 
   private Node snippet(String jinja) {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
@@ -142,8 +142,11 @@ public class MacroTagTest {
   @Test
   public void itCanAccessMacrosAcrossFiles() throws IOException {
     String template = Resources.toString(Resources.getResource("tags/macrotag/include-another-macro.jinja"), StandardCharsets.UTF_8);
-    interpreter.render(template);
+    String macroResult = Resources.toString(Resources.getResource("tags/macrotag/include-another-macro-result"), StandardCharsets.UTF_8);
+    String output = interpreter.render(template);
     assertThat(interpreter.getErrors()).isEmpty();
+    assertThat(output).isEqualTo(macroResult);
+
   }
 
   private Node snippet(String jinja) {

--- a/src/test/resources/tags/macrotag/include-another-macro-result
+++ b/src/test/resources/tags/macrotag/include-another-macro-result
@@ -8,8 +8,14 @@ a {
 }
 
 
+This is contained in my include tag.
+
+Sincerely,
+-Stevie
+
+
 a {
 
--webkit-transition: all .2s ease-in-out;
+-webkit-transition: .100 linear;
 
 }

--- a/src/test/resources/tags/macrotag/include-another-macro-result
+++ b/src/test/resources/tags/macrotag/include-another-macro-result
@@ -1,0 +1,15 @@
+
+
+
+a {
+
+-webkit-transition: all .2s ease-in-out;
+
+}
+
+
+a {
+
+-webkit-transition: all .2s ease-in-out;
+
+}

--- a/src/test/resources/tags/macrotag/include-another-macro.jinja
+++ b/src/test/resources/tags/macrotag/include-another-macro.jinja
@@ -1,5 +1,5 @@
 {% include "tags/macrotag/included-macro.jinja" %}
 
 a {
-{{ transition('all .2s ease-in-out') }}
+{{ transition('.100 linear') }}
 }

--- a/src/test/resources/tags/macrotag/include-another-macro.jinja
+++ b/src/test/resources/tags/macrotag/include-another-macro.jinja
@@ -1,1 +1,5 @@
 {% include "tags/macrotag/included-macro.jinja" %}
+
+a {
+{{ transition('all .2s ease-in-out') }}
+}

--- a/src/test/resources/tags/macrotag/include-another-macro.jinja
+++ b/src/test/resources/tags/macrotag/include-another-macro.jinja
@@ -1,0 +1,1 @@
+{% include "tags/macrotag/included-macro.jinja" %}

--- a/src/test/resources/tags/macrotag/include-another-macro.jinja
+++ b/src/test/resources/tags/macrotag/include-another-macro.jinja
@@ -1,5 +1,1 @@
 {% include "tags/macrotag/included-macro.jinja" %}
-
-a {
-{{ transition('all .2s ease-in-out') }}
-}

--- a/src/test/resources/tags/macrotag/included-macro.jinja
+++ b/src/test/resources/tags/macrotag/included-macro.jinja
@@ -6,3 +6,9 @@
 a {
 {{ transition('all .2s ease-in-out') }}
 }
+
+
+This is contained in my include tag.
+
+Sincerely,
+-Stevie

--- a/src/test/resources/tags/macrotag/included-macro.jinja
+++ b/src/test/resources/tags/macrotag/included-macro.jinja
@@ -1,0 +1,8 @@
+{% macro transition(value) %}
+-webkit-transition: {{value}};
+{% endmacro %}
+
+
+a {
+{{ transition('all .2s ease-in-out') }}
+}


### PR DESCRIPTION
@mattfurtado @boulter 

Currently, if a file contains a macro (let's call it File "Macro") and that file is included via some tag in another file (let's call it File "Included Macro"), then File "Macro" will save fine, but File "Included Macro" will have errors because the macro is saved to a lower/different context level.

This updates saving macros to save to the top-level interpreter. Looking for feedback on the approach.

