### PR TITLE
Allow tags to declare themselves safe for execution in validation mode

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/AutoEscapeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/AutoEscapeTag.java
@@ -34,6 +34,11 @@ public class AutoEscapeTag implements Tag {
   }
 
   @Override
+  public boolean isRenderedInValidationMode() {
+    return true;
+  }
+
+  @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     try (InterpreterScopeClosable c = interpreter.enterScope()) {
       String boolFlagStr = StringUtils.trim(tagNode.getHelpers());

--- a/src/main/java/com/hubspot/jinjava/lib/tag/CallTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/CallTag.java
@@ -71,7 +71,7 @@ public class CallTag implements Tag {
       MacroFunction caller = new MacroFunction(tagNode.getChildren(), "caller", args, false, false, true, interpreter.getContext());
       interpreter.getContext().addGlobalMacro(caller);
 
-      return interpreter.getContext().isValidationMode() ? "" : interpreter.render(macroExpr);
+      return interpreter.render(macroExpr);
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/CycleTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/CycleTag.java
@@ -50,6 +50,11 @@ public class CycleTag implements Tag {
   private static final String LOOP_INDEX = "loop.index0";
   private static final String TAGNAME = "cycle";
 
+  @Override
+  public boolean isRenderedInValidationMode() {
+    return true;
+  }
+
   @SuppressWarnings("unchecked")
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ElseIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ElseIfTag.java
@@ -11,6 +11,11 @@ public class ElseIfTag implements Tag {
   static final String ELSEIF = "elif";
 
   @Override
+  public boolean isRenderedInValidationMode() {
+    return true;
+  }
+
+  @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     return "";
   }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ElseTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ElseTag.java
@@ -26,6 +26,11 @@ public class ElseTag implements Tag {
   static final String ELSE = "else";
 
   @Override
+  public boolean isRenderedInValidationMode() {
+    return true;
+  }
+
+  @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     return "";
   }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -78,6 +78,11 @@ public class ForTag implements Tag {
   private static final String TAGNAME = "for";
   private static final String ENDTAGNAME = "endfor";
 
+  @Override
+  public boolean isRenderedInValidationMode() {
+    return true;
+  }
+
   @SuppressWarnings("unchecked")
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IfTag.java
@@ -53,6 +53,11 @@ public class IfTag implements Tag {
   private static final String ENDTAGNAME = "endif";
 
   @Override
+  public boolean isRenderedInValidationMode() {
+    return true;
+  }
+
+  @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     if (StringUtils.isBlank(tagNode.getHelpers())) {
       throw new TemplateSyntaxException(tagNode.getMaster().getImage(), "Tag 'if' expects expression", tagNode.getLineNumber(), tagNode.getStartPosition());

--- a/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
@@ -63,6 +63,11 @@ public class MacroTag implements Tag {
   }
 
   @Override
+  public boolean isRenderedInValidationMode() {
+    return true;
+  }
+
+  @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     Matcher matcher = MACRO_PATTERN.matcher(tagNode.getHelpers());
     if (!matcher.find()) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/PrintTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/PrintTag.java
@@ -27,8 +27,7 @@ public class PrintTag implements Tag {
 
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
-    String result = Objects.toString(interpreter.resolveELExpression(tagNode.getHelpers(), tagNode.getLineNumber()), "");
-    return interpreter.getContext().isValidationMode() ? "" : result;
+    return Objects.toString(interpreter.resolveELExpression(tagNode.getHelpers(), tagNode.getLineNumber()), "");
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/RawTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/RawTag.java
@@ -34,10 +34,6 @@ public class RawTag implements Tag {
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
 
-    if (interpreter.getContext().isValidationMode()) {
-      return "";
-    }
-
     LengthLimitingStringBuilder result = new LengthLimitingStringBuilder(interpreter.getConfig().getMaxOutputSize());
 
     for (Node n : tagNode.getChildren()) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
@@ -91,18 +91,12 @@ public class SetTag implements Tag {
 
       for (int i = 0; i < varTokens.length; i++) {
         String varItem = varTokens[i].trim();
-        Object val = exprVals.get(i);
-        if (!interpreter.getContext().isValidationMode()) {
-          interpreter.getContext().put(varItem, val);
-        }
+        interpreter.getContext().put(varItem, exprVals.get(i));
       }
 
     } else {
       // handle single variable assignment
-      Object val = interpreter.resolveELExpression(expr, tagNode.getLineNumber());
-      if (!interpreter.getContext().isValidationMode()) {
-        interpreter.getContext().put(var, val);
-      }
+      interpreter.getContext().put(var, interpreter.resolveELExpression(expr, tagNode.getLineNumber()));
     }
 
     return "";

--- a/src/main/java/com/hubspot/jinjava/lib/tag/Tag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/Tag.java
@@ -32,8 +32,12 @@ public interface Tag extends Importable, Serializable {
   String interpret(TagNode tagNode, JinjavaInterpreter interpreter);
 
   /**
-   * @return Get name of end tag lowerCase Null if it's a single tag without content.
+   * @return Get name of end tag (lowerCase). Null if it's a single tag without content.
    */
   String getEndTagName();
+
+  default boolean isRenderedInValidationMode() {
+    return false;
+  }
 
 }

--- a/src/main/java/com/hubspot/jinjava/tree/TagNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TagNode.java
@@ -19,6 +19,7 @@ import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.Tag;
 import com.hubspot.jinjava.tree.output.OutputNode;
+import com.hubspot.jinjava.tree.output.RenderedOutputNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
 
 public class TagNode extends Node {
@@ -47,6 +48,11 @@ public class TagNode extends Node {
 
   @Override
   public OutputNode render(JinjavaInterpreter interpreter) {
+
+    if (interpreter.getContext().isValidationMode() && !tag.isRenderedInValidationMode()) {
+      return new RenderedOutputNode("");
+    }
+
     try {
       return tag.interpretOutput(this, interpreter);
     } catch (InterpretException e) {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ValidationModeTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ValidationModeTest.java
@@ -61,7 +61,6 @@ public class ValidationModeTest {
     return ++functionExecutionCount;
   }
 
-
   @Before
   public void setup() {
 


### PR DESCRIPTION
Reimplements https://github.com/HubSpot/jinjava/pull/264 for tags by allowing them to override `isRenderedInValidationMode` so "safe" tags will be executed and other tags can opt in to execute.