### PR TITLE
Implements 'do' tag for expression statements

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/DoTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/DoTag.java
@@ -22,7 +22,7 @@ public class DoTag implements Tag {
     if (StringUtils.isBlank(tagNode.getHelpers())) {
       throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'do' expects expression", tagNode.getLineNumber(), tagNode.getStartPosition());
     }
-    
+
     interpreter.resolveELExpression(tagNode.getHelpers(), tagNode.getLineNumber());
     return "";
   }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/DoTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/DoTag.java
@@ -22,9 +22,8 @@ public class DoTag implements Tag {
     if (StringUtils.isBlank(tagNode.getHelpers())) {
       throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'do' expects expression", tagNode.getLineNumber(), tagNode.getStartPosition());
     }
-
-    String expression = tagNode.getHelpers();
-    interpreter.resolveELExpression(expression, tagNode.getLineNumber());
+    
+    interpreter.resolveELExpression(tagNode.getHelpers(), tagNode.getLineNumber());
     return "";
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/DoTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/DoTag.java
@@ -1,0 +1,40 @@
+package com.hubspot.jinjava.lib.tag;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
+import com.hubspot.jinjava.tree.TagNode;
+
+@JinjavaDoc(
+    value = "Evaluates expression without printing out result.",
+    snippets = {
+        @JinjavaSnippet(
+            code = "{% do list.append('value 2') %}")
+    })
+public class DoTag implements Tag {
+
+  @Override
+  public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
+
+    if (StringUtils.isBlank(tagNode.getHelpers())) {
+      throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'do' expects expression", tagNode.getLineNumber(), tagNode.getStartPosition());
+    }
+
+    String expression = tagNode.getHelpers();
+    interpreter.resolveELExpression(expression, tagNode.getLineNumber());
+    return "";
+  }
+
+  @Override
+  public String getEndTagName() {
+    return null;
+  }
+
+  @Override
+  public String getName() {
+    return "do";
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/lib/tag/TagLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/TagLibrary.java
@@ -45,7 +45,8 @@ public class TagLibrary extends SimpleLibrary<Tag> {
         PrintTag.class,
         RawTag.class,
         SetTag.class,
-        UnlessTag.class);
+        UnlessTag.class,
+        DoTag.class);
   }
 
   public Tag getTag(String tagName) {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/DoTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/DoTagTest.java
@@ -1,0 +1,42 @@
+package com.hubspot.jinjava.lib.tag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.Maps;
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.interpret.Context;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.RenderResult;
+import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
+
+public class DoTagTest {
+
+  private Context context;
+  JinjavaInterpreter interpreter;
+  Jinjava jinjava;
+
+  @Before
+  public void setup() {
+    jinjava = new Jinjava();
+    interpreter = jinjava.newInterpreter();
+    context = interpreter.getContext();
+  }
+
+  @Test
+  public void itResolvesExpressions() {
+    String template = "{% set output = [] %}{% do output.append('hey') %}{{ output }}";
+    assertThat(jinjava.render(template, Maps.newHashMap())).isEqualTo("[hey]");
+  }
+
+  @Test
+  public void itAddsTemplateErrorOnEmptyExpression() {
+    String template = "{% do %}";
+    RenderResult renderResult = jinjava.renderForResult(template, Maps.newHashMap());
+    assertThat(renderResult.getErrors()).hasSize(1);
+    assertThat(renderResult.getErrors().get(0).getReason()).isEqualTo(ErrorReason.SYNTAX_ERROR);
+  }
+
+}

--- a/src/test/java/com/hubspot/jinjava/lib/tag/DoTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/DoTagTest.java
@@ -15,8 +15,8 @@ import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 public class DoTagTest {
 
   private Context context;
-  JinjavaInterpreter interpreter;
-  Jinjava jinjava;
+  private JinjavaInterpreter interpreter;
+  private Jinjava jinjava;
 
   @Before
   public void setup() {
@@ -38,5 +38,4 @@ public class DoTagTest {
     assertThat(renderResult.getErrors()).hasSize(1);
     assertThat(renderResult.getErrors().get(0).getReason()).isEqualTo(ErrorReason.SYNTAX_ERROR);
   }
-
 }


### PR DESCRIPTION
Requested feature: https://github.com/HubSpot/jinjava/issues/197
Adds a `do` tag to evaluate an expression without printing out the result. Previously to evaluate an expression you would need to use `{{ expression }}`, however if this expression returned a value you were out of luck. Now you can do `{% do expression %}` without the side effects of what the result of `expression` returns.