### PR TITLE
Fix shading by removing basepom's say in the matter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,8 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <!-- Remove basepom's stuff -->
+        <configuration combine.self="override"/>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
Upgrading basepom seems to have broken shading, I believe because of its use of the `outputFile` field. In this change, I simply blow away this configuration as we already do in `parent-pom`.

I think that it would make sense to do a release before merging this.

I now see (previously this was 0):
```
➜  jinjava git:(fix-shading)  jar -tf target/jinjava-2.4.15-SNAPSHOT.jar | grep odysseus | wc -l
      95
```

### `mvn help:effective-pom` shade configuration changes

There are some changes to the shade configuration output by `mvn help:effective-pom` that could be worth considering. I don't *think* they should cause issues.

#### `fix-shading`
```xml
<configuration>
  <createDependencyReducedPom>true</createDependencyReducedPom>
  <shadedArtifactAttached>false</shadedArtifactAttached>
  <artifactSet>
    <includes>
      <include>de.odysseus.juel:juel-api</include>
      <include>de.odysseus.juel:juel-impl</include>
    </includes>
  </artifactSet>
  <relocations>
    <relocation>
      <pattern>javax.el</pattern>
      <shadedPattern>jinjava.javax.el</shadedPattern>
    </relocation>
    <relocation>
      <pattern>de.odysseus.el</pattern>
      <shadedPattern>jinjava.de.odysseus.el</shadedPattern>
    </relocation>
  </relocations>
  <outputFile>/Users/sgutz/dev/jinjava/target/jinjava-2.4.15-SNAPSHOT-shaded.jar</outputFile>
  <transformers>
    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
    <transformer implementation="org.basepom.maven.shade.CollectingManifestResourceTransformer">
      <mainClass />
      <collectSections>true</collectSections>
      <manifestEntries>
        <X-BasePOM-Build-Id>${basepom.shaded.id}</X-BasePOM-Build-Id>
        <X-BasePOM-Name>${project.name}</X-BasePOM-Name>
        <X-BasePOM-Git-Commit-Id>${git.commit.id}</X-BasePOM-Git-Commit-Id>
      </manifestEntries>
    </transformer>
  </transformers>
  <filters>
    <filter>
      <artifact>*:*</artifact>
      <excludes>
        <exclude>META-INF/*.SF</exclude>
        <exclude>META-INF/*.DSA</exclude>
        <exclude>META-INF/*.RSA</exclude>
      </excludes>
    </filter>
  </filters>
</configuration>
```

#### Now
```xml
<configuration combine.self="override">
  <createDependencyReducedPom>true</createDependencyReducedPom>
  <shadedArtifactAttached>false</shadedArtifactAttached>
  <artifactSet>
    <includes>
      <include>de.odysseus.juel:juel-api</include>
      <include>de.odysseus.juel:juel-impl</include>
    </includes>
  </artifactSet>
  <relocations>
    <relocation>
      <pattern>javax.el</pattern>
      <shadedPattern>jinjava.javax.el</shadedPattern>
    </relocation>
    <relocation>
      <pattern>de.odysseus.el</pattern>
      <shadedPattern>jinjava.de.odysseus.el</shadedPattern>
    </relocation>
  </relocations>
</configuration>
```

---
@boulter @jhaber @kmclarnon   @mattcoley
