### PR TITLE
Upgrade javassist to 3.24.1-GA (latest)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
 
   <properties>
     <project.build.targetJdk>1.8</project.build.targetJdk>
+    <dep.javassist.version>3.24.1-GA</dep.javassist.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Older versions of javassist don't work on JDK 11: https://github.com/jboss-javassist/javassist/issues/194. Jinjava is not affected by any of the binary incompatibilities between `3.20.0-GA` and `3.24.1-GA`.

@jboulter @mattcoley @jhaber 