### PR TITLE
Show fieldname in unknown tag error

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -52,7 +52,13 @@ public class TemplateError {
   }
 
   public static TemplateError fromException(TemplateSyntaxException ex) {
-    return new TemplateError(ErrorType.FATAL, ErrorReason.SYNTAX_ERROR, ErrorItem.OTHER, ExceptionUtils.getMessage(ex), null, ex.getLineNumber(), ex);
+    String fieldName = null;
+
+    if (ex instanceof UnknownTagException) {
+      fieldName = ((UnknownTagException) ex).getTag();
+    }
+
+    return new TemplateError(ErrorType.FATAL, ErrorReason.SYNTAX_ERROR, ErrorItem.OTHER, ExceptionUtils.getMessage(ex), fieldName, ex.getLineNumber(), ex);
   }
 
   public static TemplateError fromException(Exception ex) {

--- a/src/test/java/com/hubspot/jinjava/interpret/TemplateErrorTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/TemplateErrorTest.java
@@ -20,4 +20,10 @@ public class TemplateErrorTest {
     assertThat(e.getMessage()).isEqualTo("Cannot resolve property 'other' in '{foo=bar}'");
   }
 
+  @Test
+  public void itShowsFieldNameForUnknownTagError() {
+    TemplateError e = TemplateError.fromException(new UnknownTagException("unknown", "{% unknown() %}", 11));
+    assertThat(e.getFieldName()).isEqualTo("unknown");
+  }
+
 }


### PR DESCRIPTION
When an unknown tag is found, the error that results does not include the name of the unknown tag in question. This sets the fieldName to the name of the unknown tag (previously, this was just set to null) for ease of debugging

@jboulter 