### PR TITLE
Selectattrfirst

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/FilterLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FilterLibrary.java
@@ -50,6 +50,7 @@ public class FilterLibrary extends SimpleLibrary<Filter> {
         RejectFilter.class,
         SelectFilter.class,
         SelectAttrFilter.class,
+        SelectAttrFirstFilter.class,
         SliceFilter.class,
         ShuffleFilter.class,
         SortFilter.class,

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFirstFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFirstFilter.java
@@ -1,0 +1,85 @@
+
+package com.hubspot.jinjava.lib.filter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
+import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.lib.exptest.ExpTest;
+import com.hubspot.jinjava.util.ForLoop;
+import com.hubspot.jinjava.util.ObjectIterator;
+
+@JinjavaDoc(
+    value = "Filters a sequence of objects by applying a test to an attribute of an object and only selecting " +
+        "first with the test succeeding. This is similar to selectattr but is fast if you just want the first" +
+        "item",
+    params = {
+        @JinjavaParam(value = "sequence", type = "sequence", desc = "Sequence to test"),
+        @JinjavaParam(value = "attr", desc = "Attribute to test for and select items that contain it"),
+        @JinjavaParam(value = "exp_test", type = "name of expression test", defaultValue = "truthy", desc = "Specify which expression test to run for making the selection")
+    },
+    snippets = {
+        @JinjavaSnippet(
+            desc = "This loop would select any post containing content.post_list_summary_featured_image",
+            code = "{% for content in contents|selectattr('post_list_summary_featured_image') %}\n" +
+                "    <div class=\"post-item\">Post in listing markup</div>\n" +
+                "{% endfor %}")
+    })
+public class SelectAttrFirstFilter implements AdvancedFilter {
+
+  @Override
+  public String getName() {
+    return "selectattrfirst";
+  }
+
+  @Override
+  public Object filter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs) {
+    if (args.length == 0) {
+      throw new InterpretException(getName() + " filter requires an attr to filter on", interpreter.getLineNumber());
+    }
+
+    if (!(args[0] instanceof String)) {
+      throw new InterpretException(getName() + " filter requires the filter attr arg to be a string", interpreter.getLineNumber());
+    }
+
+    Object[] expArgs = new String[]{};
+
+    String attr = (String) args[0];
+
+    ExpTest expTest = interpreter.getContext().getExpTest("truthy");
+    if (args.length > 1) {
+
+      if (!(args[1] instanceof String)) {
+        throw new InterpretException(getName() + " filter requires the expression test arg to be a string", interpreter
+            .getLineNumber());
+      }
+
+      expTest = interpreter.getContext().getExpTest((String) args[1]);
+      if (expTest == null) {
+        throw new InterpretException("No expression test defined with name '" + args[1] + "'", interpreter.getLineNumber());
+      }
+
+      if (args.length > 2) {
+        expArgs = Arrays.copyOfRange(args, 2, args.length);
+      }
+    }
+
+    ForLoop loop = ObjectIterator.getLoop(var);
+    while (loop.hasNext()) {
+      Object val = loop.next();
+      Object attrVal = interpreter.resolveProperty(val, attr);
+
+      if (expTest.evaluate(attrVal, interpreter, expArgs)) {
+        return val;
+      }
+    }
+    return null;
+
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFirstFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFirstFilter.java
@@ -1,9 +1,7 @@
 
 package com.hubspot.jinjava.lib.filter;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
@@ -16,20 +14,20 @@ import com.hubspot.jinjava.util.ForLoop;
 import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
-    value = "Filters a sequence of objects by applying a test to an attribute of an object and only selecting " +
-        "first with the test succeeding. This is similar to selectattr but is fast if you just want the first" +
-        "item",
+    value = "Filters a sequence of objects by applying a test to an" +
+        " attribute of an object and only selecting first with the" +
+        " test succeeding. This is similar to selectattr but is fast" +
+        " if you just want the first item",
     params = {
         @JinjavaParam(value = "sequence", type = "sequence", desc = "Sequence to test"),
         @JinjavaParam(value = "attr", desc = "Attribute to test for and select items that contain it"),
-        @JinjavaParam(value = "exp_test", type = "name of expression test", defaultValue = "truthy", desc = "Specify which expression test to run for making the selection")
+        @JinjavaParam(value = "exp_test", type = "name of expression test", defaultValue = "truthy",
+            desc = "Specify which expression test to run for making the selection")
     },
     snippets = {
         @JinjavaSnippet(
-            desc = "This loop would select any post containing content.post_list_summary_featured_image",
-            code = "{% for content in contents|selectattr('post_list_summary_featured_image') %}\n" +
-                "    <div class=\"post-item\">Post in listing markup</div>\n" +
-                "{% endfor %}")
+            desc = "This expression would select the first containing content.post_list_summary_featured_image",
+            code = "{{ contents|selectattrfirst('post_list_summary_featured_image') }}")
     })
 public class SelectAttrFirstFilter implements AdvancedFilter {
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SelectAttrFirstFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SelectAttrFirstFilterTest.java
@@ -48,6 +48,11 @@ public class SelectAttrFirstFilterTest {
         .isEqualTo("1");
   }
 
+  @Test
+  public void selectAttrWithNoMatch() {
+    assertThat(jinjava.render("{{ users|selectattrfirst('email', 'equalto', 'abc') }}", new HashMap<String, Object>()))
+        .isEqualTo("");
+  }
 
   public static class User {
     private long num;

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SelectAttrFirstFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SelectAttrFirstFilterTest.java
@@ -1,0 +1,81 @@
+package com.hubspot.jinjava.lib.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+import com.hubspot.jinjava.Jinjava;
+
+public class SelectAttrFirstFilterTest {
+
+  Jinjava jinjava;
+
+  @Before
+  public void setup() {
+    jinjava = new Jinjava();
+    jinjava.getGlobalContext().put("users", Lists.newArrayList(
+        new SelectAttrFirstFilterTest.User(0, false, "foo@bar.com"),
+        new SelectAttrFirstFilterTest.User(1, true, "bar@bar.com"),
+        new SelectAttrFirstFilterTest.User(2, false, null),
+        new SelectAttrFirstFilterTest.User(3, true, "bar@bar.com")));
+  }
+
+  @Test
+  public void selectAttrWithNoExp() {
+    assertThat(jinjava.render("{{ users|selectattrfirst('is_active') }}", new HashMap<String, Object>()))
+        .isEqualTo("1");
+  }
+
+  @Test
+  public void selectAttrWithExp() {
+    assertThat(jinjava.render("{{ users|selectattrfirst('email', 'none') }}", new HashMap<String, Object>()))
+        .isEqualTo("2");
+  }
+
+  @Test
+  public void selectAttrWithIsEqualToExp() {
+    assertThat(jinjava.render("{{ users|selectattrfirst('email', 'equalto', 'bar@bar.com') }}", new HashMap<String, Object>()))
+        .isEqualTo("1");
+  }
+
+  @Test
+  public void selectAttrWithNumericIsEqualToExp() {
+    assertThat(jinjava.render("{{ users|selectattrfirst('num', 'equalto', 1) }}", new HashMap<String, Object>()))
+        .isEqualTo("1");
+  }
+
+
+  public static class User {
+    private long num;
+    private boolean isActive;
+    private String email;
+
+    public User(long num, boolean isActive, String email) {
+      this.num = num;
+      this.isActive = isActive;
+      this.email = email;
+    }
+
+    public long getNum() {
+      return num;
+    }
+
+    public String getEmail() {
+      return email;
+    }
+
+    public boolean getIsActive() {
+      return isActive;
+    }
+
+    @Override
+    public String toString() {
+      return num + "";
+    }
+  }
+
+}


### PR DESCRIPTION
Add a filter `selectattrfirst`. This is for porformance purpose. Sometimes, a larger number of items are using the `objects|selectattr|first`, which is not efficient because it go through all the items and select the attribute, and then returns the first one. This new filter will bail out at the first matching item that matches.