### PR TITLE
Map performance tests

### DIFF
--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverPerformanceTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverPerformanceTest.java
@@ -48,7 +48,7 @@ public class ExpressionResolverPerformanceTest {
     }
 
     public void testMapResolver(int iterations) {
-      System.out.println("map resolver");
+      System.out.println("map resolver with " + iterations + " iterations");
       startTimer();
 
       for (int i = 0; i < iterations; i++) {
@@ -60,7 +60,7 @@ public class ExpressionResolverPerformanceTest {
     }
 
     public void testMethodResolver(int iterations) {
-      System.out.println("method resolver");
+      System.out.println("method resolver with " + iterations + " iterations");
       startTimer();
 
       for (int i = 0; i < iterations; i++) {

--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverPerformanceTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverPerformanceTest.java
@@ -1,0 +1,150 @@
+package com.hubspot.jinjava.el;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.interpret.Context;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+
+public class ExpressionResolverPerformanceTest {
+
+  public static void main(String[] args) {
+    PerformanceTester tester = new PerformanceTester();
+    tester.run();
+  }
+
+  public static class PerformanceTester {
+
+    private JinjavaInterpreter interpreter;
+    private Context context;
+    private long startTime;
+
+    public PerformanceTester() {
+
+      interpreter = new Jinjava().newInterpreter();
+      context = interpreter.getContext();
+      context.put("customMap", new CustomMap());
+      context.put("customObject", new CustomObject());
+    }
+
+    public void run() {
+
+      int iterations = 1000000;
+
+      testMapResolver(iterations);
+      testMethodResolver(iterations);
+    }
+
+    public void startTimer() {
+      startTime = System.currentTimeMillis();
+    }
+
+    public void stopTimer() {
+      System.out.println(String.format("%d msec", System.currentTimeMillis() - startTime));
+    }
+
+    public void testMapResolver(int iterations) {
+      System.out.println("map resolver");
+      startTimer();
+
+      for (int i = 0; i < iterations; i++) {
+        Object val = interpreter.resolveELExpression("customMap.get(\"thing\")", -1);
+        assertThat(val).isEqualTo("hey");
+      }
+
+      stopTimer();
+    }
+
+    public void testMethodResolver(int iterations) {
+      System.out.println("method resolver");
+      startTimer();
+
+      for (int i = 0; i < iterations; i++) {
+        Object val = interpreter.resolveELExpression("customObject.getThing()", -1);
+        assertThat(val).isEqualTo("hey");
+      }
+
+      stopTimer();
+    }
+
+  }
+
+  static class CustomObject {
+
+    public CustomObject() {
+    }
+
+    public String getThing() {
+      return "hey";
+    }
+
+  }
+
+  static class CustomMap implements Map<String, String> {
+
+    @Override
+    public String get(Object key) {
+      return "hey";
+    }
+
+    @Override
+    public int size() {
+      return 0;
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return false;
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+      return false;
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+      return false;
+    }
+
+    @Override
+    public String put(String key, String value) {
+      return null;
+    }
+
+    @Override
+    public String remove(Object key) {
+      return null;
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends String> m) {
+
+    }
+
+    @Override
+    public void clear() {
+
+    }
+
+    @Override
+    public Set<String> keySet() {
+      return null;
+    }
+
+    @Override
+    public Collection<String> values() {
+      return null;
+    }
+
+    @Override
+    public Set<Entry<String, String>> entrySet() {
+      return null;
+    }
+  }
+
+}

--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
@@ -98,7 +98,6 @@ public class ExpressionResolverTest {
     Object val = interpreter.resolveELExpression("thedict['foo']", -1);
     assertThat(val).isEqualTo("bar");
     assertThat(interpreter.getContext().wasExpressionResolved("thedict['foo']")).isTrue();
-
   }
 
   @Test
@@ -127,9 +126,25 @@ public class ExpressionResolverTest {
     assertThat(interpreter.getContext().wasExpressionResolved("thedict.two")).isTrue();
   }
 
+  @Test
+  public void itResolvesOtherMethodsOnCustomMapObject() throws Exception {
+
+    MyCustomMap dict = new MyCustomMap();
+    context.put("thedict", dict);
+
+    Object val = interpreter.resolveELExpression("thedict.size", -1);
+    assertThat(val).isEqualTo("777");
+
+    Object val1 = interpreter.resolveELExpression("thedict.size()", -1);
+    assertThat(val1).isEqualTo(3);
+
+    Object val2 = interpreter.resolveELExpression("thedict.items()", -1);
+    assertThat(val2.toString()).isEqualTo("[foo=bar, two=2, size=777]");
+ }
+
   public static final class MyCustomMap implements Map<String, String> {
 
-    Map<String, String> data = ImmutableMap.of("foo", "bar", "two", "2");
+    Map<String, String> data = ImmutableMap.of("foo", "bar", "two", "2", "size", "777");
 
     @Override
     public int size() {

--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
@@ -3,16 +3,19 @@ package com.hubspot.jinjava.el;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ForwardingList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.hubspot.jinjava.Jinjava;
@@ -95,6 +98,7 @@ public class ExpressionResolverTest {
     Object val = interpreter.resolveELExpression("thedict['foo']", -1);
     assertThat(val).isEqualTo("bar");
     assertThat(interpreter.getContext().wasExpressionResolved("thedict['foo']")).isTrue();
+
   }
 
   @Test
@@ -106,6 +110,86 @@ public class ExpressionResolverTest {
     Object val = interpreter.resolveELExpression("thedict.foo", -1);
     assertThat(val).isEqualTo("bar");
     assertThat(interpreter.getContext().wasExpressionResolved("thedict.foo")).isTrue();
+  }
+
+  @Test
+  public void itResolvesMapValOnCustomObject() throws Exception {
+
+    MyCustomMap dict = new MyCustomMap();
+    context.put("thedict", dict);
+
+    Object val = interpreter.resolveELExpression("thedict['foo']", -1);
+    assertThat(val).isEqualTo("bar");
+    assertThat(interpreter.getContext().wasExpressionResolved("thedict['foo']")).isTrue();
+
+    Object val2 = interpreter.resolveELExpression("thedict.two", -1);
+    assertThat(val2).isEqualTo("2");
+    assertThat(interpreter.getContext().wasExpressionResolved("thedict.two")).isTrue();
+  }
+
+  public static final class MyCustomMap implements Map<String, String> {
+
+    Map<String, String> data = ImmutableMap.of("foo", "bar", "two", "2");
+
+    @Override
+    public int size() {
+      return data.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return data.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+      return data.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+      return data.containsValue(value);
+    }
+
+    @Override
+    public String get(Object key) {
+      return data.get(key);
+    }
+
+    @Override
+    public String put(String key, String value) {
+      return null;
+    }
+
+    @Override
+    public String remove(Object key) {
+      return null;
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends String> m) {
+
+    }
+
+    @Override
+    public void clear() {
+
+    }
+
+    @Override
+    public Set<String> keySet() {
+      return data.keySet();
+    }
+
+    @Override
+    public Collection<String> values() {
+      return data.values();
+    }
+
+    @Override
+    public Set<Entry<String, String>> entrySet() {
+      return data.entrySet();
+    }
   }
 
   @Test


### PR DESCRIPTION
Resolving expressions that call map.get() are more than twice as fast as resolving expressions that result in a method invocation. This adds some test to confirm expression resolution on some custom map objects and a performance test.

```
map resolver with 1000000 iterations
2793 msec
method resolver with 1000000 iterations
7566 msec
```