### PR TITLE
populate fieldname for TemplateSyntaxException

### DIFF
--- a/src/main/java/com/hubspot/jinjava/Jinjava.java
+++ b/src/main/java/com/hubspot/jinjava/Jinjava.java
@@ -33,6 +33,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.loader.ClasspathResourceLocator;
 import com.hubspot.jinjava.loader.ResourceLocator;
 
@@ -198,6 +199,9 @@ public class Jinjava {
       String result = interpreter.render(template);
       return new RenderResult(result, interpreter.getContext(), interpreter.getErrors());
     } catch (InterpretException e) {
+      if (e instanceof TemplateSyntaxException) {
+        return new RenderResult(TemplateError.fromException((TemplateSyntaxException) e), interpreter.getContext(), interpreter.getErrors());
+      }
       return new RenderResult(TemplateError.fromSyntaxError(e), interpreter.getContext(), interpreter.getErrors());
     } catch (Exception e) {
       return new RenderResult(TemplateError.fromException(e), interpreter.getContext(), interpreter.getErrors());

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -116,7 +116,7 @@ public class ForTag implements Tag {
     }
 
     if (inPos >= helper.size()) {
-      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'for' expects valid 'in' clause, got: " + tagNode.getHelpers(), tagNode.getLineNumber(), tagNode.getStartPosition());
+      throw new TemplateSyntaxException(tagNode.getHelpers().trim(), "Tag 'for' expects valid 'in' clause, got: " + tagNode.getHelpers(), tagNode.getLineNumber(), tagNode.getStartPosition());
     }
 
     String loopExpr = StringUtils.join(helper.subList(inPos + 1, helper.size()), ",");

--- a/src/test/java/com/hubspot/jinjava/interpret/TemplateErrorTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/TemplateErrorTest.java
@@ -10,17 +10,15 @@ import com.hubspot.jinjava.Jinjava;
 
 public class TemplateErrorTest {
 
-  private Context context;
   private JinjavaInterpreter interpreter;
+  private Jinjava jinjava;
 
   @Before
   public void setup() {
-    interpreter = new Jinjava().newInterpreter();
+    jinjava = new Jinjava();
+    interpreter = jinjava.newInterpreter();
     JinjavaInterpreter.pushCurrent(interpreter);
-
-    context = interpreter.getContext();
   }
-
 
   @Test
   public void itShowsFriendlyNameOfBaseObjectForPropNotFound() {
@@ -51,4 +49,11 @@ public class TemplateErrorTest {
     interpreter.render("{% unKnown() %}");
     assertThat(interpreter.getErrors().get(0).getFieldName()).isEqualTo("unKnown");
   }
+
+  @Test
+  public void itSetsFieldNameCaseForSyntaxErrorInFor() {
+    RenderResult renderResult = jinjava.renderForResult("{% for item inna navigation %}{% endfor %}", ImmutableMap.of());
+    assertThat(renderResult.getErrors().get(0).getFieldName()).isEqualTo("item inna navigation");
+  }
+
 }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
@@ -15,7 +15,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.base.Splitter;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -45,7 +44,7 @@ public class ForTagTest {
   }
 
   @Test
-  public void forLoopUsingLoopLastVar() throws Exception {
+  public void forLoopUsingLoopLastVar() {
     context.put("the_list", Lists.newArrayList(1L, 2L, 3L, 7L));
     TagNode tagNode = (TagNode) fixture("loop-last-var");
     Document dom = Jsoup.parseBodyFragment(tag.interpret(tagNode, interpreter));
@@ -54,7 +53,7 @@ public class ForTagTest {
   }
 
   @Test
-  public void forLoopUsingScalarValue() throws Exception {
+  public void forLoopUsingScalarValue() {
     context.put("the_list", 999L);
     TagNode tagNode = (TagNode) fixture("loop-with-scalar");
     String output = tag.interpret(tagNode, interpreter);
@@ -62,7 +61,7 @@ public class ForTagTest {
   }
 
   @Test
-  public void forLoopNestedFor() throws Exception {
+  public void forLoopNestedFor() {
     TagNode tagNode = (TagNode) fixture("nested-fors");
     assertThat(Splitter.on("\n").trimResults().omitEmptyStrings().split(
         tag.interpret(tagNode, interpreter)))
@@ -70,7 +69,7 @@ public class ForTagTest {
   }
 
   @Test
-  public void forLoopMultipleLoopVars() throws Exception {
+  public void forLoopMultipleLoopVars() {
     Map<String, Object> dict = Maps.newHashMap();
     dict.put("foo", "one");
     dict.put("bar", 2L);
@@ -83,7 +82,7 @@ public class ForTagTest {
   }
 
   @Test
-  public void forLoopMultipleLoopVarsArbitraryNames() throws Exception {
+  public void forLoopMultipleLoopVarsArbitraryNames() {
     Map<String, Object> dict = ImmutableMap.of(
         "grand", "ol'",
         "adserving", "team");
@@ -99,13 +98,13 @@ public class ForTagTest {
   }
 
   @Test
-  public void forLoopLiteralLoopExpr() throws Exception {
+  public void forLoopLiteralLoopExpr() {
     TagNode tagNode = (TagNode) fixture("literal-loop-expr");
     assertThat(tag.interpret(tagNode, interpreter)).isEqualTo("012345");
   }
 
   @Test
-  public void forLoopWithNestedCycle() throws Exception {
+  public void forLoopWithNestedCycle() {
     context.put("cycle1", "odd");
     context.put("cycle2", "even");
 
@@ -115,13 +114,13 @@ public class ForTagTest {
   }
 
   @Test
-  public void forLoopIndexVar() throws Exception {
+  public void forLoopIndexVar() {
     TagNode tagNode = (TagNode) fixture("loop-index-var");
     assertThat(tag.interpret(tagNode, interpreter)).isEqualTo("012345");
   }
 
   @Test
-  public void forLoopSupportsAllLoopVarsInHublDocs() throws Exception {
+  public void forLoopSupportsAllLoopVarsInHublDocs() {
     TagNode tagNode = (TagNode) fixture("hubl-docs-loop-vars");
     Document dom = Jsoup.parseBodyFragment(tag.interpret(tagNode, interpreter));
 
@@ -200,7 +199,7 @@ public class ForTagTest {
           Resources.getResource(String.format("tags/fortag/%s.jinja", name)), StandardCharsets.UTF_8))
               .buildTree().getChildren().getFirst();
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 


### PR DESCRIPTION
Specifically if a syntax exception occurs in a for tag, set up the exception to return the code with the syntax error for the fieldName,