### PR TITLE
Fixing filters with uppercase letters

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/SimpleLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/SimpleLibrary.java
@@ -57,7 +57,7 @@ public abstract class SimpleLibrary<T extends Importable> {
       throw new DisabledException(item);
     }
 
-    return lib.get(StringUtils.lowerCase(item));
+    return lib.get(item);
   }
 
   @SafeVarargs
@@ -82,7 +82,7 @@ public abstract class SimpleLibrary<T extends Importable> {
   }
 
   public void register(String name, T obj) {
-    if (!disabled.contains(obj.getName().toLowerCase())) {
+    if (!disabled.contains(obj.getName())) {
       lib.put(name, obj);
       ENGINE_LOG.debug(getClass().getSimpleName() + ": Registered " + obj.getName());
     }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/CamelCaseRegisteringFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/CamelCaseRegisteringFilterTest.java
@@ -1,0 +1,37 @@
+package com.hubspot.jinjava.lib.filter;
+
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CamelCaseRegisteringFilterTest {
+
+  Jinjava jinjava;
+
+  @Test
+  public void testCamelCaseIsRegistered() {
+    jinjava = new Jinjava();
+    jinjava.getGlobalContext().registerFilter(new ReturnHelloFilter());
+
+    assertThat(jinjava.render("{{ 'test'|returnHello }}", new HashMap<>())).isEqualTo("Hello");
+  }
+
+  private static class ReturnHelloFilter implements AdvancedFilter {
+    @Override
+    public String getName() {
+      return "returnHello";
+    }
+
+    @Override
+    public Object filter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs) {
+      return "Hello";
+    }
+  }
+
+}

--- a/src/test/java/com/hubspot/jinjava/lib/filter/CamelCaseRegisteringFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/CamelCaseRegisteringFilterTest.java
@@ -15,7 +15,7 @@ public class CamelCaseRegisteringFilterTest {
   Jinjava jinjava;
 
   @Test
-  public void testCamelCaseIsRegistered() {
+  public void itAllowsCamelCasedFilterNames() {
     jinjava = new Jinjava();
     jinjava.getGlobalContext().registerFilter(new ReturnHelloFilter());
 


### PR DESCRIPTION
Hi!

Filters that are using uppercase characters are broken as the `lowercase()` method is being executed to the name before registering them into the `SimpleLibrary`.

They are broken because in the `fetch` method the filter name is just lowercased before being compared with the existing ones, but **not** before adding them to the library, so what's happening is that:

* The filters are registered with the camelcase name inside the library, ex: `filterName`.
* The filters cannot be accessed, as the fetch method tries to find a filter named `filtername`.

There were two solutions:

1) Lowercasing the filter before doing the `put` into the HashMap.
2) Allowing filter names to have not just lowercase characters.

I chose the second option as I didn't see any reason for the restriction.

I added one test and the patch is backwards compatible, as filters with uppercase characters were not usable before.