### PR TITLE
handle large values in range function

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -259,21 +259,21 @@ public class Functions {
 
     List<Integer> result = new ArrayList<>();
 
-    int start = 0;
-    int end;
+    long start = 0;
+    long end;
     int step = 1;
 
     switch (args.length) {
       case 0:
-        end = NumberUtils.toInt(arg1.toString());
+        end = NumberUtils.toLong(arg1.toString());
         break;
       case 1:
-        start = NumberUtils.toInt(arg1.toString());
-        end = NumberUtils.toInt(args[0].toString());
+        start = NumberUtils.toLong(arg1.toString());
+        end = NumberUtils.toLong(args[0].toString());
         break;
       default:
-        start = NumberUtils.toInt(arg1.toString());
-        end = NumberUtils.toInt(args[0].toString());
+        start = NumberUtils.toLong(arg1.toString());
+        end = NumberUtils.toLong(args[0].toString());
         step = NumberUtils.toInt(args[1].toString(), 1);
     }
 
@@ -287,11 +287,11 @@ public class Functions {
         return result;
       }
 
-      for (int i = start; i < end; i += step) {
+      for (long i = start; i < end; i += step) {
         if (result.size() >= RANGE_LIMIT) {
           break;
         }
-        result.add(i);
+        result.add(((Long) i).intValue());
       }
     } else {
 
@@ -299,11 +299,11 @@ public class Functions {
         return result;
       }
 
-      for (int i = start; i > end; i += step) {
+      for (long i = start; i > end; i += step) {
         if (result.size() >= RANGE_LIMIT) {
           break;
         }
-        result.add(i);
+        result.add(((Long) i).intValue());
       }
     }
 

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -259,21 +259,27 @@ public class Functions {
 
     List<Integer> result = new ArrayList<>();
 
-    long start = 0;
-    long end;
+    int start = 0;
+    int end = 0;
     int step = 1;
 
     switch (args.length) {
       case 0:
-        end = NumberUtils.toLong(arg1.toString());
+        if (NumberUtils.isNumber(arg1.toString())) {
+          end = NumberUtils.toInt(arg1.toString(), RANGE_LIMIT);
+        }
         break;
       case 1:
-        start = NumberUtils.toLong(arg1.toString());
-        end = NumberUtils.toLong(args[0].toString());
+        start = NumberUtils.toInt(arg1.toString());
+        if (NumberUtils.isNumber(args[0].toString())) {
+          end = NumberUtils.toInt(args[0].toString(), start + RANGE_LIMIT);
+        }
         break;
       default:
-        start = NumberUtils.toLong(arg1.toString());
-        end = NumberUtils.toLong(args[0].toString());
+        start = NumberUtils.toInt(arg1.toString());
+        if (NumberUtils.isNumber(args[0].toString())) {
+          end = NumberUtils.toInt(args[0].toString(), start + RANGE_LIMIT);
+        }
         step = NumberUtils.toInt(args[1].toString(), 1);
     }
 
@@ -287,11 +293,11 @@ public class Functions {
         return result;
       }
 
-      for (long i = start; i < end; i += step) {
+      for (int i = start; i < end; i += step) {
         if (result.size() >= RANGE_LIMIT) {
           break;
         }
-        result.add(((Long) i).intValue());
+        result.add(i);
       }
     } else {
 
@@ -299,11 +305,11 @@ public class Functions {
         return result;
       }
 
-      for (long i = start; i > end; i += step) {
+      for (int i = start; i > end; i += step) {
         if (result.size() >= RANGE_LIMIT) {
           break;
         }
-        result.add(((Long) i).intValue());
+        result.add(i);
       }
     }
 

--- a/src/test/java/com/hubspot/jinjava/lib/fn/RangeFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/RangeFunctionTest.java
@@ -43,6 +43,7 @@ public class RangeFunctionTest {
   @Test
   public void itTruncatesHugeRanges() {
     assertThat(Functions.range(2, 200000000).size()).isEqualTo(Functions.RANGE_LIMIT);
+    assertThat(Functions.range(2, Long.MAX_VALUE).size()).isEqualTo(Functions.RANGE_LIMIT);
   }
 
 }

--- a/src/test/java/com/hubspot/jinjava/lib/fn/RangeFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/RangeFunctionTest.java
@@ -37,13 +37,14 @@ public class RangeFunctionTest {
 
   @Test
   public void itHandlesBadValues() {
+    assertThat(Functions.range("f")).isEmpty();
     assertThat(Functions.range(2, "f")).isEmpty();
   }
 
   @Test
   public void itTruncatesHugeRanges() {
     assertThat(Functions.range(2, 200000000).size()).isEqualTo(Functions.RANGE_LIMIT);
-    assertThat(Functions.range(2, Long.MAX_VALUE).size()).isEqualTo(Functions.RANGE_LIMIT);
+    assertThat(Functions.range(Long.MAX_VALUE - 1, Long.MAX_VALUE).size()).isEqualTo(Functions.RANGE_LIMIT);
   }
 
 }


### PR DESCRIPTION
Fixes https://github.com/HubSpot/jinjava/issues/263 by defaulting numeric, out of range values in the range function to `start + RANGE_LIMIT`