### PR TITLE
Stop using Guava Objects methods deprecated in 19

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -5,7 +5,6 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.interpret.errorcategory.BasicTemplateErrorCategory;
 import com.hubspot.jinjava.interpret.errorcategory.TemplateErrorCategory;
@@ -191,16 +190,16 @@ public class TemplateError {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-        .add("severity", severity)
-        .add("reason", reason)
-        .add("message", message)
-        .add("fieldName", fieldName)
-        .add("lineno", lineno)
-        .add("item", item)
-        .add("category", category)
-        .add("categoryErrors", categoryErrors)
-        .toString();
+    return "TemplateError{" +
+        "severity=" + severity +
+        ", reason=" + reason +
+        ", item=" + item +
+        ", message='" + message + '\'' +
+        ", fieldName='" + fieldName + '\'' +
+        ", lineno=" + lineno +
+        ", category=" + category +
+        ", categoryErrors=" + categoryErrors +
+        '}';
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
@@ -7,8 +7,8 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
@@ -70,7 +70,7 @@ public class MacroTag implements Tag {
     }
 
     String name = matcher.group(1);
-    String args = Objects.firstNonNull(matcher.group(2), "");
+    String args = Strings.nullToEmpty(matcher.group(2));
 
     LinkedHashMap<String, Object> argNamesWithDefaults = new LinkedHashMap<>();
 


### PR DESCRIPTION
`Objects.ToStringHelper` and `Objects.firstNonNull` were [deprecated](https://google.github.io/guava/releases/19.0/api/docs/com/google/common/base/Objects.html) in Guava 19 and removed in 21.

I've replaced them with cross-version compatible  alternatives to avoid requiring Guava 19. The alternative is to use the appropriate Guava 19 `MoreObjects` methods.

@boulter @jhaber  