### PR TITLE
Restrict tags, expression tests and filters

### DIFF
--- a/src/main/java/com/hubspot/jinjava/Jinjava.java
+++ b/src/main/java/com/hubspot/jinjava/Jinjava.java
@@ -186,7 +186,7 @@ public class Jinjava {
    * @return result object containing rendered output, render context, and any encountered errors
    */
   public RenderResult renderForResult(String template, Map<String, ?> bindings, JinjavaConfig renderConfig) {
-    Context context = new Context(globalContext, bindings);
+    Context context = new Context(globalContext, bindings, null);
 
     JinjavaInterpreter parentInterpreter = JinjavaInterpreter.getCurrent();
     if (parentInterpreter != null) {

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -22,8 +22,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.Stack;
 
 import org.apache.commons.lang3.StringUtils;
@@ -93,7 +95,11 @@ public class JinjavaInterpreter {
    * </code>
    */
   public InterpreterScopeClosable enterScope() {
-    context = new Context(context);
+    return enterScope(null);
+  }
+
+  public InterpreterScopeClosable enterScope(Map<Context.Library, Set<String>> disabled) {
+    context = new Context(context, null, disabled);
     return new InterpreterScopeClosable();
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/ExpTestLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/ExpTestLibrary.java
@@ -1,11 +1,13 @@
 package com.hubspot.jinjava.lib.exptest;
 
+import java.util.Set;
+
 import com.hubspot.jinjava.lib.SimpleLibrary;
 
 public class ExpTestLibrary extends SimpleLibrary<ExpTest> {
 
-  public ExpTestLibrary(boolean registerDefaults) {
-    super(registerDefaults);
+  public ExpTestLibrary(boolean registerDefaults, Set<String> disabled) {
+    super(registerDefaults, disabled);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FilterLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FilterLibrary.java
@@ -15,12 +15,14 @@
  **********************************************************************/
 package com.hubspot.jinjava.lib.filter;
 
+import java.util.Set;
+
 import com.hubspot.jinjava.lib.SimpleLibrary;
 
 public class FilterLibrary extends SimpleLibrary<Filter> {
 
-  public FilterLibrary(boolean registerDefaults) {
-    super(registerDefaults);
+  public FilterLibrary(boolean registerDefaults, Set<String> disabled) {
+    super(registerDefaults, disabled);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/fn/FunctionLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/FunctionLibrary.java
@@ -1,12 +1,14 @@
 package com.hubspot.jinjava.lib.fn;
 
+import java.util.Set;
+
 import com.google.common.collect.Lists;
 import com.hubspot.jinjava.lib.SimpleLibrary;
 
 public class FunctionLibrary extends SimpleLibrary<ELFunctionDefinition> {
 
-  public FunctionLibrary(boolean registerDefaults) {
-    super(registerDefaults);
+  public FunctionLibrary(boolean registerDefaults, Set<String> disabled) {
+    super(registerDefaults, disabled);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/TagLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/TagLibrary.java
@@ -15,12 +15,14 @@ limitations under the License.
  **********************************************************************/
 package com.hubspot.jinjava.lib.tag;
 
+import java.util.Set;
+
 import com.hubspot.jinjava.lib.SimpleLibrary;
 
 public class TagLibrary extends SimpleLibrary<Tag> {
 
-  public TagLibrary(boolean registerDefaults) {
-    super(registerDefaults);
+  public TagLibrary(boolean registerDefaults, Set<String> disabled) {
+    super(registerDefaults, disabled);
   }
 
   @Override

--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.interpret.Context;
+import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
@@ -342,6 +343,19 @@ public class ExpressionResolverTest {
 
     try (JinjavaInterpreter.InterpreterScopeClosable c = interpreter.enterScope(disabled)) {
       interpreter.render("{% raw %} foo {% endraw %}");
+    }
+  }
+
+  @Test(expected = InterpretException.class)
+  public void itBlocksDisabledTagsInIncludes() throws Exception {
+
+    final String jinja = "top {% include \"tags/includetag/raw.html\" %}";
+
+    Map<Context.Library, Set<String>> disabled =  ImmutableMap.of(Context.Library.TAG, ImmutableSet.of("raw"));
+    assertThat(interpreter.render(jinja)).isEqualTo("top before raw after\n");
+
+    try (JinjavaInterpreter.InterpreterScopeClosable c = interpreter.enterScope(disabled)) {
+      interpreter.render(jinja);
     }
   }
 

--- a/src/test/resources/tags/includetag/raw.html
+++ b/src/test/resources/tags/includetag/raw.html
@@ -1,0 +1,1 @@
+before{% raw %} raw{% endraw %} after


### PR DESCRIPTION
Certain tags, expression tests and filters may be incompatible with a tag or perhaps you want to disable some of these for security. This allows you to specific tags, expression tests and filters that cannot be called in child nodes.
