### PR TITLE
add function and filter to get unix timestamps

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/FilterLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FilterLibrary.java
@@ -58,6 +58,7 @@ public class FilterLibrary extends SimpleLibrary<Filter> {
 
     DatetimeFilter.class,
         DateTimeFormatFilter.class,
+        UnixTimestampFilter.class,
 
     AbsFilter.class,
         AddFilter.class,

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilter.java
@@ -7,7 +7,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.fn.Functions;
 
 @JinjavaDoc(
-    value = "gets the unix timestamp value (in millseconds) of a date object",
+    value = "gets the unix timestamp value (in milliseconds) of a date object",
     params = {
         @JinjavaParam(value = "value", defaultValue = "current time", desc = "The date variable"),
     },

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilter.java
@@ -1,0 +1,29 @@
+package com.hubspot.jinjava.lib.filter;
+
+import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
+import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.lib.fn.Functions;
+
+@JinjavaDoc(
+    value = "gets the unix timestamp value (in millseconds) of a date object",
+    params = {
+        @JinjavaParam(value = "value", defaultValue = "current time", desc = "The date variable"),
+    },
+    snippets = {
+        @JinjavaSnippet(code = "{% local_dt|unixtimestamp"),
+    })
+public class UnixTimestampFilter implements Filter {
+
+  @Override
+  public String getName() {
+    return "unixtimestamp";
+  }
+
+  @Override
+  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+      return Functions.getUnixTimestamp(var);
+  }
+
+}

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilter.java
@@ -23,7 +23,7 @@ public class UnixTimestampFilter implements Filter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
-      return Functions.getUnixTimestamp(var);
+      return Functions.unixtimestamp(var);
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilter.java
@@ -7,12 +7,12 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.fn.Functions;
 
 @JinjavaDoc(
-    value = "gets the unix timestamp value (in milliseconds) of a date object",
+    value = "Gets the UNIX timestamp value (in milliseconds) of a date object",
     params = {
         @JinjavaParam(value = "value", defaultValue = "current time", desc = "The date variable"),
     },
     snippets = {
-        @JinjavaSnippet(code = "{% local_dt|unixtimestamp"),
+        @JinjavaSnippet(code = "{% mydatetime|unixtimestamp %}"),
     })
 public class UnixTimestampFilter implements Filter {
 

--- a/src/main/java/com/hubspot/jinjava/lib/fn/FunctionLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/FunctionLibrary.java
@@ -14,6 +14,7 @@ public class FunctionLibrary extends SimpleLibrary<ELFunctionDefinition> {
   @Override
   protected void registerDefaults() {
     register(new ELFunctionDefinition("", "datetimeformat", Functions.class, "dateTimeFormat", Object.class, String[].class));
+    register(new ELFunctionDefinition("", "unixtimestamp", Functions.class, "getUnixTimestamp", Object.class));
     register(new ELFunctionDefinition("", "truncate", Functions.class, "truncate", Object.class, Object[].class));
     register(new ELFunctionDefinition("", "range", Functions.class, "range", Object.class, Object[].class));
 

--- a/src/main/java/com/hubspot/jinjava/lib/fn/FunctionLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/FunctionLibrary.java
@@ -14,7 +14,7 @@ public class FunctionLibrary extends SimpleLibrary<ELFunctionDefinition> {
   @Override
   protected void registerDefaults() {
     register(new ELFunctionDefinition("", "datetimeformat", Functions.class, "dateTimeFormat", Object.class, String[].class));
-    register(new ELFunctionDefinition("", "unixtimestamp", Functions.class, "getUnixTimestamp", Object.class));
+    register(new ELFunctionDefinition("", "unixtimestamp", Functions.class, "unixtimestamp", Object.class));
     register(new ELFunctionDefinition("", "truncate", Functions.class, "truncate", Object.class, Object[].class));
     register(new ELFunctionDefinition("", "range", Functions.class, "range", Object.class, Object[].class));
 

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -99,7 +99,7 @@ public class Functions {
   @JinjavaDoc(value = "gets the unix timestamp milliseconds value of a datetime", params = {
       @JinjavaParam(value = "var", type = "date", defaultValue = "current time"),
   })
-  public static Object getUnixTimestamp(Object var) {
+  public static Object unixtimestamp(Object var) {
     ZonedDateTime d = getDateTimeArg(var);
 
     if (d == null) {

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -99,11 +99,11 @@ public class Functions {
   @JinjavaDoc(value = "gets the unix timestamp milliseconds value of a datetime", params = {
       @JinjavaParam(value = "var", type = "date", defaultValue = "current time"),
   })
-  public static Object unixtimestamp(Object var) {
+  public static long unixtimestamp(Object var) {
     ZonedDateTime d = getDateTimeArg(var);
 
     if (d == null) {
-      return 0L;
+      return 0;
     }
 
     return d.toEpochSecond() * 1000;

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -59,19 +59,7 @@ public class Functions {
       @JinjavaParam(value = "format", defaultValue = StrftimeFormatter.DEFAULT_DATE_FORMAT)
   })
   public static String dateTimeFormat(Object var, String... format) {
-    ZonedDateTime d = null;
-
-    if (var == null) {
-      d = ZonedDateTime.now(ZoneOffset.UTC);
-    } else if (var instanceof Number) {
-      d = ZonedDateTime.ofInstant(Instant.ofEpochMilli(((Number) var).longValue()), ZoneOffset.UTC);
-    } else if (var instanceof PyishDate) {
-      d = ((PyishDate) var).toDateTime();
-    } else if (var instanceof ZonedDateTime) {
-      d = (ZonedDateTime) var;
-    } else if (!ZonedDateTime.class.isAssignableFrom(var.getClass())) {
-      throw new InterpretException("Input to datetimeformat function must be a date object, was: " + var.getClass());
-    }
+    ZonedDateTime d = getDateTimeArg(var);
 
     if (d == null) {
       return "";
@@ -87,6 +75,38 @@ public class Functions {
     } else {
       return StrftimeFormatter.format(d, locale);
     }
+  }
+
+  private static ZonedDateTime getDateTimeArg(Object var) {
+
+    ZonedDateTime d = null;
+
+    if (var == null) {
+      d = ZonedDateTime.now(ZoneOffset.UTC);
+    } else if (var instanceof Number) {
+      d = ZonedDateTime.ofInstant(Instant.ofEpochMilli(((Number) var).longValue()), ZoneOffset.UTC);
+    } else if (var instanceof PyishDate) {
+      d = ((PyishDate) var).toDateTime();
+    } else if (var instanceof ZonedDateTime) {
+      d = (ZonedDateTime) var;
+    } else if (!ZonedDateTime.class.isAssignableFrom(var.getClass())) {
+      throw new InterpretException("Input to function must be a date object, was: " + var.getClass());
+    }
+
+    return d;
+  }
+
+  @JinjavaDoc(value = "gets the unix timestamp milliseconds value of a datetime", params = {
+      @JinjavaParam(value = "var", type = "date", defaultValue = "current time"),
+  })
+  public static Object getUnixTimestamp(Object var) {
+    ZonedDateTime d = getDateTimeArg(var);
+
+    if (d == null) {
+      return 0L;
+    }
+
+    return d.toEpochSecond() * 1000;
   }
 
   private static final int DEFAULT_TRUNCATE_LENGTH = 255;

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
@@ -52,7 +52,6 @@ public class DateTimeFormatFilterTest {
   public void itHandlesVarsAndLiterals() throws Exception {
     interpreter.getContext().put("d", d);
     interpreter.getContext().put("foo", "%Y-%m");
-
     assertThat(interpreter.renderFlat("{{ d|datetimeformat(foo) }}")).isEqualTo("2013-11");
     assertThat(interpreter.renderFlat("{{ d|datetimeformat(\"%Y-%m-%d\") }}")).isEqualTo("2013-11-06");
     assertThat(interpreter.getErrors()).isEmpty();

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
@@ -52,6 +52,7 @@ public class DateTimeFormatFilterTest {
   public void itHandlesVarsAndLiterals() throws Exception {
     interpreter.getContext().put("d", d);
     interpreter.getContext().put("foo", "%Y-%m");
+
     assertThat(interpreter.renderFlat("{{ d|datetimeformat(foo) }}")).isEqualTo("2013-11");
     assertThat(interpreter.renderFlat("{{ d|datetimeformat(\"%Y-%m-%d\") }}")).isEqualTo("2013-11-06");
     assertThat(interpreter.getErrors()).isEmpty();

--- a/src/test/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilterTest.java
@@ -16,7 +16,7 @@ public class UnixTimestampFilterTest {
   JinjavaInterpreter interpreter;
 
   private final ZonedDateTime d = ZonedDateTime.parse("2013-11-06T14:22:00.000+00:00[UTC]");
-  private final String timestamp = new Long(d.toEpochSecond() * 1000).toString();
+  private final String timestamp = Long.toString(d.toEpochSecond() * 1000);
 
   @Before
   public void setup() {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilterTest.java
@@ -1,0 +1,37 @@
+package com.hubspot.jinjava.lib.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZonedDateTime;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+
+public class UnixTimestampFilterTest {
+
+  JinjavaInterpreter interpreter;
+
+  private final ZonedDateTime d = ZonedDateTime.parse("2013-11-06T14:22:00.000+00:00[UTC]");
+  private final String timestamp = new Long(d.toEpochSecond() * 1000).toString();
+
+  @Before
+  public void setup() {
+    interpreter = new Jinjava().newInterpreter();
+    interpreter.getContext().put("d", d);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    assertThat(interpreter.getErrors()).isEmpty();
+  }
+
+  @Test
+  public void itRendersFromDate() throws Exception {
+    assertThat(interpreter.renderFlat("{{ d|unixtimestamp }}")).isEqualTo(timestamp);
+  }
+
+}

--- a/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
@@ -1,0 +1,19 @@
+package com.hubspot.jinjava.lib.fn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZonedDateTime;
+
+import org.junit.Test;
+
+public class UnixTimestampFunctionTest {
+
+  private final ZonedDateTime d = ZonedDateTime.parse("2013-11-06T14:22:00.000+00:00[UTC]");
+
+  @Test
+  public void itGetsUnixTimestamps() {
+    assertThat(Functions.getUnixTimestamp(d.toEpochSecond() * 1000)).isEqualTo(d.toEpochSecond() * 1000);
+    assertThat(Functions.getUnixTimestamp(null)).isEqualTo(ZonedDateTime.now().toEpochSecond() * 1000);
+  }
+
+}

--- a/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
@@ -12,9 +12,9 @@ public class UnixTimestampFunctionTest {
 
   @Test
   public void itGetsUnixTimestamps() {
-    assertThat(Functions.getUnixTimestamp(d.toEpochSecond() * 1000)).isEqualTo(d.toEpochSecond() * 1000);
-    assertThat(Functions.getUnixTimestamp(d)).isEqualTo(d.toEpochSecond() * 1000);
-    assertThat(Functions.getUnixTimestamp(null)).isEqualTo(ZonedDateTime.now().toEpochSecond() * 1000);
+    assertThat(Functions.unixtimestamp(d.toEpochSecond() * 1000)).isEqualTo(d.toEpochSecond() * 1000);
+    assertThat(Functions.unixtimestamp(d)).isEqualTo(d.toEpochSecond() * 1000);
+    assertThat(Functions.unixtimestamp(null)).isEqualTo(ZonedDateTime.now().toEpochSecond() * 1000);
   }
 
 }

--- a/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
@@ -9,11 +9,12 @@ import org.junit.Test;
 public class UnixTimestampFunctionTest {
 
   private final ZonedDateTime d = ZonedDateTime.parse("2013-11-06T14:22:00.000+00:00[UTC]");
+  private final long epochMilliseconds = d.toEpochSecond() * 1000;
 
   @Test
   public void itGetsUnixTimestamps() {
-    assertThat(Functions.unixtimestamp(d.toEpochSecond() * 1000)).isEqualTo(d.toEpochSecond() * 1000);
-    assertThat(Functions.unixtimestamp(d)).isEqualTo(d.toEpochSecond() * 1000);
+    assertThat(Functions.unixtimestamp(epochMilliseconds)).isEqualTo(epochMilliseconds);
+    assertThat(Functions.unixtimestamp(d)).isEqualTo(epochMilliseconds);
     assertThat(Functions.unixtimestamp(null)).isEqualTo(ZonedDateTime.now().toEpochSecond() * 1000);
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
@@ -13,6 +13,7 @@ public class UnixTimestampFunctionTest {
   @Test
   public void itGetsUnixTimestamps() {
     assertThat(Functions.getUnixTimestamp(d.toEpochSecond() * 1000)).isEqualTo(d.toEpochSecond() * 1000);
+    assertThat(Functions.getUnixTimestamp(d)).isEqualTo(d.toEpochSecond() * 1000);
     assertThat(Functions.getUnixTimestamp(null)).isEqualTo(ZonedDateTime.now().toEpochSecond() * 1000);
   }
 


### PR DESCRIPTION
unix timestamps make it easier to do comparisons and calculate relative values of dates

As a filter:

`{{ d|unixtimestamp }}`

As a function:

`{{ unixtimestamp() }}` returns the timestamp of now

`{{ unixtimestamp(d) }}` returns the timestamp of a particular datetime

@pfarrel @lcmartinez @bgoodies
