### PR TITLE
Better handling for bad syntax errors on truncdiv and powerof operators

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/PowerOfOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/PowerOfOperator.java
@@ -30,7 +30,7 @@ public class PowerOfOperator extends SimpleOperator {
       Double e = converter.convert(b, Double.class);
       return Math.pow(d, e);
     }
-    throw new IllegalArgumentException(String.format("Unsupported operand type(s) for **: '%s' ('%s') and '%s' ('%s')",
+    throw new IllegalArgumentException(String.format("Unsupported operand type(s) for **: '%s' (%s) and '%s' (%s)",
                                                      a,
                                                      (a == null ? "null" : a.getClass().getSimpleName()),
                                                      b,

--- a/src/main/java/com/hubspot/jinjava/el/ext/PowerOfOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/PowerOfOperator.java
@@ -12,24 +12,28 @@ public class PowerOfOperator extends SimpleOperator {
 
   @Override
   protected Object apply(TypeConverter converter, Object a, Object b) {
-      boolean aInt = a instanceof Integer || a instanceof Long;
-      boolean bInt = b instanceof Integer || b instanceof Long;
-      boolean aNum = aInt || a instanceof Double || a instanceof Float;
-      boolean bNum = bInt || b instanceof Double || b instanceof Float;
+    boolean aInt = a instanceof Integer || a instanceof Long;
+    boolean bInt = b instanceof Integer || b instanceof Long;
+    boolean aNum = aInt || a instanceof Double || a instanceof Float;
+    boolean bNum = bInt || b instanceof Double || b instanceof Float;
 
-      if (aInt && bInt) {
-          Long d = converter.convert(a, Long.class);
-          Long e = converter.convert(b, Long.class);
-          return (long)Math.pow(d, e);
-   }
-      if (aNum && bNum) {
-          Double d = converter.convert(a, Double.class);
-          Double e = converter.convert(b, Double.class);
-          return Math.pow(d, e);
-      }
-      throw new IllegalArgumentException("Unsupported operand type(s) for **: "
-              + "'" + a.getClass().getSimpleName() + "' and "
-              + "'" + b.getClass().getSimpleName() + "'");
+    if (aInt && bInt) {
+      Long d = converter.convert(a, Long.class);
+      Long e = converter.convert(b, Long.class);
+      return (long) Math.pow(d, e);
+    }
+    if (aNum && bNum) {
+      Double d = converter.convert(a, Double.class);
+      Double e = converter.convert(b, Double.class);
+      return Math.pow(d, e);
+    }
+    throw new IllegalArgumentException(String.format("Unsupported operand type(s) for **: '%s' ('%s') and '%s' ('%s')",
+                                                     a,
+                                                     (a == null ? "null" : a.getClass().getSimpleName()),
+                                                     b,
+                                                     (b == null ? "null" : b.getClass().getSimpleName())
+    )
+    );
   }
 
   public static final Scanner.ExtensionToken TOKEN = new Scanner.ExtensionToken("**");

--- a/src/main/java/com/hubspot/jinjava/el/ext/PowerOfOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/PowerOfOperator.java
@@ -10,6 +10,9 @@ import de.odysseus.el.tree.impl.ast.AstNode;
 
 public class PowerOfOperator extends SimpleOperator {
 
+  public static final Scanner.ExtensionToken TOKEN = new Scanner.ExtensionToken("**");
+  public static final PowerOfOperator OP = new PowerOfOperator();
+
   @Override
   protected Object apply(TypeConverter converter, Object a, Object b) {
     boolean aInt = a instanceof Integer || a instanceof Long;
@@ -35,9 +38,6 @@ public class PowerOfOperator extends SimpleOperator {
     )
     );
   }
-
-  public static final Scanner.ExtensionToken TOKEN = new Scanner.ExtensionToken("**");
-  public static final PowerOfOperator OP = new PowerOfOperator();
 
   public static final ExtensionHandler HANDLER = new ExtensionHandler(ExtensionPoint.MUL) {
     @Override

--- a/src/main/java/com/hubspot/jinjava/el/ext/TruncDivOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/TruncDivOperator.java
@@ -10,31 +10,35 @@ import de.odysseus.el.tree.impl.ast.AstNode;
 
 public class TruncDivOperator extends SimpleOperator {
 
+  public static final Scanner.ExtensionToken TOKEN = new Scanner.ExtensionToken("//");
+  public static final TruncDivOperator OP = new TruncDivOperator();
+
   @Override
   protected Object apply(TypeConverter converter, Object a, Object b) {
 
-      boolean aInt = a instanceof Integer || a instanceof Long;
-      boolean bInt = b instanceof Integer || b instanceof Long;
-      boolean aNum = aInt || a instanceof Double || a instanceof Float;
-      boolean bNum = bInt || b instanceof Double || b instanceof Float;
+    boolean aInt = a instanceof Integer || a instanceof Long;
+    boolean bInt = b instanceof Integer || b instanceof Long;
+    boolean aNum = aInt || a instanceof Double || a instanceof Float;
+    boolean bNum = bInt || b instanceof Double || b instanceof Float;
 
-      if (aInt && bInt) {
-          Long d = converter.convert(a, Long.class);
-          Long e = converter.convert(b, Long.class);
-          return Math.floorDiv(d, e);
-      }
-      if (aNum && bNum) {
-          Double d = converter.convert(a, Double.class);
-          Double e = converter.convert(b, Double.class);
-          return Math.floor(d/e);
-      }
-      throw new IllegalArgumentException("Unsupported operand type(s) for //: "
-              + "'" + a.getClass().getSimpleName() + "' and "
-              + "'" + b.getClass().getSimpleName() + "'");
+    if (aInt && bInt) {
+      Long d = converter.convert(a, Long.class);
+      Long e = converter.convert(b, Long.class);
+      return Math.floorDiv(d, e);
+    }
+    if (aNum && bNum) {
+      Double d = converter.convert(a, Double.class);
+      Double e = converter.convert(b, Double.class);
+      return Math.floor(d / e);
+    }
+    throw new IllegalArgumentException(String.format("Unsupported operand type(s) for //: '%s' ('%s') and '%s' ('%s')",
+                                                     a,
+                                                     (a == null ? "null" : a.getClass().getSimpleName()),
+                                                     b,
+                                                     (b == null ? "null" : b.getClass().getSimpleName())
+                                                    )
+    );
   }
-
-  public static final Scanner.ExtensionToken TOKEN = new Scanner.ExtensionToken("//");
-  public static final TruncDivOperator OP = new TruncDivOperator();
 
   public static final ExtensionHandler HANDLER = new ExtensionHandler(ExtensionPoint.MUL) {
     @Override

--- a/src/main/java/com/hubspot/jinjava/el/ext/TruncDivOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/TruncDivOperator.java
@@ -31,7 +31,7 @@ public class TruncDivOperator extends SimpleOperator {
       Double e = converter.convert(b, Double.class);
       return Math.floor(d / e);
     }
-    throw new IllegalArgumentException(String.format("Unsupported operand type(s) for //: '%s' ('%s') and '%s' ('%s')",
+    throw new IllegalArgumentException(String.format("Unsupported operand type(s) for //: '%s' (%s) and '%s' (%s)",
                                                      a,
                                                      (a == null ? "null" : a.getClass().getSimpleName()),
                                                      b,

--- a/src/test/java/com/hubspot/jinjava/el/ext/TruncDivTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/TruncDivTest.java
@@ -1,7 +1,7 @@
 package com.hubspot.jinjava.el.ext;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.util.Map;
 
@@ -13,6 +13,8 @@ import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.interpret.FatalTemplateErrorsException;
 
 public class TruncDivTest {
+
+    private Jinjava jinja;
 
     @Before
     public void setUp() {
@@ -58,15 +60,12 @@ public class TruncDivTest {
         context.put("dividend", "5");
         context.put("divisor",  "2");
 
-        String template = "{% set x = dividend // divisor %}{{x}}";
+        String template = "{% set x = dividend // divisor %}";
         try {
             jinja.render(template, context);
         } catch (FatalTemplateErrorsException e) {
             String msg = e.getMessage();
-            assertTrue(msg.contains("Unsupported operand type(s)"));
+            assertThat(msg).contains("Unsupported operand type(s): '5' ('String') and '2' ('String')");
         }
     }
-
-
-    private Jinjava jinja;
 }

--- a/src/test/java/com/hubspot/jinjava/el/ext/TruncDivTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/TruncDivTest.java
@@ -64,8 +64,7 @@ public class TruncDivTest {
         try {
             jinja.render(template, context);
         } catch (FatalTemplateErrorsException e) {
-            String msg = e.getMessage();
-            assertThat(msg).contains("Unsupported operand type(s): '5' ('String') and '2' ('String')");
+            assertThat(e.getMessage()).contains("Unsupported operand type(s) for //: '5' (String) and '2' (String)");
         }
     }
 }


### PR DESCRIPTION
Don't throw an NPE when building the IllegalArgumentException. Also a little cleanup.