### PR TITLE
persist dependencies found in lower scopes

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -368,6 +368,10 @@ public class Context extends ScopeMap<String, Object> {
     this.dependencies.get(type).add(identification);
   }
 
+  public void addDependencies(SetMultimap<String, String> dependencies) {
+    this.dependencies.putAll(dependencies);
+  }
+
   public SetMultimap<String, String> getDependencies() {
     return this.dependencies;
   }

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -110,6 +110,7 @@ public class JinjavaInterpreter {
   public void leaveScope() {
     Context parent = context.getParent();
     if (parent != null) {
+      parent.addDependencies(context.getDependencies());
       context = parent;
     }
   }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -133,6 +133,19 @@ public class JinjavaInterpreterTest {
   }
 
   @Test
+  public void bubbleUpDependenciesFromLowerScope() {
+    String dependencyType = "foo";
+    String dependencyIdentifier = "123";
+
+    interpreter.enterScope();
+    interpreter.getContext().addDependency(dependencyType, dependencyIdentifier);
+    assertThat(interpreter.getContext().getDependencies().get(dependencyType)).contains(dependencyIdentifier);
+    interpreter.leaveScope();
+
+    assertThat(interpreter.getContext().getDependencies().get(dependencyType)).contains(dependencyIdentifier);
+  }
+
+  @Test
   public void parseWithSyntaxError() {
     RenderResult result = new Jinjava().renderForResult("{%}", new HashMap<>());
     assertThat(result.getErrors()).isNotEmpty();


### PR DESCRIPTION
Dependencies in lower scopes would not be bubbled up to the parent; this copies all lower scope dependencies to the parent context before leaving the scope

@boulter 