### PR TITLE
Preserve case of unknown tokens for error reporting

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/UnknownTagException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/UnknownTagException.java
@@ -6,24 +6,32 @@ public class UnknownTagException extends TemplateSyntaxException {
   private static final long serialVersionUID = 1L;
 
   private final String tag;
-  private final String defintion;
+  private final String definition;
 
   public UnknownTagException(String tag, String definition, int lineNumber, int startPosition) {
     super(definition, "Unknown tag: " + tag, lineNumber, startPosition);
     this.tag = tag;
-    this.defintion = definition;
+    this.definition = definition;
   }
 
   public UnknownTagException(TagToken tagToken) {
-    this(tagToken.getTagName(), tagToken.getImage(), tagToken.getLineNumber(), tagToken.getStartPosition());
+    this(tagToken.getRawTagName(), tagToken.getImage(), tagToken.getLineNumber(), tagToken.getStartPosition());
   }
 
   public String getTag() {
     return tag;
   }
 
+  /**
+   * @deprecated use correct spelling
+   */
+  @Deprecated
   public String getDefintion() {
-    return defintion;
+    return definition;
+  }
+
+  public String getDefinition() {
+    return definition;
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -121,8 +121,7 @@ public class TreeParser {
     final Node lastSibling = getLastSibling();
 
     // if last sibling was a tag and has rightTrimAfterEnd, strip whitespace
-    if (lastSibling != null
-        && lastSibling instanceof TagNode
+    if (lastSibling instanceof TagNode
         && lastSibling.getMaster().isRightTrimAfterEnd()) {
       textToken.setLeftTrim(true);
     }
@@ -167,7 +166,7 @@ public class TreeParser {
       // if a tag has left trim, mark the last sibling to trim right whitespace
       if (tagToken.isLeftTrim()) {
         final Node lastSibling = getLastSibling();
-        if (lastSibling != null && lastSibling instanceof TextNode) {
+        if (lastSibling instanceof TextNode) {
           lastSibling.getMaster().setRightTrim(true);
         }
       }

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TagToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TagToken.java
@@ -25,6 +25,7 @@ public class TagToken extends Token {
   private static final long serialVersionUID = -4927751270481832992L;
 
   private String tagName;
+  private String rawTagName;
   private String helpers;
 
   public TagToken(String image, int lineNumber, int startPosition) {
@@ -69,12 +70,17 @@ public class TagToken extends Token {
     }
 
     if (pos < content.length()) {
-      tagName = content.substring(nameStart, pos).toLowerCase();
+      rawTagName = content.substring(nameStart, pos);
       helpers = content.substring(pos);
     } else {
-      tagName = content.toLowerCase().trim();
+      rawTagName = content.trim();
       helpers = "";
     }
+    tagName = rawTagName.toLowerCase();
+  }
+
+  public String getRawTagName() {
+    return rawTagName;
   }
 
   public String getTagName() {

--- a/src/test/java/com/hubspot/jinjava/interpret/TemplateErrorTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/TemplateErrorTest.java
@@ -2,11 +2,25 @@ package com.hubspot.jinjava.interpret;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
+import com.hubspot.jinjava.Jinjava;
 
 public class TemplateErrorTest {
+
+  private Context context;
+  private JinjavaInterpreter interpreter;
+
+  @Before
+  public void setup() {
+    interpreter = new Jinjava().newInterpreter();
+    JinjavaInterpreter.pushCurrent(interpreter);
+
+    context = interpreter.getContext();
+  }
+
 
   @Test
   public void itShowsFriendlyNameOfBaseObjectForPropNotFound() {
@@ -22,8 +36,8 @@ public class TemplateErrorTest {
 
   @Test
   public void itShowsFieldNameForUnknownTagError() {
-    TemplateError e = TemplateError.fromException(new UnknownTagException("unknown", "{% unknown() %}", 11, 3));
-    assertThat(e.getFieldName()).isEqualTo("unknown");
+    TemplateError e = TemplateError.fromException(new UnknownTagException("unKnown", "{% unKnown() %}", 11, 3));
+    assertThat(e.getFieldName()).isEqualTo("unKnown");
   }
 
   @Test
@@ -32,4 +46,9 @@ public class TemplateErrorTest {
     assertThat(e.getFieldName()).isEqualTo("da codez");
   }
 
+  @Test
+  public void itRetainsFieldNameCaseForUnknownToken() {
+    interpreter.render("{% unKnown() %}");
+    assertThat(interpreter.getErrors().get(0).getFieldName()).isEqualTo("unKnown");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/tree/FailOnUnknownTokensTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/FailOnUnknownTokensTest.java
@@ -1,7 +1,6 @@
 package com.hubspot.jinjava.tree;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -17,25 +16,24 @@ public class FailOnUnknownTokensTest {
   private static Jinjava jinjava;
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     JinjavaConfig.Builder builder = JinjavaConfig.newBuilder();
     builder.withFailOnUnknownTokens(true);
     JinjavaConfig config = builder.build();
     jinjava = new Jinjava(config);
-
   }
 
   @Test(expected = FatalTemplateErrorsException.class)
   public void itThrowsExceptionOnUnknownToken() {
-    Map<String, String> context = new HashMap<String, String>();
+    Map<String, String> context = new HashMap<>();
     context.put("token1", "test");
     String template = "hello {{ token1 }} and {{ token2 }}";
-    String str = jinjava.render(template, context);
+    jinjava.render(template, context);
   }
 
   @Test
   public void itReplaceTokensWithoutException() {
-    Map<String, String> context = new HashMap<String, String>();
+    Map<String, String> context = new HashMap<>();
     context.put("token1", "test");
     context.put("token2", "test1");
     String template = "hello {{ token1 }} and {{ token2 }}";


### PR DESCRIPTION
While jinjava tags are case insensitive, report back errors in the original case so they match what's in the source.