### PR TITLE
Deepen equalto expression test comparison.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTest.java
@@ -1,12 +1,13 @@
 package com.hubspot.jinjava.lib.exptest;
 
-import java.util.Objects;
-
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.el.TruthyTypeConverter;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+
+import de.odysseus.el.misc.BooleanOperations;
 
 @JinjavaDoc(
     value = "Check if an object has the same value as another object",
@@ -35,7 +36,7 @@ public class IsEqualToExpTest implements ExpTest {
       throw new InterpretException(getName() + " test requires 1 argument");
     }
 
-    return Objects.equals(var, args[0]);
+    return BooleanOperations.eq(new TruthyTypeConverter(), var, args[0]);
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTest.java
@@ -8,6 +8,7 @@ import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 import de.odysseus.el.misc.BooleanOperations;
+import de.odysseus.el.misc.TypeConverter;
 
 @JinjavaDoc(
     value = "Check if an object has the same value as another object",
@@ -25,6 +26,8 @@ import de.odysseus.el.misc.BooleanOperations;
     })
 public class IsEqualToExpTest implements ExpTest {
 
+  private static final TypeConverter TYPE_CONVERTER = new TruthyTypeConverter();
+
   @Override
   public String getName() {
     return "equalto";
@@ -36,7 +39,7 @@ public class IsEqualToExpTest implements ExpTest {
       throw new InterpretException(getName() + " test requires 1 argument");
     }
 
-    return BooleanOperations.eq(new TruthyTypeConverter(), var, args[0]);
+    return BooleanOperations.eq(TYPE_CONVERTER, var, args[0]);
   }
 
 }

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTestTest.java
@@ -1,0 +1,48 @@
+package com.hubspot.jinjava.lib.exptest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.hubspot.jinjava.Jinjava;
+
+public class IsEqualToExpTestTest {
+
+  private static final String EQUAL_TEMPLATE = "{{ %s is equalto %s }}";
+
+  private Jinjava jinjava;
+
+  @Before
+  public void setup() {
+    jinjava = new Jinjava();
+  }
+
+  @Test
+  public void itEquatesNumbers() {
+    assertThat(jinjava.render(String.format(EQUAL_TEMPLATE, "4", "4"), new HashMap<>())).isEqualTo("true");
+    assertThat(jinjava.render(String.format(EQUAL_TEMPLATE, "4", "5"), new HashMap<>())).isEqualTo("false");
+  }
+
+  @Test
+  public void itEquatesStrings() {
+    assertThat(jinjava.render(String.format(EQUAL_TEMPLATE, "\"jinjava\"", "\"jinjava\""), new HashMap<>())).isEqualTo("true");
+    assertThat(jinjava.render(String.format(EQUAL_TEMPLATE, "\"jinjava\"", "\"not jinjava\""), new HashMap<>())).isEqualTo("false");
+  }
+
+  @Test
+  public void itEquatesBooleans() {
+    assertThat(jinjava.render(String.format(EQUAL_TEMPLATE, "true", "true"), new HashMap<>())).isEqualTo("true");
+    assertThat(jinjava.render(String.format(EQUAL_TEMPLATE, "true", "false"), new HashMap<>())).isEqualTo("false");
+  }
+
+  @Test
+  public void itEquatesDifferentTypes() {
+    assertThat(jinjava.render(String.format(EQUAL_TEMPLATE, "4", "\"4\""), new HashMap<>())).isEqualTo("true");
+    assertThat(jinjava.render(String.format(EQUAL_TEMPLATE, "4", "\"5\""), new HashMap<>())).isEqualTo("false");
+    assertThat(jinjava.render(String.format(EQUAL_TEMPLATE, "'c'", "\"c\""), new HashMap<>())).isEqualTo("true");
+    assertThat(jinjava.render(String.format(EQUAL_TEMPLATE, "'c'", "\"b\""), new HashMap<>())).isEqualTo("false");
+  }
+}


### PR DESCRIPTION
Let's say you have a string `TEST` and an enum TEST. Under the usual `==` operation the expression evaluater will convert the enum to a string for comparison using `BooleanOperations`. This mimics this behavior in `equalto` expression test so there is no distinction between them.