### PR TITLE
add line positions to error messages

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -76,7 +76,7 @@ public class ExpressionResolver {
           BasicTemplateErrorCategory.UNKNOWN, ImmutableMap.of("exception", e.getMessage())));
     } catch (TreeBuilderException e) {
       interpreter.addError(TemplateError.fromException(new TemplateSyntaxException(expression,
-          "Error parsing '" + expression + "': " + StringUtils.substringAfter(e.getMessage(), "': "), interpreter.getLineNumber(), e)));
+          "Error parsing '" + expression + "': " + StringUtils.substringAfter(e.getMessage(), "': "), interpreter.getLineNumber(), e.getPosition(), e)));
     } catch (ELException e) {
       interpreter.addError(TemplateError.fromException(new TemplateSyntaxException(expression, e.getMessage(), interpreter.getLineNumber(), e)));
     } catch (DisabledException e) {

--- a/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
@@ -155,7 +155,7 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
       } else {
         if (base == null) {
           // Look up property in context.
-          value = interpreter.retraceVariable((String) property, interpreter.getLineNumber());
+          value = interpreter.retraceVariable((String) property, interpreter.getLineNumber(), -1);
         } else {
           // Get property of base object.
           try {

--- a/src/main/java/com/hubspot/jinjava/el/ext/AstMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstMacroFunction.java
@@ -36,7 +36,7 @@ public class AstMacroFunction extends AstFunction {
           if (interpreter.getConfig().isEnableRecursiveMacroCalls()) {
             macroStack.pushWithoutCycleCheck(getName());
           } else {
-            macroStack.push(getName(), -1);
+            macroStack.push(getName(), -1, -1);
           }
         } catch (MacroTagCycleException e) {
           interpreter.addError(new TemplateError(TemplateError.ErrorType.WARNING,

--- a/src/main/java/com/hubspot/jinjava/interpret/CallStack.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/CallStack.java
@@ -35,9 +35,9 @@ public class CallStack {
     stack.push(path);
   }
 
-  public void push(String path, int lineNumber) {
+  public void push(String path, int lineNumber, int startPosition) {
     if (contains(path)) {
-      throw TagCycleException.create(exceptionClass, path, Optional.of(lineNumber));
+      throw TagCycleException.create(exceptionClass, path, Optional.of(lineNumber), Optional.of(startPosition));
     }
 
     stack.push(path);

--- a/src/main/java/com/hubspot/jinjava/interpret/ExtendsTagCycleException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/ExtendsTagCycleException.java
@@ -3,8 +3,8 @@ package com.hubspot.jinjava.interpret;
 public class ExtendsTagCycleException extends TagCycleException {
   private static final long serialVersionUID = 3183769038400532542L;
 
-  public ExtendsTagCycleException(String path, int lineNumber) {
-    super("Extends", path, lineNumber);
+  public ExtendsTagCycleException(String path, int lineNumber, int startPosition) {
+    super("Extends", path, lineNumber, startPosition);
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/ImportTagCycleException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/ImportTagCycleException.java
@@ -3,8 +3,8 @@ package com.hubspot.jinjava.interpret;
 public class ImportTagCycleException extends TagCycleException {
   private static final long serialVersionUID = 1092085697026161185L;
 
-  public ImportTagCycleException(String path, int lineNumber) {
-    super("Import", path, lineNumber);
+  public ImportTagCycleException(String path, int lineNumber, int startPosition) {
+    super("Import", path, lineNumber, startPosition);
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/IncludeTagCycleException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/IncludeTagCycleException.java
@@ -3,8 +3,8 @@ package com.hubspot.jinjava.interpret;
 public class IncludeTagCycleException extends TagCycleException {
   private static final long serialVersionUID = -5487642459443650227L;
 
-  public IncludeTagCycleException(String path, int lineNumber) {
-    super("Include", path, lineNumber);
+  public IncludeTagCycleException(String path, int lineNumber, int startPosition) {
+    super("Include", path, lineNumber, startPosition);
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/InterpretException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/InterpretException.java
@@ -17,9 +17,10 @@ package com.hubspot.jinjava.interpret;
 
 public class InterpretException extends RuntimeException {
 
-  private static final long serialVersionUID = -3471306977643116138L;
+  private static final long serialVersionUID = -3471306977643126138L;
 
   private int lineNumber = -1;
+  private int startPosition = -1;
 
   public InterpretException(String msg) {
     super(msg);
@@ -30,17 +31,30 @@ public class InterpretException extends RuntimeException {
   }
 
   public InterpretException(String msg, int lineNumber) {
-    this(msg);
-    this.lineNumber = lineNumber;
+    this(msg,lineNumber, -1);
   }
 
-  public InterpretException(String msg, Throwable e, int lineNumber) {
+  public InterpretException(String msg, int lineNumber, int startPosition) {
+    this(msg);
+    this.lineNumber = lineNumber;
+    this.startPosition = startPosition;
+  }
+
+  public InterpretException(String msg, Throwable e, int lineNumber, int startPosition) {
     this(msg, e);
     this.lineNumber = lineNumber;
+    this.startPosition = startPosition;
+  }
+
+  public InterpretException(String msg, Throwable throwable, int lineNumber) {
+    this(msg, throwable, lineNumber, -1);
   }
 
   public int getLineNumber() {
     return lineNumber;
   }
 
+  public int getStartPosition() {
+    return startPosition;
+  }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -292,9 +292,11 @@ public class JinjavaInterpreter {
    *          name of variable in context
    * @param lineNumber
    *          current line number, for error reporting
+   * @param startPosition
+   *          current line position, for error reporting
    * @return resolved value for variable
    */
-  public Object retraceVariable(String variable, int lineNumber) {
+  public Object retraceVariable(String variable, int lineNumber, int startPosition) {
     if (StringUtils.isBlank(variable)) {
       return "";
     }
@@ -304,7 +306,7 @@ public class JinjavaInterpreter {
     if (obj != null) {
       obj = var.resolve(obj);
     } else  if (getConfig().isFailOnUnknownTokens()) {
-      throw new UnknownTokenException(variable, getLineNumber());
+      throw new UnknownTokenException(variable, lineNumber, startPosition);
     }
     return obj;
   }
@@ -316,16 +318,18 @@ public class JinjavaInterpreter {
    *          name of variable in context
    * @param lineNumber
    *          current line number, for error reporting
+   * @param startPosition
+   *          current line position, for error reporting
    * @return resolved value for variable
    */
-  public Object resolveObject(String variable, int lineNumber) {
+  public Object resolveObject(String variable, int lineNumber, int startPosition) {
     if (StringUtils.isBlank(variable)) {
       return "";
     }
     if (WhitespaceUtils.isQuoted(variable)) {
       return WhitespaceUtils.unquote(variable);
     } else {
-      Object val = retraceVariable(variable, lineNumber);
+      Object val = retraceVariable(variable, lineNumber, startPosition);
       if (val == null) {
         return variable;
       }
@@ -340,10 +344,12 @@ public class JinjavaInterpreter {
    *          name of variable in context
    * @param lineNumber
    *          current line number, for error reporting
+   * @param startPosition
+   *          current line position, for error reporting
    * @return resolved value for variable
    */
-  public String resolveString(String variable, int lineNumber) {
-    return Objects.toString(resolveObject(variable, lineNumber), "");
+  public String resolveString(String variable, int lineNumber, int startPosition) {
+    return Objects.toString(resolveObject(variable, lineNumber, startPosition), "");
   }
 
   public Context getContext() {

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -311,6 +311,11 @@ public class JinjavaInterpreter {
     return obj;
   }
 
+  public Object retraceVariable(String variable, int lineNumber) {
+    return retraceVariable(variable, lineNumber, -1);
+  }
+
+
   /**
    * Resolve a variable into an object value. If given a string literal (e.g. 'foo' or "foo"), this method returns the literal unquoted. If the variable is undefined in the context, this method returns the given variable string.
    *
@@ -337,6 +342,10 @@ public class JinjavaInterpreter {
     }
   }
 
+  public Object resolveObject(String variable, int lineNumber) {
+    return resolveObject(variable, lineNumber, -1);
+  }
+
   /**
    * Resolve a variable into a string value. If given a string literal (e.g. 'foo' or "foo"), this method returns the literal unquoted. If the variable is undefined in the context, this method returns the given variable string.
    *
@@ -351,6 +360,11 @@ public class JinjavaInterpreter {
   public String resolveString(String variable, int lineNumber, int startPosition) {
     return Objects.toString(resolveObject(variable, lineNumber, startPosition), "");
   }
+
+  public String resolveString(String variable, int lineNumber) {
+    return resolveString(variable, lineNumber, -1);
+  }
+
 
   public Context getContext() {
     return context;

--- a/src/main/java/com/hubspot/jinjava/interpret/MacroTagCycleException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/MacroTagCycleException.java
@@ -4,8 +4,8 @@ public class MacroTagCycleException extends TagCycleException {
 
   private static final long serialVersionUID = -7552850581260771832L;
 
-  public MacroTagCycleException(String path, int lineNumber) {
-    super("Macro", path, lineNumber);
+  public MacroTagCycleException(String path, int lineNumber, int startPosition) {
+    super("Macro", path, lineNumber, startPosition);
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/MissingEndTagException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/MissingEndTagException.java
@@ -8,8 +8,8 @@ public class MissingEndTagException extends TemplateSyntaxException {
   private final String endTag;
   private final String startDefinition;
 
-  public MissingEndTagException(String endTag, String startDefintion, int lineNumber) {
-    super(startDefintion, "Missing end tag: " + endTag + " for tag defined as: " + StringUtils.abbreviate(startDefintion, 255), lineNumber);
+  public MissingEndTagException(String endTag, String startDefintion, int lineNumber, int startPosition) {
+    super(startDefintion, "Missing end tag: " + endTag + " for tag defined as: " + StringUtils.abbreviate(startDefintion, 255), lineNumber, startPosition);
     this.endTag = endTag;
     this.startDefinition = startDefintion;
   }

--- a/src/main/java/com/hubspot/jinjava/interpret/TagCycleException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TagCycleException.java
@@ -8,8 +8,8 @@ public class TagCycleException extends TemplateStateException {
   private final String path;
   private final String tagName;
 
-  public TagCycleException(String tagName, String path, int lineNumber) {
-    super(tagName + " tag cycle for '" + path + "'", lineNumber);
+  public TagCycleException(String tagName, String path, int lineNumber, int startPosition) {
+    super(tagName + " tag cycle for '" + path + "'", lineNumber, startPosition);
 
     this.path = path;
     this.tagName = tagName;
@@ -23,23 +23,24 @@ public class TagCycleException extends TemplateStateException {
     return tagName;
   }
 
-  public static TagCycleException create(Class<? extends TagCycleException> clazz, String path, Optional<Integer> linenumber) {
+  public static TagCycleException create(Class<? extends TagCycleException> clazz, String path, Optional<Integer> lineNumber, Optional<Integer> startPosition) {
 
-    final Integer line = linenumber.orElse(-1);
+    final Integer line = lineNumber.orElse(-1);
+    final Integer position = startPosition.orElse(-1);
 
     if (clazz != null) {
       if (clazz.equals(ExtendsTagCycleException.class)) {
-        return new ExtendsTagCycleException(path, line);
+        return new ExtendsTagCycleException(path, line, position);
       } else if (clazz.equals(ImportTagCycleException.class)) {
-        return new ImportTagCycleException(path, line);
+        return new ImportTagCycleException(path, line, position);
       } else if (clazz.equals(IncludeTagCycleException.class)) {
-        return new IncludeTagCycleException(path, line);
+        return new IncludeTagCycleException(path, line, position);
       } else if (clazz.equals(MacroTagCycleException.class)) {
-        return new MacroTagCycleException(path, line);
+        return new MacroTagCycleException(path, line, position);
       }
     }
 
-    return new TagCycleException("", path, line);
+    return new TagCycleException("", path, line, position);
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateStateException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateStateException.java
@@ -15,8 +15,16 @@ public class TemplateStateException extends InterpretException {
     super(msg, lineNumber, startPosition);
   }
 
+  public TemplateStateException(String msg, int lineNumber) {
+    super(msg, lineNumber, -1);
+  }
+
   public TemplateStateException(String msg, Throwable e, int lineNumber, int startPosition) {
     super(msg, e, lineNumber, startPosition);
+  }
+
+  public TemplateStateException(String msg, Throwable e, int lineNumber) {
+    super(msg, e, lineNumber, -1);
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateStateException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateStateException.java
@@ -11,12 +11,12 @@ public class TemplateStateException extends InterpretException {
     super(msg, e);
   }
 
-  public TemplateStateException(String msg, int lineNumber) {
-    super(msg, lineNumber);
+  public TemplateStateException(String msg, int lineNumber, int startPosition) {
+    super(msg, lineNumber, startPosition);
   }
 
-  public TemplateStateException(String msg, Throwable e, int lineNumber) {
-    super(msg, e, lineNumber);
+  public TemplateStateException(String msg, Throwable e, int lineNumber, int startPosition) {
+    super(msg, e, lineNumber, startPosition);
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateSyntaxException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateSyntaxException.java
@@ -5,14 +5,22 @@ public class TemplateSyntaxException extends InterpretException {
 
   private final String code;
 
+  public TemplateSyntaxException(String code, String message, int lineNumber, int startPosition) {
+    super("Syntax error in '" + code + "': " + message, lineNumber, startPosition);
+    this.code = code;
+  }
+
   public TemplateSyntaxException(String code, String message, int lineNumber) {
-    super("Syntax error in '" + code + "': " + message, lineNumber);
+    this(code, message, lineNumber, -1);
+  }
+
+  public TemplateSyntaxException(String code, String message, int lineNumber, int startPosition, Throwable t) {
+    super(message, t, lineNumber, startPosition);
     this.code = code;
   }
 
   public TemplateSyntaxException(String code, String message, int lineNumber, Throwable t) {
-    super(message, t, lineNumber);
-    this.code = code;
+    this(code, message, lineNumber, -1, t);
   }
 
   public String getCode() {

--- a/src/main/java/com/hubspot/jinjava/interpret/UnexpectedTokenException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/UnexpectedTokenException.java
@@ -5,8 +5,8 @@ public class UnexpectedTokenException extends TemplateSyntaxException {
 
   private final String token;
 
-  public UnexpectedTokenException(String token, int lineNumber) {
-    super(token, "Unexpected token: " + token, lineNumber);
+  public UnexpectedTokenException(String token, int lineNumber, int startPosition) {
+    super(token, "Unexpected token: " + token, lineNumber, startPosition);
     this.token = token;
   }
 

--- a/src/main/java/com/hubspot/jinjava/interpret/UnknownTagException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/UnknownTagException.java
@@ -8,14 +8,14 @@ public class UnknownTagException extends TemplateSyntaxException {
   private final String tag;
   private final String defintion;
 
-  public UnknownTagException(String tag, String definition, int lineNumber) {
-    super(definition, "Unknown tag: " + tag, lineNumber);
+  public UnknownTagException(String tag, String definition, int lineNumber, int startPosition) {
+    super(definition, "Unknown tag: " + tag, lineNumber, startPosition);
     this.tag = tag;
     this.defintion = definition;
   }
 
   public UnknownTagException(TagToken tagToken) {
-    this(tagToken.getTagName(), tagToken.getImage(), tagToken.getLineNumber());
+    this(tagToken.getTagName(), tagToken.getImage(), tagToken.getLineNumber(), tagToken.getStartPosition());
   }
 
   public String getTag() {

--- a/src/main/java/com/hubspot/jinjava/interpret/UnknownTokenException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/UnknownTokenException.java
@@ -5,8 +5,8 @@ public class UnknownTokenException extends InterpretException {
   private static final long serialVersionUID = -388757722051666198L;
   private final String token;
 
-  public UnknownTokenException(String token, int lineNumber) {
-    super("Unknown token found: " + token, lineNumber);
+  public UnknownTokenException(String token, int lineNumber, int startPosition) {
+    super("Unknown token found: " + token, lineNumber, startPosition);
     this.token = token;
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/BlockTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/BlockTag.java
@@ -49,7 +49,7 @@ public class BlockTag implements Tag {
   public OutputNode interpretOutput(TagNode tagNode, JinjavaInterpreter interpreter) {
     HelperStringTokenizer tagData = new HelperStringTokenizer(tagNode.getHelpers());
     if (!tagData.hasNext()) {
-      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'block' expects an identifier", tagNode.getLineNumber());
+      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'block' expects an identifier", tagNode.getLineNumber(), tagNode.getStartPosition());
     }
 
     String blockName = WhitespaceUtils.unquote(tagData.next());

--- a/src/main/java/com/hubspot/jinjava/lib/tag/CycleTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/CycleTag.java
@@ -62,19 +62,19 @@ public class CycleTag implements Tag {
       HelperStringTokenizer items = new HelperStringTokenizer(helper.get(0));
       items.splitComma(true);
       values = items.allTokens();
-      Integer forindex = (Integer) interpreter.retraceVariable(LOOP_INDEX, tagNode.getLineNumber());
+      Integer forindex = (Integer) interpreter.retraceVariable(LOOP_INDEX, tagNode.getLineNumber(), tagNode.getStartPosition());
       if (forindex == null) {
         forindex = 0;
       }
       if (values.size() == 1) {
         var = values.get(0);
-        values = (List<String>) interpreter.retraceVariable(var, tagNode.getLineNumber());
+        values = (List<String>) interpreter.retraceVariable(var, tagNode.getLineNumber(), tagNode.getStartPosition());
         if (values == null) {
-          return interpreter.resolveString(var, tagNode.getLineNumber());
+          return interpreter.resolveString(var, tagNode.getLineNumber(), tagNode.getStartPosition());
         }
       } else {
         for (int i = 0; i < values.size(); i++) {
-          values.set(i, interpreter.resolveString(values.get(i), tagNode.getLineNumber()));
+          values.set(i, interpreter.resolveString(values.get(i), tagNode.getLineNumber(), tagNode.getStartPosition()));
         }
       }
       return values.get(forindex % values.size());
@@ -83,13 +83,13 @@ public class CycleTag implements Tag {
       items.splitComma(true);
       values = items.allTokens();
       for (int i = 0; i < values.size(); i++) {
-        values.set(i, interpreter.resolveString(values.get(i), tagNode.getLineNumber()));
+        values.set(i, interpreter.resolveString(values.get(i), tagNode.getLineNumber(), tagNode.getStartPosition()));
       }
       var = helper.get(2);
       interpreter.getContext().put(var, values);
       return "";
     } else {
-      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'cycle' expects 1 or 3 helper(s), was: " + helper.size(), tagNode.getLineNumber());
+      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'cycle' expects 1 or 3 helper(s), was: " + helper.size(), tagNode.getLineNumber(), tagNode.getStartPosition());
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ExtendsTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ExtendsTag.java
@@ -82,11 +82,11 @@ public class ExtendsTag implements Tag {
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     HelperStringTokenizer tokenizer = new HelperStringTokenizer(tagNode.getHelpers());
     if (!tokenizer.hasNext()) {
-      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'extends' expects template path", tagNode.getLineNumber());
+      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'extends' expects template path", tagNode.getLineNumber(), tagNode.getStartPosition());
     }
 
-    String path = interpreter.resolveString(tokenizer.next(), tagNode.getLineNumber());
-    interpreter.getContext().getExtendPathStack().push(path, tagNode.getLineNumber());
+    String path = interpreter.resolveString(tokenizer.next(), tagNode.getLineNumber(), tagNode.getStartPosition());
+    interpreter.getContext().getExtendPathStack().push(path, tagNode.getLineNumber(), tagNode.getStartPosition());
 
     try {
       String template = interpreter.getResource(path);
@@ -97,7 +97,7 @@ public class ExtendsTag implements Tag {
 
       return "";
     } catch (IOException e) {
-      throw new InterpretException(e.getMessage(), e, tagNode.getLineNumber());
+      throw new InterpretException(e.getMessage(), e, tagNode.getLineNumber(), tagNode.getStartPosition());
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -116,7 +116,7 @@ public class ForTag implements Tag {
     }
 
     if (inPos >= helper.size()) {
-      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'for' expects valid 'in' clause, got: " + tagNode.getHelpers(), tagNode.getLineNumber());
+      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'for' expects valid 'in' clause, got: " + tagNode.getHelpers(), tagNode.getLineNumber(), tagNode.getStartPosition());
     }
 
     String loopExpr = StringUtils.join(helper.subList(inPos + 1, helper.size()), ",");
@@ -156,7 +156,7 @@ public class ForTag implements Tag {
                   }
                 }
               } catch (Exception e) {
-                throw new InterpretException(e.getMessage(), e, tagNode.getLineNumber());
+                throw new InterpretException(e.getMessage(), e, tagNode.getLineNumber(), tagNode.getStartPosition());
               }
             }
           }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/FromTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/FromTag.java
@@ -51,10 +51,10 @@ public class FromTag implements Tag {
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     List<String> helper = new HelperStringTokenizer(tagNode.getHelpers()).splitComma(true).allTokens();
     if (helper.size() < 3 || !helper.get(1).equals("import")) {
-      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'from' expects import list: " + helper, tagNode.getLineNumber());
+      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'from' expects import list: " + helper, tagNode.getLineNumber(), tagNode.getStartPosition());
     }
 
-    String templateFile = interpreter.resolveString(helper.get(0), tagNode.getLineNumber());
+    String templateFile = interpreter.resolveString(helper.get(0), tagNode.getLineNumber(), tagNode.getStartPosition());
     Map<String, String> imports = new LinkedHashMap<>();
 
     PeekingIterator<String> args = Iterators.peekingIterator(helper.subList(2, helper.size()).iterator());
@@ -96,7 +96,7 @@ public class FromTag implements Tag {
 
       return "";
     } catch (IOException e) {
-      throw new InterpretException(e.getMessage(), e, tagNode.getLineNumber());
+      throw new InterpretException(e.getMessage(), e, tagNode.getLineNumber(), tagNode.getStartPosition());
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IfTag.java
@@ -55,7 +55,7 @@ public class IfTag implements Tag {
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     if (StringUtils.isBlank(tagNode.getHelpers())) {
-      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'if' expects expression", tagNode.getLineNumber());
+      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'if' expects expression", tagNode.getLineNumber(), tagNode.getStartPosition());
     }
 
     Iterator<Node> nodeIterator = tagNode.getChildren().iterator();

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IfchangedTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IfchangedTag.java
@@ -43,12 +43,12 @@ public class IfchangedTag implements Tag {
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     if (StringUtils.isBlank(tagNode.getHelpers())) {
-      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'ifchanged' expects a variable parameter", tagNode.getLineNumber());
+      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'ifchanged' expects a variable parameter", tagNode.getLineNumber(), tagNode.getStartPosition());
     }
     boolean isChanged = true;
     String var = tagNode.getHelpers().trim();
     Object older = interpreter.getContext().get(LASTKEY + var);
-    Object test = interpreter.retraceVariable(var, tagNode.getLineNumber());
+    Object test = interpreter.retraceVariable(var, tagNode.getLineNumber(), tagNode.getStartPosition());
     if (older == null) {
       if (test == null) {
         isChanged = false;

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -4,13 +4,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-
-import com.google.common.collect.ImmutableMap;
-import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
-import com.hubspot.jinjava.interpret.errorcategory.BasicTemplateErrorCategory;
-
 import org.apache.commons.lang3.StringUtils;
 
+import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
@@ -19,9 +15,11 @@ import com.hubspot.jinjava.interpret.ImportTagCycleException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateError;
+import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
+import com.hubspot.jinjava.interpret.errorcategory.BasicTemplateErrorCategory;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.TagNode;
@@ -67,7 +65,7 @@ public class ImportTag implements Tag {
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     List<String> helper = new HelperStringTokenizer(tagNode.getHelpers()).allTokens();
     if (helper.isEmpty()) {
-      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'import' expects 1 helper, was: " + helper.size(), tagNode.getLineNumber());
+      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'import' expects 1 helper, was: " + helper.size(), tagNode.getLineNumber(), tagNode.getStartPosition());
     }
 
     String contextVar = "";
@@ -79,7 +77,7 @@ public class ImportTag implements Tag {
     String path = StringUtils.trimToEmpty(helper.get(0));
 
     try {
-      interpreter.getContext().getImportPathStack().push(path, tagNode.getLineNumber());
+      interpreter.getContext().getImportPathStack().push(path, tagNode.getLineNumber(), tagNode.getStartPosition());
     } catch (ImportTagCycleException e) {
       interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.EXCEPTION, ErrorItem.TAG,
           "Import cycle detected for path: '" + path + "'", null, tagNode.getLineNumber(),
@@ -87,7 +85,7 @@ public class ImportTag implements Tag {
       return "";
     }
 
-    String templateFile = interpreter.resolveString(path, tagNode.getLineNumber());
+    String templateFile = interpreter.resolveString(path, tagNode.getLineNumber(), tagNode.getStartPosition());
     interpreter.getContext().addDependency("coded_files", templateFile);
     try {
       String template = interpreter.getResource(templateFile);
@@ -112,7 +110,7 @@ public class ImportTag implements Tag {
 
       return "";
     } catch (IOException e) {
-      throw new InterpretException(e.getMessage(), e, tagNode.getLineNumber());
+      throw new InterpretException(e.getMessage(), e, tagNode.getLineNumber(), tagNode.getStartPosition());
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IncludeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IncludeTag.java
@@ -17,12 +17,9 @@ package com.hubspot.jinjava.lib.tag;
 
 import java.io.IOException;
 
-import com.google.common.collect.ImmutableMap;
-import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
-import com.hubspot.jinjava.interpret.errorcategory.BasicTemplateErrorCategory;
-
 import org.apache.commons.lang3.StringUtils;
 
+import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
@@ -30,9 +27,11 @@ import com.hubspot.jinjava.interpret.IncludeTagCycleException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateError;
+import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
+import com.hubspot.jinjava.interpret.errorcategory.BasicTemplateErrorCategory;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.util.HelperStringTokenizer;
@@ -54,14 +53,14 @@ public class IncludeTag implements Tag {
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     HelperStringTokenizer helper = new HelperStringTokenizer(tagNode.getHelpers());
     if (!helper.hasNext()) {
-      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'include' expects template path", tagNode.getLineNumber());
+      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'include' expects template path", tagNode.getLineNumber(), tagNode.getStartPosition());
     }
 
     String path = StringUtils.trimToEmpty(helper.next());
-    String templateFile = interpreter.resolveString(path, tagNode.getLineNumber());
+    String templateFile = interpreter.resolveString(path, tagNode.getLineNumber(), tagNode.getStartPosition());
 
     try {
-      interpreter.getContext().getIncludePathStack().push(templateFile, tagNode.getLineNumber());
+      interpreter.getContext().getIncludePathStack().push(templateFile, tagNode.getLineNumber(), tagNode.getStartPosition());
     } catch (IncludeTagCycleException e) {
       interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.EXCEPTION, ErrorItem.TAG,
           "Include cycle detected for path: '" + templateFile + "'", null, tagNode.getLineNumber(), e,
@@ -83,7 +82,7 @@ public class IncludeTag implements Tag {
       return result;
 
     } catch (IOException e) {
-      throw new InterpretException(e.getMessage(), e, tagNode.getLineNumber());
+      throw new InterpretException(e.getMessage(), e, tagNode.getLineNumber(), tagNode.getStartPosition());
     } finally {
       interpreter.getContext().getIncludePathStack().pop();
     }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
@@ -66,7 +66,7 @@ public class MacroTag implements Tag {
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     Matcher matcher = MACRO_PATTERN.matcher(tagNode.getHelpers());
     if (!matcher.find()) {
-      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Unable to parse macro definition: " + tagNode.getHelpers(), tagNode.getLineNumber());
+      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Unable to parse macro definition: " + tagNode.getHelpers(), tagNode.getLineNumber(), tagNode.getStartPosition());
     }
 
     String name = matcher.group(1);

--- a/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
@@ -64,7 +64,7 @@ public class SetTag implements Tag {
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     if (!tagNode.getHelpers().contains("=")) {
-      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'set' expects an assignment expression with '=', but was: " + tagNode.getHelpers(), tagNode.getLineNumber());
+      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'set' expects an assignment expression with '=', but was: " + tagNode.getHelpers(), tagNode.getLineNumber(), tagNode.getStartPosition());
     }
 
     int eqPos = tagNode.getHelpers().indexOf('=');
@@ -72,10 +72,10 @@ public class SetTag implements Tag {
     String expr = tagNode.getHelpers().substring(eqPos + 1, tagNode.getHelpers().length());
 
     if (var.length() == 0) {
-      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'set' requires a var name to assign to", tagNode.getLineNumber());
+      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'set' requires a var name to assign to", tagNode.getLineNumber(), tagNode.getStartPosition());
     }
     if (StringUtils.isBlank(expr)) {
-      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'set' requires an expression to assign to a var", tagNode.getLineNumber());
+      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'set' requires an expression to assign to a var", tagNode.getLineNumber(), tagNode.getStartPosition());
     }
 
     String[] varTokens = var.split(",");
@@ -86,7 +86,7 @@ public class SetTag implements Tag {
       List<Object> exprVals = (List<Object>) interpreter.resolveELExpression("[" + expr + "]", tagNode.getLineNumber());
 
       if (varTokens.length != exprVals.size()) {
-        throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'set' declares an uneven number of variables and assigned values", tagNode.getLineNumber());
+        throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'set' declares an uneven number of variables and assigned values", tagNode.getLineNumber(), tagNode.getStartPosition());
       }
 
       for (int i = 0; i < varTokens.length; i++) {

--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -27,12 +27,13 @@ import com.hubspot.jinjava.tree.parse.ExpressionToken;
 import com.hubspot.jinjava.util.Logging;
 
 public class ExpressionNode extends Node {
-  private static final long serialVersionUID = 341642231109911346L;
+
+  private static final long serialVersionUID = -6063173739682221042L;
 
   private final ExpressionToken master;
 
   public ExpressionNode(ExpressionToken token) {
-    super(token, token.getLineNumber());
+    super(token, token.getLineNumber(), token.getStartPosition());
     master = token;
   }
 

--- a/src/main/java/com/hubspot/jinjava/tree/Node.java
+++ b/src/main/java/com/hubspot/jinjava/tree/Node.java
@@ -26,17 +26,19 @@ import com.hubspot.jinjava.tree.parse.Token;
 
 public abstract class Node implements Serializable {
 
-  private static final long serialVersionUID = 7323842986596895498L;
+  private static final long serialVersionUID = -6194634312533310816L;
 
   private final Token master;
   private final int lineNumber;
+  private final int startPosition;
 
   private Node parent = null;
   private LinkedList<Node> children = new LinkedList<Node>();
 
-  public Node(Token master, int lineNumber) {
+  public Node(Token master, int lineNumber, int startPosition) {
     this.master = master;
     this.lineNumber = lineNumber;
+    this.startPosition = startPosition;
   }
 
   public Node getParent() {
@@ -53,6 +55,10 @@ public abstract class Node implements Serializable {
 
   public int getLineNumber() {
     return lineNumber;
+  }
+
+  public int getStartPosition() {
+    return startPosition;
   }
 
   public LinkedList<Node> getChildren() {

--- a/src/main/java/com/hubspot/jinjava/tree/Node.java
+++ b/src/main/java/com/hubspot/jinjava/tree/Node.java
@@ -35,6 +35,10 @@ public abstract class Node implements Serializable {
   private Node parent = null;
   private LinkedList<Node> children = new LinkedList<Node>();
 
+  public Node(Token master, int lineNumber) {
+    this(master, lineNumber, -1);
+  }
+
   public Node(Token master, int lineNumber, int startPosition) {
     this.master = master;
     this.lineNumber = lineNumber;

--- a/src/main/java/com/hubspot/jinjava/tree/RootNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/RootNode.java
@@ -19,10 +19,10 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.tree.output.OutputNode;
 
 public class RootNode extends Node {
-  private static final long serialVersionUID = 97675838726004658L;
+  private static final long serialVersionUID = 5904181260202954424L;
 
   RootNode() {
-    super(null, 0);
+    super(null, 0, 0);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/tree/TagNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TagNode.java
@@ -22,14 +22,15 @@ import com.hubspot.jinjava.tree.output.OutputNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
 
 public class TagNode extends Node {
-  private static final long serialVersionUID = 2405693063353887509L;
+
+  private static final long serialVersionUID = -6971280448795354252L;
 
   private final Tag tag;
   private final TagToken master;
   private final String endName;
 
   public TagNode(Tag tag, TagToken token) {
-    super(token, token.getLineNumber());
+    super(token, token.getLineNumber(), token.getStartPosition());
 
     this.master = token;
     this.tag = tag;
@@ -37,7 +38,7 @@ public class TagNode extends Node {
   }
 
   private TagNode(TagNode n) {
-    super(n.master, n.getLineNumber());
+    super(n.master, n.getLineNumber(), n.getStartPosition());
 
     tag = n.tag;
     master = n.master;
@@ -51,7 +52,7 @@ public class TagNode extends Node {
     } catch (InterpretException e) {
       throw e;
     } catch (Exception e) {
-      throw new InterpretException("Error rendering tag", e, master.getLineNumber());
+      throw new InterpretException("Error rendering tag", e, master.getLineNumber(), master.getStartPosition());
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/tree/TextNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TextNode.java
@@ -21,12 +21,13 @@ import com.hubspot.jinjava.tree.output.RenderedOutputNode;
 import com.hubspot.jinjava.tree.parse.TextToken;
 
 public class TextNode extends Node {
-  private static final long serialVersionUID = 8488738480534354216L;
+
+  private static final long serialVersionUID = 127827773323298439L;
 
   private final TextToken master;
 
   public TextNode(TextToken token) {
-    super(token, token.getLineNumber());
+    super(token, token.getLineNumber(), token.getStartPosition());
     master = token;
   }
 

--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -71,7 +71,7 @@ public class TreeParser {
       interpreter.addError(TemplateError.fromException(
           new MissingEndTagException(((TagNode) parent).getEndName(),
                                      parent.getMaster().getImage(),
-                                     parent.getLineNumber())));
+                                     parent.getLineNumber(), parent.getStartPosition())));
     }
 
     return root;
@@ -99,7 +99,7 @@ public class TreeParser {
 
       default:
         interpreter.addError(TemplateError.fromException(new UnexpectedTokenException(token.getImage(),
-                                                                                      token.getLineNumber())));
+                                                                                      token.getLineNumber(), token.getStartPosition())));
     }
     return null;
   }
@@ -114,7 +114,7 @@ public class TreeParser {
   private Node text(TextToken textToken) {
     if (interpreter.getConfig().isLstripBlocks()) {
       if (scanner.hasNext() && scanner.peek().getType() == TOKEN_TAG) {
-        textToken = new TextToken(StringUtils.stripEnd(textToken.getImage(), "\t "), textToken.getLineNumber());
+        textToken = new TextToken(StringUtils.stripEnd(textToken.getImage(), "\t "), textToken.getLineNumber(), textToken.getStartPosition());
       }
     }
 
@@ -210,7 +210,7 @@ public class TreeParser {
         interpreter.addError(TemplateError.fromException(
             new TemplateSyntaxException(tagToken.getImage(),
                                         "Mismatched end tag, expected: " + parentTag.getEndName(),
-                                        tagToken.getLineNumber())));
+                                        tagToken.getLineNumber(), tagToken.getStartPosition())));
       }
     }
   }

--- a/src/main/java/com/hubspot/jinjava/tree/parse/ExpressionToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/ExpressionToken.java
@@ -22,12 +22,13 @@ import org.apache.commons.lang3.StringUtils;
 import com.hubspot.jinjava.util.WhitespaceUtils;
 
 public class ExpressionToken extends Token {
-  private static final long serialVersionUID = 8307037212944170832L;
+
+  private static final long serialVersionUID = 6336768632140743908L;
 
   private String expr;
 
-  public ExpressionToken(String image, int lineNumber) {
-    super(image, lineNumber);
+  public ExpressionToken(String image, int lineNumber, int startPosition) {
+    super(image, lineNumber, startPosition);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/tree/parse/NoteToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/NoteToken.java
@@ -19,10 +19,10 @@ import static com.hubspot.jinjava.tree.parse.TokenScannerSymbols.TOKEN_NOTE;
 
 public class NoteToken extends Token {
 
-  private static final long serialVersionUID = 6112027107603795408L;
+  private static final long serialVersionUID = -3859011447900311329L;
 
-  public NoteToken(String image, int lineNumber) {
-    super(image, lineNumber);
+  public NoteToken(String image, int lineNumber, int startPosition) {
+    super(image, lineNumber, startPosition);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TagToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TagToken.java
@@ -22,13 +22,13 @@ import com.hubspot.jinjava.util.WhitespaceUtils;
 
 public class TagToken extends Token {
 
-  private static final long serialVersionUID = 2766011408032384360L;
+  private static final long serialVersionUID = -4927751270481832992L;
 
   private String tagName;
   private String helpers;
 
-  public TagToken(String image, int lineNumber) {
-    super(image, lineNumber);
+  public TagToken(String image, int lineNumber, int startPosition) {
+    super(image, lineNumber, startPosition);
   }
 
   @Override
@@ -42,7 +42,7 @@ public class TagToken extends Token {
   @Override
   protected void parse() {
     if (image.length() < 4) {
-      throw new TemplateSyntaxException(image, "Malformed tag token", getLineNumber());
+      throw new TemplateSyntaxException(image, "Malformed tag token", getLineNumber(), getStartPosition());
     }
 
     content = image.substring(2, image.length() - 2);

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TextToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TextToken.java
@@ -21,10 +21,10 @@ import org.apache.commons.lang3.StringUtils;
 
 public class TextToken extends Token {
 
-  private static final long serialVersionUID = -5015884072204770458L;
+  private static final long serialVersionUID = -6168990984496468543L;
 
-  public TextToken(String image, int lineNumber) {
-    super(image, lineNumber);
+  public TextToken(String image, int lineNumber, int startPosition) {
+    super(image, lineNumber, startPosition);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
@@ -46,6 +46,10 @@ public abstract class Token implements Serializable {
     parse();
   }
 
+  public Token(String image, int lineNumber) {
+    this(image, lineNumber, -1);
+  }
+
   public String getImage() {
     return image;
   }

--- a/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
@@ -26,21 +26,23 @@ import com.hubspot.jinjava.interpret.UnexpectedTokenException;
 
 public abstract class Token implements Serializable {
 
-  private static final long serialVersionUID = -7513379852268838992L;
+  private static final long serialVersionUID = 3359084948763661809L;
 
   protected final String image;
   // useful for some token type
   protected String content;
 
   protected final int lineNumber;
+  protected final int startPosition;
 
   private boolean leftTrim;
   private boolean rightTrim;
   private boolean rightTrimAfterEnd;
 
-  public Token(String image, int lineNumber) {
+  public Token(String image, int lineNumber, int startPosition) {
     this.image = image;
     this.lineNumber = lineNumber;
+    this.startPosition = startPosition;
     parse();
   }
 
@@ -76,6 +78,10 @@ public abstract class Token implements Serializable {
     this.rightTrimAfterEnd = rightTrimAfterEnd;
   }
 
+  public int getStartPosition() {
+    return startPosition;
+  }
+
   @Override
   public String toString() {
     return image;
@@ -85,18 +91,18 @@ public abstract class Token implements Serializable {
 
   public abstract int getType();
 
-  static Token newToken(int tokenKind, String image, int lineNumber) {
+  static Token newToken(int tokenKind, String image, int lineNumber, int startPosition) {
     switch (tokenKind) {
     case TOKEN_FIXED:
-      return new TextToken(image, lineNumber);
+      return new TextToken(image, lineNumber, startPosition);
     case TOKEN_NOTE:
-      return new NoteToken(image, lineNumber);
+      return new NoteToken(image, lineNumber, startPosition);
     case TOKEN_EXPR_START:
-      return new ExpressionToken(image, lineNumber);
+      return new ExpressionToken(image, lineNumber, startPosition);
     case TOKEN_TAG:
-      return new TagToken(image, lineNumber);
+      return new TagToken(image, lineNumber, startPosition);
     default:
-      throw new UnexpectedTokenException(String.valueOf((char) tokenKind), lineNumber);
+      throw new UnexpectedTokenException(String.valueOf((char) tokenKind), lineNumber, startPosition);
     }
   }
 

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -40,14 +40,14 @@ public class JinjavaInterpreterTest {
 
   @Test
   public void resolveBlockStubs() throws Exception {
-    interpreter.addBlock("foobar", Lists.newLinkedList(Lists.newArrayList((new TextNode(new TextToken("sparta", -1))))));
+    interpreter.addBlock("foobar", Lists.newLinkedList(Lists.newArrayList((new TextNode(new TextToken("sparta", -1, -1))))));
     String content = "this is {% block foobar %}foobar{% endblock %}!";
     assertThat(interpreter.render(content)).isEqualTo("this is sparta!");
   }
 
   @Test
   public void resolveBlockStubsWithSpecialChars() throws Exception {
-    interpreter.addBlock("foobar", Lists.newLinkedList(Lists.newArrayList(new TextNode(new TextToken("$150.00", -1)))));
+    interpreter.addBlock("foobar", Lists.newLinkedList(Lists.newArrayList(new TextNode(new TextToken("$150.00", -1, -1)))));
     String content = "this is {% block foobar %}foobar{% endblock %}!";
     assertThat(interpreter.render(content)).isEqualTo("this is $150.00!");
   }

--- a/src/test/java/com/hubspot/jinjava/interpret/TemplateErrorTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/TemplateErrorTest.java
@@ -22,7 +22,7 @@ public class TemplateErrorTest {
 
   @Test
   public void itShowsFieldNameForUnknownTagError() {
-    TemplateError e = TemplateError.fromException(new UnknownTagException("unknown", "{% unknown() %}", 11));
+    TemplateError e = TemplateError.fromException(new UnknownTagException("unknown", "{% unknown() %}", 11, 3));
     assertThat(e.getFieldName()).isEqualTo("unknown");
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/TruncateFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/TruncateFilterTest.java
@@ -26,7 +26,7 @@ public class TruncateFilterTest {
 
   @Before
   public void setup() {
-    when(interpreter.resolveString(anyString(), anyInt())).thenAnswer(new ReturnsArgumentAt(0));
+    when(interpreter.resolveString(anyString(), anyInt(), anyInt())).thenAnswer(new ReturnsArgumentAt(0));
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
@@ -79,7 +79,7 @@ public class ImportTagTest {
   @Test
   public void importedContextExposesMacros() {
     assertThat(fixture("import")).contains("<td height=\"42\">");
-    MacroFunction fn = (MacroFunction) interpreter.resolveObject("pegasus.spacer", -1);
+    MacroFunction fn = (MacroFunction) interpreter.resolveObject("pegasus.spacer", -1, -1);
     assertThat(fn.getName()).isEqualTo("spacer");
     assertThat(fn.getArguments()).containsExactly("orientation", "size");
     assertThat(fn.getDefaults()).contains(entry("orientation", "h"), entry("size", 42));

--- a/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
@@ -51,7 +51,7 @@ public class MacroTagTest {
     TagNode t = fixture("simple");
     assertThat(t.render(interpreter).getValue()).isEmpty();
 
-    MacroFunction fn = (MacroFunction) interpreter.resolveObject("__macros__.getPath", -1);
+    MacroFunction fn = (MacroFunction) interpreter.resolveObject("__macros__.getPath", -1, -1);
     assertThat(fn.getName()).isEqualTo("getPath");
     assertThat(fn.getArguments()).isEmpty();
     assertThat(fn.isCaller()).isFalse();
@@ -67,7 +67,7 @@ public class MacroTagTest {
     TagNode t = fixture("with-args");
     assertThat(t.render(interpreter).getValue()).isEmpty();
 
-    MacroFunction fn = (MacroFunction) interpreter.resolveObject("__macros__.section_link", -1);
+    MacroFunction fn = (MacroFunction) interpreter.resolveObject("__macros__.section_link", -1, -1);
     assertThat(fn.getName()).isEqualTo("section_link");
     assertThat(fn.getArguments()).containsExactly("link", "text");
 
@@ -79,7 +79,7 @@ public class MacroTagTest {
     TagNode t = fixture("def-vals");
     assertThat(t.render(interpreter).getValue()).isEmpty();
 
-    MacroFunction fn = (MacroFunction) interpreter.resolveObject("__macros__.article", -1);
+    MacroFunction fn = (MacroFunction) interpreter.resolveObject("__macros__.article", -1, -1);
     assertThat(fn.getArguments()).containsExactly("title", "thumb", "link", "summary", "last");
     assertThat(fn.getDefaults()).contains(entry("last", false));
 
@@ -94,7 +94,7 @@ public class MacroTagTest {
     TagNode t = fixture("array-def-val");
     assertThat(t.render(interpreter).getValue()).isEmpty();
 
-    MacroFunction fn = (MacroFunction) interpreter.resolveObject("__macros__.prefix", -1);
+    MacroFunction fn = (MacroFunction) interpreter.resolveObject("__macros__.prefix", -1, -1);
     assertThat(fn.getArguments()).containsExactly("property", "value", "prefixes", "prefixval");
     assertThat(fn.getDefaults()).contains(entry("prefixes", Lists.newArrayList("webkit", "moz")));
   }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/SetTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/SetTagTest.java
@@ -52,7 +52,7 @@ public class SetTagTest {
   public void itAssignsValToVar() throws Exception {
     TagNode tagNode = (TagNode) fixture("set-val");
     tag.interpret(tagNode, interpreter);
-    assertThat(interpreter.resolveObject("primary_line_height", -1)).isEqualTo(42L);
+    assertThat(interpreter.resolveObject("primary_line_height", -1, -1)).isEqualTo(42L);
   }
 
   @Test
@@ -60,7 +60,7 @@ public class SetTagTest {
     context.put("primary_font_size_num", 10);
     TagNode tagNode = (TagNode) fixture("set-var-exp");
     tag.interpret(tagNode, interpreter);
-    assertThat(interpreter.resolveObject("primary_line_height", -1)).isEqualTo(15.0);
+    assertThat(interpreter.resolveObject("primary_line_height", -1, -1)).isEqualTo(15.0);
   }
 
   @Test
@@ -79,7 +79,7 @@ public class SetTagTest {
     TagNode tagNode = (TagNode) fixture("set-complex-dict");
     tag.interpret(tagNode, interpreter);
 
-    Map<String, Object> dict = (Map<String, Object>) interpreter.resolveObject("styles", -1);
+    Map<String, Object> dict = (Map<String, Object>) interpreter.resolveObject("styles", -1, -1);
     assertThat(dict).contains(
         entry("heading", "color:bluecolor;text-shadow:2px 2px 1px rgba(0,0,0,.1);font-family:fontfam"),
         entry("module", "background:#ffffff;padding:123px;border:1px solid 10"));
@@ -90,7 +90,7 @@ public class SetTagTest {
     context.put("lw_font_size_base", 42);
     TagNode tagNode = (TagNode) fixture("set-string-concat");
     tag.interpret(tagNode, interpreter);
-    assertThat(interpreter.resolveObject("lw_font_size", -1)).isEqualTo("font-size: 42px; ");
+    assertThat(interpreter.resolveObject("lw_font_size", -1 ,-1)).isEqualTo("font-size: 42px; ");
   }
 
   @Test
@@ -98,7 +98,7 @@ public class SetTagTest {
     context.put("lw_font_size_base", 10);
     TagNode tagNode = (TagNode) fixture("set-expr-concat");
     tag.interpret(tagNode, interpreter);
-    assertThat(interpreter.resolveObject("lw_secondary_font_size", -1)).isEqualTo("font-size: 8px; ");
+    assertThat(interpreter.resolveObject("lw_secondary_font_size", -1, -1)).isEqualTo("font-size: 8px; ");
   }
 
   @Test
@@ -106,7 +106,7 @@ public class SetTagTest {
     context.put("max_size", "470");
     TagNode tagNode = (TagNode) fixture("set-filter-expr");
     tag.interpret(tagNode, interpreter);
-    assertThat(interpreter.resolveObject("ie_max_size", -1)).isEqualTo(440L);
+    assertThat(interpreter.resolveObject("ie_max_size", -1 ,-1)).isEqualTo(440L);
   }
 
   @Test
@@ -115,7 +115,7 @@ public class SetTagTest {
     TagNode tagNode = (TagNode) fixture("set-array");
     tag.interpret(tagNode, interpreter);
 
-    List<Object> result = (List<Object>) interpreter.resolveObject("the_list", -1);
+    List<Object> result = (List<Object>) interpreter.resolveObject("the_list", -1,-1);
     assertThat(result).containsExactly(1L, 2L, 3L, 7L);
   }
 
@@ -126,7 +126,7 @@ public class SetTagTest {
     TagNode tagNode = (TagNode) fixture("set-dictionary");
     tag.interpret(tagNode, interpreter);
 
-    Map<String, Object> result = (Map<String, Object>) interpreter.resolveObject("the_dictionary", -1);
+    Map<String, Object> result = (Map<String, Object>) interpreter.resolveObject("the_dictionary", -1,-1);
     assertThat(result).contains(entry("seven", 7L));
   }
 

--- a/src/test/java/com/hubspot/jinjava/tree/parse/TagTokenTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/parse/TagTokenTest.java
@@ -11,20 +11,20 @@ public class TagTokenTest {
 
   @Test
   public void testParseTag() {
-    TagToken t = new TagToken("{% foo %}", 1);
+    TagToken t = new TagToken("{% foo %}", 1, 2);
     assertThat(t.getTagName()).isEqualTo("foo");
   }
 
   @Test
   public void testParseTagWithHelpers() {
-    TagToken t = new TagToken("{% foo bar %}", 1);
+    TagToken t = new TagToken("{% foo bar %}", 1,2);
     assertThat(t.getTagName()).isEqualTo("foo");
     assertThat(t.getHelpers().trim()).isEqualTo("bar");
   }
 
   @Test
   public void tagNameIsAllJavaIdentifiers() {
-    TagToken t = new TagToken("{%rich_text\"top_left\"%}", 1);
+    TagToken t = new TagToken("{%rich_text\"top_left\"%}", 1,2);
     assertThat(t.getTagName()).isEqualTo("rich_text");
     assertThat(t.getHelpers()).isEqualTo("\"top_left\"");
   }
@@ -32,7 +32,7 @@ public class TagTokenTest {
   @Test
   public void itThrowsParseErrorWhenMalformed() {
     try {
-      new TagToken("{% ", 1);
+      new TagToken("{% ", 1,2);
       failBecauseExceptionWasNotThrown(TemplateSyntaxException.class);
     } catch (TemplateSyntaxException e) {
       assertThat(e).hasMessageContaining("Malformed");

--- a/src/test/java/com/hubspot/jinjava/tree/parse/TagTokenTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/parse/TagTokenTest.java
@@ -17,14 +17,14 @@ public class TagTokenTest {
 
   @Test
   public void testParseTagWithHelpers() {
-    TagToken t = new TagToken("{% foo bar %}", 1,2);
+    TagToken t = new TagToken("{% foo bar %}", 1, 2);
     assertThat(t.getTagName()).isEqualTo("foo");
     assertThat(t.getHelpers().trim()).isEqualTo("bar");
   }
 
   @Test
   public void tagNameIsAllJavaIdentifiers() {
-    TagToken t = new TagToken("{%rich_text\"top_left\"%}", 1,2);
+    TagToken t = new TagToken("{%rich_text\"top_left\"%}", 1, 2);
     assertThat(t.getTagName()).isEqualTo("rich_text");
     assertThat(t.getHelpers()).isEqualTo("\"top_left\"");
   }
@@ -32,7 +32,7 @@ public class TagTokenTest {
   @Test
   public void itThrowsParseErrorWhenMalformed() {
     try {
-      new TagToken("{% ", 1,2);
+      new TagToken("{% ", 1, 2);
       failBecauseExceptionWasNotThrown(TemplateSyntaxException.class);
     } catch (TemplateSyntaxException e) {
       assertThat(e).hasMessageContaining("Malformed");

--- a/src/test/java/com/hubspot/jinjava/tree/parse/TokenScannerTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/parse/TokenScannerTest.java
@@ -14,6 +14,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
 import com.hubspot.jinjava.JinjavaConfig;
@@ -183,6 +184,12 @@ public class TokenScannerTest {
   }
 
   @Test
+  public void itGetsPositionsOfTokens() {
+    List<Token> tokens = tokens("positions");
+    assertThat(tokens.stream().map(Token::getStartPosition).collect(Collectors.toList())).isEqualTo(ImmutableList.of(1, 0, 4, 0, 6, 0, 6, 0, 4, 0, 4, 13, 25, 0, 1));
+  }
+
+  @Test
   public void itProperlyTokenizesCommentBlocksContainingTags() {
     List<Token> tokens = tokens("comment-with-tags");
     assertThat(tokens).hasSize(5);
@@ -272,11 +279,10 @@ public class TokenScannerTest {
 
   private TokenScanner fixture(String fixture) {
     try {
-      TokenScanner t = new TokenScanner(
+      return new TokenScanner(
           Resources.toString(Resources.getResource(String.format("parse/tokenizer/%s.jinja", fixture)),
               StandardCharsets.UTF_8),
           config);
-      return t;
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/src/test/resources/parse/tokenizer/positions.jinja
+++ b/src/test/resources/parse/tokenizer/positions.jinja
@@ -1,0 +1,7 @@
+{% if foo %}
+   {% if bar %}
+     {{ 1 }}
+     {# this is a comment #}
+   {% endif %}
+   {% raw %}hello world.{% endraw %}
+{% endif


### PR DESCRIPTION
Keeps track of line positions of tokens were possible so we can provide more detailed error messages.