### PR TITLE
more accurate fieldName for TemplateSyntaxException

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -37,6 +37,9 @@ public class ExpressionResolver {
   private final JinjavaInterpreterResolver resolver;
   private final JinjavaELContext elContext;
 
+  private static final String EXPRESSION_START_TOKEN = "#{";
+  private static final String EXPRESSION_END_TOKEN = "}";
+
   public ExpressionResolver(JinjavaInterpreter interpreter, ExpressionFactory expressionFactory) {
     this.interpreter = interpreter;
     this.expressionFactory = expressionFactory;
@@ -63,7 +66,7 @@ public class ExpressionResolver {
     interpreter.getContext().addResolvedExpression(expression.trim());
 
     try {
-      String elExpression = "#{" + expression.trim() + "}";
+      String elExpression = EXPRESSION_START_TOKEN + expression.trim() + EXPRESSION_END_TOKEN;
       ValueExpression valueExp = expressionFactory.createValueExpression(elContext, elExpression, Object.class);
       Object result = valueExp.getValue(elContext);
 
@@ -78,7 +81,7 @@ public class ExpressionResolver {
       int position = interpreter.getPosition() + e.getPosition();
       // replacing the position in the string like this isn't great, but JUEL's parser does not allow passing in a starting position
       String errorMessage = StringUtils.substringAfter(e.getMessage(), "': ").replaceFirst("position [0-9]+", "position " + position);
-      interpreter.addError(TemplateError.fromException(new TemplateSyntaxException(expression,
+      interpreter.addError(TemplateError.fromException(new TemplateSyntaxException(expression.substring(e.getPosition() - EXPRESSION_START_TOKEN.length()),
           "Error parsing '" + expression + "': " + errorMessage, interpreter.getLineNumber(), position, e)));
     } catch (ELException e) {
       interpreter.addError(TemplateError.fromException(new TemplateSyntaxException(expression, e.getMessage(), interpreter.getLineNumber(), e)));

--- a/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
@@ -265,12 +265,15 @@ public class ExtendedSyntaxBuilderTest {
     assertThat(interpreter.getErrors().get(0).getLineno()).isEqualTo(1);
     assertThat(interpreter.getErrors().get(0).getMessage()).contains("position 14");
     assertThat(interpreter.getErrors().get(0).getStartPosition()).isEqualTo(14);
+    assertThat(interpreter.getErrors().get(0).getFieldName()).isEqualTo("thing");
     assertThat(interpreter.getErrors().get(1).getLineno()).isEqualTo(1);
     assertThat(interpreter.getErrors().get(1).getMessage()).contains("position 33");
     assertThat(interpreter.getErrors().get(1).getStartPosition()).isEqualTo(33);
+    assertThat(interpreter.getErrors().get(1).getFieldName()).isEqualTo("thing");
     assertThat(interpreter.getErrors().get(2).getLineno()).isEqualTo(2);
     assertThat(interpreter.getErrors().get(2).getMessage()).contains("position 13");
     assertThat(interpreter.getErrors().get(2).getStartPosition()).isEqualTo(13);
+    assertThat(interpreter.getErrors().get(2).getFieldName()).isEqualTo("blabbity");
   }
 
   private Object val(String expr) {


### PR DESCRIPTION
Set the field name to just the substring of where the error started.