### PR TITLE
update ** and // to support int/float literals

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Jinjava Releases #
 
+### 2018-09-07 Version 2.4.8 ([Maven Central](https://search.maven.org/#artifactdetails%7Ccom.hubspot.jinjava%7Cjinjava%7C2.4.8%7Cjar)) ###
+* [Bug fix for trunc division and power operations](https://github.com/HubSpot/jinjava/pull/234)
+
 ### 2018-08-31 Version 2.4.7 ([Maven Central](https://search.maven.org/#artifactdetails%7Ccom.hubspot.jinjava%7Cjinjava%7C2.4.7%7Cjar)) ###
 * [Do not allow returning objects of type Class](https://github.com/HubSpot/jinjava/pull/232)
 

--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -52,8 +52,8 @@ public class ExtendedParser extends Parser {
   static final Scanner.ExtensionToken LITERAL_DICT_START = new Scanner.ExtensionToken("{");
   static final Scanner.ExtensionToken LITERAL_DICT_END = new Scanner.ExtensionToken("}");
 
-  static final Scanner.ExtensionToken TRUNC_DIV = new Scanner.ExtensionToken("//");
-  static final Scanner.ExtensionToken POWER_OF  = new Scanner.ExtensionToken("**");
+  static final Scanner.ExtensionToken TRUNC_DIV = TruncDivOperator.TOKEN;
+  static final Scanner.ExtensionToken POWER_OF  = PowerOfOperator.TOKEN;
 
   static {
     ExtendedScanner.addKeyToken(IF);
@@ -393,14 +393,8 @@ public class ExtendedParser extends Parser {
 
           AstProperty exptestProperty = createAstDot(identifier(EXPTEST_PREFIX + exptestName), "evaluate", true);
           v = createAstMethod(exptestProperty, new AstParameters(exptestParams));
-        } else if ("//".equals(getToken().getImage()) && lookahead(0).getSymbol() == IDENTIFIER) {
-            consumeToken(); // '//'
-            v = createAstBinary(v, mul(true), TruncDivOperator.OP);
-
-        } else if ("**".equals(getToken().getImage()) && lookahead(0).getSymbol() == IDENTIFIER) {
-            consumeToken(); // '**'
-            v = createAstBinary(v, mul(true), PowerOfOperator.OP);
         }
+
         return v;
       }
     }

--- a/src/test/java/com/hubspot/jinjava/el/ext/PowerOfTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/PowerOfTest.java
@@ -21,31 +21,66 @@ public class PowerOfTest {
 
     @Test
     public void testPowerOfInteger() {
-
         Map<String, Object> context = Maps.newHashMap();
         context.put("base",     2);
-        context.put("exponent", 8);
+        context.put("evenExponent", 8);
+        context.put("oddExponent", 7);
+        context.put("negativeBase", -2);
+        context.put("negativeExponent", -8);
 
-        String template = "{% set x = base ** exponent %}{{x}}";
-        String rendered = jinja.render(template, context);
-        assertEquals("256", rendered);
+        String[][] testCases = {
+            { "{% set x = base ** evenExponent %}{{x}}", "256" },
+            { "{% set x = 2 ** 8 %}{{x}}", "256" },
+            { "{% set x = base ** 8 %}{{x}}", "256" },
+            { "{% set x = 2 ** evenExponent %}{{x}}", "256" },
+            { "{% set x = negativeBase ** evenExponent %}{{x}}", "256" },
+            { "{% set x = -2 ** 8 %}{{x}}", "256" },
+            { "{% set x = base ** negativeExponent %}{{x}}", "0" },
+            { "{% set x = 2 ** -8 %}{{x}}", "0" },
+            { "{% set x = negativeBase ** oddExponent %}{{x}}", "-128"},
+            { "{% set x = -2 ** 7 %}{{x}}", "-128" }
+        };
+
+        for (String[] testCase : testCases ) {
+            String template = testCase[0];
+            String expected = testCase[1];
+            String rendered = jinja.render(template, context);
+            assertEquals(expected, rendered);
+        }
     }
 
     @Test
     public void testPowerOfFractional() {
-
         Map<String, Object> context = Maps.newHashMap();
         context.put("base",     2);
-        context.put("exponent", 8.0);
+        context.put("evenExponent", 8.0);
+        context.put("oddExponent", 7.0);
+        context.put("negativeBase", -2);
+        context.put("negativeExponent", -8.0);
 
-        String template = "{% set x = base ** exponent %}{{x}}";
-        String rendered = jinja.render(template, context);
-        assertEquals("256.0", rendered);
+        String[][] testCases = {
+            { "{% set x = base ** evenExponent %}{{x}}", "256.0" },
+            { "{% set x = 2 ** 8.0 %}{{x}}", "256.0" },
+            { "{% set x = base ** 8.0 %}{{x}}", "256.0" },
+            { "{% set x = 2 ** evenExponent %}{{x}}", "256.0" },
+            { "{% set x = negativeBase ** evenExponent %}{{x}}", "256.0" },
+            { "{% set x = -2 ** 8.0 %}{{x}}", "256.0" },
+            { "{% set x = base ** negativeExponent %}{{x}}", "0.00390625" },
+            { "{% set x = 2 ** -8.0 %}{{x}}", "0.00390625" },
+            { "{% set x = negativeBase ** oddExponent %}{{x}}", "-128.0"},
+            { "{% set x = -2 ** 7.0 %}{{x}}", "-128.0" }
+        };
+
+        for (String[] testCase : testCases ) {
+            String template = testCase[0];
+            String expected = testCase[1];
+            String rendered = jinja.render(template, context);
+            assertEquals(expected, rendered);
+        }
     }
 
     @Test
-    public void test04PowerOfStringFails() {
-
+    public void testPowerOfStringFails() {
         Map<String, Object> context = Maps.newHashMap();
         context.put("base",     "2");
         context.put("exponent", "8");

--- a/src/test/java/com/hubspot/jinjava/el/ext/TruncDivTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/TruncDivTest.java
@@ -29,10 +29,28 @@ public class TruncDivTest {
         Map<String, Object> context = Maps.newHashMap();
         context.put("dividend", 5);
         context.put("divisor",  2);
+        context.put("negativeDividend", -5);
+        context.put("negativeDivisor", -2);
 
-        String template = "{% set x = dividend // divisor %}{{x}}";
-        String rendered = jinja.render(template, context);
-        assertEquals("2", rendered);
+        String[][] testCases = {
+            { "{% set x = dividend // divisor %}{{x}}", "2" },
+            { "{% set x = 5 // 2 %}{{x}}", "2" },
+            { "{% set x = dividend // 2 %}{{x}}", "2" },
+            { "{% set x = 5 // divisor %}{{x}}", "2" },
+            { "{% set x = negativeDividend // divisor %}{{x}}", "-3" },
+            { "{% set x = -5 // 2 %}{{x}}", "-3" },
+            { "{% set x = dividend // negativeDivisor %}{{x}}", "-3" },
+            { "{% set x = 5 // -2 %}{{x}}", "-3" },
+            { "{% set x = negativeDividend // negativeDivisor %}{{x}}", "2" },
+            { "{% set x = -5 // -2 %}{{x}}", "2" }
+        };
+
+        for (String[] testCase : testCases) {
+            String template = testCase[0];
+            String expected = testCase[1];
+            String rendered = jinja.render(template, context);
+            assertEquals(expected, rendered);
+        }
     }
 
     /**
@@ -40,14 +58,31 @@ public class TruncDivTest {
      */
     @Test
     public void testTruncDivFractional() {
-
         Map<String, Object> context = Maps.newHashMap();
         context.put("dividend", 5.0);
         context.put("divisor",  2);
+        context.put("negativeDividend", -5.0);
+        context.put("negativeDivisor", -2);
 
-        String template = "{% set x = dividend // divisor %}{{x}}";
-        String rendered = jinja.render(template, context);
-        assertEquals("2.0", rendered);
+        String[][] testCases = {
+            { "{% set x = dividend // divisor %}{{x}}", "2.0" },
+            { "{% set x = 5.0 // 2 %}{{x}}", "2.0" },
+            { "{% set x = dividend // 2 %}{{x}}", "2.0" },
+            { "{% set x = 5.0 // divisor %}{{x}}", "2.0" },
+            { "{% set x = negativeDividend // divisor %}{{x}}", "-3.0" },
+            { "{% set x = -5.0 // 2 %}{{x}}", "-3.0" },
+            { "{% set x = dividend // negativeDivisor %}{{x}}", "-3.0" },
+            { "{% set x = 5.0 // -2 %}{{x}}", "-3.0" },
+            { "{% set x = negativeDividend // negativeDivisor %}{{x}}", "2.0" },
+            { "{% set x = -5.0 // -2 %}{{x}}", "2.0"}
+        };
+
+        for (String[] testCase : testCases) {
+            String template = testCase[0];
+            String expected = testCase[1];
+            String rendered = jinja.render(template, context);
+            assertEquals(expected, rendered);
+        }
     }
 
     /**
@@ -55,7 +90,6 @@ public class TruncDivTest {
      */
     @Test
     public void testTruncDivStringFails() {
-
         Map<String, Object> context = Maps.newHashMap();
         context.put("dividend", "5");
         context.put("divisor",  "2");


### PR DESCRIPTION
These changes address issue #169.

The current logic for // and ** specifies that the operands need to be `IDENTIFIER` symbols. This works when jinjava variables are used, but fails for actual numerical values (as these are `INTEGER` symbols, not `IDENTIFIER`).

The fix for this was to remove the special // and ** logic in `ExtendedParser.value` and instead rely on the existing extension framework via the pre-existing calls to `Parser.getExtensionHandler`