### PR TITLE
Make jinjajava interpreter render timings trackable..

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -479,4 +479,24 @@ public class JinjavaInterpreter {
     }
   }
 
+  public void startRender(String name) {
+    RenderTimings renderTimings = (RenderTimings) getContext().get("request");
+    if (renderTimings != null) {
+      renderTimings.start(this, name);
+    }
+  }
+
+  public void endRender(String name) {
+    RenderTimings renderTimings = (RenderTimings) getContext().get("request");
+    if (renderTimings != null) {
+      renderTimings.end(this, name);
+    }
+  }
+
+  public void endRender(String name, Map<String, Object> data) {
+    RenderTimings renderTimings = (RenderTimings) getContext().get("request");
+    if (renderTimings != null) {
+      renderTimings.end(this, name, data);
+    }
+  }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/RenderTimings.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/RenderTimings.java
@@ -1,0 +1,9 @@
+package com.hubspot.jinjava.interpret;
+
+import java.util.Map;
+
+public interface RenderTimings {
+  void start(JinjavaInterpreter interpreter, String name);
+  void end(JinjavaInterpreter interpreter, String name);
+  void end(JinjavaInterpreter interpreter, String name, Map<String, Object> data);
+}


### PR DESCRIPTION
Sometime, we want to track the timings of some tags rendering. The application need to provide an instance of the RenderTimings.