### PR TITLE
Implement nested properties for selectattr and rejectattr filters.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/RejectAttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RejectAttrFilter.java
@@ -1,18 +1,11 @@
 package com.hubspot.jinjava.lib.filter;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.Map;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.lib.exptest.ExpTest;
-import com.hubspot.jinjava.util.ForLoop;
-import com.hubspot.jinjava.util.ObjectIterator;
-import com.hubspot.jinjava.util.Variable;
 
 @JinjavaDoc(
     value = "Filters a sequence of objects by applying a test to an attribute of an object or the attribute and "
@@ -29,7 +22,7 @@ import com.hubspot.jinjava.util.Variable;
                 "    <div class=\"post-item\">Post in listing markup</div>\n" +
                 "{% endfor %}")
     })
-public class RejectAttrFilter implements Filter {
+public class RejectAttrFilter extends SelectAttrFilter implements AdvancedFilter {
 
   @Override
   public String getName() {
@@ -37,39 +30,7 @@ public class RejectAttrFilter implements Filter {
   }
 
   @Override
-  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
-    List<Object> result = new ArrayList<>();
-
-    if (args.length == 0) {
-      throw new InterpretException(getName() + " filter requires an attr to filter on", interpreter.getLineNumber());
-    }
-
-    String[] expArgs = new String[]{};
-    String attr = args[0];
-
-    ExpTest expTest = interpreter.getContext().getExpTest("truthy");
-    if (args.length > 1) {
-      expTest = interpreter.getContext().getExpTest(args[1]);
-      if (expTest == null) {
-        throw new InterpretException("No expression test defined with name '" + args[1] + "'",
-                                     interpreter.getLineNumber());
-      }
-    }
-
-    if (args.length > 2) {
-      expArgs = Arrays.copyOfRange(args, 2, args.length);
-    }
-    ForLoop loop = ObjectIterator.getLoop(var);
-    while (loop.hasNext()) {
-      Object val = loop.next();
-      Object attrVal = new Variable(interpreter, String.format("%s.%s", val.toString(), attr)).resolve(val);
-
-      if (!expTest.evaluate(attrVal, interpreter, (Object[]) expArgs)) {
-        result.add(val);
-      }
-    }
-
-    return result;
+  public Object filter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs) {
+    return applyFilter(var, interpreter, args, kwargs, false);
   }
-
 }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RejectAttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RejectAttrFilter.java
@@ -12,6 +12,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.exptest.ExpTest;
 import com.hubspot.jinjava.util.ForLoop;
 import com.hubspot.jinjava.util.ObjectIterator;
+import com.hubspot.jinjava.util.Variable;
 
 @JinjavaDoc(
     value = "Filters a sequence of objects by applying a test to an attribute of an object or the attribute and "
@@ -61,7 +62,7 @@ public class RejectAttrFilter implements Filter {
     ForLoop loop = ObjectIterator.getLoop(var);
     while (loop.hasNext()) {
       Object val = loop.next();
-      Object attrVal = interpreter.resolveProperty(val, attr);
+      Object attrVal = new Variable(interpreter, String.format("%s.%s", val.toString(), attr)).resolve(val);
 
       if (!expTest.evaluate(attrVal, interpreter, (Object[]) expArgs)) {
         result.add(val);

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.base.Splitter;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
@@ -13,6 +14,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.exptest.ExpTest;
 import com.hubspot.jinjava.util.ForLoop;
 import com.hubspot.jinjava.util.ObjectIterator;
+import com.hubspot.jinjava.util.Variable;
 
 @JinjavaDoc(
     value = "Filters a sequence of objects by applying a test to an attribute of an object and only selecting the ones with the test succeeding.",
@@ -29,6 +31,8 @@ import com.hubspot.jinjava.util.ObjectIterator;
                 "{% endfor %}")
     })
 public class SelectAttrFilter implements AdvancedFilter {
+
+  private static final Splitter PROPERTY_SPLITTER = Splitter.on('.');
 
   @Override
   public String getName() {
@@ -71,8 +75,8 @@ public class SelectAttrFilter implements AdvancedFilter {
     ForLoop loop = ObjectIterator.getLoop(var);
     while (loop.hasNext()) {
       Object val = loop.next();
-      Object attrVal = interpreter.resolveProperty(val, attr);
 
+      Object attrVal = new Variable(interpreter, String.format("%s.%s", val.toString(), attr)).resolve(val);
       if (expTest.evaluate(attrVal, interpreter, expArgs)) {
         result.add(val);
       }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
@@ -76,7 +76,7 @@ public class SelectAttrFilter implements AdvancedFilter {
     while (loop.hasNext()) {
       Object val = loop.next();
 
-      Object attrVal = new Variable(interpreter, String.format("%s.%s", val.toString(), attr)).resolve(val);
+      Object attrVal = new Variable(interpreter, String.format("%s.%s", "placeholder", attr)).resolve(val);
       if (expTest.evaluate(attrVal, interpreter, expArgs)) {
         result.add(val);
       }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
@@ -78,8 +78,7 @@ public class SelectAttrFilter implements AdvancedFilter {
       Object val = loop.next();
 
       Object attrVal = new Variable(interpreter, String.format("%s.%s", "placeholder", attr)).resolve(val);
-      boolean pass = expTest.evaluate(attrVal, interpreter, expArgs);
-      if ((acceptObjects && pass) || (!acceptObjects && !pass)) {
+      if (acceptObjects == expTest.evaluate(attrVal, interpreter, expArgs)) {
         result.add(val);
       }
     }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
@@ -41,6 +41,10 @@ public class SelectAttrFilter implements AdvancedFilter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs) {
+    return applyFilter(var, interpreter, args, kwargs, true);
+  }
+
+  protected Object applyFilter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs, boolean acceptObjects) {
     List<Object> result = new ArrayList<>();
 
     if (args.length == 0) {
@@ -77,7 +81,8 @@ public class SelectAttrFilter implements AdvancedFilter {
       Object val = loop.next();
 
       Object attrVal = new Variable(interpreter, String.format("%s.%s", "placeholder", attr)).resolve(val);
-      if (expTest.evaluate(attrVal, interpreter, expArgs)) {
+      boolean pass = expTest.evaluate(attrVal, interpreter, expArgs);
+      if ((acceptObjects && pass) || (!acceptObjects && !pass)) {
         result.add(val);
       }
     }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.base.Splitter;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
@@ -31,8 +30,6 @@ import com.hubspot.jinjava.util.Variable;
                 "{% endfor %}")
     })
 public class SelectAttrFilter implements AdvancedFilter {
-
-  private static final Splitter PROPERTY_SPLITTER = Splitter.on('.');
 
   @Override
   public String getName() {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RejectAttrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RejectAttrFilterTest.java
@@ -49,8 +49,7 @@ public class RejectAttrFilterTest {
     assertThat(jinjava.render("{{ users|rejectattr('option.name', 'equalto', 'option0') }}", new HashMap<String, Object>()))
         .isEqualTo("[1, 2]");
   }
-
-
+  
   public static class User {
     private int num;
     private boolean isActive;

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RejectAttrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RejectAttrFilterTest.java
@@ -18,9 +18,9 @@ public class RejectAttrFilterTest {
   public void setup() {
     jinjava = new Jinjava();
     jinjava.getGlobalContext().put("users", Lists.newArrayList(
-        new User(0, false, "foo@bar.com"),
-        new User(1, true, "bar@bar.com"),
-        new User(2, false, null)));
+        new User(0, false, "foo@bar.com", new Option(0, "option0")),
+        new User(1, true, "bar@bar.com", new Option(1, "option1")),
+        new User(2, false, null, new Option(2, "option2"))));
   }
 
   @Test
@@ -36,9 +36,18 @@ public class RejectAttrFilterTest {
   }
 
   @Test
-  public void selectAttrWithIsEqualToExp() {
+  public void rejectAttrWithIsEqualToExp() {
     assertThat(jinjava.render("{{ users|rejectattr('email', 'equalto', 'bar@bar.com') }}", new HashMap<String, Object>()))
         .isEqualTo("[0, 2]");
+  }
+
+  @Test
+  public void rejectAttrWithNestedProperty() {
+    assertThat(jinjava.render("{{ users|rejectattr('option.id', 'equalto', 1) }}", new HashMap<String, Object>()))
+        .isEqualTo("[0, 2]");
+
+    assertThat(jinjava.render("{{ users|rejectattr('option.name', 'equalto', 'option0') }}", new HashMap<String, Object>()))
+        .isEqualTo("[1, 2]");
   }
 
 
@@ -46,11 +55,13 @@ public class RejectAttrFilterTest {
     private int num;
     private boolean isActive;
     private String email;
+    private Option option;
 
-    public User(int num, boolean isActive, String email) {
+    public User(int num, boolean isActive, String email, Option option) {
       this.num = num;
       this.isActive = isActive;
       this.email = email;
+      this.option = option;
     }
 
     public int getNum() {
@@ -65,10 +76,36 @@ public class RejectAttrFilterTest {
       return isActive;
     }
 
+    public Option getOption() {
+      return option;
+    }
+
     @Override
     public String toString() {
       return num + "";
     }
   }
 
+  public static class Option {
+    private long id;
+    private String name;
+
+    public Option(long id, String name) {
+      this.id = id;
+      this.name = name;
+    }
+
+    public long getId() {
+      return id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public String toString() {
+      return id + "";
+    }
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RejectAttrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RejectAttrFilterTest.java
@@ -49,7 +49,7 @@ public class RejectAttrFilterTest {
     assertThat(jinjava.render("{{ users|rejectattr('option.name', 'equalto', 'option0') }}", new HashMap<String, Object>()))
         .isEqualTo("[1, 2]");
   }
-  
+
   public static class User {
     private int num;
     private boolean isActive;

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SelectAttrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SelectAttrFilterTest.java
@@ -18,7 +18,9 @@ public class SelectAttrFilterTest {
   public void setup() {
     jinjava = new Jinjava();
     jinjava.getGlobalContext().put("users", Lists.newArrayList(
-        new User(0, false, "foo@bar.com"), new User(1, true, "bar@bar.com"), new User(2, false, null)));
+        new User(0, false, "foo@bar.com", new Option(0, "option0")),
+        new User(1, true, "bar@bar.com", new Option(1, "option1")),
+        new User(2, false, null, new Option(2, "option2"))));
   }
 
   @Test
@@ -45,16 +47,27 @@ public class SelectAttrFilterTest {
         .isEqualTo("[1]");
   }
 
+  @Test
+  public void selectAttrWithNestedProperty() {
+    assertThat(jinjava.render("{{ users|selectattr('option.id', 'equalto', 1) }}", new HashMap<String, Object>()))
+        .isEqualTo("[1]");
+
+    assertThat(jinjava.render("{{ users|selectattr('option.name', 'equalto', 'option2') }}", new HashMap<String, Object>()))
+        .isEqualTo("[2]");
+  }
+
 
   public static class User {
     private long num;
     private boolean isActive;
     private String email;
+    private Option option;
 
-    public User(long num, boolean isActive, String email) {
+    public User(long num, boolean isActive, String email, Option option) {
       this.num = num;
       this.isActive = isActive;
       this.email = email;
+      this.option = option;
     }
 
     public long getNum() {
@@ -69,10 +82,36 @@ public class SelectAttrFilterTest {
       return isActive;
     }
 
+    public Option getOption() {
+      return option;
+    }
+
     @Override
     public String toString() {
       return num + "";
     }
   }
 
+  public static class Option {
+    private long id;
+    private String name;
+
+    public Option(long id, String name) {
+      this.id = id;
+      this.name = name;
+    }
+
+    public long getId() {
+      return id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public String toString() {
+      return id + "";
+    }
+  }
 }


### PR DESCRIPTION
Continuation of https://github.com/HubSpot/jinjava/pull/183 to make these filters expressive. Previously if you had a nested object there would be no way to `selectattr` on the nested property, thereby requiring the need to use a for loop or make another API call. This changes `selectattr` to use the chain property resolver and modifies `rejectattr` to share code with `selectattr`.