### PR TITLE
Shade-relocate JUEL dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 .DS_Store
 
 # Maven
+dependency-reduced-pom.xml
 log/
 target/
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,30 @@ Get it:
   </dependency>
 ```
 
+or if you have a conflicting EL implementation on your classpath:
+```xml
+<dependency>
+  <groupId>com.hubspot.jinjava</groupId>
+  <artifactId>jinjava</artifactId>
+  <version>2.1.14</version>
+  <classifier>with-shaded-juel</classifier>
+  <exclusions>
+    <exclusion>
+      <artifactId>juel-api</artifactId>
+      <groupId>de.odysseus.juel</groupId>
+    </exclusion>
+    <exclusion>
+      <artifactId>juel-impl</artifactId>
+      <groupId>de.odysseus.juel</groupId>
+    </exclusion>
+    <exclusion>
+      <artifactId>juel-spi</artifactId>
+      <groupId>de.odysseus.juel</groupId>
+    </exclusion>
+  </exclusions>
+</dependency>
+```
+
 or if you're stuck on java 7:
 ```xml
   <dependency>

--- a/README.md
+++ b/README.md
@@ -21,30 +21,6 @@ Get it:
   </dependency>
 ```
 
-or if you have a conflicting EL implementation on your classpath:
-```xml
-<dependency>
-  <groupId>com.hubspot.jinjava</groupId>
-  <artifactId>jinjava</artifactId>
-  <version>2.1.14</version>
-  <classifier>with-shaded-juel</classifier>
-  <exclusions>
-    <exclusion>
-      <artifactId>juel-api</artifactId>
-      <groupId>de.odysseus.juel</groupId>
-    </exclusion>
-    <exclusion>
-      <artifactId>juel-impl</artifactId>
-      <groupId>de.odysseus.juel</groupId>
-    </exclusion>
-    <exclusion>
-      <artifactId>juel-spi</artifactId>
-      <groupId>de.odysseus.juel</groupId>
-    </exclusion>
-  </exclusions>
-</dependency>
-```
-
 or if you're stuck on java 7:
 ```xml
   <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,7 @@
             </goals>
             <configuration>
               <createDependencyReducedPom>true</createDependencyReducedPom>
+              <shadedArtifactAttached>false</shadedArtifactAttached>
               <artifactSet>
                 <includes>
                   <include>de.odysseus.juel:juel-api</include>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,6 @@
     <project.build.targetJdk>1.8</project.build.targetJdk>
     <basepom.check.skip-findbugs>false</basepom.check.skip-findbugs>
     <dep.plugin.checkstyle.version>2.17</dep.plugin.checkstyle.version>
-    <classifier.juel>with-shaded-juel</classifier.juel>
   </properties>
 
   <dependencies>
@@ -59,11 +58,6 @@
     <dependency>
       <groupId>de.odysseus.juel</groupId>
       <artifactId>juel-impl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>de.odysseus.juel</groupId>
-      <artifactId>juel-spi</artifactId>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -118,11 +112,6 @@
         <artifactId>juel-impl</artifactId>
         <version>2.2.7</version>
       </dependency>
-      <dependency>
-        <groupId>de.odysseus.juel</groupId>
-        <artifactId>juel-spi</artifactId>
-        <version>2.2.7</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -156,8 +145,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <shadedArtifactAttached>true</shadedArtifactAttached>
-              <shadedClassifierName>${classifier.juel}</shadedClassifierName>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
               <artifactSet>
                 <includes>
                   <include>de.odysseus.juel:juel-api</include>
@@ -170,8 +158,8 @@
                   <shadedPattern>jinjava.javax.el</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>de.odysseus.juel</pattern>
-                  <shadedPattern>jinjava.de.odysseus.juel</shadedPattern>
+                  <pattern>de.odysseus.el</pattern>
+                  <shadedPattern>jinjava.de.odysseus.el</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <project.build.targetJdk>1.8</project.build.targetJdk>
     <basepom.check.skip-findbugs>false</basepom.check.skip-findbugs>
     <dep.plugin.checkstyle.version>2.17</dep.plugin.checkstyle.version>
+    <classifier.juel>with-shaded-juel</classifier.juel>
   </properties>
 
   <dependencies>
@@ -142,6 +143,38 @@
             <goals>
               <goal>report</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>${classifier.juel}</shadedClassifierName>
+              <artifactSet>
+                <includes>
+                  <include>de.odysseus.juel:juel-api</include>
+                  <include>de.odysseus.juel:juel-impl</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>javax.el</pattern>
+                  <shadedPattern>jinjava.javax.el</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>de.odysseus.juel</pattern>
+                  <shadedPattern>jinjava.de.odysseus.juel</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Related to #39 - this PR shade-relocates the JUEL dependency which solves the problem of conflicting EL implementations available at run-time.

I'm not sure how to exclude dependencies if building for a separate classifier - any help on that front would be much appreciated!