### PR TITLE
remove findbugs annotations because there's no findbugs analysis happening

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,10 +65,6 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
@@ -179,4 +175,3 @@
     </plugins>
   </build>
 </project>
-

--- a/src/main/java/com/hubspot/jinjava/util/ScopeMap.java
+++ b/src/main/java/com/hubspot/jinjava/util/ScopeMap.java
@@ -7,8 +7,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public class ScopeMap<K, V> implements Map<K, V> {
 
   private final Map<K, V> scope;
@@ -134,8 +132,6 @@ public class ScopeMap<K, V> implements Map<K, V> {
   }
 
   @Override
-  @SuppressFBWarnings(justification = "using overridden get() to do scoped retrieve with parent fallback",
-      value = "WMI_WRONG_MAP_ITERATOR")
   public Set<java.util.Map.Entry<K, V>> entrySet() {
     Set<java.util.Map.Entry<K, V>> entries = new HashSet<>();
 


### PR DESCRIPTION
Seems findbugs analysis was on in the past (https://github.com/HubSpot/jinjava/commit/43c7e72d225842747fe2821de096b41c00c746f7), but has since been disabled (maybe https://github.com/HubSpot/jinjava/commit/4916b55ce1ef353d4f3e7d882222b00e927ba022#diff-600376dffeb79835ede4a0b285078036, maybe earlier).  In any case, it doesn't appear that findbugs is running at the moment (or at least, removing the suppression doesn't cause any failures for me).

It'd be wonderful to get com.google.code.findbugs:annotations off the classpath as it causes conflicts for me.  With the [migration to spotbugs](https://spotbugs.readthedocs.io/en/stable/migration.html) it seems like conflicts are all too easy at the moment.