### PR TITLE
use code as field name

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -52,12 +52,7 @@ public class TemplateError {
   }
 
   public static TemplateError fromException(TemplateSyntaxException ex) {
-    String fieldName = null;
-
-    if (ex instanceof UnknownTagException) {
-      fieldName = ((UnknownTagException) ex).getTag();
-    }
-
+    String fieldName = (ex instanceof UnknownTagException) ? ((UnknownTagException) ex).getTag() : ex.getCode();
     return new TemplateError(ErrorType.FATAL, ErrorReason.SYNTAX_ERROR, ErrorItem.OTHER, ExceptionUtils.getMessage(ex), fieldName, ex.getLineNumber(), ex);
   }
 

--- a/src/test/java/com/hubspot/jinjava/interpret/TemplateErrorTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/TemplateErrorTest.java
@@ -26,4 +26,10 @@ public class TemplateErrorTest {
     assertThat(e.getFieldName()).isEqualTo("unknown");
   }
 
+  @Test
+  public void itShowsFieldNameForSyntaxError() {
+    TemplateError e = TemplateError.fromException(new TemplateSyntaxException("da codez", "{{ lolo lolo }}", 11));
+    assertThat(e.getFieldName()).isEqualTo("da codez");
+  }
+
 }


### PR DESCRIPTION
For `TemplateSyntaxErrors`, use the evaluated code as the field name to provide more visibility into the location of the syntax error.