### PR TITLE
Add max string length to Jinjava config.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -54,11 +54,11 @@ public class JinjavaConfig {
   }
 
   public JinjavaConfig() {
-    this(StandardCharsets.UTF_8, Locale.ENGLISH, ZoneOffset.UTC, 10, new HashMap<>(), false, false, true, false, false, 0, true, RandomNumberGeneratorStrategy.THREAD_LOCAL, false, Long.MAX_VALUE);
+    this(StandardCharsets.UTF_8, Locale.ENGLISH, ZoneOffset.UTC, 10, new HashMap<>(), false, false, true, false, false, 0, true, RandomNumberGeneratorStrategy.THREAD_LOCAL, false, 0);
   }
 
   public JinjavaConfig(Charset charset, Locale locale, ZoneId timeZone, int maxRenderDepth) {
-    this(charset, locale, timeZone, maxRenderDepth, new HashMap<>(), false, false, true, false, false, 0, true, RandomNumberGeneratorStrategy.THREAD_LOCAL, false, Long.MAX_VALUE);
+    this(charset, locale, timeZone, maxRenderDepth, new HashMap<>(), false, false, true, false, false, 0, true, RandomNumberGeneratorStrategy.THREAD_LOCAL, false, 0);
   }
 
   private JinjavaConfig(Charset charset,
@@ -170,7 +170,7 @@ public class JinjavaConfig {
     private boolean nestedInterpretationEnabled = true;
     private RandomNumberGeneratorStrategy randomNumberGeneratorStrategy = RandomNumberGeneratorStrategy.THREAD_LOCAL;
     private boolean validationMode = false;
-    private long maxStringLength = Long.MAX_VALUE;
+    private long maxStringLength = 0;
 
     private Builder() {}
 

--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -47,17 +47,18 @@ public class JinjavaConfig {
   private final boolean nestedInterpretationEnabled;
   private final RandomNumberGeneratorStrategy randomNumberGenerator;
   private final boolean validationMode;
+  private final long maxStringLength;
 
   public static Builder newBuilder() {
     return new Builder();
   }
 
   public JinjavaConfig() {
-    this(StandardCharsets.UTF_8, Locale.ENGLISH, ZoneOffset.UTC, 10, new HashMap<>(), false, false, true, false, false, 0, true, RandomNumberGeneratorStrategy.THREAD_LOCAL, false);
+    this(StandardCharsets.UTF_8, Locale.ENGLISH, ZoneOffset.UTC, 10, new HashMap<>(), false, false, true, false, false, 0, true, RandomNumberGeneratorStrategy.THREAD_LOCAL, false, Long.MAX_VALUE);
   }
 
   public JinjavaConfig(Charset charset, Locale locale, ZoneId timeZone, int maxRenderDepth) {
-    this(charset, locale, timeZone, maxRenderDepth, new HashMap<>(), false, false, true, false, false, 0, true, RandomNumberGeneratorStrategy.THREAD_LOCAL, false);
+    this(charset, locale, timeZone, maxRenderDepth, new HashMap<>(), false, false, true, false, false, 0, true, RandomNumberGeneratorStrategy.THREAD_LOCAL, false, Long.MAX_VALUE);
   }
 
   private JinjavaConfig(Charset charset,
@@ -73,7 +74,8 @@ public class JinjavaConfig {
                         long maxOutputSize,
                         boolean nestedInterpretationEnabled,
                         RandomNumberGeneratorStrategy randomNumberGenerator,
-                        boolean validationMode) {
+                        boolean validationMode,
+                        long maxStringLength) {
     this.charset = charset;
     this.locale = locale;
     this.timeZone = timeZone;
@@ -88,6 +90,7 @@ public class JinjavaConfig {
     this.nestedInterpretationEnabled = nestedInterpretationEnabled;
     this.randomNumberGenerator = randomNumberGenerator;
     this.validationMode = validationMode;
+    this.maxStringLength = maxStringLength;
   }
 
   public Charset getCharset() {
@@ -146,6 +149,10 @@ public class JinjavaConfig {
     return validationMode;
   }
 
+  public long getMaxStringLength() {
+    return maxStringLength;
+  }
+
   public static class Builder {
     private Charset charset = StandardCharsets.UTF_8;
     private Locale locale = Locale.ENGLISH;
@@ -163,6 +170,7 @@ public class JinjavaConfig {
     private boolean nestedInterpretationEnabled = true;
     private RandomNumberGeneratorStrategy randomNumberGeneratorStrategy = RandomNumberGeneratorStrategy.THREAD_LOCAL;
     private boolean validationMode = false;
+    private long maxStringLength = Long.MAX_VALUE;
 
     private Builder() {}
 
@@ -237,8 +245,27 @@ public class JinjavaConfig {
       return this;
     }
 
+    public Builder withMaxStringLength(long maxStringLength) {
+      this.maxStringLength = maxStringLength;
+      return this;
+    }
+
     public JinjavaConfig build() {
-      return new JinjavaConfig(charset, locale, timeZone, maxRenderDepth, disabled, trimBlocks, lstripBlocks, readOnlyResolver, enableRecursiveMacroCalls, failOnUnknownTokens, maxOutputSize, nestedInterpretationEnabled, randomNumberGeneratorStrategy, validationMode);
+      return new JinjavaConfig(charset,
+          locale,
+          timeZone,
+          maxRenderDepth,
+          disabled,
+          trimBlocks,
+          lstripBlocks,
+          readOnlyResolver,
+          enableRecursiveMacroCalls,
+          failOnUnknownTokens,
+          maxOutputSize,
+          nestedInterpretationEnabled,
+          randomNumberGeneratorStrategy,
+          validationMode,
+          maxStringLength);
     }
 
   }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/JoinFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/JoinFilter.java
@@ -75,7 +75,7 @@ public class JoinFilter implements Filter {
         interpreter.addError(new TemplateError(ErrorType.WARNING,
             ErrorReason.OTHER,
             ErrorItem.FILTER,
-            String.format("Result of %s filter has been truncuated to the max String length of %d", getName(), interpreter.getConfig().getMaxStringLength()),
+            String.format("Result of %s filter has been truncated to the max String length of %d", getName(), interpreter.getConfig().getMaxStringLength()),
             null,
             interpreter.getLineNumber(),
             interpreter.getPosition(),

--- a/src/main/java/com/hubspot/jinjava/lib/filter/JoinFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/JoinFilter.java
@@ -7,6 +7,10 @@ import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.OutputTooBigException;
+import com.hubspot.jinjava.interpret.TemplateError;
+import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
+import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
+import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import com.hubspot.jinjava.util.ForLoop;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import com.hubspot.jinjava.util.ObjectIterator;
@@ -68,6 +72,15 @@ public class JoinFilter implements Filter {
         }
         stringBuilder.append(Objects.toString(val, ""));
       } catch (OutputTooBigException ex) {
+        interpreter.addError(new TemplateError(ErrorType.WARNING,
+            ErrorReason.OTHER,
+            ErrorItem.OTHER,
+            String.format("Result of %s filter has been truncuated to the max String length of %d", getName(), interpreter.getConfig().getMaxStringLength()),
+            null,
+            interpreter.getLineNumber(),
+            interpreter.getPosition(),
+            ex));
+
         return stringBuilder.toString();
       }
     }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/JoinFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/JoinFilter.java
@@ -74,7 +74,7 @@ public class JoinFilter implements Filter {
       } catch (OutputTooBigException ex) {
         interpreter.addError(new TemplateError(ErrorType.WARNING,
             ErrorReason.OTHER,
-            ErrorItem.OTHER,
+            ErrorItem.FILTER,
             String.format("Result of %s filter has been truncuated to the max String length of %d", getName(), interpreter.getConfig().getMaxStringLength()),
             null,
             interpreter.getLineNumber(),

--- a/src/main/java/com/hubspot/jinjava/lib/filter/JoinFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/JoinFilter.java
@@ -1,15 +1,14 @@
 package com.hubspot.jinjava.lib.filter;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
-import com.google.common.base.Joiner;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.OutputTooBigException;
 import com.hubspot.jinjava.util.ForLoop;
+import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
@@ -39,7 +38,8 @@ public class JoinFilter implements Filter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
-    List<String> vals = new ArrayList<>();
+
+    LengthLimitingStringBuilder stringBuilder = new LengthLimitingStringBuilder(interpreter.getConfig().getMaxStringLength());
 
     String separator = "";
     if (args.length > 0) {
@@ -52,6 +52,7 @@ public class JoinFilter implements Filter {
     }
 
     ForLoop loop = ObjectIterator.getLoop(var);
+    boolean first = true;
     while (loop.hasNext()) {
       Object val = loop.next();
 
@@ -59,10 +60,19 @@ public class JoinFilter implements Filter {
         val = interpreter.resolveProperty(val, attr);
       }
 
-      vals.add(Objects.toString(val, ""));
+      try {
+        if (!first) {
+          stringBuilder.append(separator);
+        } else {
+          first = false;
+        }
+        stringBuilder.append(Objects.toString(val, ""));
+      } catch (OutputTooBigException ex) {
+        return stringBuilder.toString();
+      }
     }
 
-    return Joiner.on(separator).join(vals);
+    return stringBuilder.toString();
   }
 
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/JoinFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/JoinFilterTest.java
@@ -35,7 +35,7 @@ public class JoinFilterTest {
   }
 
   @Test
-  public void itLimitsString() {
+  public void itTruncatesStringToConfigLimit() {
     jinjava = new Jinjava(JinjavaConfig.newBuilder()
         .withMaxStringLength(5)
         .build());
@@ -43,6 +43,7 @@ public class JoinFilterTest {
     RenderResult result = jinjava.renderForResult("{{ [1, 2, 3, 4, 5]|join('|') }}", new HashMap<String, Object>());
     assertThat(result.getOutput()).isEqualTo("1|2|3");
     assertThat(result.getErrors().size()).isEqualTo(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("filter has been truncated to the max String length");
   }
 
   public static class User {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/JoinFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/JoinFilterTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 
 import com.google.common.collect.Lists;
 import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.JinjavaConfig;
 
 public class JoinFilterTest {
 
@@ -30,6 +31,15 @@ public class JoinFilterTest {
   public void testJoinAttrs() {
     assertThat(jinjava.render("{{ users|join(', ', attribute='username') }}", new HashMap<String, Object>()))
         .isEqualTo("foo, bar");
+  }
+
+  @Test
+  public void itLimitsString() {
+    jinjava = new Jinjava(JinjavaConfig.newBuilder()
+        .withMaxStringLength(5)
+        .build());
+
+    assertThat(jinjava.render("{{ [1, 2, 3, 4, 5]|join('|') }}", new HashMap<String, Object>())).isEqualTo("1|2|3");
   }
 
   public static class User {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/JoinFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/JoinFilterTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import com.google.common.collect.Lists;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.interpret.RenderResult;
 
 public class JoinFilterTest {
 
@@ -39,7 +40,9 @@ public class JoinFilterTest {
         .withMaxStringLength(5)
         .build());
 
-    assertThat(jinjava.render("{{ [1, 2, 3, 4, 5]|join('|') }}", new HashMap<String, Object>())).isEqualTo("1|2|3");
+    RenderResult result = jinjava.renderForResult("{{ [1, 2, 3, 4, 5]|join('|') }}", new HashMap<String, Object>());
+    assertThat(result.getOutput()).isEqualTo("1|2|3");
+    assertThat(result.getErrors().size()).isEqualTo(1);
   }
 
   public static class User {


### PR DESCRIPTION
Adds a max string length to the config. As a test, I have used this setting to limit the output of the `Join` filter, however it can be used in other filters as well if the approach looks fine.