### PR TITLE
Add conversion to Java datetime format for strtotime.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -171,7 +171,8 @@ public class Functions {
     }
 
     try {
-      return new PyishDate(ZonedDateTime.parse(datetimeString, DateTimeFormatter.ofPattern(datetimeFormat)));
+      String convertedFormat = StrftimeFormatter.toJavaDateTimeFormat(datetimeFormat);
+      return new PyishDate(ZonedDateTime.parse(datetimeString, DateTimeFormatter.ofPattern(convertedFormat)));
     } catch (DateTimeParseException e) {
       throw new InterpretException(String.format("%s() could not match datetime input %s with datetime format %s",
           STRING_TO_TIME_FUNCTION,

--- a/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
@@ -57,7 +57,7 @@ public class StrftimeFormatter {
    * @param strftime
    * @return date formatted as string
    */
-  private static String toJavaDateTimeFormat(String strftime) {
+  public static String toJavaDateTimeFormat(String strftime) {
     if (!StringUtils.contains(strftime, '%')) {
       return replaceL(strftime);
     }


### PR DESCRIPTION
We need to convert the pattern for `strtotime` and `datetimeFormat` to be unified.