### PR TITLE
Fix import tag tests for cycle detection.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -217,7 +217,7 @@ public class JinjavaInterpreter {
       if (context.doesRenderStackContain(renderStr)) {
         // This is a circular rendering. Stop rendering it here.
         addError(new TemplateError(ErrorType.WARNING, ErrorReason.EXCEPTION, ErrorItem.TAG,
-            "Circular rendering detected: '" + renderStr + "'", null, getLineNumber(),
+            "Rendering cycle detected: '" + renderStr + "'", null, getLineNumber(),
             null, BasicTemplateErrorCategory.IMPORT_CYCLE_DETECTED, ImmutableMap.of("string", renderStr)));
         output.addNode(new RenderedOutputNode(renderStr));
       } else {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
@@ -56,7 +56,7 @@ public class ImportTagTest {
     interpreter.render(Resources.toString(Resources.getResource("tags/importtag/imports-self.jinja"), StandardCharsets.UTF_8));
     assertThat(context.get("c")).isEqualTo("hello");
 
-    assertThat(interpreter.getErrors().get(0).getMessage()).contains("Import cycle detected for path:", "imports-self.jinja");
+    assertThat(interpreter.getErrors().get(0).getMessage()).contains("Circular rendering detected:", "imports-self.jinja");
   }
 
   @Test
@@ -68,7 +68,7 @@ public class ImportTagTest {
     assertThat(context.get("a")).isEqualTo("foo");
     assertThat(context.get("b")).isEqualTo("bar");
 
-    assertThat(interpreter.getErrors().get(0).getMessage()).contains("Import cycle detected for path:", "b-imports-a.jinja");
+    assertThat(interpreter.getErrors().get(0).getMessage()).contains("Circular rendering detected:", "b-imports-a.jinja");
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
@@ -56,7 +56,7 @@ public class ImportTagTest {
     interpreter.render(Resources.toString(Resources.getResource("tags/importtag/imports-self.jinja"), StandardCharsets.UTF_8));
     assertThat(context.get("c")).isEqualTo("hello");
 
-    assertThat(interpreter.getErrors().get(0).getMessage()).contains("Circular rendering detected:", "imports-self.jinja");
+    assertThat(interpreter.getErrors().get(0).getMessage()).contains("Rendering cycle detected:", "imports-self.jinja");
   }
 
   @Test
@@ -68,7 +68,7 @@ public class ImportTagTest {
     assertThat(context.get("a")).isEqualTo("foo");
     assertThat(context.get("b")).isEqualTo("bar");
 
-    assertThat(interpreter.getErrors().get(0).getMessage()).contains("Circular rendering detected:", "b-imports-a.jinja");
+    assertThat(interpreter.getErrors().get(0).getMessage()).contains("Rendering cycle detected:", "b-imports-a.jinja");
   }
 
   @Test


### PR DESCRIPTION
We have redundant cycle detection now. This PR fixes the tests that expect the detection inside the importTag, in fact it is detected and stopped before the importTag.