### PR TITLE
Prevent recursion in Jinjava.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -396,8 +396,8 @@ public class Context extends ScopeMap<String, Object> {
     return renderStack.pop();
   }
 
-  public Stack getRenderStack() {
-    return renderStack;
+  public boolean doesRenderStackContain(String template) {
+    return renderStack.contains(template);
   }
 
   public void addDependency(String type, String identification) {

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Stack;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.HashMultimap;
@@ -73,6 +74,8 @@ public class Context extends ScopeMap<String, Object> {
   private int renderDepth = -1;
   private Boolean autoEscape;
   private List<? extends Node> superBlock;
+
+  private final Stack<String> renderStack = new Stack<>();
 
   public Context() {
     this(null, null, null);
@@ -383,6 +386,18 @@ public class Context extends ScopeMap<String, Object> {
 
   public void setRenderDepth(int renderDepth) {
     this.renderDepth = renderDepth;
+  }
+
+  public void pushRenderStack(String template) {
+    renderStack.push(template);
+  }
+
+  public String popRenderStack() {
+    return renderStack.pop();
+  }
+
+  public Stack getRenderStack() {
+    return renderStack;
   }
 
   public void addDependency(String type, String identification) {

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -45,6 +45,7 @@ import com.hubspot.jinjava.tree.TreeParser;
 import com.hubspot.jinjava.tree.output.BlockPlaceholderOutputNode;
 import com.hubspot.jinjava.tree.output.OutputList;
 import com.hubspot.jinjava.tree.output.OutputNode;
+import com.hubspot.jinjava.tree.output.RenderedOutputNode;
 import com.hubspot.jinjava.util.Variable;
 import com.hubspot.jinjava.util.WhitespaceUtils;
 
@@ -207,8 +208,15 @@ public class JinjavaInterpreter {
 
     for (Node node : root.getChildren()) {
       lineNumber = node.getLineNumber();
-      OutputNode out = node.render(this);
-      output.addNode(out);
+      if (context.getRenderStack().contains(node.getMaster().getImage())) {
+        // This is a circular rendering. Stop rendering it here.
+        output.addNode(new RenderedOutputNode(node.getMaster().getImage()));
+      } else {
+        context.pushRenderStack(node.getMaster().getImage());
+        OutputNode out = node.render(this);
+        context.popRenderStack();
+        output.addNode(out);
+      }
     }
 
     // render all extend parents, keeping the last as the root output

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -208,7 +208,7 @@ public class JinjavaInterpreter {
 
     for (Node node : root.getChildren()) {
       lineNumber = node.getLineNumber();
-      if (context.getRenderStack().contains(node.getMaster().getImage())) {
+      if (context.doesRenderStackContain(node.getMaster().getImage())) {
         // This is a circular rendering. Stop rendering it here.
         output.addNode(new RenderedOutputNode(node.getMaster().getImage()));
       } else {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
@@ -160,24 +160,22 @@ public class MacroTagTest {
 
   @Test
   public void itPreventsRecursionForMacroWithVar() {
-    String jinja = "{%- macro allSpans(spans) %}" +
-        "{%- for span in spans %}" +
-        "{{ span.tag }}" +
+    String jinja = "{%- macro func(var) %}" +
+        "{%- for f in var %}" +
+        "{{ f.val }}" +
         "{%- endfor %}" +
         "{%- endmacro %}" +
-        "{%- set spans = {" +
-        "    'html_1' : {" +
-        "        'tag'           : 'html {{ selector }}'," +
-        "        'span'          : 12" +
+        "{%- set var = {" +
+        "    'f' : {" +
+        "        'val': '{{ self }}'," +
         "    }" +
         "} %}" +
-        "{% set selector='{{spans}}' %}" +
-        "{{ allSpans(spans, '') }}" +
+        "{% set self='{{var}}' %}" +
+        "{{ func(var) }}" +
         "";
     Node node = new TreeParser(interpreter, jinja).buildTree();
-    assertThat(JinjavaInterpreter.getCurrent() == interpreter).isTrue();
     assertThat(interpreter.render(node)).isEqualTo(
-        "html {html_1={tag=html {html_1={tag=html {{ selector }}, span=12}}, span=12}}");
+        "{f={val={f={val={{ self }}}}}}");
   }
 
   private Node snippet(String jinja) {

--- a/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
@@ -68,6 +68,35 @@ public class ExpressionNodeTest {
   }
 
   @Test
+  public void itAvoidsInfiniteRecursionOfItself() throws Exception {
+    context.put("myvar", "hello {{myvar}}");
+
+    ExpressionNode node = fixture("simplevar");
+    // It renders once, and then stop further rendering after detecting recursion.
+    assertThat(node.render(interpreter).toString()).isEqualTo("hello hello {{myvar}}");
+  }
+
+  @Test
+  public void itNoRecursionHere() throws Exception {
+    context.put("myvar", "hello {{ place }}");
+    context.put("place", "{{location}}");
+    context.put("location", "this is a place.");
+
+    ExpressionNode node = fixture("simplevar");
+    assertThat(node.render(interpreter).toString()).isEqualTo("hello this is a place.");
+  }
+
+  @Test
+  public void itAvoidsInfiniteRecursion() throws Exception {
+    context.put("myvar", "hello {{ place }}");
+    context.put("place", "there, {{ location }}");
+    context.put("location", "this is {{ place }}");
+
+    ExpressionNode node = fixture("simplevar");
+    assertThat(node.render(interpreter).toString()).isEqualTo("hello there, this is {{ place }}");
+  }
+
+  @Test
   public void itRendersStringRange() throws Exception {
     context.put("theString", "1234567890");
 


### PR DESCRIPTION
Although we limit the rendering depth at 10, but that can still be large if the recursive expression has multiple self references. With this change, we still render the recursion once, then stop render is any further.