### PR TITLE
Adding named parameters to filters

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
@@ -121,15 +121,11 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
       return astParams; // We only change the signature method for filters
     }
 
-    List<Object> methodParams = new ArrayList<Object>() {{
-      add(astParams[0]); // Left Value
-      add(astParams[1]); // JinjavaInterpreter
-    }};
-
     List<Object> args = new ArrayList<>();
     Map<String, Object> kwargs = new HashMap<>();
 
-    for (Object param: Arrays.asList(astParams).subList(methodParams.size(), astParams.length)) {
+    // 2 -> Ignore the Left Value (0) and the JinjavaInterpreter (1)
+    for (Object param: Arrays.asList(astParams).subList(2, astParams.length)) {
       if (param instanceof NamedParameter) {
         NamedParameter namedParameter = (NamedParameter) param;
         kwargs.put(namedParameter.getName(), namedParameter.getValue());
@@ -138,10 +134,7 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
       }
     }
 
-    methodParams.add(args.toArray());
-    methodParams.add(kwargs);
-
-    return methodParams.toArray();
+    return new Object[] {astParams[0], astParams[1], args.toArray(), kwargs};
   }
 
   private Object getValue(ELContext context, Object base, Object property, boolean errOnUnknownProp) {

--- a/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
@@ -7,7 +7,15 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 import javax.el.ArrayELResolver;
 import javax.el.CompositeELResolver;
@@ -17,11 +25,16 @@ import javax.el.MapELResolver;
 import javax.el.PropertyNotFoundException;
 import javax.el.ResourceBundleELResolver;
 
-import com.hubspot.jinjava.el.ext.*;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.collect.ImmutableMap;
+import com.hubspot.jinjava.el.ext.AbstractCallableMethod;
+import com.hubspot.jinjava.el.ext.ExtendedParser;
+import com.hubspot.jinjava.el.ext.JinjavaBeanELResolver;
+import com.hubspot.jinjava.el.ext.JinjavaListELResolver;
+import com.hubspot.jinjava.el.ext.NamedParameter;
+
 import com.hubspot.jinjava.interpret.DisabledException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateError;

--- a/src/main/java/com/hubspot/jinjava/lib/filter/AdvancedFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AdvancedFilter.java
@@ -17,13 +17,11 @@ package com.hubspot.jinjava.lib.filter;
 
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.Importable;
-import org.apache.commons.lang3.ArrayUtils;
 
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 
-public interface Filter extends Importable {
+public interface AdvancedFilter extends Importable, Filter {
 
   /**
    * Filter the specified template variable within the context of a render process. {{ myvar|myfiltername(arg1,arg2) }}
@@ -33,24 +31,15 @@ public interface Filter extends Importable {
    * @param interpreter
    *          current interpreter context
    * @param args
-   *          any arguments passed to this filter invocation
+   *          any positional arguments passed to this filter invocation
+   * @param kwargs
+   *          any named arguments passed to this filter invocation
    * @return the filtered form of the given variable
    */
-  Object filter(Object var, JinjavaInterpreter interpreter, String... args);
+   Object filter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs);
 
-  /*
-   * The JinjaJava parser calls filters giving to them two list of parameters:
-   *   - Positional arguments as Object[]
-   *   - Named arguments as Map<String, Object>
-   *
-   * This default method transforms that call to a simple filter that only receives String positional arguments to
-   * maintain backward-compatibility with old filters that don't support named arguments.
-   */
-  default Object filter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs) {
-    // We append the named arguments at the end of the positional ones
-    Object[] allArgs = ArrayUtils.addAll(args, kwargs.values().toArray());
-    String[] stringArgs = Arrays.stream(allArgs).map(Object::toString).toArray(String[]::new);
-
-    return filter(var, interpreter, stringArgs);
-  }
+   // Default implementation to maintain backward-compatibility with old Filters
+   default Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+       return filter(var, interpreter, (Object[]) args, new HashMap<>());
+   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/Filter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/Filter.java
@@ -39,7 +39,7 @@ public interface Filter extends Importable {
   Object filter(Object var, JinjavaInterpreter interpreter, String... args);
 
   /*
-   * The JinjaJava parser calls filters giving to them two list of parameters:
+   * The JinJava parser calls filters giving to them two lists of parameters:
    *   - Positional arguments as Object[]
    *   - Named arguments as Map<String, Object>
    *

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SumFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SumFilter.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.lib.filter;
 
 import java.math.BigDecimal;
+import java.util.Map;
 import java.util.Objects;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
@@ -25,7 +26,7 @@ import com.hubspot.jinjava.util.ObjectIterator;
             desc = "Sum up only certain attributes",
             code = "Total: {{ items|sum(attribute='price') }}")
     })
-public class SumFilter implements Filter {
+public class SumFilter implements AdvancedFilter {
 
   @Override
   public String getName() {
@@ -33,18 +34,15 @@ public class SumFilter implements Filter {
   }
 
   @Override
-  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+  public Object filter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs) {
     ForLoop loop = ObjectIterator.getLoop(var);
 
     BigDecimal sum = BigDecimal.ZERO;
-    String attr = null;
+    String attr = kwargs.containsKey("attribute") ? kwargs.get("attribute").toString() : null;
 
     if (args.length > 0) {
-      attr = args[0];
-    }
-    if (args.length > 1) {
       try {
-        sum = sum.add(new BigDecimal(args[1]));
+        sum = sum.add(new BigDecimal(args[0].toString()));
       } catch (NumberFormatException e) {
       }
     }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/AdvancedFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/AdvancedFilterTest.java
@@ -1,0 +1,126 @@
+package com.hubspot.jinjava.lib.filter;
+
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AdvancedFilterTest {
+
+  Jinjava jinjava;
+
+  @Test
+  public void testOnlyArgs() {
+    jinjava = new Jinjava();
+
+    Object[] expectedArgs = new Object[] {3L, 1L};
+    Map<String, Object> expectedKwargs = new HashMap<>();
+
+    jinjava.getGlobalContext().registerFilter(new MyMirrorFilter(expectedArgs, expectedKwargs));
+
+    assertThat(jinjava.render("{{ 'test'|mirror(3, 1) }}", new HashMap<>())).isEqualTo("test");
+  }
+
+  @Test
+  public void testOnlyKwargs() {
+    jinjava = new Jinjava();
+
+    Object[] expectedArgs = new Object[] {};
+    Map<String, Object> expectedKwargs = new HashMap<String, Object>() {{
+      put("named10", "str");
+      put("named2", 3L);
+      put("namedB", true);
+    }};
+
+    jinjava.getGlobalContext().registerFilter(new MyMirrorFilter(expectedArgs, expectedKwargs));
+
+    assertThat(jinjava.render("{{ 'test'|mirror(named2=3, named10='str', namedB=true) }}", new HashMap<>())).isEqualTo("test");
+  }
+
+  @Test
+  public void testMixedArgsAndKwargs() {
+    jinjava = new Jinjava();
+
+    Object[] expectedArgs = new Object[] {1L, 2L};
+    Map<String, Object> expectedKwargs = new HashMap<String, Object>() {{
+      put("named", "test");
+    }};
+
+    jinjava.getGlobalContext().registerFilter(new MyMirrorFilter(expectedArgs, expectedKwargs));
+
+    assertThat(jinjava.render("{{ 'test'|mirror(1, 2, named='test') }}", new HashMap<>())).isEqualTo("test");
+  }
+
+  @Test
+  public void testUnorderedArgsAndKwargs() {
+    jinjava = new Jinjava();
+
+    Object[] expectedArgs = new Object[] {"1", 2L};
+    Map<String, Object> expectedKwargs = new HashMap<String, Object>() {{
+      put("named", "test");
+    }};
+
+    jinjava.getGlobalContext().registerFilter(new MyMirrorFilter(expectedArgs, expectedKwargs));
+
+    assertThat(jinjava.render("{{ 'test'|mirror('1', named='test', 2) }}", new HashMap<>())).isEqualTo("test");
+  }
+
+  @Test
+  public void testRepeatedKwargs() {
+    jinjava = new Jinjava();
+
+    Object[] expectedArgs = new Object[] {true};
+    Map<String, Object> expectedKwargs = new HashMap<String, Object>() {{
+      put("named", "overwrite");
+    }};
+
+    jinjava.getGlobalContext().registerFilter(new MyMirrorFilter(expectedArgs, expectedKwargs));
+
+    assertThat(jinjava.render("{{ 'test'|mirror(true, named='test', named='overwrite') }}", new HashMap<>())).isEqualTo("test");
+  }
+
+  private static class MyMirrorFilter implements AdvancedFilter {
+    private Object[] expectedArgs;
+    private Map<String, Object> expectedKwargs;
+
+    MyMirrorFilter(Object[] args, Map<String, Object> kwargs) {
+      this.expectedArgs = args;
+      this.expectedKwargs = kwargs;
+    }
+
+    @Override
+    public String getName() {
+      return "mirror";
+    }
+
+    @Override
+    public Object filter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs) {
+      if (!Arrays.equals(expectedArgs, args)) {
+        throw new RuntimeException(
+            "Args are different than expected: " +
+            Arrays.toString(args) +
+            " to " +
+            Arrays.toString(expectedArgs)
+        );
+      }
+
+      if (!expectedKwargs.equals(kwargs)) {
+        throw new RuntimeException(
+            "Kwargs are different than expected: " +
+            Arrays.toString(kwargs.entrySet().toArray()) +
+            " to " +
+            Arrays.toString(expectedKwargs.entrySet().toArray())
+        );
+      }
+
+      return var;
+    }
+  }
+
+}


### PR DESCRIPTION
Implementing named arguments in the filters (Issue #11).

I hope the code is self-explanatory but here are some comments to clarify design decisions:

* The AST is not changed in any way (to be a representation of what is read in the template)
* There is a new interface called `AdvancedFilter` (a better name is welcome 😄 ) that has one abstract method with the signature `filter(var, interpreter, args, kwargs)`. This method should be implemented by new Filters.
* I take the chance to make `AdvancedFilter` receive `Object` instead of `String` (as `Filter` does) so they can receive more variety of arguments (numbers, floats, bools, ...).
* The old interface `Filter` still exists to maintain backward-compatibility and to allow clients to create simpler filters (without named parameters compatibility and receiving only strings).
* The `AdvancedFilter` implements the `Filter` interface to maintain backwards compatibility (so they can be registered as normal filters).
* The Interpreter Resolver changes the signature when it detects that a filter should be run. The signature separate positional arguments and named arguments. Because at this point we don't know if the filter implements the `Filter` or the `AdvancedFilter` interface, the `Filter` interface knows how to transform the `(args, kwargs)` arguments to an old `(args)` one.
* I changed the `SumFilter` as an example.

At this point all tests pass. I would like to create more tests but I want to receive some feedback from you before doing it.

Cheers