### PR TITLE
Add new EscapeJinjavaFilter

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilter.java
@@ -63,7 +63,7 @@ public class EscapeJinjavaFilter implements Filter {
 
   @Override
   public String getName() {
-    return "escapeJinjava";
+    return "escape_jinjava";
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilter.java
@@ -1,0 +1,69 @@
+
+/**********************************************************************
+ * Copyright (c) 2017 HubSpot Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **********************************************************************/
+package com.hubspot.jinjava.lib.filter;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
+import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+
+@JinjavaDoc(
+    value = "Converts the characters { and } in string s to Jinjava-safe sequences. "
+        + "Use this filter if you need to display text that might contain such characters in Jinjava. "
+        + "Marks return value as markup string.",
+    params = {
+        @JinjavaParam(value = "s", desc = "String to escape")
+    },
+    snippets = {
+        @JinjavaSnippet(
+            code = "{% set escape_string = \"{{This markup is printed as text}}\" %}\n" +
+                "{{ escape_string|escapeJinjava }}")
+    })
+
+public class EscapeJinjavaFilter implements Filter {
+
+  private static final String SLBRACE = "{";
+  private static final String BLBRACE = "&lbrace;";
+  private static final String SRBRACE = "}";
+  private static final String BRBRACE = "&rbrace;";
+
+  private static final String[] TO_REPLACE = new String[] {
+      SLBRACE, SRBRACE
+  };
+  private static final String[] REPLACE_WITH = new String[] {
+      BLBRACE, BRBRACE
+  };
+
+  public static String escapeJinjavaEntities(String input) {
+    return StringUtils.replaceEach(input, TO_REPLACE, REPLACE_WITH);
+  }
+
+  @Override
+  public Object filter(Object object, JinjavaInterpreter interpreter, String... arg) {
+    return escapeJinjavaEntities(Objects.toString(object, ""));
+  }
+
+  @Override
+  public String getName() {
+    return "escapeJinjava";
+  }
+
+}

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FilterLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FilterLibrary.java
@@ -83,6 +83,7 @@ public class FilterLibrary extends SimpleLibrary<Filter> {
         UrlEncodeFilter.class,
         XmlAttrFilter.class,
         EscapeJsonFilter.class,
+        EscapeJinjavaFilter.class,
 
         CapitalizeFilter.class,
         CenterFilter.class,

--- a/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilterTest.java
@@ -1,0 +1,28 @@
+package com.hubspot.jinjava.lib.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+
+public class EscapeJinjavaFilterTest {
+
+  JinjavaInterpreter interpreter;
+  EscapeJinjavaFilter f;
+
+  @Before
+  public void setup() {
+    interpreter = mock(JinjavaInterpreter.class);
+    f = new EscapeJinjavaFilter();
+  }
+
+  @Test
+  public void testEscape() {
+    assertThat(f.filter("", interpreter)).isEqualTo("");
+    assertThat(f.filter("{{ me & you }}", interpreter)).isEqualTo("&lbrace;&lbrace; me & you &rbrace;&rbrace;");
+  }
+
+}


### PR DESCRIPTION
@jboulter 
I had issues rendering jinjava syntax text within a jinjava interpreted page and found this function missing from our library. Figured it was worth adding. 