### PR TITLE
Create interpreter errors for disabled functions, tags and filters

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.el.ext.NamedParameter;
+import com.hubspot.jinjava.interpret.DisabledException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateError;
@@ -77,6 +78,8 @@ public class ExpressionResolver {
           "Error parsing '" + expression + "': " + StringUtils.substringAfter(e.getMessage(), "': "), interpreter.getLineNumber(), e)));
     } catch (ELException e) {
       interpreter.addError(TemplateError.fromException(new TemplateSyntaxException(expression, e.getMessage(), interpreter.getLineNumber(), e)));
+    } catch (DisabledException e) {
+      interpreter.addError(new TemplateError(ErrorType.FATAL, ErrorReason.DISABLED, ErrorItem.FUNCTION, e.getMessage(), expression, interpreter.getLineNumber(), e));
     } catch (Exception e) {
       interpreter.addError(TemplateError.fromException(new InterpretException(
           String.format("Error resolving expression [%s]: " + getRootCauseMessage(e), expression), e, interpreter.getLineNumber())));

--- a/src/main/java/com/hubspot/jinjava/el/MacroFunctionMapper.java
+++ b/src/main/java/com/hubspot/jinjava/el/MacroFunctionMapper.java
@@ -6,10 +6,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.el.FunctionMapper;
-import javax.el.MethodNotFoundException;
 
 import com.hubspot.jinjava.el.ext.AbstractCallableMethod;
 import com.hubspot.jinjava.interpret.Context;
+import com.hubspot.jinjava.interpret.DisabledException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
 
@@ -33,7 +33,7 @@ public class MacroFunctionMapper extends FunctionMapper {
     final String functionName = buildFunctionName(prefix, localName);
 
     if (context.isFunctionDisabled(functionName)) {
-      throw new MethodNotFoundException("'" + functionName + "' is disabled in this context");
+      throw new DisabledException(functionName);
     }
 
     return map.get(functionName);
@@ -41,7 +41,7 @@ public class MacroFunctionMapper extends FunctionMapper {
 
   public void setFunction(String prefix, String localName, Method method) {
     if (map.isEmpty()) {
-      map = new HashMap<String, Method>();
+      map = new HashMap<>();
     }
     map.put(buildFunctionName(prefix, localName), method);
   }

--- a/src/main/java/com/hubspot/jinjava/interpret/DisabledException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/DisabledException.java
@@ -1,0 +1,15 @@
+package com.hubspot.jinjava.interpret;
+
+public class DisabledException extends InterpretException {
+
+  private final String token;
+
+  public DisabledException(String token) {
+    super("'" + token + "' is disabled in this context");
+    this.token = token;
+  }
+
+  public String getToken() {
+    return token;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -3,12 +3,12 @@ package com.hubspot.jinjava.interpret;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import com.google.common.collect.ImmutableMap;
-import com.hubspot.jinjava.interpret.errorcategory.BasicTemplateErrorCategory;
-import com.hubspot.jinjava.interpret.errorcategory.TemplateErrorCategory;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableMap;
+import com.hubspot.jinjava.interpret.errorcategory.BasicTemplateErrorCategory;
+import com.hubspot.jinjava.interpret.errorcategory.TemplateErrorCategory;
 
 public class TemplateError {
   public enum ErrorType {
@@ -22,6 +22,7 @@ public class TemplateError {
     BAD_URL,
     EXCEPTION,
     MISSING,
+    DISABLED,
     OTHER
   }
 
@@ -31,6 +32,8 @@ public class TemplateError {
     TAG,
     FUNCTION,
     PROPERTY,
+    FILTER,
+    EXPRESSION_TEST,
     OTHER
   }
 

--- a/src/main/java/com/hubspot/jinjava/interpret/UnknownTagException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/UnknownTagException.java
@@ -8,10 +8,10 @@ public class UnknownTagException extends TemplateSyntaxException {
   private final String tag;
   private final String defintion;
 
-  public UnknownTagException(String tag, String defintion, int lineNumber) {
-    super(defintion, "Unknown tag: " + tag, lineNumber);
+  public UnknownTagException(String tag, String definition, int lineNumber) {
+    super(definition, "Unknown tag: " + tag, lineNumber);
     this.tag = tag;
-    this.defintion = defintion;
+    this.defintion = definition;
   }
 
   public UnknownTagException(TagToken tagToken) {

--- a/src/main/java/com/hubspot/jinjava/lib/SimpleLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/SimpleLibrary.java
@@ -26,12 +26,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.el.MethodNotFoundException;
-
 import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
+import com.hubspot.jinjava.interpret.DisabledException;
 
 public abstract class SimpleLibrary<T extends Importable> {
 
@@ -55,7 +54,7 @@ public abstract class SimpleLibrary<T extends Importable> {
 
   public T fetch(String item) {
     if (disabled.contains(item)) {
-      throw new MethodNotFoundException("'" + item + "' is disabled in this context");
+      throw new DisabledException(item);
     }
 
     return lib.get(StringUtils.lowerCase(item));


### PR DESCRIPTION
This updates https://github.com/HubSpot/jinjava/pull/83 and https://github.com/HubSpot/jinjava/pull/84 to create interpreter errors when functionality is disabled instead of rudely throwing a `MethodNotFoundException`. This allows detailed syntax checking and iteration of all errors in the template.

@bgoodies @pfarrel @lcmartinez @jessbrandi