### PR TITLE
support expression tests for select filter that use arguments

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTest.java
@@ -30,8 +30,7 @@ public class IsEqualToExpTest implements ExpTest {
   }
 
   @Override
-  public boolean evaluate(Object var, JinjavaInterpreter interpreter,
-      Object... args) {
+  public boolean evaluate(Object var, JinjavaInterpreter interpreter, Object... args) {
     if (args.length == 0) {
       throw new InterpretException(getName() + " test requires 1 argument");
     }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SelectFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SelectFilter.java
@@ -1,7 +1,9 @@
 package com.hubspot.jinjava.lib.filter;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
@@ -23,7 +25,7 @@ import com.hubspot.jinjava.util.ObjectIterator;
             code = "{% set some_numbers = [10, 12, 13, 3, 5, 17, 22] %}\n" +
                 "{% some_numbers|select('even') %}")
     })
-public class SelectFilter implements Filter {
+public class SelectFilter implements AdvancedFilter {
 
   @Override
   public String getName() {
@@ -31,14 +33,20 @@ public class SelectFilter implements Filter {
   }
 
   @Override
-  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+  public Object filter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs) {
     List<Object> result = new ArrayList<>();
 
     if (args.length == 0) {
       throw new InterpretException(getName() + " requires an exp test to filter on", interpreter.getLineNumber());
     }
 
-    ExpTest expTest = interpreter.getContext().getExpTest(args[0]);
+    Object[] expArgs = new Object[]{};
+
+    if (args.length > 1) {
+      expArgs = Arrays.copyOfRange(args, 1, args.length);
+    }
+
+    ExpTest expTest = interpreter.getContext().getExpTest(args[0].toString());
     if (expTest == null) {
       throw new InterpretException("No exp test defined for name '" + args[0] + "'", interpreter.getLineNumber());
     }
@@ -47,7 +55,7 @@ public class SelectFilter implements Filter {
     while (loop.hasNext()) {
       Object val = loop.next();
 
-      if (expTest.evaluate(val, interpreter)) {
+      if (expTest.evaluate(val, interpreter, expArgs)) {
         result.add(val);
       }
     }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SelectFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SelectFilterTest.java
@@ -17,13 +17,18 @@ public class SelectFilterTest {
   @Before
   public void setup() {
     jinjava = new Jinjava();
-    jinjava.getGlobalContext().put("numbers", Lists.newArrayList(1, 2, 3, 4, 5));
+    jinjava.getGlobalContext().put("numbers", Lists.newArrayList(1L, 2L, 3L, 4L, 5L));
   }
 
   @Test
   public void testSelect() {
-    assertThat(jinjava.render("{{numbers|select('odd')}}", new HashMap<String, Object>())).isEqualTo("[1, 3, 5]");
-    assertThat(jinjava.render("{{numbers|select('even')}}", new HashMap<String, Object>())).isEqualTo("[2, 4]");
+    assertThat(jinjava.render("{{numbers|select('odd')}}", new HashMap<>())).isEqualTo("[1, 3, 5]");
+    assertThat(jinjava.render("{{numbers|select('even')}}", new HashMap<>())).isEqualTo("[2, 4]");
+  }
+
+  @Test
+  public void testSelectWithEqualToAttr() {
+    assertThat(jinjava.render("{{numbers|select('equalto', 3)}}", new HashMap<>())).isEqualTo("[3]");
   }
 
 }


### PR DESCRIPTION
Allows expression tests with arguments like equal_to, just like https://github.com/HubSpot/jinjava/pull/80

Fixes https://github.com/HubSpot/jinjava/issues/156