### PR TITLE
render nested code

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -44,7 +44,8 @@ public class ExpressionNode extends Node {
     String result = Objects.toString(var, "");
 
     if (interpreter.getConfig().isNestedInterpretationEnabled()) {
-      if (!StringUtils.equals(result, master.getImage()) && StringUtils.contains(result, "{{")) {
+      if (!StringUtils.equals(result, master.getImage()) &&
+          (StringUtils.contains(result, "{{") || StringUtils.contains(result, "{%"))) {
         try {
           result = interpreter.renderFlat(result);
         } catch (Exception e) {

--- a/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
@@ -61,6 +61,17 @@ public class ExpressionNodeTest {
   }
 
   @Test
+  public void itRendersNestedTags() throws Exception {
+    final JinjavaConfig config = JinjavaConfig.newBuilder().build();
+    JinjavaInterpreter jinjava =  new Jinjava(config).newInterpreter();
+    Context context = jinjava.getContext();
+    context.put("myvar", "hello {% if (true) %}nasty{% endif %}");
+
+    ExpressionNode node = fixture("simplevar");
+    assertThat(node.render(jinjava).toString()).isEqualTo("hello nasty");
+  }
+
+  @Test
   public void itAvoidsInfiniteRecursionWhenVarsContainBraceBlocks() throws Exception {
     context.put("myvar", "hello {{ place }}");
     context.put("place", "{{ place }}");


### PR DESCRIPTION
When nested interpretation is enabled, we previously checked if a string contained `{{` to see if we should interpret it. This did not catch strings that contained `{%` even though those would be interpreted too if the string also had `{{`. Now we check for both so we evaluate nested code consistently.

