### PR TITLE
Add function to apply resolved strings from another Context object

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -221,6 +221,18 @@ public class Context extends ScopeMap<String, Object> {
     this.superBlock = null;
   }
 
+  /**
+   * Take all resolved strings from a context object and apply them to this context.
+   * Useful for passing resolved values up a tag hierarchy.
+   *
+   * @param context - context object to apply resolved values from.
+   */
+  public void applyResolvedFrom(Context context) {
+    context.getResolvedExpressions().forEach(this::addResolvedExpression);
+    context.getResolvedFunctions().forEach(this::addResolvedFunction);
+    context.getResolvedValues().forEach(this::addResolvedValue);
+  }
+
   @SafeVarargs
   @SuppressWarnings("unchecked")
   public final void registerClasses(Class<? extends Importable>... classes) {

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -227,7 +227,7 @@ public class Context extends ScopeMap<String, Object> {
    *
    * @param context - context object to apply resolved values from.
    */
-  public void applyResolvedFrom(Context context) {
+  public void addResolvedFrom(Context context) {
     context.getResolvedExpressions().forEach(this::addResolvedExpression);
     context.getResolvedFunctions().forEach(this::addResolvedFunction);
     context.getResolvedValues().forEach(this::addResolvedValue);

--- a/src/test/java/com/hubspot/jinjava/interpret/ContextTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/ContextTest.java
@@ -28,7 +28,7 @@ public class ContextTest {
     assertThat(context.getResolvedFunctions()).doesNotContain(RESOLVED_FUNCTION);
     assertThat(context.getResolvedExpressions()).doesNotContain(RESOLVED_EXPRESSION);
 
-    context.applyResolvedFrom(appliedFrom);
+    context.addResolvedFrom(appliedFrom);
 
     assertThat(context.getResolvedValues()).contains(RESOLVED_VALUE);
     assertThat(context.getResolvedFunctions()).contains(RESOLVED_FUNCTION);

--- a/src/test/java/com/hubspot/jinjava/interpret/ContextTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/ContextTest.java
@@ -18,17 +18,17 @@ public class ContextTest {
   }
 
   @Test
-  public void itAppliesResolvedValuesFromAnotherContextObject() {
-    Context appliedFrom = new Context();
-    appliedFrom.addResolvedValue(RESOLVED_VALUE);
-    appliedFrom.addResolvedFunction(RESOLVED_FUNCTION);
-    appliedFrom.addResolvedExpression(RESOLVED_EXPRESSION);
+  public void itAddsResolvedValuesFromAnotherContextObject() {
+    Context donor = new Context();
+    donor.addResolvedValue(RESOLVED_VALUE);
+    donor.addResolvedFunction(RESOLVED_FUNCTION);
+    donor.addResolvedExpression(RESOLVED_EXPRESSION);
 
     assertThat(context.getResolvedValues()).doesNotContain(RESOLVED_VALUE);
     assertThat(context.getResolvedFunctions()).doesNotContain(RESOLVED_FUNCTION);
     assertThat(context.getResolvedExpressions()).doesNotContain(RESOLVED_EXPRESSION);
 
-    context.addResolvedFrom(appliedFrom);
+    context.addResolvedFrom(donor);
 
     assertThat(context.getResolvedValues()).contains(RESOLVED_VALUE);
     assertThat(context.getResolvedFunctions()).contains(RESOLVED_FUNCTION);

--- a/src/test/java/com/hubspot/jinjava/interpret/ContextTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/ContextTest.java
@@ -1,0 +1,37 @@
+package com.hubspot.jinjava.interpret;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ContextTest {
+  private static final String RESOLVED_EXPRESSION = "exp" ;
+  private static final String RESOLVED_FUNCTION = "func" ;
+  private static final String RESOLVED_VALUE = "val" ;
+
+  private Context context;
+
+  @Before
+  public void setUp() {
+    context = new Context();
+  }
+
+  @Test
+  public void itAppliesResolvedValuesFromAnotherContextObject() {
+    Context appliedFrom = new Context();
+    appliedFrom.addResolvedValue(RESOLVED_VALUE);
+    appliedFrom.addResolvedFunction(RESOLVED_FUNCTION);
+    appliedFrom.addResolvedExpression(RESOLVED_EXPRESSION);
+
+    assertThat(context.getResolvedValues()).doesNotContain(RESOLVED_VALUE);
+    assertThat(context.getResolvedFunctions()).doesNotContain(RESOLVED_FUNCTION);
+    assertThat(context.getResolvedExpressions()).doesNotContain(RESOLVED_EXPRESSION);
+
+    context.applyResolvedFrom(appliedFrom);
+
+    assertThat(context.getResolvedValues()).contains(RESOLVED_VALUE);
+    assertThat(context.getResolvedFunctions()).contains(RESOLVED_FUNCTION);
+    assertThat(context.getResolvedExpressions()).contains(RESOLVED_EXPRESSION);
+  }
+}


### PR DESCRIPTION
Useful for passing resolved expressions, functions, and values to the parent Context object. This way when evaluating nested content, these resolved values can be exposed up the context chain. 

@jboulter @jmagnarelli-hs 