### PR TITLE
Upgrade format filter to advanced filter.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/FormatFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FormatFilter.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.filter;
 
+import java.util.Map;
 import java.util.Objects;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
@@ -18,7 +19,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
             desc = "%s can be replaced with other variables or values",
             code = "{{ \"Hi %s %s\"|format(contact.firstname, contact.lastname) }} ")
     })
-public class FormatFilter implements Filter {
+public class FormatFilter implements AdvancedFilter {
 
   @Override
   public String getName() {
@@ -26,9 +27,8 @@ public class FormatFilter implements Filter {
   }
 
   @Override
-  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+  public Object filter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs) {
     String fmt = Objects.toString(var, "");
-    return String.format(fmt, (Object[]) args);
+    return String.format(fmt, args);
   }
-
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/FormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FormatFilterTest.java
@@ -20,7 +20,12 @@ public class FormatFilterTest {
 
   @Test
   public void testFormatFilter() {
-    assertThat(jinjava.render("{{ '%s - %s'|format(\"Hello?\", \"Foo!\") }}", new HashMap<String, Object>())).isEqualTo("Hello? - Foo!");
+    assertThat(jinjava.render("{{ '%s - %s'|format(\"Hello?\", \"Foo!\") }}", new HashMap<>())).isEqualTo("Hello? - Foo!");
+  }
+
+  @Test
+  public void testFormatNumber() {
+    assertThat(jinjava.render("{{ '%,d'|format(10000) }}", new HashMap<>())).isEqualTo("10,000");
   }
 
 }


### PR DESCRIPTION
Making this an advanced filter allows us to do more powerful formats. For example, `'%,d'|format(10000)` to format the number to use commas: `10,000`.