### PR TITLE
correct function binding syntax in custom function example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You can provide custom jinja tags, filters, and static functions to the template
 jinjava.getGlobalContext().registerTag(new MyCustomTag());
 // define a custom filter implementing com.hubspot.jinjava.lib.Filter
 jinjava.getGlobalContext().registerFilter(new MyAwesomeFilter());
-// define a custom public static function (this one will bind to myfn.my_func('foo', 42))
+// define a custom public static function (this one will bind to myfn:my_func('foo', 42))
 jinjava.getGlobalContext().registerFunction(new ELFunctionDefinition("myfn", "my_func", 
     MyFuncsClass.class, "myFunc", String.class, Integer.class);
 


### PR DESCRIPTION
Example in README.md contains incorrect syntax for calling a custom function - correcting this so that people don't have to read through the code to find out how to call a custom function.