### PR TITLE
clear resolved things in global context after render

### DIFF
--- a/src/main/java/com/hubspot/jinjava/Jinjava.java
+++ b/src/main/java/com/hubspot/jinjava/Jinjava.java
@@ -206,6 +206,7 @@ public class Jinjava {
     } catch (Exception e) {
       return new RenderResult(TemplateError.fromException(e), interpreter.getContext(), interpreter.getErrorsCopy());
     } finally {
+      globalContext.reset();
       JinjavaInterpreter.popCurrent();
     }
   }

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -112,13 +112,20 @@ public class Context extends ScopeMap<String, Object> {
         FromTagCycleException.class);
 
     if (disabled == null) {
-      disabled = new HashMap<Library, Set<String>>();
+      disabled = new HashMap<>();
     }
 
     this.expTestLibrary = new ExpTestLibrary(parent == null, disabled.get(Library.EXP_TEST));
     this.filterLibrary = new FilterLibrary(parent == null, disabled.get(Library.FILTER));
     this.tagLibrary = new TagLibrary(parent == null, disabled.get(Library.TAG));
     this.functionLibrary = new FunctionLibrary(parent == null, disabled.get(Library.FUNCTION));
+  }
+
+  public void reset() {
+    // clear anything that pushes up to its parent's values
+    resolvedExpressions.clear();
+    resolvedValues.clear();
+    resolvedFunctions.clear();
   }
 
   @Override
@@ -162,7 +169,7 @@ public class Context extends ScopeMap<String, Object> {
 
   public boolean isAutoEscape() {
     if (autoEscape != null) {
-      return autoEscape.booleanValue();
+      return autoEscape;
     }
 
     if (parent != null) {

--- a/src/test/java/com/hubspot/jinjava/interpret/ContextTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/ContextTest.java
@@ -56,9 +56,6 @@ public class ContextTest {
     Jinjava jinjava = new Jinjava();
     Context globalContext = jinjava.getGlobalContext();
 
-    context.addResolvedExpression("exp");
-    context.addDependency("dep", "mydep");
-
     RenderResult result = jinjava.renderForResult("{{ foo + 1 }}", ImmutableMap.of("foo", 1));
 
     assertThat(result.getOutput()).isEqualTo("2");

--- a/src/test/java/com/hubspot/jinjava/interpret/ContextTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/ContextTest.java
@@ -5,6 +5,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableMap;
+import com.hubspot.jinjava.Jinjava;
+
 public class ContextTest {
   private static final String RESOLVED_EXPRESSION = "exp" ;
   private static final String RESOLVED_FUNCTION = "func" ;
@@ -45,5 +48,23 @@ public class ContextTest {
     assertThat(context.getResolvedValues()).contains(RESOLVED_VALUE);
     assertThat(context.getResolvedFunctions()).contains(RESOLVED_FUNCTION);
     assertThat(context.getResolvedExpressions()).contains(RESOLVED_EXPRESSION);
+  }
+
+  @Test
+  public void itResetsGlobalContextAfterRender() {
+
+    Jinjava jinjava = new Jinjava();
+    Context globalContext = jinjava.getGlobalContext();
+
+    context.addResolvedExpression("exp");
+    context.addDependency("dep", "mydep");
+
+    RenderResult result = jinjava.renderForResult("{{ foo + 1 }}", ImmutableMap.of("foo", 1));
+
+    assertThat(result.getOutput()).isEqualTo("2");
+    assertThat(result.getContext().getResolvedExpressions()).containsOnly("foo + 1");
+    assertThat(result.getContext().getResolvedValues()).containsOnly("foo");
+    assertThat(globalContext.getResolvedExpressions()).isEmpty();
+    assertThat(globalContext.getResolvedValues()).isEmpty();
   }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -18,8 +18,8 @@ import com.hubspot.jinjava.tree.parse.TextToken;
 
 public class JinjavaInterpreterTest {
 
-  Jinjava jinjava;
-  JinjavaInterpreter interpreter;
+  private Jinjava jinjava;
+  private JinjavaInterpreter interpreter;
 
   @Before
   public void setup() {
@@ -39,21 +39,21 @@ public class JinjavaInterpreterTest {
   }
 
   @Test
-  public void resolveBlockStubs() throws Exception {
+  public void resolveBlockStubs() {
     interpreter.addBlock("foobar", Lists.newLinkedList(Lists.newArrayList((new TextNode(new TextToken("sparta", -1, -1))))));
     String content = "this is {% block foobar %}foobar{% endblock %}!";
     assertThat(interpreter.render(content)).isEqualTo("this is sparta!");
   }
 
   @Test
-  public void resolveBlockStubsWithSpecialChars() throws Exception {
+  public void resolveBlockStubsWithSpecialChars() {
     interpreter.addBlock("foobar", Lists.newLinkedList(Lists.newArrayList(new TextNode(new TextToken("$150.00", -1, -1)))));
     String content = "this is {% block foobar %}foobar{% endblock %}!";
     assertThat(interpreter.render(content)).isEqualTo("this is $150.00!");
   }
 
   @Test
-  public void resolveBlockStubsWithCycle() throws Exception {
+  public void resolveBlockStubsWithCycle() {
     String content = interpreter.render("{% block foo %}{% block foo %}{% endblock %}{% endblock %}");
     assertThat(content).isEmpty();
   }
@@ -155,7 +155,7 @@ public class JinjavaInterpreterTest {
   }
 
   @Test
-  public void itLimitsOutputSize() throws Exception {
+  public void itLimitsOutputSize() {
 
     JinjavaConfig outputSizeLimitedConfig = JinjavaConfig.newBuilder().withMaxOutputSize(20).build();
     String output = "123456789012345678901234567890";
@@ -169,7 +169,7 @@ public class JinjavaInterpreterTest {
   }
 
   @Test
-  public void itLimitsOutputSizeWhenSumOfNodeSizesExceedsMax() throws Exception {
+  public void itLimitsOutputSizeWhenSumOfNodeSizesExceedsMax() {
     JinjavaConfig outputSizeLimitedConfig = JinjavaConfig.newBuilder().withMaxOutputSize(19).build();
     String input = "1234567890{% block testchild %}1234567890{% endblock %}";
     String output = "12345678901234567890"; // Note that this exceeds the max size


### PR DESCRIPTION
When calling `Jinjava.renderForResult`, resolved variables, functions and expressions were added all the way up to the global context, but were never cleared. This created a memory leak where resolved expressions kept accumulating in these maps. 

Clear these transient values after each render.