### PR TITLE
Correctly report column positions of syntax errors

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -72,21 +72,21 @@ public class ExpressionResolver {
       return result;
 
     } catch (PropertyNotFoundException e) {
-      interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.UNKNOWN, ErrorItem.PROPERTY, e.getMessage(), "", interpreter.getLineNumber(), -1, e,
+      interpreter.addError(new TemplateError(ErrorType.WARNING, ErrorReason.UNKNOWN, ErrorItem.PROPERTY, e.getMessage(), "", interpreter.getLineNumber(), interpreter.getPosition(), e,
           BasicTemplateErrorCategory.UNKNOWN, ImmutableMap.of("exception", e.getMessage())));
     } catch (TreeBuilderException e) {
       interpreter.addError(TemplateError.fromException(new TemplateSyntaxException(expression,
-          "Error parsing '" + expression + "': " + StringUtils.substringAfter(e.getMessage(), "': "), interpreter.getLineNumber(), e.getPosition(), e)));
+          "Error parsing '" + expression + "': " + StringUtils.substringAfter(e.getMessage(), "': "), interpreter.getLineNumber(), interpreter.getPosition() + e.getPosition(), e)));
     } catch (ELException e) {
       interpreter.addError(TemplateError.fromException(new TemplateSyntaxException(expression, e.getMessage(), interpreter.getLineNumber(), e)));
     } catch (DisabledException e) {
-      interpreter.addError(new TemplateError(ErrorType.FATAL, ErrorReason.DISABLED, ErrorItem.FUNCTION, e.getMessage(), expression, interpreter.getLineNumber(), -1, e));
+      interpreter.addError(new TemplateError(ErrorType.FATAL, ErrorReason.DISABLED, ErrorItem.FUNCTION, e.getMessage(), expression, interpreter.getLineNumber(), interpreter.getPosition(), e));
     } catch (UnknownTokenException e) {
       // Re-throw the exception because you only get this when the config failOnUnknownTokens is enabled.
       throw e;
     } catch (Exception e) {
       interpreter.addError(TemplateError.fromException(new InterpretException(
-          String.format("Error resolving expression [%s]: " + getRootCauseMessage(e), expression), e, interpreter.getLineNumber())));
+          String.format("Error resolving expression [%s]: " + getRootCauseMessage(e), expression), e, interpreter.getLineNumber(), interpreter.getPosition())));
     }
 
     return "";

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -67,6 +67,7 @@ public class JinjavaInterpreter {
   private final Random random;
 
   private int lineNumber = -1;
+  private int position = 0;
   private int scopeDepth = 1;
   private final List<TemplateError> errors = new LinkedList<>();
 
@@ -217,6 +218,7 @@ public class JinjavaInterpreter {
 
     for (Node node : root.getChildren()) {
       lineNumber = node.getLineNumber();
+      position = node.getStartPosition();
       String renderStr = node.getMaster().getImage();
       if (context.doesRenderStackContain(renderStr)) {
         // This is a circular rendering. Stop rendering it here.
@@ -393,6 +395,7 @@ public class JinjavaInterpreter {
    */
   public Object resolveELExpression(String expression, int lineNumber) {
     this.lineNumber = lineNumber;
+    this.position = 0;
 
     return expressionResolver.resolveExpression(expression);
   }
@@ -425,6 +428,10 @@ public class JinjavaInterpreter {
 
   public int getLineNumber() {
     return lineNumber;
+  }
+
+  public int getPosition() {
+    return position;
   }
 
   public void addError(TemplateError templateError) {

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -395,8 +395,6 @@ public class JinjavaInterpreter {
    */
   public Object resolveELExpression(String expression, int lineNumber) {
     this.lineNumber = lineNumber;
-    this.position = 0;
-
     return expressionResolver.resolveExpression(expression);
   }
 

--- a/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
@@ -24,8 +24,8 @@ import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 @SuppressWarnings("unchecked")
 public class ExtendedSyntaxBuilderTest {
 
-  Context context;
-  JinjavaInterpreter interpreter;
+  private Context context;
+  private JinjavaInterpreter interpreter;
 
   @Before
   public void setup() {
@@ -164,7 +164,7 @@ public class ExtendedSyntaxBuilderTest {
   }
 
   @Test
-  public void itParsesDictWithVariableRefs() throws Exception {
+  public void itParsesDictWithVariableRefs() {
     List<?> theList = Lists.newArrayList(1L, 2L, 3L);
     context.put("the_list", theList);
     context.put("i_am_seven", 7L);
@@ -181,7 +181,7 @@ public class ExtendedSyntaxBuilderTest {
   }
 
   @Test
-  public void itReturnsLeftResultForOrExpr() throws Exception {
+  public void itReturnsLeftResultForOrExpr() {
     context.put("left", "foo");
     context.put("right", "bar");
 
@@ -189,7 +189,7 @@ public class ExtendedSyntaxBuilderTest {
   }
 
   @Test
-  public void itReturnsRightResultForOrExpr() throws Exception {
+  public void itReturnsRightResultForOrExpr() {
     context.put("right", "bar");
 
     assertThat(val("left or right")).isEqualTo("bar");
@@ -205,7 +205,7 @@ public class ExtendedSyntaxBuilderTest {
   }
 
   @Test
-  public void testParseExp() throws Exception {
+  public void testParseExp() {
     context.put("foo", "fff");
     context.put("a", "aaa");
     context.put("b", "bbb");
@@ -214,7 +214,7 @@ public class ExtendedSyntaxBuilderTest {
   }
 
   @Test
-  public void listRangeSyntax() throws Exception {
+  public void listRangeSyntax() {
     List<?> theList = Lists.newArrayList(1, 2, 3, 4, 5);
     context.put("mylist", theList);
     assertThat(val("mylist[0:3]")).isEqualTo(Lists.newArrayList(1, 2, 3));
@@ -223,7 +223,7 @@ public class ExtendedSyntaxBuilderTest {
   }
 
   @Test
-  public void invalidNestedAssignmentExpr() throws Exception {
+  public void invalidNestedAssignmentExpr() {
     assertThat(val("content.template_path = 'Custom/Email/Responsive/testing.html'")).isEqualTo("");
     assertThat(interpreter.getErrors()).isNotEmpty();
     assertThat(interpreter.getErrors().get(0).getReason()).isEqualTo(ErrorReason.SYNTAX_ERROR);
@@ -231,7 +231,7 @@ public class ExtendedSyntaxBuilderTest {
   }
 
   @Test
-  public void invalidIdentifierAssignmentExpr() throws Exception {
+  public void invalidIdentifierAssignmentExpr() {
     assertThat(val("content = 'Custom/Email/Responsive/testing.html'")).isEqualTo("");
     assertThat(interpreter.getErrors()).isNotEmpty();
     assertThat(interpreter.getErrors().get(0).getReason()).isEqualTo(ErrorReason.SYNTAX_ERROR);
@@ -239,10 +239,22 @@ public class ExtendedSyntaxBuilderTest {
   }
 
   @Test
-  public void invalidPipeOperatorExpr() throws Exception {
+  public void invalidPipeOperatorExpr() {
     assertThat(val("topics|1")).isEqualTo("");
     assertThat(interpreter.getErrors()).isNotEmpty();
     assertThat(interpreter.getErrors().get(0).getReason()).isEqualTo(ErrorReason.SYNTAX_ERROR);
+  }
+
+  @Test
+  public void itReturnsCorrectSyntaxErrorPositions() {
+    assertThat(interpreter.render("hi {{ missing thing }}{{ missing thing }}\nI am {{ blah blabbity }} too")).isEqualTo("hi \nI am  too");
+    assertThat(interpreter.getErrors().size()).isEqualTo(3);
+    assertThat(interpreter.getErrors().get(0).getLineno()).isEqualTo(1);
+    assertThat(interpreter.getErrors().get(0).getStartPosition()).isEqualTo(14);
+    assertThat(interpreter.getErrors().get(1).getLineno()).isEqualTo(1);
+    assertThat(interpreter.getErrors().get(1).getStartPosition()).isEqualTo(33);
+    assertThat(interpreter.getErrors().get(2).getLineno()).isEqualTo(2);
+    assertThat(interpreter.getErrors().get(2).getStartPosition()).isEqualTo(13);
   }
 
   private Object val(String expr) {


### PR DESCRIPTION
Follows up on https://github.com/HubSpot/jinjava/pull/152. 

The syntax exceptions report only the position of the error within the expression, not within the entire rendered content. This adds the interpreter column position and the exception position together to report accurate column positions.