### PR TITLE
add scope depth to errors

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -67,7 +67,7 @@ public class JinjavaInterpreter {
   private final Random random;
 
   private int lineNumber = -1;
-  private short scopeLevel = 1;
+  private int scopeLevel = 1;
   private final List<TemplateError> errors = new LinkedList<>();
 
   public JinjavaInterpreter(Jinjava application, Context context, JinjavaConfig renderConfig) {
@@ -88,7 +88,7 @@ public class JinjavaInterpreter {
 
   public JinjavaInterpreter(JinjavaInterpreter orig) {
     this(orig.application, new Context(orig.context), orig.config);
-    scopeLevel++;
+    scopeLevel = orig.getScopeLevel() + 1;
   }
 
   /**
@@ -429,6 +429,10 @@ public class JinjavaInterpreter {
 
   public void addError(TemplateError templateError) {
     this.errors.add(templateError.withScopeLevel(scopeLevel));
+  }
+
+  public int getScopeLevel() {
+    return scopeLevel;
   }
 
   public List<TemplateError> getErrors() {

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -67,6 +67,7 @@ public class JinjavaInterpreter {
   private final Random random;
 
   private int lineNumber = -1;
+  private short scopeLevel = 1;
   private final List<TemplateError> errors = new LinkedList<>();
 
   public JinjavaInterpreter(Jinjava application, Context context, JinjavaConfig renderConfig) {
@@ -124,11 +125,13 @@ public class JinjavaInterpreter {
 
   public InterpreterScopeClosable enterScope(Map<Context.Library, Set<String>> disabled) {
     context = new Context(context, null, disabled);
+    scopeLevel++;
     return new InterpreterScopeClosable();
   }
 
   public void leaveScope() {
     Context parent = context.getParent();
+    scopeLevel--;
     if (parent != null) {
       parent.addDependencies(context.getDependencies());
       context = parent;
@@ -424,7 +427,7 @@ public class JinjavaInterpreter {
   }
 
   public void addError(TemplateError templateError) {
-    this.errors.add(templateError);
+    this.errors.add(templateError.withScopeLevel(scopeLevel));
   }
 
   public List<TemplateError> getErrors() {

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -88,6 +88,7 @@ public class JinjavaInterpreter {
 
   public JinjavaInterpreter(JinjavaInterpreter orig) {
     this(orig.application, new Context(orig.context), orig.config);
+    scopeLevel++;
   }
 
   /**

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -67,7 +67,7 @@ public class JinjavaInterpreter {
   private final Random random;
 
   private int lineNumber = -1;
-  private int scopeLevel = 1;
+  private int scopeDepth = 1;
   private final List<TemplateError> errors = new LinkedList<>();
 
   public JinjavaInterpreter(Jinjava application, Context context, JinjavaConfig renderConfig) {
@@ -88,7 +88,7 @@ public class JinjavaInterpreter {
 
   public JinjavaInterpreter(JinjavaInterpreter orig) {
     this(orig.application, new Context(orig.context), orig.config);
-    scopeLevel = orig.getScopeLevel() + 1;
+    scopeDepth = orig.getScopeDepth() + 1;
   }
 
   /**
@@ -126,13 +126,13 @@ public class JinjavaInterpreter {
 
   public InterpreterScopeClosable enterScope(Map<Context.Library, Set<String>> disabled) {
     context = new Context(context, null, disabled);
-    scopeLevel++;
+    scopeDepth++;
     return new InterpreterScopeClosable();
   }
 
   public void leaveScope() {
     Context parent = context.getParent();
-    scopeLevel--;
+    scopeDepth--;
     if (parent != null) {
       parent.addDependencies(context.getDependencies());
       context = parent;
@@ -428,11 +428,11 @@ public class JinjavaInterpreter {
   }
 
   public void addError(TemplateError templateError) {
-    this.errors.add(templateError.withScopeLevel(scopeLevel));
+    this.errors.add(templateError.withScopeDepth(scopeDepth));
   }
 
-  public int getScopeLevel() {
-    return scopeLevel;
+  public int getScopeDepth() {
+    return scopeDepth;
   }
 
   public List<TemplateError> getErrors() {

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -283,7 +283,7 @@ public class TemplateError {
   }
 
   public TemplateError serializable() {
-    return new TemplateError(severity, reason, item, message, fieldName, lineno, startPosition, null, category, categoryErrors);
+    return new TemplateError(severity, reason, item, message, fieldName, lineno, startPosition, category, categoryErrors, scopeLevel, null);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -46,12 +46,12 @@ public class TemplateError {
   private final TemplateErrorCategory category;
   private final Map<String, String> categoryErrors;
 
-  private int scopeLevel = 1;
+  private int scopeDepth = 1;
 
   private final Exception exception;
 
-  public TemplateError withScopeLevel(int scopeLevel) {
-    return new TemplateError(getSeverity(), getReason(), getItem(), getMessage(), getFieldName(), getLineno(), getStartPosition(), getException(), getCategory(), getCategoryErrors(), scopeLevel);
+  public TemplateError withScopeDepth(int scopeDepth) {
+    return new TemplateError(getSeverity(), getReason(), getItem(), getMessage(), getFieldName(), getLineno(), getStartPosition(), getException(), getCategory(), getCategoryErrors(), scopeDepth);
   }
 
   public static TemplateError fromSyntaxError(InterpretException ex) {
@@ -161,7 +161,7 @@ public class TemplateError {
                        Exception exception,
                        TemplateErrorCategory category,
                        Map<String, String> categoryErrors,
-                       int scopeLevel) {
+                       int scopeDepth) {
     this.severity = severity;
     this.reason = reason;
     this.item = item;
@@ -172,7 +172,7 @@ public class TemplateError {
     this.exception = exception;
     this.category = category;
     this.categoryErrors = categoryErrors;
-    this.scopeLevel = scopeLevel;
+    this.scopeDepth = scopeDepth;
   }
 
 
@@ -278,12 +278,12 @@ public class TemplateError {
     return categoryErrors;
   }
 
-  public int getScopeLevel() {
-    return scopeLevel;
+  public int getScopeDepth() {
+    return scopeDepth;
   }
 
   public TemplateError serializable() {
-    return new TemplateError(severity, reason, item, message, fieldName, lineno, startPosition, null, category, categoryErrors, scopeLevel);
+    return new TemplateError(severity, reason, item, message, fieldName, lineno, startPosition, null, category, categoryErrors, scopeDepth);
   }
 
   @Override
@@ -296,7 +296,7 @@ public class TemplateError {
         ", fieldName='" + fieldName + '\'' +
         ", lineno=" + lineno +
         ", startPosition=" + startPosition +
-        ", scopeLevel=" + scopeLevel +
+        ", scopeDepth=" + scopeDepth +
         ", category=" + category +
         ", categoryErrors=" + categoryErrors +
         '}';

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -46,7 +46,13 @@ public class TemplateError {
   private final TemplateErrorCategory category;
   private final Map<String, String> categoryErrors;
 
+  private short scopeLevel = 1;
+
   private final Exception exception;
+
+  public TemplateError withScopeLevel(short scopeLevel) {
+    return new TemplateError(getSeverity(), getReason(), getItem(), getMessage(), getFieldName(), getLineno(), getStartPosition(), getCategory(), getCategoryErrors(), scopeLevel, getException());
+  }
 
   public static TemplateError fromSyntaxError(InterpretException ex) {
     return new TemplateError(ErrorType.FATAL, ErrorReason.SYNTAX_ERROR, ErrorItem.OTHER, ExceptionUtils.getMessage(ex), null, ex.getLineNumber(), ex.getStartPosition(), ex);
@@ -143,6 +149,32 @@ public class TemplateError {
     this.category = BasicTemplateErrorCategory.UNKNOWN;
     this.categoryErrors = null;
   }
+
+
+  public TemplateError(ErrorType severity,
+                       ErrorReason reason,
+                       ErrorItem item,
+                       String message,
+                       String fieldName,
+                       int lineno,
+                       int startPosition,
+                       TemplateErrorCategory category,
+                       Map<String, String> categoryErrors,
+                       short scopeLevel,
+                       Exception exception) {
+    this.severity = severity;
+    this.reason = reason;
+    this.item = item;
+    this.message = message;
+    this.fieldName = fieldName;
+    this.lineno = lineno;
+    this.startPosition = startPosition;
+    this.exception = exception;
+    this.category = category;
+    this.categoryErrors = categoryErrors;
+    this.scopeLevel = scopeLevel;
+  }
+
 
   public TemplateError(ErrorType severity,
                        ErrorReason reason,
@@ -246,6 +278,10 @@ public class TemplateError {
     return categoryErrors;
   }
 
+  public short getScopeLevel() {
+    return scopeLevel;
+  }
+
   public TemplateError serializable() {
     return new TemplateError(severity, reason, item, message, fieldName, lineno, startPosition, null, category, categoryErrors);
   }
@@ -260,6 +296,7 @@ public class TemplateError {
         ", fieldName='" + fieldName + '\'' +
         ", lineno=" + lineno +
         ", startPosition=" + startPosition +
+        ", scopeLevel=" + scopeLevel +
         ", category=" + category +
         ", categoryErrors=" + categoryErrors +
         '}';

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -51,7 +51,7 @@ public class TemplateError {
   private final Exception exception;
 
   public TemplateError withScopeLevel(int scopeLevel) {
-    return new TemplateError(getSeverity(), getReason(), getItem(), getMessage(), getFieldName(), getLineno(), getStartPosition(), getCategory(), getCategoryErrors(), scopeLevel, getException());
+    return new TemplateError(getSeverity(), getReason(), getItem(), getMessage(), getFieldName(), getLineno(), getStartPosition(), getException(), getCategory(), getCategoryErrors(), scopeLevel);
   }
 
   public static TemplateError fromSyntaxError(InterpretException ex) {
@@ -158,10 +158,10 @@ public class TemplateError {
                        String fieldName,
                        int lineno,
                        int startPosition,
+                       Exception exception,
                        TemplateErrorCategory category,
                        Map<String, String> categoryErrors,
-                       int scopeLevel,
-                       Exception exception) {
+                       int scopeLevel) {
     this.severity = severity;
     this.reason = reason;
     this.item = item;
@@ -283,7 +283,7 @@ public class TemplateError {
   }
 
   public TemplateError serializable() {
-    return new TemplateError(severity, reason, item, message, fieldName, lineno, startPosition, category, categoryErrors, scopeLevel, null);
+    return new TemplateError(severity, reason, item, message, fieldName, lineno, startPosition, null, category, categoryErrors, scopeLevel);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -46,11 +46,11 @@ public class TemplateError {
   private final TemplateErrorCategory category;
   private final Map<String, String> categoryErrors;
 
-  private short scopeLevel = 1;
+  private int scopeLevel = 1;
 
   private final Exception exception;
 
-  public TemplateError withScopeLevel(short scopeLevel) {
+  public TemplateError withScopeLevel(int scopeLevel) {
     return new TemplateError(getSeverity(), getReason(), getItem(), getMessage(), getFieldName(), getLineno(), getStartPosition(), getCategory(), getCategoryErrors(), scopeLevel, getException());
   }
 
@@ -160,7 +160,7 @@ public class TemplateError {
                        int startPosition,
                        TemplateErrorCategory category,
                        Map<String, String> categoryErrors,
-                       short scopeLevel,
+                       int scopeLevel,
                        Exception exception) {
     this.severity = severity;
     this.reason = reason;
@@ -278,7 +278,7 @@ public class TemplateError {
     return categoryErrors;
   }
 
-  public short getScopeLevel() {
+  public int getScopeLevel() {
     return scopeLevel;
   }
 


### PR DESCRIPTION
Currently errors for all scopes are returned from the interpreter, but the line numbers from these can be confusing when some of the errors are from sub-interpreters or scopes. This at least puts a scope de;pth on the error so if you only care about the top level errors, you can filter by that.