### PR TITLE
limit size of strings in TemplateErrors

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -10,6 +10,10 @@ import com.hubspot.jinjava.interpret.errorcategory.BasicTemplateErrorCategory;
 import com.hubspot.jinjava.interpret.errorcategory.TemplateErrorCategory;
 
 public class TemplateError {
+
+  private static final Pattern GENERIC_TOSTRING_PATTERN = Pattern.compile("@[0-9a-z]{4,}$");
+  private static final int MAX_STRING_LENGTH = 1024;
+
   public enum ErrorType {
     FATAL,
     WARNING
@@ -101,6 +105,10 @@ public class TemplateError {
 
     String s = o.toString();
 
+    if (s.length() > MAX_STRING_LENGTH) {
+      s = s.substring(0, MAX_STRING_LENGTH) + "...";
+    }
+
     if (!GENERIC_TOSTRING_PATTERN.matcher(s).find()) {
       return s;
     }
@@ -108,8 +116,6 @@ public class TemplateError {
     Class<?> c = o.getClass();
     return c.getSimpleName();
   }
-
-  private static final Pattern GENERIC_TOSTRING_PATTERN = Pattern.compile("@[0-9a-z]{4,}$");
 
   public TemplateError(ErrorType severity,
                        ErrorReason reason,

--- a/src/test/java/com/hubspot/jinjava/interpret/TemplateErrorTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/TemplateErrorTest.java
@@ -46,4 +46,17 @@ public class TemplateErrorTest {
     assertThat(renderResult.getErrors().get(0).getFieldName()).isEqualTo("item inna navigation");
   }
 
+  @Test
+  public void itLimitsErrorStringToAReasonableSize() {
+
+    String veryLong = "";
+
+    for (int i = 0; i < 1500; i++) {
+      veryLong = veryLong.concat("0");
+    }
+
+    TemplateError e = TemplateError.fromUnknownProperty(ImmutableMap.of("foo", veryLong), "other", 123, 4);
+    assertThat(e.getMessage()).startsWith("Cannot resolve property 'other' in '{foo=");
+    assertThat(e.getMessage().length()).isLessThan(1500);
+  }
 }


### PR DESCRIPTION
so huge objects don't become huge strings.