### PR TITLE
ignore replace() on null expr

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/ReplaceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ReplaceFilter.java
@@ -39,7 +39,7 @@ public class ReplaceFilter implements Filter {
       String... args) {
 
     if (var == null) {
-      throw new InterpretException("filter " + getName() + " requires a var to operate on");
+      return null;
     }
     if (args.length < 2) {
       throw new InterpretException("filter " + getName() + " requires two string args");

--- a/src/test/java/com/hubspot/jinjava/lib/filter/ReplaceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/ReplaceFilterTest.java
@@ -25,9 +25,8 @@ public class ReplaceFilterTest {
     filter.filter("foo", interpreter);
   }
 
-  @Test(expected = InterpretException.class)
-  public void expectsFilterVar() {
-    filter.filter(null, interpreter, "foo", "bar");
+  public void noopOnNullExpr() {
+    assertThat(filter.filter(null, interpreter, "foo", "bar")).isNull();
   }
 
   @Test


### PR DESCRIPTION
Rather than blowing up, just treat a replace on a null expr as a noop so templates will validate even if the target expr isn't defined.