### PR TITLE
Make int and float parsing more strict

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/FloatFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FloatFilter.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.lib.filter;
 
 import java.text.NumberFormat;
+import java.text.ParsePosition;
 import java.util.Locale;
 
 import org.apache.commons.lang3.math.NumberUtils;
@@ -47,12 +48,17 @@ public class FloatFilter implements Filter {
       return ((Number) var).floatValue();
     }
 
+    String input = var.toString();
     Locale locale = interpreter.getConfig().getLocale();
     NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
+    ParsePosition pp = new ParsePosition(0);
     float result;
     try {
-      result = numberFormat.parse(var.toString()).floatValue();
+      result = numberFormat.parse(input, pp).floatValue();
     } catch (Exception e) {
+      result = defaultVal;
+    }
+    if (pp.getErrorIndex() != -1 || pp.getIndex() != input.length()) {
       result = defaultVal;
     }
     return result;

--- a/src/main/java/com/hubspot/jinjava/lib/filter/IntFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IntFilter.java
@@ -1,6 +1,8 @@
 package com.hubspot.jinjava.lib.filter;
 
+import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
+import java.text.ParsePosition;
 import java.util.Locale;
 
 import org.apache.commons.lang3.math.NumberUtils;
@@ -49,13 +51,17 @@ public class IntFilter implements Filter {
       return ((Number) var).intValue();
     }
 
+    String input = var.toString().trim();
     Locale locale = interpreter.getConfig().getLocale();
     NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
-    numberFormat.setParseIntegerOnly(true);
+    ParsePosition pp = new ParsePosition(0);
     int result;
     try {
-      result = numberFormat.parse(var.toString()).intValue();
+      result = numberFormat.parse(input, pp).intValue();
     } catch (Exception e) {
+      result = defaultVal;
+    }
+    if (pp.getErrorIndex() != -1 || pp.getIndex() != input.length()) {
       result = defaultVal;
     }
     return result;

--- a/src/test/java/com/hubspot/jinjava/lib/filter/FloatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FloatFilterTest.java
@@ -62,6 +62,7 @@ public class FloatFilterTest {
   @Test
   public void itReturnsVarAsFloat() {
     assertThat(filter.filter("123.45", interpreter)).isEqualTo(123.45f);
+    assertThat(filter.filter("1.100000", interpreter)).isEqualTo(1.100000f);
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/filter/FloatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FloatFilterTest.java
@@ -65,13 +65,38 @@ public class FloatFilterTest {
   }
 
   @Test
+  public void itReturnsVarWithTrailingPercentAsDefault() {
+    assertThat(filter.filter("123%", interpreter)).isEqualTo(0.0f);
+  }
+
+  @Test
+  public void itReturnsVarWithLeadingLettersAsDefault() {
+    assertThat(filter.filter("abc123", interpreter)).isEqualTo(0.0f);
+  }
+
+  @Test
+  public void itReturnsVarWithTrailingLettersAsDefault() {
+    assertThat(filter.filter("123abc", interpreter)).isEqualTo(0.0f);
+  }
+
+  @Test
+  public void itReturnsVarWithLeadingCurrencySymbolAsDefault() {
+    assertThat(filter.filter("$123", interpreter)).isEqualTo(0.0f);
+  }
+
+  @Test
+  public void itReturnsVarWithTrailingCurrencySymbolAsDefault() {
+    assertThat(filter.filter("123$", interpreter)).isEqualTo(0.0f);
+  }
+
+  @Test
   public void itInterpretsUsCommasAndPeriodsWithUsLocale() {
     assertThat(filter.filter("123,123.45", interpreter)).isEqualTo(123123.45f);
   }
 
   @Test
-  public void itInterpretsFrenchCommasAndPeriodsWithUsLocale() {
-    assertThat(filter.filter("123.123,45", interpreter)).isEqualTo(123.123f);
+  public void itDoesntInterpretFrenchCommasAndPeriodsWithUsLocale() {
+    assertThat(filter.filter("123.123,45", interpreter)).isEqualTo(0.0f);
   }
 
   @Test
@@ -80,9 +105,9 @@ public class FloatFilterTest {
   }
 
   @Test
-  public void itInterpretsUsCommasAndPeriodsWithFrenchLocale() {
+  public void itDoesntInterpretUsCommasAndPeriodsWithFrenchLocale() {
     interpreter = new Jinjava(FRENCH_LOCALE_CONFIG).newInterpreter();
-    assertThat(filter.filter("123,123.12", interpreter)).isEqualTo(123.123f);
+    assertThat(filter.filter("123,123.12", interpreter)).isEqualTo(0.0f);
   }
 
   @Test
@@ -90,5 +115,4 @@ public class FloatFilterTest {
     interpreter = new Jinjava(FRENCH_LOCALE_CONFIG).newInterpreter();
     assertThat(filter.filter("123\u00A0123,45", interpreter)).isEqualTo(123123.45f);
   }
-
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/IntFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/IntFilterTest.java
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
 import java.util.Locale;
 
+import org.apache.commons.lang3.math.NumberUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -50,13 +51,43 @@ public class IntFilterTest {
   }
 
   @Test
-  public void itInterpretsUsCommasAndPeriodsWithUsLocale() {
+  public void itReturnsVarWithLeadingPercentAsDefault() {
+    assertThat(filter.filter("%60", interpreter)).isEqualTo(0);
+  }
+
+  @Test
+  public void itReturnsVarWithTrailingPercentAsDefault() {
+    assertThat(filter.filter("60%", interpreter)).isEqualTo(0);
+  }
+
+  @Test
+  public void itReturnsVarWithLeadingLettersAsDefault() {
+    assertThat(filter.filter("abc60", interpreter)).isEqualTo(0);
+  }
+
+  @Test
+  public void itReturnsVarWithTrailingLettersAsDefault() {
+    assertThat(filter.filter("60abc", interpreter)).isEqualTo(0);
+  }
+
+  @Test
+  public void itReturnsVarWithLeadingCurrencySymbolAsDefault() {
+    assertThat(filter.filter("$60", interpreter)).isEqualTo(0);
+  }
+
+  @Test
+  public void itReturnsVarWithTrailingCurrencySymbolAsDefault() {
+    assertThat(filter.filter("60$", interpreter)).isEqualTo(0);
+  }
+
+  @Test
+  public void itDoesntInterpretsUsCommasAndPeriodsWithUsLocale() {
     assertThat(filter.filter("123,123.12", interpreter)).isEqualTo(123123);
   }
 
   @Test
-  public void itInterpretsFrenchCommasAndPeriodsWithUsLocale() {
-    assertThat(filter.filter("123.123,12", interpreter)).isEqualTo(123);
+  public void itDoesntInterpreFrenchCommasAndPeriodsWithUsLocale() {
+    assertThat(filter.filter("123.123,12", interpreter)).isEqualTo(0);
   }
 
   @Test
@@ -65,9 +96,9 @@ public class IntFilterTest {
   }
 
   @Test
-  public void itInterpretsUsCommasAndPeriodsWithFrenchLocale() {
+  public void itDoesntInterpretUsCommasAndPeriodsWithFrenchLocale() {
     interpreter = new Jinjava(FRENCH_LOCALE_CONFIG).newInterpreter();
-    assertThat(filter.filter("123,123.12", interpreter)).isEqualTo(123);
+    assertThat(filter.filter("123,123.12", interpreter)).isEqualTo(0);
   }
 
   @Test
@@ -75,5 +106,4 @@ public class IntFilterTest {
     interpreter = new Jinjava(FRENCH_LOCALE_CONFIG).newInterpreter();
     assertThat(filter.filter("123\u00A0123,12", interpreter)).isEqualTo(123123);
   }
-
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/IntFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/IntFilterTest.java
@@ -47,7 +47,14 @@ public class IntFilterTest {
 
   @Test
   public void itReturnsVarAsInt() {
-    assertThat(filter.filter("123", interpreter)).isEqualTo(123);
+    assertThat(filter.filter("123", interpreter))
+        .isInstanceOf(Integer.class)
+        .isEqualTo(123);
+  }
+
+  @Test
+  public void itReturnsVarWithFloatingPointAsInt() {
+    assertThat(filter.filter("123.1", interpreter)).isEqualTo(123);
   }
 
   @Test
@@ -81,12 +88,12 @@ public class IntFilterTest {
   }
 
   @Test
-  public void itDoesntInterpretsUsCommasAndPeriodsWithUsLocale() {
+  public void itInterpretsUsCommasAndPeriodsWithUsLocale() {
     assertThat(filter.filter("123,123.12", interpreter)).isEqualTo(123123);
   }
 
   @Test
-  public void itDoesntInterpreFrenchCommasAndPeriodsWithUsLocale() {
+  public void itDoesntInterpretFrenchCommasAndPeriodsWithUsLocale() {
     assertThat(filter.filter("123.123,12", interpreter)).isEqualTo(0);
   }
 


### PR DESCRIPTION
Fix for https://github.com/HubSpot/jinjava/issues/184 reported by @anthmatic.
https://github.com/HubSpot/jinjava/pull/178 unintentionally made int and float parsing a lot more lax. This change restores some of the original strictness to match behaviour with `jinja` , while keeping support for our locale specific changes. It does so by:
- Checking that all of the input string was consumed by the parse operation, to ensure that trailing symbols or characters cause a parse to fail.
- Parsing integers first as a float, then converting to an integer, so that the above change doesn't prevent decimal expressions from parsing as integers.