### PR TITLE
Don't put stack trace in the exception message

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/FatalTemplateErrorsException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/FatalTemplateErrorsException.java
@@ -1,6 +1,6 @@
 package com.hubspot.jinjava.interpret;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
+import java.util.Collection;
 
 /**
  * Container exception thrown when fatal errors are encountered while rendering a template.
@@ -13,24 +13,18 @@ public class FatalTemplateErrorsException extends InterpretException {
   private final String template;
   private final Iterable<TemplateError> errors;
 
-  public FatalTemplateErrorsException(String template, Iterable<TemplateError> errors) {
+  public FatalTemplateErrorsException(String template, Collection<TemplateError> errors) {
     super(generateMessage(errors));
     this.template = template;
     this.errors = errors;
   }
 
-  private static String generateMessage(Iterable<TemplateError> errors) {
-    StringBuilder msg = new StringBuilder();
-
-    for (TemplateError error : errors) {
-      msg.append(error.toString()).append('\n');
-
-      if (error.getException() != null) {
-        msg.append(ExceptionUtils.getStackTrace(error.getException())).append('\n');
-      }
+  private static String generateMessage(Collection<TemplateError> errors) {
+    if (errors.isEmpty()) {
+      throw new IllegalArgumentException("FatalTemplateErrorsException should have at least one error");
     }
 
-    return msg.toString();
+    return errors.iterator().next().getMessage();
   }
 
   public String getTemplate() {


### PR DESCRIPTION
Exception stacktrace for each error could be easily extracted by doing
`((FatalTemplateErrorsException) e).getErrors().get(n).getException()`,
if needed