### PR TITLE
Fix sporadic test failures introduced in e65ee0b

### DIFF
--- a/src/test/java/com/hubspot/jinjava/interpret/TemplateErrorTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/TemplateErrorTest.java
@@ -2,23 +2,12 @@ package com.hubspot.jinjava.interpret;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.Jinjava;
 
 public class TemplateErrorTest {
-
-  private JinjavaInterpreter interpreter;
-  private Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-    interpreter = jinjava.newInterpreter();
-    JinjavaInterpreter.pushCurrent(interpreter);
-  }
 
   @Test
   public void itShowsFriendlyNameOfBaseObjectForPropNotFound() {
@@ -46,13 +35,14 @@ public class TemplateErrorTest {
 
   @Test
   public void itRetainsFieldNameCaseForUnknownToken() {
+    JinjavaInterpreter interpreter = new Jinjava().newInterpreter();
     interpreter.render("{% unKnown() %}");
     assertThat(interpreter.getErrors().get(0).getFieldName()).isEqualTo("unKnown");
   }
 
   @Test
   public void itSetsFieldNameCaseForSyntaxErrorInFor() {
-    RenderResult renderResult = jinjava.renderForResult("{% for item inna navigation %}{% endfor %}", ImmutableMap.of());
+    RenderResult renderResult = new Jinjava().renderForResult("{% for item inna navigation %}{% endfor %}", ImmutableMap.of());
     assertThat(renderResult.getErrors().get(0).getFieldName()).isEqualTo("item inna navigation");
   }
 


### PR DESCRIPTION
Running "mvn test" in a loop fails randomly after some iterations with errors like below. This fixes the issue and, AFAICT, doesn't cause any side effects.

```
Results :

Failed tests: 
  FailOnUnknownTokensTest.itThrowsExceptionOnUnknownToken Expected exception: com.hubspot.jinjava.interpret.FatalTemplateErrorsException

Tests run: 501, Failures: 1, Errors: 0, Skipped: 0
```