### PR TITLE
Track resolved functions in context

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/MacroFunctionMapper.java
+++ b/src/main/java/com/hubspot/jinjava/el/MacroFunctionMapper.java
@@ -36,6 +36,10 @@ public class MacroFunctionMapper extends FunctionMapper {
       throw new DisabledException(functionName);
     }
 
+    if (map.containsKey(functionName)) {
+      context.addResolvedFunction(functionName);
+    }
+
     return map.get(functionName);
   }
 

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -61,6 +61,7 @@ public class Context extends ScopeMap<String, Object> {
 
   private final Set<String> resolvedExpressions = new HashSet<>();
   private final Set<String> resolvedValues = new HashSet<>();
+  private final Set<String> resolvedFunctions = new HashSet<>();
 
   private final ExpTestLibrary expTestLibrary;
   private final FilterLibrary filterLibrary;
@@ -190,6 +191,14 @@ public class Context extends ScopeMap<String, Object> {
 
   public boolean wasValueResolved(String value) {
     return resolvedValues.contains(value);
+  }
+
+  public Set<String> getResolvedFunctions() {
+    return ImmutableSet.copyOf(resolvedFunctions);
+  }
+
+  public void addResolvedFunction(String value) {
+    resolvedFunctions.add(value);
   }
 
   public List<? extends Node> getSuperBlock() {

--- a/src/main/java/com/hubspot/jinjava/lib/SimpleLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/SimpleLibrary.java
@@ -34,7 +34,7 @@ import com.hubspot.jinjava.interpret.DisabledException;
 
 public abstract class SimpleLibrary<T extends Importable> {
 
-  private Map<String, T> lib = new HashMap<String, T>();
+  private Map<String, T> lib = new HashMap<>();
   private Set<String> disabled = new HashSet<String>();
 
   protected SimpleLibrary(boolean registerDefaults) {

--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
@@ -424,6 +424,16 @@ public class ExpressionResolverTest {
   }
 
   @Test
+  public void itStoresResolvedFunctions() throws Exception {
+    context.put("datetime", 12345);
+    final JinjavaConfig config = JinjavaConfig.newBuilder().build();
+    String template = "{% for i in range(1, 5) %}{{i}} {% endfor %}\n{{ unixtimestamp(datetime) }}";
+    final RenderResult renderResult = jinjava.renderForResult(template, context, config);
+    assertThat(renderResult.getOutput()).isEqualTo("1 2 3 4 \n12000");
+    assertThat(renderResult.getContext().getResolvedFunctions()).hasSameElementsAs(ImmutableSet.of(":range", ":unixtimestamp"));
+  }
+
+  @Test
   public void presentOptionalProperty() {
     context.put("myobj", new OptionalProperty(null, "foo"));
     assertThat(interpreter.resolveELExpression("myobj.val", -1)).isEqualTo("foo");


### PR DESCRIPTION
For every function resolved in a template, add it to the context since those don’t get put in the resolved expressions set.

@jmp3833