### PR TITLE
Null check within filter

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/Filter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/Filter.java
@@ -15,13 +15,13 @@ limitations under the License.
  **********************************************************************/
 package com.hubspot.jinjava.lib.filter;
 
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.lib.Importable;
+import java.util.Arrays;
+import java.util.Map;
+
 import org.apache.commons.lang3.ArrayUtils;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Map;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.lib.Importable;
 
 public interface Filter extends Importable {
 
@@ -49,7 +49,7 @@ public interface Filter extends Importable {
   default Object filter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs) {
     // We append the named arguments at the end of the positional ones
     Object[] allArgs = ArrayUtils.addAll(args, kwargs.values().toArray());
-    String[] stringArgs = Arrays.stream(allArgs).map(Object::toString).toArray(String[]::new);
+    String[] stringArgs = Arrays.stream(allArgs).map(arg -> arg != null ? arg.toString() : null).toArray(String[]::new);
 
     return filter(var, interpreter, stringArgs);
   }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/Filter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/Filter.java
@@ -17,6 +17,7 @@ package com.hubspot.jinjava.lib.filter;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -49,7 +50,7 @@ public interface Filter extends Importable {
   default Object filter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs) {
     // We append the named arguments at the end of the positional ones
     Object[] allArgs = ArrayUtils.addAll(args, kwargs.values().toArray());
-    String[] stringArgs = Arrays.stream(allArgs).map(arg -> arg != null ? arg.toString() : null).toArray(String[]::new);
+    String[] stringArgs = Arrays.stream(allArgs).map(arg -> Objects.toString(arg, null)).toArray(String[]::new);
 
     return filter(var, interpreter, stringArgs);
   }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/AdvancedFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/AdvancedFilterTest.java
@@ -1,15 +1,15 @@
 package com.hubspot.jinjava.lib.filter;
 
-import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import org.junit.Before;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
+
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 public class AdvancedFilterTest {
 
@@ -41,6 +41,20 @@ public class AdvancedFilterTest {
     jinjava.getGlobalContext().registerFilter(new MyMirrorFilter(expectedArgs, expectedKwargs));
 
     assertThat(jinjava.render("{{ 'test'|mirror(named2=3, named10='str', namedB=true) }}", new HashMap<>())).isEqualTo("test");
+  }
+
+  @Test
+  public void itTestsNullKwargs() {
+    jinjava = new Jinjava();
+
+    Object[] expectedArgs = new Object[] {};
+    Map<String, Object> expectedKwargs = new HashMap<String, Object>() {{
+      put("named1", null);
+    }};
+
+    jinjava.getGlobalContext().registerFilter(new MyMirrorFilter(expectedArgs, expectedKwargs));
+
+    assertThat(jinjava.render("{{ 'test'|divide(named1) }}", new HashMap<>())).isEqualTo("test");
   }
 
   @Test


### PR DESCRIPTION
This prevents null pointer exception in cases where a default value is used and is not supplied during validation.

@jboulter @olyazavr 