### PR TITLE
Fix NPE in PrettyPrintFilter

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/PrettyPrintFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/PrettyPrintFilter.java
@@ -62,7 +62,7 @@ public class PrettyPrintFilter implements Filter {
 
       for (PropertyDescriptor pd : beanInfo.getPropertyDescriptors()) {
         try {
-          if (pd.getPropertyType().equals(Class.class)) {
+          if (pd.getPropertyType() != null && pd.getPropertyType().equals(Class.class)) {
             continue;
           }
 


### PR DESCRIPTION
Sometimes a NullPointerException is thrown here. This is because `PropertyDescriptor::getPropertyType` can return null. 

I know this from service error logs, but haven't reproduced the issue myself to find out what exact circumstances cause this.