### PR TITLE
Add resolved expressions recursively up the context chain

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.el;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
 
 import java.util.List;
+import java.util.Optional;
 
 import javax.el.ELException;
 import javax.el.ExpressionFactory;
@@ -61,6 +62,7 @@ public class ExpressionResolver {
     }
 
     interpreter.getContext().addResolvedExpression(expression.trim());
+    Optional.ofNullable(interpreter.getContext().getParent()).ifPresent(parent -> parent.addResolvedExpression(expression.trim()));
 
     try {
       String elExpression = "#{" + expression.trim() + "}";

--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -3,7 +3,6 @@ package com.hubspot.jinjava.el;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
 
 import java.util.List;
-import java.util.Optional;
 
 import javax.el.ELException;
 import javax.el.ExpressionFactory;
@@ -62,7 +61,6 @@ public class ExpressionResolver {
     }
 
     interpreter.getContext().addResolvedExpression(expression.trim());
-    Optional.ofNullable(interpreter.getContext().getParent()).ifPresent(parent -> parent.addResolvedExpression(expression.trim()));
 
     try {
       String elExpression = "#{" + expression.trim() + "}";

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -189,6 +189,9 @@ public class Context extends ScopeMap<String, Object> {
 
   public void addResolvedValue(String value) {
     resolvedValues.add(value);
+    if (getParent() != null) {
+      getParent().addResolvedValue(value);
+    }
   }
 
   public Set<String> getResolvedValues() {
@@ -203,8 +206,11 @@ public class Context extends ScopeMap<String, Object> {
     return ImmutableSet.copyOf(resolvedFunctions);
   }
 
-  public void addResolvedFunction(String value) {
-    resolvedFunctions.add(value);
+  public void addResolvedFunction(String function) {
+    resolvedFunctions.add(function);
+    if (getParent() != null) {
+      getParent().addResolvedFunction(function);
+    }
   }
 
   public List<? extends Node> getSuperBlock() {

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -174,6 +174,9 @@ public class Context extends ScopeMap<String, Object> {
 
   public void addResolvedExpression(String expression) {
     resolvedExpressions.add(expression);
+    if (getParent() != null) {
+      getParent().addResolvedExpression(expression);
+    }
   }
 
   public Set<String> getResolvedExpressions() {

--- a/src/test/java/com/hubspot/jinjava/interpret/ContextTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/ContextTest.java
@@ -38,8 +38,12 @@ public class ContextTest {
   @Test
   public void itRecursivelyAddsValuesUpTheContextChain() {
     Context child = new Context(context);
+    child.addResolvedValue(RESOLVED_VALUE);
+    child.addResolvedFunction(RESOLVED_FUNCTION);
     child.addResolvedExpression(RESOLVED_EXPRESSION);
 
-    assertThat(context.getResolvedExpressions().contains(RESOLVED_EXPRESSION));
+    assertThat(context.getResolvedValues()).contains(RESOLVED_VALUE);
+    assertThat(context.getResolvedFunctions()).contains(RESOLVED_FUNCTION);
+    assertThat(context.getResolvedExpressions()).contains(RESOLVED_EXPRESSION);
   }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/ContextTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/ContextTest.java
@@ -34,4 +34,12 @@ public class ContextTest {
     assertThat(context.getResolvedFunctions()).contains(RESOLVED_FUNCTION);
     assertThat(context.getResolvedExpressions()).contains(RESOLVED_EXPRESSION);
   }
+
+  @Test
+  public void itRecursivelyAddsValuesUpTheContextChain() {
+    Context child = new Context(context);
+    child.addResolvedExpression(RESOLVED_EXPRESSION);
+
+    assertThat(context.getResolvedExpressions().contains(RESOLVED_EXPRESSION));
+  }
 }


### PR DESCRIPTION
Rather than using `addResolvedFrom` to combine resolved expressions from multiple `Context` objects, it would be more widely applicable to recursively add resolved expressions up the parent context chain. This way information isn't lost when rendering a nested structure, with multiple nested contexts and resolved expressions. 

@boulter do you think this would be worth applying to `Context`'s resolved functions and values as well? 

cc @hs-lsong 