### PR TITLE
use correct conversion for day of week as number

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
@@ -40,7 +40,7 @@ public class StrftimeFormatter {
     CONVERSIONS['p'] = "a";
     CONVERSIONS['S'] = "ss";
     CONVERSIONS['U'] = "ww";
-    CONVERSIONS['w'] = "uu";
+    CONVERSIONS['w'] = "e";
     CONVERSIONS['W'] = "ww";
     CONVERSIONS['x'] = "MM/dd/yy";
     CONVERSIONS['X'] = "HH:mm:ss";

--- a/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
@@ -55,6 +55,11 @@ public class StrftimeFormatterTest {
   }
 
   @Test
+  public void testDayOfWeekNumber() {
+    assertThat(StrftimeFormatter.format(d, "%w")).isEqualTo("4");
+  }
+
+  @Test
   public void testTime() {
     assertThat(StrftimeFormatter.format(d, "%X")).isEqualTo("14:22:00");
   }


### PR DESCRIPTION
the python strftime %w was being converted to a 2-digit year instead of the day of week number. Note that Java days of week are 0-based, so this value will be one off from a python value.