### PR TITLE
support negative indeces with arrays

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
@@ -171,9 +171,9 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
               base = optBase.get();
             }
 
-            // java doesn't natively support negative array indeces, so the
+            // java doesn't natively support negative array indices, so the
             // super class getValue returns null for them.  To make negative
-            // indeces work as they do in python, detect them here and convert
+            // indices work as they do in python, detect them here and convert
             // to the equivalent positive index.
             if (base.getClass().isArray() && (property instanceof Number)) {
                int propertyNum = ((Number)property).intValue();

--- a/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
@@ -171,6 +171,18 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
               base = optBase.get();
             }
 
+            // java doesn't natively support negative array indeces, so the
+            // super class getValue returns null for them.  To make negative
+            // indeces work as they do in python, detect them here and convert
+            // to the equivalent positive index.
+            if (base.getClass().isArray() && (property instanceof Number)) {
+               int propertyNum = ((Number)property).intValue();
+               if (propertyNum < 0) {
+                  propertyNum += ((Object[])base).length;
+                  propertyName = String.valueOf(propertyNum);
+               }
+            }
+
             value = super.getValue(context, base, propertyName);
 
             if (value instanceof Optional) {

--- a/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
@@ -175,7 +175,11 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
             // super class getValue returns null for them.  To make negative
             // indices work as they do in python, detect them here and convert
             // to the equivalent positive index.
-            if (base.getClass().isArray() && (property instanceof Number)) {
+            //
+            // Check for Integer or Long instead of Number so the behavior for a
+            // floating-point index doesn't change (e.g. -1.5 stays -1.5, it
+            // doesn't become -1).
+            if (base.getClass().isArray() && ((property instanceof Integer) || (property instanceof Long))) {
                int propertyNum = ((Number)property).intValue();
                if (propertyNum < 0) {
                   propertyNum += ((Object[])base).length;

--- a/src/main/java/com/hubspot/jinjava/el/ext/AstRangeBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstRangeBracket.java
@@ -72,7 +72,7 @@ public class AstRangeBracket extends AstBracket {
     PyList result = new PyList(new ArrayList<>());
     int index = 0;
 
-    // Handle negative indeces.
+    // Handle negative indices.
     if ((startNum < 0) || (endNum < 0)) {
        int size = Iterables.size(baseItr);
        if (startNum < 0) {

--- a/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
@@ -274,6 +274,8 @@ public class ExtendedSyntaxBuilderTest {
     assertThat(val("stringToSplit.split('-')")).isEqualTo(new String[]{ "one", "two", "three", "four", "five" });
 
     assertThat(val("stringToSplit.split('-')[-1]")).isEqualTo("five");
+    assertThat(val("stringToSplit.split('-')[1.5]")).isEqualTo("");
+    assertThat(val("stringToSplit.split('-')[-1.5]")).isEqualTo("");
 
     // out of range returns null, as -6 + the length of the array is still
     // negative, and java doesn't support negative array indices.

--- a/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
@@ -265,6 +265,25 @@ public class ExtendedSyntaxBuilderTest {
   }
 
   @Test
+  public void arrayWithNegativeIndeces() {
+    String stringToSplit = "one-two-three-four-five";
+    context.put("stringToSplit", stringToSplit);
+
+    // Negative index handling on lists happens elsewhere, so make sure we're
+    // dealing with an array of Strings.
+    assertThat(val("stringToSplit.split('-')")).isEqualTo(new String[]{ "one", "two", "three", "four", "five" });
+
+    assertThat(val("stringToSplit.split('-')[-1]")).isEqualTo("five");
+
+    // out of range returns null, as -6 + the length of the array is still
+    // negative, and java doesn't support negative array indeces.
+    assertThat(val("stringToSplit.split('-')[-6]")).isEqualTo(null);
+
+    assertThat(val("stringToSplit.split('-')[0:2]")).isEqualTo(Lists.newArrayList("one", "two"));
+    assertThat(val("stringToSplit.split('-')[0:-2]")).isEqualTo(Lists.newArrayList("one", "two", "three"));
+  }
+
+  @Test
   public void invalidNestedAssignmentExpr() {
     assertThat(val("content.template_path = 'Custom/Email/Responsive/testing.html'")).isEqualTo("");
     assertThat(interpreter.getErrorsCopy()).isNotEmpty();

--- a/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
@@ -235,7 +235,7 @@ public class ExtendedSyntaxBuilderTest {
   }
 
   @Test
-  public void listRangeSyntaxNegativeIndeces() {
+  public void listRangeSyntaxNegativeIndices() {
     List<?> theList = Lists.newArrayList(1, 2, 3, 4, 5);
     context.put("mylist", theList);
 
@@ -265,7 +265,7 @@ public class ExtendedSyntaxBuilderTest {
   }
 
   @Test
-  public void arrayWithNegativeIndeces() {
+  public void arrayWithNegativeIndices() {
     String stringToSplit = "one-two-three-four-five";
     context.put("stringToSplit", stringToSplit);
 
@@ -276,7 +276,7 @@ public class ExtendedSyntaxBuilderTest {
     assertThat(val("stringToSplit.split('-')[-1]")).isEqualTo("five");
 
     // out of range returns null, as -6 + the length of the array is still
-    // negative, and java doesn't support negative array indeces.
+    // negative, and java doesn't support negative array indices.
     assertThat(val("stringToSplit.split('-')[-6]")).isEqualTo(null);
 
     assertThat(val("stringToSplit.split('-')[0:2]")).isEqualTo(Lists.newArrayList("one", "two"));


### PR DESCRIPTION
so e.g.

{{ (split_me.split('-'))[-2] }}

works

It's probably dicey of me to use the native java split method, as opposed to the split filter implemented in jinjava.  I haven't yet figured out how much better the filter is, but it's pretty tempting to have at least some templates work in both jinjava and python without needing to add a split filter to python.