### PR TITLE
Fix calling macros with kwargs

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -60,7 +60,7 @@ public class MacroFunction extends AbstractCallableMethod {
         interpreter.getContext().put(argEntry.getKey(), argEntry.getValue());
       }
       // parameter map
-      interpreter.getContext().put("kwargs", argMap);
+      interpreter.getContext().put("kwargs", kwargMap);
       // varargs list
       interpreter.getContext().put("varargs", varArgs);
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
@@ -75,6 +75,17 @@ public class MacroTagTest {
   }
 
   @Test
+  public void testFnWithKwArgs() {
+    TagNode t = fixture("list_kwargs");
+    assertThat(t.render(interpreter).getValue()).isEmpty();
+
+    String out = snippet("{{ list_kwargs(foo=\"bar\", bas='baz', answer=42) }}").render(interpreter).getValue().trim();
+    assertThat(out).contains("foo=bar");
+    assertThat(out).contains("bas=baz");
+    assertThat(out).contains("answer=42");
+  }
+
+  @Test
   public void testFnWithArgsWithDefVals() {
     TagNode t = fixture("def-vals");
     assertThat(t.render(interpreter).getValue()).isEmpty();

--- a/src/test/resources/tags/macrotag/list_kwargs.jinja
+++ b/src/test/resources/tags/macrotag/list_kwargs.jinja
@@ -1,0 +1,5 @@
+{% macro list_kwargs() %}
+    {% for k,v in kwargs.items() %}
+        {{k}}={{v}}
+    {% endfor %}
+{% endmacro %}


### PR DESCRIPTION
The `kwargs` variable currently contains the named parameters listed in a macro's definition, whereas the Jinja documentation says:

> Like varargs but for keyword arguments. All unconsumed keyword arguments are stored in this special variable.

python-jinja2 behaves accordingly as well.