### PR TITLE
remove FileResourceLocator as a default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Jinjava Releases #
 
+### 2017-05-12 Version 2.2.0 ([Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.hubspot.jinjava%22%20AND%20v%3A%222.2.0%22)) ###
+
+* Removes `FileResourceLocator` as a default `ResourceLocator` to close a security hole. See the [README](README.md#template-loading) for details on how to reenable it.
+
 ### 2017-04-11 Version 2.1.19 ([Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.hubspot.jinjava%22%20AND%20v%3A%222.1.19%22)) ###
 
 * preserve order of named parameters

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 <img src="https://github.com/HubSpot/jinjava/raw/master/jinjava.png" width="250" height="250" alt="jinjava">
 
 Java-based template engine based on django template syntax, adapted to render jinja templates (at least the subset of jinja in use in HubSpot content). Currently used in production to render thousands of websites with hundreds of millions of page views per month on the [HubSpot COS](http://www.hubspot.com/products/sites).
+
 *Note*: Requires Java >= 8. Originally forked from [jangod](https://code.google.com/p/jangod/).
 
 Get it:
@@ -17,9 +18,11 @@ Get it:
   <dependency>
     <groupId>com.hubspot.jinjava</groupId>
     <artifactId>jinjava</artifactId>
-    <version>2.1.14</version>
+    <version>{ LATEST_VERSION }</version>
   </dependency>
 ```
+
+where LATEST_VERSION is the [latest version from CHANGES](CHANGES.md).
 
 or if you're stuck on java 7:
 ```xml
@@ -67,14 +70,27 @@ Jinjava needs to know how to interpret template paths, so it can properly handle
 {% extends "foo/bar/base.html" %}
 ```
 
-By default, it will load a ```FileLocator```; you will likely want to provide your own implementation of 
-```ResourceLoader``` to hook into your application's template repository, and then tell jinjava about it:
+By default, it will load only a `ClasspathResourceLocator`. If you want to allow Jinjava to load any file from the 
+file system, you can add a `FileResourceLocator`. Be aware the security risks of allowing user input to prevent a user
+from adding code such as `{% include '/etc/password' %}`.
+ 
+You will likely want to provide your own implementation of 
+`ResourceLoader` to hook into your application's template repository, and then tell jinjava about it:
 
 ```java
 JinjavaConfig config = new JinjavaConfig();
 
 Jinjava jinjava = new Jinjava(config);
 jinjava.setResourceLocator(new MyCustomResourceLocator());
+```
+
+To use more than one `ResourceLocator`, use a `CascadingResourceLocator`. 
+
+```java
+JinjavaConfig config = new JinjavaConfig();
+
+Jinjava jinjava = new Jinjava(config);
+jinjava.setResourceLocator(new MyCustomResourceLocator(), new FileResourceLocator());
 ```
 
 ### Custom tags, filters and functions

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>com.hubspot.jinjava</groupId>
   <artifactId>jinjava</artifactId>
-  <version>2.1.20-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
   <description>Jinja templating engine implemented in Java</description>
   <url>https://github.com/HubSpot/jinjava</url>
 
@@ -25,6 +25,11 @@
       <id>jaredstehler</id>
       <name>Jared Stehler</name>
       <email>jstehler@hubspot.com</email>
+    </developer>
+    <developer>
+      <id>boulter</id>
+      <name>Jeff Boulter</name>
+      <email>boulter@hubspot.com</email>
     </developer>
   </developers>
 

--- a/src/main/java/com/hubspot/jinjava/Jinjava.java
+++ b/src/main/java/com/hubspot/jinjava/Jinjava.java
@@ -33,9 +33,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
-import com.hubspot.jinjava.loader.CascadingResourceLocator;
 import com.hubspot.jinjava.loader.ClasspathResourceLocator;
-import com.hubspot.jinjava.loader.FileLocator;
 import com.hubspot.jinjava.loader.ResourceLocator;
 
 import de.odysseus.el.ExpressionFactoryImpl;
@@ -87,7 +85,7 @@ public class Jinjava {
     TypeConverter converter = new TruthyTypeConverter();
     this.expressionFactory = new ExpressionFactoryImpl(expConfig, converter);
 
-    this.resourceLocator = new CascadingResourceLocator(new ClasspathResourceLocator(), new FileLocator());
+    this.resourceLocator = new ClasspathResourceLocator();
   }
 
   /**


### PR DESCRIPTION
ClasspathResourceLocator is the only default now to avoid accidentally allowing loading files from arbitrary locations.