### PR TITLE
Enable use of arbitrary variable names when looping over dictionary entries

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -40,7 +40,7 @@ import com.hubspot.jinjava.util.ObjectIterator;
 /**
  * {% for a in b|f1:d,c %}
  *
- * {% for key, value in my_dict %}
+ * {% for key, value in my_dict.items() %}
  *
  * @author anysome
  *
@@ -54,6 +54,16 @@ import com.hubspot.jinjava.util.ObjectIterator;
         @JinjavaSnippet(
             code = "{% for item in items %}\n" +
                 "    {{ item }}\n" +
+                "{% endfor %}"),
+        @JinjavaSnippet(
+            desc = "Iterating over dictionary values",
+            code = "{% for value in dictionary %}\n" +
+                "    {{ value }}\n" +
+                "{% endfor %}"),
+        @JinjavaSnippet(
+            desc = "Iterating over dictionary entries",
+            code = "{% for key, value in dictionary.items() %}\n" +
+                "    {{ key }}: {{ value }}\n" +
                 "{% endfor %}"),
         @JinjavaSnippet(
             desc = "Standard blog listing loop",
@@ -128,9 +138,9 @@ public class ForTag implements Tag {
               Map.Entry<String, Object> entry = (Entry<String, Object>) val;
               Object entryVal = null;
 
-              if ("key".equals(loopVar)) {
+              if (loopVars.indexOf(loopVar) == 0) {
                 entryVal = entry.getKey();
-              } else if ("value".equals(loopVar)) {
+              } else if (loopVars.indexOf(loopVar) == 1) {
                 entryVal = entry.getValue();
               }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
@@ -8,6 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.collect.ImmutableMap;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
@@ -71,6 +72,22 @@ public class ForTagTest {
     Document dom = Jsoup.parseBodyFragment(tag.interpret(tagNode, interpreter));
 
     assertThat(dom.select("p")).hasSize(2);
+  }
+
+  @Test
+  public void forLoopMultipleLoopVarsArbitraryNames() throws Exception {
+    Map<String, Object> dict = ImmutableMap.of(
+        "grand", "ol'",
+        "adserving", "team");
+
+    context.put("the_dictionary", dict);
+    String template = ""
+        + "{% for foo, bar in the_dictionary.items() %}"
+        + "{{ foo }}: {{ bar }}\n"
+        + "{% endfor %}";
+
+    String rendered = jinjava.render(template, context);
+    assertEquals("grand: ol'\nadserving: team\n", rendered);
   }
 
   @Test


### PR DESCRIPTION
Previously you could only use the variable names `key` and `value` when
looping over a dictionary. This conflicted with the python implementation
of jinja where the loop variables can have arbitrary names, and would
have made nested looping over dictionary entries hard due to name
collisions.

Worth noting is that the existing `forLoopMultipleLoopVars()` still passed if the template was changed to use different names than `key` and `value` for the variables. The loop still worked but the variables didn't contain any content, i.e. they were empty strings. The test still passed since it only checked the number of lines.