### PR TITLE
respect '-' in tags to eliminate whitespace

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -20,8 +20,6 @@ import static com.hubspot.jinjava.tree.parse.TokenScannerSymbols.TOKEN_FIXED;
 import static com.hubspot.jinjava.tree.parse.TokenScannerSymbols.TOKEN_NOTE;
 import static com.hubspot.jinjava.tree.parse.TokenScannerSymbols.TOKEN_TAG;
 
-import java.util.LinkedList;
-
 import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.collect.Iterators;
@@ -181,14 +179,13 @@ public class TreeParser {
 
   private void endTag(Tag tag, TagToken tagToken) {
 
-    final LinkedList<Node> children = parent.getChildren();
-    final Node lastChild = children.isEmpty() ? null : children.get(children.size() - 1);
+    final Node lastSibling = getLastSibling();
 
     if (parent instanceof TagNode
         && tagToken.isLeftTrim()
-        && lastChild != null
-        && lastChild instanceof TextNode) {
-      lastChild.getMaster().setRightTrim(true);
+        && lastSibling != null
+        && lastSibling instanceof TextNode) {
+      lastSibling.getMaster().setRightTrim(true);
     }
 
     parent.getMaster().setRightTrimAfterEnd(tagToken.isRightTrim());

--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -97,16 +97,13 @@ public class TreeParser {
         interpreter.addError(TemplateError.fromException(new UnexpectedTokenException(token.getImage(),
                                                                                       token.getLineNumber())));
     }
-
     return null;
   }
 
   private Node getLastSibling() {
-
     if (parent == null || parent.getChildren().isEmpty()) {
       return null;
     }
-
     return parent.getChildren().getLast();
   }
 
@@ -155,7 +152,6 @@ public class TreeParser {
       endTag(tag, tagToken);
       return null;
     } else {
-
       // if a tag has left trim, mark the last sibling to trim right whitespace
       if (tagToken.isLeftTrim()) {
         final Node lastSibling = getLastSibling();
@@ -204,5 +200,4 @@ public class TreeParser {
       }
     }
   }
-
 }

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TextToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TextToken.java
@@ -46,6 +46,14 @@ public class TextToken extends Token {
   }
 
   public String output() {
+
+    if (isLeftTrim() && isRightTrim()) {
+      return trim();
+    } else if (isLeftTrim()) {
+      return StringUtils.stripStart(content, null);
+    } else if (isRightTrim()) {
+      return StringUtils.stripEnd(content, null);
+    }
     return content;
   }
 

--- a/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
@@ -36,6 +36,7 @@ public abstract class Token implements Serializable {
 
   private boolean leftTrim;
   private boolean rightTrim;
+  private boolean rightTrimAfterEnd;
 
   public Token(String image, int lineNumber) {
     this.image = image;
@@ -59,12 +60,20 @@ public abstract class Token implements Serializable {
     return rightTrim;
   }
 
+  public boolean isRightTrimAfterEnd() {
+    return rightTrimAfterEnd;
+  }
+
   public void setLeftTrim(boolean leftTrim) {
     this.leftTrim = leftTrim;
   }
 
   public void setRightTrim(boolean rightTrim) {
     this.rightTrim = rightTrim;
+  }
+
+  public void setRightTrimAfterEnd(boolean rightTrimAfterEnd) {
+    this.rightTrimAfterEnd = rightTrimAfterEnd;
   }
 
   @Override

--- a/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
@@ -29,6 +29,34 @@ public class TreeParserTest {
   }
 
   @Test
+  public void itStripsRightWhiteSpace() throws Exception {
+    String leftSpace = "{% for foo in [1,2,3] -%}\n.{{ foo }}\n{% endfor %}";
+    final Node tree = new TreeParser(interpreter, leftSpace).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo(".1\n.2\n.3\n");
+  }
+
+  @Test
+  public void itStripsLeftWhiteSpace() throws Exception {
+    String leftSpace = "{% for foo in [1,2,3] %}\n{{ foo }}.\n{%- endfor %}";
+    final Node tree = new TreeParser(interpreter, leftSpace).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo("\n1.\n2.\n3.");
+  }
+
+  @Test
+  public void itStripsLeftAndRightWhiteSpace() throws Exception {
+    String leftSpace = "{% for foo in [1,2,3] -%}\n.{{ foo }}.\n{%- endfor %}";
+    final Node tree = new TreeParser(interpreter, leftSpace).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo(".1..2..3.");
+  }
+
+  @Test
+  public void itPreservesInnerWhiteSpace() throws Exception {
+    String leftSpace = "{% for foo in [1,2,3] -%}\nL{% if true %}\n{{ foo }}\n{% endif %}R\n{%- endfor %}";
+    final Node tree = new TreeParser(interpreter, leftSpace).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo("L\n1\nRL\n2\nRL\n3\nR");
+  }
+
+  @Test
   public void trimAndLstripBlocks() {
     interpreter = new Jinjava(JinjavaConfig.newBuilder().withLstripBlocks(true).withTrimBlocks(true).build()).newInterpreter();
 

--- a/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
@@ -30,21 +30,21 @@ public class TreeParserTest {
 
   @Test
   public void itStripsRightWhiteSpace() throws Exception {
-    String leftSpace = "{% for foo in [1,2,3] -%}\n.{{ foo }}\n{% endfor %}";
+    String leftSpace = "{% for foo in [1,2,3] -%} \n .{{ foo }}\n{% endfor %}";
     final Node tree = new TreeParser(interpreter, leftSpace).buildTree();
     assertThat(interpreter.render(tree)).isEqualTo(".1\n.2\n.3\n");
   }
 
   @Test
   public void itStripsLeftWhiteSpace() throws Exception {
-    String leftSpace = "{% for foo in [1,2,3] %}\n{{ foo }}.\n{%- endfor %}";
+    String leftSpace = "{% for foo in [1,2,3] %}\n{{ foo }}. \n {%- endfor %}";
     final Node tree = new TreeParser(interpreter, leftSpace).buildTree();
     assertThat(interpreter.render(tree)).isEqualTo("\n1.\n2.\n3.");
   }
 
   @Test
   public void itStripsLeftAndRightWhiteSpace() throws Exception {
-    String leftSpace = "{% for foo in [1,2,3] -%}\n.{{ foo }}.\n{%- endfor %}";
+    String leftSpace = "{% for foo in [1,2,3] -%} \n .{{ foo }}. \n {%- endfor %}";
     final Node tree = new TreeParser(interpreter, leftSpace).buildTree();
     assertThat(interpreter.render(tree)).isEqualTo(".1..2..3.");
   }

--- a/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
@@ -30,30 +30,51 @@ public class TreeParserTest {
 
   @Test
   public void itStripsRightWhiteSpace() throws Exception {
-    String leftSpace = "{% for foo in [1,2,3] -%} \n .{{ foo }}\n{% endfor %}";
-    final Node tree = new TreeParser(interpreter, leftSpace).buildTree();
+    String expression = "{% for foo in [1,2,3] -%} \n .{{ foo }}\n{% endfor %}";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(tree)).isEqualTo(".1\n.2\n.3\n");
   }
 
   @Test
   public void itStripsLeftWhiteSpace() throws Exception {
-    String leftSpace = "{% for foo in [1,2,3] %}\n{{ foo }}. \n {%- endfor %}";
-    final Node tree = new TreeParser(interpreter, leftSpace).buildTree();
+    String expression = "{% for foo in [1,2,3] %}\n{{ foo }}. \n {%- endfor %}";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(tree)).isEqualTo("\n1.\n2.\n3.");
   }
 
   @Test
   public void itStripsLeftAndRightWhiteSpace() throws Exception {
-    String leftSpace = "{% for foo in [1,2,3] -%} \n .{{ foo }}. \n {%- endfor %}";
-    final Node tree = new TreeParser(interpreter, leftSpace).buildTree();
+    String expression = "{% for foo in [1,2,3] -%} \n .{{ foo }}. \n {%- endfor %}";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(tree)).isEqualTo(".1..2..3.");
   }
 
   @Test
   public void itPreservesInnerWhiteSpace() throws Exception {
-    String leftSpace = "{% for foo in [1,2,3] -%}\nL{% if true %}\n{{ foo }}\n{% endif %}R\n{%- endfor %}";
-    final Node tree = new TreeParser(interpreter, leftSpace).buildTree();
+    String expression = "{% for foo in [1,2,3] -%}\nL{% if true %}\n{{ foo }}\n{% endif %}R\n{%- endfor %}";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(tree)).isEqualTo("L\n1\nRL\n2\nRL\n3\nR");
+  }
+
+  @Test
+  public void itStripsLeftWhiteSpaceBeforeTag() throws Exception {
+    String expression = ".\n {%- for foo in [1,2,3] %} {{ foo }} {% endfor %} \n.";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo(". 1  2  3  \n.");
+  }
+
+  @Test
+  public void itStripsRightWhiteSpaceAfterTag() throws Exception {
+    String expression = ".\n {% for foo in [1,2,3] %} {{ foo }} {% endfor -%} \n.";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo(".\n  1  2  3 .");
+  }
+
+  @Test
+  public void itStripsAllOuterWhiteSpace() throws Exception {
+    String expression = ".\n {%- for foo in [1,2,3] -%} {{ foo }} {%- endfor -%} \n.";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo(".123.");
   }
 
   @Test


### PR DESCRIPTION
```
{% for foo in [1,2,3] -%}
  {{ foo }}
{%- endfor %}
```

now produces `1,2,3`, eliminating whitespace chars after or before the tag.

Fixes #86 

@pfarrel @lcmartinez @bgoodies @derkork