### PR TITLE
Allow null in string exp tests.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringContainingExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringContainingExpTest.java
@@ -26,8 +26,12 @@ public class IsStringContainingExpTest extends IsStringExpTest {
       return false;
     }
 
-    if (args.length == 0 || args[0] == null) {
+    if (args.length == 0) {
       throw new InterpretException(getName() + " test requires an argument");
+    }
+
+    if (args[0] == null) {
+      return false;
     }
 
     return ((String) var).contains(args[0].toString());

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringStartingWithExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringStartingWithExpTest.java
@@ -26,8 +26,12 @@ public class IsStringStartingWithExpTest extends IsStringExpTest {
       return false;
     }
 
-    if (args.length == 0 || args[0] == null) {
+    if (args.length == 0) {
       throw new InterpretException(getName() + " test requires an argument");
+    }
+
+    if (args[0] == null) {
+      return false;
     }
 
     return ((String) var).startsWith(args[0].toString());

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsStringContainingExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsStringContainingExpTestTest.java
@@ -1,0 +1,38 @@
+package com.hubspot.jinjava.lib.exptest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.hubspot.jinjava.Jinjava;
+
+public class IsStringContainingExpTestTest {
+
+  private static final String CONTAINING_TEMPLATE = "{{ var is string_containing arg }}";
+
+  private Jinjava jinjava;
+
+  @Before
+  public void setup() {
+    jinjava = new Jinjava();
+  }
+
+  @Test
+  public void itReturnsTrueForContainedString() {
+    assertThat(jinjava.render(CONTAINING_TEMPLATE, ImmutableMap.of("var", "testing", "arg", "esti"))).isEqualTo("true");
+    assertThat(jinjava.render(CONTAINING_TEMPLATE, ImmutableMap.of("var", "testing", "arg", ""))).isEqualTo("true");
+    assertThat(jinjava.render(CONTAINING_TEMPLATE, ImmutableMap.of("var", "testing", "arg", "testing"))).isEqualTo("true");
+  }
+
+  @Test
+  public void itReturnsFalseForExcludedString() {
+    assertThat(jinjava.render(CONTAINING_TEMPLATE, ImmutableMap.of("var", "testing", "arg", "blah"))).isEqualTo("false");
+  }
+
+  @Test
+  public void itReturnsFalseForNull() {
+    assertThat(jinjava.render(CONTAINING_TEMPLATE, ImmutableMap.of("var", "testing"))).isEqualTo("false");
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsStringStartingWithExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsStringStartingWithExpTestTest.java
@@ -1,0 +1,37 @@
+package com.hubspot.jinjava.lib.exptest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.hubspot.jinjava.Jinjava;
+
+public class IsStringStartingWithExpTestTest {
+  private static final String STARTING_TEMPLATE = "{{ var is string_startingwith arg }}";
+
+  private Jinjava jinjava;
+
+  @Before
+  public void setup() {
+    jinjava = new Jinjava();
+  }
+
+  @Test
+  public void itReturnsTrueForContainedString() {
+    assertThat(jinjava.render(STARTING_TEMPLATE, ImmutableMap.of("var", "testing", "arg", "tes"))).isEqualTo("true");
+    assertThat(jinjava.render(STARTING_TEMPLATE, ImmutableMap.of("var", "testing", "arg", ""))).isEqualTo("true");
+    assertThat(jinjava.render(STARTING_TEMPLATE, ImmutableMap.of("var", "testing", "arg", "testing"))).isEqualTo("true");
+  }
+
+  @Test
+  public void itReturnsFalseForExcludedString() {
+    assertThat(jinjava.render(STARTING_TEMPLATE, ImmutableMap.of("var", "testing", "arg", "esting"))).isEqualTo("false");
+  }
+
+  @Test
+  public void itReturnsFalseForNull() {
+    assertThat(jinjava.render(STARTING_TEMPLATE, ImmutableMap.of("var", "testing"))).isEqualTo("false");
+  }
+}


### PR DESCRIPTION
Previously passing in null would result in an `InterpretException` being thrown resulting in a template error stating that no argument was passed in. It makes better sense to return false for these tests when a null value is used. I also added tests for both string expression tests.