### PR TITLE
Preserve groupby order

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/GroupByFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/GroupByFilter.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
@@ -49,7 +49,7 @@ public class GroupByFilter implements Filter {
     String attr = args[0];
 
     ForLoop loop = ObjectIterator.getLoop(var);
-    Multimap<String, Object> groupBuckets = ArrayListMultimap.create();
+    Multimap<String, Object> groupBuckets = LinkedListMultimap.create();
 
     while (loop.hasNext()) {
       Object val = loop.next();

--- a/src/test/java/com/hubspot/jinjava/lib/filter/GroupByFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/GroupByFilterTest.java
@@ -36,7 +36,9 @@ public class GroupByFilterTest {
                 new Person("female", "barb", "smith")
                 ))));
 
+    String test = dom.select("ul.root > li").get(0).text();
     assertThat(dom.select("ul.root > li")).hasSize(2);
+    assertThat(dom.select("ul.root > li").get(0).text()).contains("male jared");
     assertThat(dom.select("ul.root > li.male > ul > li")).hasSize(3);
     assertThat(dom.select("ul.root > li.female > ul > li")).hasSize(2);
   }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/GroupByFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/GroupByFilterTest.java
@@ -35,8 +35,7 @@ public class GroupByFilterTest {
                 new Person("male", "jim", "jones"),
                 new Person("female", "barb", "smith")
                 ))));
-
-    String test = dom.select("ul.root > li").get(0).text();
+    
     assertThat(dom.select("ul.root > li")).hasSize(2);
     assertThat(dom.select("ul.root > li").get(0).text()).contains("male jared");
     assertThat(dom.select("ul.root > li.male > ul > li")).hasSize(3);


### PR DESCRIPTION
When using the `groupby` filter, the order of groups should depend on the order of objects (as is done in most languages). For example, if you have a sorted list of dates and groupby those dates, the groups should preserve that order.