### PR TITLE
Disable interpreting variables in expression.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -43,7 +43,7 @@ public class JinjavaConfig {
 
   private Map<Context.Library, Set<String>> disabled;
   private final boolean failOnUnknownTokens;
-  private final boolean enableNestedInterpretation;
+  private final boolean nestedInterpretationEnabled;
 
   public static Builder newBuilder() {
     return new Builder();
@@ -69,7 +69,7 @@ public class JinjavaConfig {
                         boolean enableRecursiveMacroCalls,
                         boolean failOnUnknownTokens,
                         long maxOutputSize,
-                        boolean enableNestedInterpretation) {
+                        boolean nestedInterpretationEnabled) {
     this.charset = charset;
     this.locale = locale;
     this.timeZone = timeZone;
@@ -81,7 +81,7 @@ public class JinjavaConfig {
     this.enableRecursiveMacroCalls = enableRecursiveMacroCalls;
     this.failOnUnknownTokens = failOnUnknownTokens;
     this.maxOutputSize = maxOutputSize;
-    this.enableNestedInterpretation = enableNestedInterpretation;
+    this.nestedInterpretationEnabled = nestedInterpretationEnabled;
   }
 
   public Charset getCharset() {
@@ -128,8 +128,8 @@ public class JinjavaConfig {
     return failOnUnknownTokens;
   }
 
-  public boolean isEnableNestedInterpretation() {
-    return enableNestedInterpretation;
+  public boolean isNestedInterpretationEnabled() {
+    return nestedInterpretationEnabled;
   }
 
   public static class Builder {
@@ -146,7 +146,7 @@ public class JinjavaConfig {
     private boolean readOnlyResolver = true;
     private boolean enableRecursiveMacroCalls;
     private boolean failOnUnknownTokens;
-    private boolean enableNestedInterpretation;
+    private boolean nestedInterpretationEnabled;
 
     private Builder() {}
 
@@ -205,13 +205,13 @@ public class JinjavaConfig {
       return this;
     }
 
-    public Builder withEnableNestedInterpretation(boolean enableNestedInterpretation) {
-      this.enableNestedInterpretation = enableNestedInterpretation;
+    public Builder withNestedInterpretationEnabled(boolean nestedInterpretationEnabled) {
+      this.nestedInterpretationEnabled = nestedInterpretationEnabled;
       return this;
     }
 
     public JinjavaConfig build() {
-      return new JinjavaConfig(charset, locale, timeZone, maxRenderDepth, disabled, trimBlocks, lstripBlocks, readOnlyResolver, enableRecursiveMacroCalls, failOnUnknownTokens, maxOutputSize, enableNestedInterpretation);
+      return new JinjavaConfig(charset, locale, timeZone, maxRenderDepth, disabled, trimBlocks, lstripBlocks, readOnlyResolver, enableRecursiveMacroCalls, failOnUnknownTokens, maxOutputSize, nestedInterpretationEnabled);
     }
 
   }

--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -43,18 +43,18 @@ public class JinjavaConfig {
 
   private Map<Context.Library, Set<String>> disabled;
   private final boolean failOnUnknownTokens;
-  private final boolean noNestedInterpretation;
+  private final boolean enableNestedInterpretation;
 
   public static Builder newBuilder() {
     return new Builder();
   }
 
   public JinjavaConfig() {
-    this(StandardCharsets.UTF_8, Locale.ENGLISH, ZoneOffset.UTC, 10, new HashMap<>(), false, false, true, false, false, 0, false);
+    this(StandardCharsets.UTF_8, Locale.ENGLISH, ZoneOffset.UTC, 10, new HashMap<>(), false, false, true, false, false, 0, true);
   }
 
   public JinjavaConfig(Charset charset, Locale locale, ZoneId timeZone, int maxRenderDepth) {
-    this(charset, locale, timeZone, maxRenderDepth, new HashMap<>(), false, false, true, false, false, 0, false);
+    this(charset, locale, timeZone, maxRenderDepth, new HashMap<>(), false, false, true, false, false, 0, true);
   }
 
   private JinjavaConfig(Charset charset,
@@ -69,7 +69,7 @@ public class JinjavaConfig {
                         boolean enableRecursiveMacroCalls,
                         boolean failOnUnknownTokens,
                         long maxOutputSize,
-                        boolean noNestedInterpretation) {
+                        boolean enableNestedInterpretation) {
     this.charset = charset;
     this.locale = locale;
     this.timeZone = timeZone;
@@ -81,7 +81,7 @@ public class JinjavaConfig {
     this.enableRecursiveMacroCalls = enableRecursiveMacroCalls;
     this.failOnUnknownTokens = failOnUnknownTokens;
     this.maxOutputSize = maxOutputSize;
-    this.noNestedInterpretation = noNestedInterpretation;
+    this.enableNestedInterpretation = enableNestedInterpretation;
   }
 
   public Charset getCharset() {
@@ -128,8 +128,8 @@ public class JinjavaConfig {
     return failOnUnknownTokens;
   }
 
-  public boolean isNoNestedInterpretation() {
-    return noNestedInterpretation;
+  public boolean isEnableNestedInterpretation() {
+    return enableNestedInterpretation;
   }
 
   public static class Builder {
@@ -146,7 +146,7 @@ public class JinjavaConfig {
     private boolean readOnlyResolver = true;
     private boolean enableRecursiveMacroCalls;
     private boolean failOnUnknownTokens;
-    private boolean noNestedInterpretation;
+    private boolean enableNestedInterpretation;
 
     private Builder() {}
 
@@ -205,13 +205,13 @@ public class JinjavaConfig {
       return this;
     }
 
-    public Builder withNoNestedInpterpretation(boolean noNestedInterpretation) {
-      this.noNestedInterpretation = noNestedInterpretation;
+    public Builder withEnableNestedInterpretation(boolean enableNestedInterpretation) {
+      this.enableNestedInterpretation = enableNestedInterpretation;
       return this;
     }
 
     public JinjavaConfig build() {
-      return new JinjavaConfig(charset, locale, timeZone, maxRenderDepth, disabled, trimBlocks, lstripBlocks, readOnlyResolver, enableRecursiveMacroCalls, failOnUnknownTokens, maxOutputSize, noNestedInterpretation);
+      return new JinjavaConfig(charset, locale, timeZone, maxRenderDepth, disabled, trimBlocks, lstripBlocks, readOnlyResolver, enableRecursiveMacroCalls, failOnUnknownTokens, maxOutputSize, enableNestedInterpretation);
     }
 
   }

--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -43,17 +43,18 @@ public class JinjavaConfig {
 
   private Map<Context.Library, Set<String>> disabled;
   private final boolean failOnUnknownTokens;
+  private final boolean noNestedInterpretation;
 
   public static Builder newBuilder() {
     return new Builder();
   }
 
   public JinjavaConfig() {
-    this(StandardCharsets.UTF_8, Locale.ENGLISH, ZoneOffset.UTC, 10, new HashMap<>(), false, false, true, false, false, 0);
+    this(StandardCharsets.UTF_8, Locale.ENGLISH, ZoneOffset.UTC, 10, new HashMap<>(), false, false, true, false, false, 0, false);
   }
 
   public JinjavaConfig(Charset charset, Locale locale, ZoneId timeZone, int maxRenderDepth) {
-    this(charset, locale, timeZone, maxRenderDepth, new HashMap<>(), false, false, true, false, false, 0);
+    this(charset, locale, timeZone, maxRenderDepth, new HashMap<>(), false, false, true, false, false, 0, false);
   }
 
   private JinjavaConfig(Charset charset,
@@ -67,7 +68,8 @@ public class JinjavaConfig {
                         boolean readOnlyResolver,
                         boolean enableRecursiveMacroCalls,
                         boolean failOnUnknownTokens,
-                        long maxOutputSize) {
+                        long maxOutputSize,
+                        boolean noNestedInterpretation) {
     this.charset = charset;
     this.locale = locale;
     this.timeZone = timeZone;
@@ -79,6 +81,7 @@ public class JinjavaConfig {
     this.enableRecursiveMacroCalls = enableRecursiveMacroCalls;
     this.failOnUnknownTokens = failOnUnknownTokens;
     this.maxOutputSize = maxOutputSize;
+    this.noNestedInterpretation = noNestedInterpretation;
   }
 
   public Charset getCharset() {
@@ -125,6 +128,10 @@ public class JinjavaConfig {
     return failOnUnknownTokens;
   }
 
+  public boolean isNoNestedInterpretation() {
+    return noNestedInterpretation;
+  }
+
   public static class Builder {
     private Charset charset = StandardCharsets.UTF_8;
     private Locale locale = Locale.ENGLISH;
@@ -139,6 +146,7 @@ public class JinjavaConfig {
     private boolean readOnlyResolver = true;
     private boolean enableRecursiveMacroCalls;
     private boolean failOnUnknownTokens;
+    private boolean noNestedInterpretation;
 
     private Builder() {}
 
@@ -197,8 +205,13 @@ public class JinjavaConfig {
       return this;
     }
 
+    public Builder withNoNestedInpterpretation(boolean noNestedInterpretation) {
+      this.noNestedInterpretation = noNestedInterpretation;
+      return this;
+    }
+
     public JinjavaConfig build() {
-      return new JinjavaConfig(charset, locale, timeZone, maxRenderDepth, disabled, trimBlocks, lstripBlocks, readOnlyResolver, enableRecursiveMacroCalls, failOnUnknownTokens, maxOutputSize);
+      return new JinjavaConfig(charset, locale, timeZone, maxRenderDepth, disabled, trimBlocks, lstripBlocks, readOnlyResolver, enableRecursiveMacroCalls, failOnUnknownTokens, maxOutputSize, noNestedInterpretation);
     }
 
   }

--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -17,15 +17,12 @@ package com.hubspot.jinjava.tree;
 
 import java.util.Objects;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.UnknownTokenException;
 import com.hubspot.jinjava.lib.filter.EscapeFilter;
 import com.hubspot.jinjava.tree.output.OutputNode;
 import com.hubspot.jinjava.tree.output.RenderedOutputNode;
 import com.hubspot.jinjava.tree.parse.ExpressionToken;
-import com.hubspot.jinjava.util.Logging;
 
 public class ExpressionNode extends Node {
   private static final long serialVersionUID = 341642231109911346L;
@@ -46,14 +43,6 @@ public class ExpressionNode extends Node {
     }
 
     String result = Objects.toString(var, "");
-
-    if (!StringUtils.equals(result, master.getImage()) && StringUtils.contains(result, "{{")) {
-      try {
-        result = interpreter.renderFlat(result);
-      } catch (Exception e) {
-        Logging.ENGINE_LOG.warn("Error rendering variable node result", e);
-      }
-    }
 
     if (interpreter.getContext().isAutoEscape()) {
       result = EscapeFilter.escapeHtmlEntities(result);

--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -47,7 +47,7 @@ public class ExpressionNode extends Node {
 
     String result = Objects.toString(var, "");
 
-    if (!interpreter.getConfig().isNoNestedInterpretation()) {
+    if (interpreter.getConfig().isEnableNestedInterpretation()) {
       if (!StringUtils.equals(result, master.getImage()) && StringUtils.contains(result, "{{")) {
         try {
           result = interpreter.renderFlat(result);

--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -47,7 +47,7 @@ public class ExpressionNode extends Node {
 
     String result = Objects.toString(var, "");
 
-    if (interpreter.getConfig().isEnableNestedInterpretation()) {
+    if (interpreter.getConfig().isNestedInterpretationEnabled()) {
       if (!StringUtils.equals(result, master.getImage()) && StringUtils.contains(result, "{{")) {
         try {
           result = interpreter.renderFlat(result);

--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -17,12 +17,15 @@ package com.hubspot.jinjava.tree;
 
 import java.util.Objects;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.UnknownTokenException;
 import com.hubspot.jinjava.lib.filter.EscapeFilter;
 import com.hubspot.jinjava.tree.output.OutputNode;
 import com.hubspot.jinjava.tree.output.RenderedOutputNode;
 import com.hubspot.jinjava.tree.parse.ExpressionToken;
+import com.hubspot.jinjava.util.Logging;
 
 public class ExpressionNode extends Node {
   private static final long serialVersionUID = 341642231109911346L;
@@ -43,6 +46,16 @@ public class ExpressionNode extends Node {
     }
 
     String result = Objects.toString(var, "");
+
+    if (!interpreter.getConfig().isNoNestedInterpretation()) {
+      if (!StringUtils.equals(result, master.getImage()) && StringUtils.contains(result, "{{")) {
+        try {
+          result = interpreter.renderFlat(result);
+        } catch (Exception e) {
+          Logging.ENGINE_LOG.warn("Error rendering variable node result", e);
+        }
+      }
+    }
 
     if (interpreter.getContext().isAutoEscape()) {
       result = EscapeFilter.escapeHtmlEntities(result);

--- a/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
@@ -35,7 +35,7 @@ public class ExpressionNodeTest {
   }
 
   @Test
-  public void itRendersResultWithoutInterpretateExpression() throws Exception {
+  public void itRendersResultWithoutInterpreterExpression() throws Exception {
     final JinjavaConfig config = JinjavaConfig.newBuilder().withNestedInterpretationEnabled(false).build();
     JinjavaInterpreter noNestedInterpreter =  new Jinjava(config).newInterpreter();
     Context contextNoNestedInterpretation = noNestedInterpreter.getContext();

--- a/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
@@ -35,7 +35,7 @@ public class ExpressionNodeTest {
   }
 
   @Test
-  public void itRendersResultWithoutInterpreterExpression() throws Exception {
+  public void itRendersResultWithoutNestedExpressionInterpretation() throws Exception {
     final JinjavaConfig config = JinjavaConfig.newBuilder().withNestedInterpretationEnabled(false).build();
     JinjavaInterpreter noNestedInterpreter =  new Jinjava(config).newInterpreter();
     Context contextNoNestedInterpretation = noNestedInterpreter.getContext();

--- a/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
@@ -36,7 +36,7 @@ public class ExpressionNodeTest {
 
   @Test
   public void itRendersResultWithoutInterpretateExpression() throws Exception {
-    final JinjavaConfig config = JinjavaConfig.newBuilder().withEnableNestedInterpretation(false).build();
+    final JinjavaConfig config = JinjavaConfig.newBuilder().withNestedInterpretationEnabled(false).build();
     JinjavaInterpreter noNestedInterpreter =  new Jinjava(config).newInterpreter();
     Context contextNoNestedInterpretation = noNestedInterpreter.getContext();
     contextNoNestedInterpretation.put("myvar", "hello {{ place }}");

--- a/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
@@ -36,7 +36,7 @@ public class ExpressionNodeTest {
 
   @Test
   public void itRendersResultWithoutInterpretateExpression() throws Exception {
-    final JinjavaConfig config = JinjavaConfig.newBuilder().withNoNestedInpterpretation(true).build();
+    final JinjavaConfig config = JinjavaConfig.newBuilder().withEnableNestedInterpretation(false).build();
     JinjavaInterpreter noNestedInterpreter =  new Jinjava(config).newInterpreter();
     Context contextNoNestedInterpretation = noNestedInterpreter.getContext();
     contextNoNestedInterpretation.put("myvar", "hello {{ place }}");

--- a/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
@@ -30,7 +30,7 @@ public class ExpressionNodeTest {
     context.put("place", "world");
 
     ExpressionNode node = fixture("simplevar");
-    assertThat(node.render(interpreter).toString()).isEqualTo("hello world");
+    assertThat(node.render(interpreter).toString()).isEqualTo("hello {{ place }}");
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import com.google.common.base.Throwables;
 import com.google.common.io.Resources;
 import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
@@ -30,7 +31,19 @@ public class ExpressionNodeTest {
     context.put("place", "world");
 
     ExpressionNode node = fixture("simplevar");
-    assertThat(node.render(interpreter).toString()).isEqualTo("hello {{ place }}");
+    assertThat(node.render(interpreter).toString()).isEqualTo("hello world");
+  }
+
+  @Test
+  public void itRendersResultWithoutInterpretateExpression() throws Exception {
+    final JinjavaConfig config = JinjavaConfig.newBuilder().withNoNestedInpterpretation(true).build();
+    JinjavaInterpreter noNestedInterpreter =  new Jinjava(config).newInterpreter();
+    Context contextNoNestedInterpretation = noNestedInterpreter.getContext();
+    contextNoNestedInterpretation.put("myvar", "hello {{ place }}");
+    contextNoNestedInterpretation.put("place", "world");
+
+    ExpressionNode node = fixture("simplevar");
+    assertThat(node.render(noNestedInterpreter).toString()).isEqualTo("hello {{ place }}");
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/HubSpot/jinjava/issues/121

This PR removes the code that interprets strings containing '{{' that is already an expression.
