### PR TITLE
Negated expressions

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
@@ -22,11 +22,11 @@ public class CollectionMembershipOperator extends SimpleOperator {
     }
 
     if (CharSequence.class.isAssignableFrom(o2.getClass())) {
-      return Boolean.valueOf(StringUtils.contains((CharSequence) o2, Objects.toString(o1, "")));
+      return StringUtils.contains((CharSequence) o2, Objects.toString(o1, ""));
     }
 
     if (Collection.class.isAssignableFrom(o2.getClass())) {
-      return Boolean.valueOf(((Collection<?>) o2).contains(o1));
+      return ((Collection<?>) o2).contains(o1);
     }
 
     return Boolean.FALSE;

--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -181,7 +181,7 @@ public class ExtendedParser extends Parser {
     List<AstNode> l = Collections.emptyList();
     AstNode v = expr(false);
     if (v != null) {
-      l = new ArrayList<AstNode>();
+      l = new ArrayList<>();
       l.add(v);
       while (getToken().getSymbol() == COMMA) {
         consumeToken();
@@ -363,8 +363,23 @@ public class ExtendedParser extends Parser {
 
             AstProperty filterProperty = createAstDot(identifier(FILTER_PREFIX + filterName), "filter", true);
             v = createAstMethod(filterProperty, new AstParameters(filterParams)); // function("filter:" + filterName, new AstParameters(filterParams));
-
           } while ("|".equals(getToken().getImage()));
+        } else if ("is".equals(getToken().getImage()) &&
+            "not".equals(lookahead(0).getImage()) &&
+            lookahead(1).getSymbol() == IDENTIFIER) {
+          consumeToken(); // 'is'
+          consumeToken(); // 'not'
+          String exptestName = consumeToken().getImage();
+          List<AstNode> exptestParams = Lists.newArrayList(v, interpreter());
+
+          // optional exptest arg
+          AstNode arg = expr(false);
+          if (arg != null) {
+            exptestParams.add(arg);
+          }
+
+          AstProperty exptestProperty = createAstDot(identifier(EXPTEST_PREFIX + exptestName), "evaluate", true);
+          v = createAstMethod(exptestProperty, new AstParameters(exptestParams));
         } else if ("is".equals(getToken().getImage()) && lookahead(0).getSymbol() == IDENTIFIER) {
           consumeToken(); // 'is'
           String exptestName = consumeToken().getImage();

--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -378,7 +378,7 @@ public class ExtendedParser extends Parser {
             exptestParams.add(arg);
           }
 
-          AstProperty exptestProperty = createAstDot(identifier(EXPTEST_PREFIX + exptestName), "evaluate", true);
+          AstProperty exptestProperty = createAstDot(identifier(EXPTEST_PREFIX + exptestName), "evaluateNegated", true);
           v = createAstMethod(exptestProperty, new AstParameters(exptestParams));
         } else if ("is".equals(getToken().getImage()) && lookahead(0).getSymbol() == IDENTIFIER) {
           consumeToken(); // 'is'

--- a/src/main/java/com/hubspot/jinjava/el/ext/OrOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/OrOperator.java
@@ -11,7 +11,7 @@ public class OrOperator implements Operator {
   @Override
   public Object eval(Bindings bindings, ELContext context, AstNode left, AstNode right) {
     Object leftResult = left.eval(bindings, context);
-    if (bindings.convert(leftResult, Boolean.class).booleanValue()) {
+    if (bindings.convert(leftResult, Boolean.class)) {
       return leftResult;
     }
 

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/ExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/ExpTest.java
@@ -18,4 +18,8 @@ public interface ExpTest extends Importable {
 
   boolean evaluate(Object var, JinjavaInterpreter interpreter, Object... args);
 
+  default boolean evaluateNegated(Object var, JinjavaInterpreter interpreter, Object... args) {
+    return !evaluate(var, interpreter, args);
+  }
+
 }

--- a/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
@@ -24,8 +24,8 @@ import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 @SuppressWarnings("unchecked")
 public class ExtendedSyntaxBuilderTest {
 
-  Context context;
-  JinjavaInterpreter interpreter;
+  private Context context;
+  private JinjavaInterpreter interpreter;
 
   @Before
   public void setup() {
@@ -109,6 +109,19 @@ public class ExtendedSyntaxBuilderTest {
     assertThat(val("12 in [1, 2, 3]")).isEqualTo(false);
     assertThat(val("12 in [1, 12, 3]")).isEqualTo(true);
   }
+
+  // TODO: support negated collection membership. See CollectionMembershipOperator
+//  @Test
+//  public void stringNotInStringOperator() {
+//    assertThat(val("'foo' not in 'foobar'")).isEqualTo(false);
+//    assertThat(val("'gg' not in 'foobar'")).isEqualTo(true);
+//  }
+
+//  @Test
+//  public void objNotInCollectionOperator() {
+//    assertThat(val("12 not in [1, 2, 3]")).isEqualTo(true);
+//    assertThat(val("12 not in [1, 12, 3]")).isEqualTo(false);
+//  }
 
   @Test
   public void conditionalExprWithNoElse() {

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/NegatedExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/NegatedExpTestTest.java
@@ -11,7 +11,7 @@ import com.hubspot.jinjava.Jinjava;
 
 public class NegatedExpTestTest {
 
-  private static final String TEMPLATE = "{%% if %s is not %s %%}pass{%% else %%}fail{%% endif %%}";
+  private static final String TEMPLATE = "{%% if %s is %s %s %%}pass{%% else %%}fail{%% endif %%}";
   private static final String CONTAINING_TEMPLATE = "{%% if %s is not containing %s %%}pass{%% else %%}fail{%% endif %%}";
 
   private Jinjava jinjava;
@@ -23,7 +23,8 @@ public class NegatedExpTestTest {
 
   @Test
   public void itNegatesDefined() {
-    assertThat(jinjava.render(String.format(TEMPLATE, "blah", "defined"), new HashMap<>())).isEqualTo("pass");
+    assertThat(jinjava.render(String.format(TEMPLATE, "blah", "", "defined"), new HashMap<>())).isEqualTo("fail");
+    assertThat(jinjava.render(String.format(TEMPLATE, "blah", "not", "defined"), new HashMap<>())).isEqualTo("pass");
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/NegatedExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/NegatedExpTestTest.java
@@ -1,0 +1,27 @@
+package com.hubspot.jinjava.lib.exptest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.hubspot.jinjava.Jinjava;
+
+public class NegatedExpTestTest {
+
+  private static final String TEMPLATE = "{%% if %s is not %s %%}pass{%% else %%}fail{%% endif %%}";
+
+  private Jinjava jinjava;
+
+  @Before
+  public void setup() {
+    jinjava = new Jinjava();
+  }
+
+  @Test
+  public void itNegatesDefined() {
+    assertThat(jinjava.render(String.format(TEMPLATE, "blah", "defined"), new HashMap<>())).isEqualTo("pass");
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/NegatedExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/NegatedExpTestTest.java
@@ -12,6 +12,7 @@ import com.hubspot.jinjava.Jinjava;
 public class NegatedExpTestTest {
 
   private static final String TEMPLATE = "{%% if %s is not %s %%}pass{%% else %%}fail{%% endif %%}";
+  private static final String CONTAINING_TEMPLATE = "{%% if %s is not containing %s %%}pass{%% else %%}fail{%% endif %%}";
 
   private Jinjava jinjava;
 
@@ -24,4 +25,11 @@ public class NegatedExpTestTest {
   public void itNegatesDefined() {
     assertThat(jinjava.render(String.format(TEMPLATE, "blah", "defined"), new HashMap<>())).isEqualTo("pass");
   }
+
+  @Test
+  public void itNegatesContaining() {
+    assertThat(jinjava.render(String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "4"), new HashMap<>())).isEqualTo("pass");
+  }
 }
+
+

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
@@ -31,7 +31,7 @@ public class ForTagTest {
 
   ForTag tag;
 
-  Context context;
+  private Context context;
   JinjavaInterpreter interpreter;
   Jinjava jinjava;
 
@@ -169,7 +169,7 @@ public class ForTagTest {
   }
 
   @Test
-  public void testFoorLoopVariablesWithSpaces() {
+  public void testForLoopVariablesWithSpaces() {
 
       Map<String, Object> context = Maps.newHashMap();
       context.put("a", 2);

--- a/src/test/java/com/hubspot/jinjava/lib/tag/IfTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/IfTagTest.java
@@ -28,7 +28,7 @@ public class IfTagTest {
   IfTag tag;
 
   Jinjava jinjava;
-  Context context;
+  private Context context;
 
   @Before
   public void setup() {


### PR DESCRIPTION
Adds support for "not" as a prefix for expression tests such as

`{% if variable is not defined %}`

Fixes https://github.com/HubSpot/jinjava/issues/180