### PR TITLE
Support expressions in selectattr/rejectattr

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
@@ -79,18 +79,19 @@ public class SelectAttrFilter implements AdvancedFilter {
 
       // push temporary variable to be resolved
       String tempValue = generateTempVariable();
-      while (interpreter.getContext().containsKey(tempValue)) {
+      String expression = generateTempVariable(tempValue, attr);
+
+      // ensure this random value hasn't been seen before
+      while (interpreter.getContext().containsKey(tempValue) || interpreter.getContext().getResolvedExpressions().contains(expression)) {
         tempValue = generateTempVariable();
       }
 
       interpreter.getContext().put(tempValue, val);
 
-      String expression = String.format("%s.%s", tempValue, attr).trim();
       Object attrVal = interpreter.resolveELExpression(expression, interpreter.getLineNumber());
 
       // cleanup
       interpreter.getContext().remove(tempValue);
-      interpreter.getContext().getResolvedExpressions().remove(expression);
 
       if (acceptObjects == expTest.evaluate(attrVal, interpreter, expArgs)) {
         result.add(val);
@@ -102,6 +103,10 @@ public class SelectAttrFilter implements AdvancedFilter {
 
   private String generateTempVariable() {
     return "jj_temp_" + Math.abs(ThreadLocalRandom.current().nextInt());
+  }
+
+  private String generateTempVariable(String tempValue, String expression) {
+    return String.format("%s.%s", tempValue, expression).trim();
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
@@ -85,8 +85,13 @@ public class SelectAttrFilter implements AdvancedFilter {
 
       interpreter.getContext().put(tempValue, val);
 
-      Object attrVal = interpreter.resolveELExpression(String.format("%s.%s", tempValue, attr), interpreter.getLineNumber());
+      String expression = String.format("%s.%s", tempValue, attr).trim();
+      Object attrVal = interpreter.resolveELExpression(expression, interpreter.getLineNumber());
+
+      // cleanup
       interpreter.getContext().remove(tempValue);
+      interpreter.getContext().getResolvedExpressions().remove(expression);
+
       if (acceptObjects == expTest.evaluate(attrVal, interpreter, expArgs)) {
         result.add(val);
       }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
@@ -13,7 +14,6 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.exptest.ExpTest;
 import com.hubspot.jinjava.util.ForLoop;
 import com.hubspot.jinjava.util.ObjectIterator;
-import com.hubspot.jinjava.util.Variable;
 
 @JinjavaDoc(
     value = "Filters a sequence of objects by applying a test to an attribute of an object and only selecting the ones with the test succeeding.",
@@ -77,7 +77,16 @@ public class SelectAttrFilter implements AdvancedFilter {
     while (loop.hasNext()) {
       Object val = loop.next();
 
-      Object attrVal = new Variable(interpreter, String.format("%s.%s", "placeholder", attr)).resolve(val);
+      // push temporary variable to be resolved
+      String tempValue = generateTempVariable();
+      while (interpreter.getContext().containsKey(tempValue)) {
+        tempValue = generateTempVariable();
+      }
+
+      interpreter.getContext().put(tempValue, val);
+
+      Object attrVal = interpreter.resolveELExpression(String.format("%s.%s", tempValue, attr), interpreter.getLineNumber());
+      interpreter.getContext().remove(tempValue);
       if (acceptObjects == expTest.evaluate(attrVal, interpreter, expArgs)) {
         result.add(val);
       }
@@ -85,4 +94,9 @@ public class SelectAttrFilter implements AdvancedFilter {
 
     return result;
   }
+
+  private String generateTempVariable() {
+    return "jj_temp_" + Math.abs(ThreadLocalRandom.current().nextInt());
+  }
+
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SelectAttrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SelectAttrFilterTest.java
@@ -3,10 +3,12 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.hubspot.jinjava.Jinjava;
 
@@ -18,9 +20,9 @@ public class SelectAttrFilterTest {
   public void setup() {
     jinjava = new Jinjava();
     jinjava.getGlobalContext().put("users", Lists.newArrayList(
-        new User(0, false, "foo@bar.com", new Option(0, "option0")),
-        new User(1, true, "bar@bar.com", new Option(1, "option1")),
-        new User(2, false, null, new Option(2, "option2"))));
+        new User(0, false, "foo@bar.com", new Option(0, "option0"), ImmutableList.of(new Option(0, "option0"))),
+        new User(1, true, "bar@bar.com", new Option(1, "option1"), ImmutableList.of(new Option(1, "option1"))),
+        new User(2, false, null, new Option(2, "option2"), ImmutableList.of(new Option(2, "option2")))));
   }
 
   @Test
@@ -56,18 +58,30 @@ public class SelectAttrFilterTest {
         .isEqualTo("[2]");
   }
 
+  @Test
+  public void selectAttrWithNestedFilter() {
+
+    assertThat(jinjava.render("{{ users|selectattr(\"optionList|map('id')\", 'containing', 1) }}", new HashMap<String, Object>()))
+        .isEqualTo("[1]");
+
+    assertThat(jinjava.render("{{ users|selectattr(\"optionList|map('name')\", 'containing', 'option2') }}", new HashMap<String, Object>()))
+        .isEqualTo("[2]");
+  }
+
 
   public static class User {
     private long num;
     private boolean isActive;
     private String email;
     private Option option;
+    private List<Option> optionList;
 
-    public User(long num, boolean isActive, String email, Option option) {
+    public User(long num, boolean isActive, String email, Option option, List<Option> optionList) {
       this.num = num;
       this.isActive = isActive;
       this.email = email;
       this.option = option;
+      this.optionList = optionList;
     }
 
     public long getNum() {
@@ -84,6 +98,10 @@ public class SelectAttrFilterTest {
 
     public Option getOption() {
       return option;
+    }
+
+    public List<Option> getOptionList() {
+      return optionList;
     }
 
     @Override


### PR DESCRIPTION
Previous PR allowed nested properties in `selectattr` and `rejectattr` https://github.com/HubSpot/jinjava/pull/238.

This is great however is still limiting because you cannot execute filters. For example you may have a list of objects you would like to map to a value before executing the filter: `|selectattr("optionList|map('id')", "containing", 1)` or perhaps you would like to trim the values `|selectattr("name|trim|lower", "equalto", "matt")`. 

This resolves the first argument as an expression and then applies the test case. The solution is hacky as it stores a temporary variable to resolve the expression against. I have not thought of a way to get around this.

Motivation: This makes it easier to filter many HubL/HubSpot objects that have properties that are lists of other objects. Previously this required a for loop.