### PR TITLE
WIP Error and documentation overhaul

### DIFF
--- a/src/main/java/com/hubspot/jinjava/Jinjava.java
+++ b/src/main/java/com/hubspot/jinjava/Jinjava.java
@@ -30,6 +30,7 @@ import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.FatalTemplateErrorsException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.InvalidArgumentException;
+import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.interpret.TemplateError;
@@ -206,6 +207,8 @@ public class Jinjava {
       return new RenderResult(TemplateError.fromSyntaxError(e), interpreter.getContext(), interpreter.getErrorsCopy());
     } catch (InvalidArgumentException e) {
       return new RenderResult(TemplateError.fromInvalidArgumentException(e), interpreter.getContext(), interpreter.getErrorsCopy());
+    } catch (InvalidInputException e) {
+      return new RenderResult(TemplateError.fromInvalidInputException(e), interpreter.getContext(), interpreter.getErrorsCopy());
     }
     catch (Exception e) {
       return new RenderResult(TemplateError.fromException(e), interpreter.getContext(), interpreter.getErrorsCopy());

--- a/src/main/java/com/hubspot/jinjava/Jinjava.java
+++ b/src/main/java/com/hubspot/jinjava/Jinjava.java
@@ -29,6 +29,7 @@ import com.hubspot.jinjava.el.TruthyTypeConverter;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.FatalTemplateErrorsException;
 import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.interpret.TemplateError;
@@ -203,7 +204,10 @@ public class Jinjava {
         return new RenderResult(TemplateError.fromException((TemplateSyntaxException) e), interpreter.getContext(), interpreter.getErrorsCopy());
       }
       return new RenderResult(TemplateError.fromSyntaxError(e), interpreter.getContext(), interpreter.getErrorsCopy());
-    } catch (Exception e) {
+    } catch (InvalidArgumentException e) {
+      return new RenderResult(TemplateError.fromInvalidArgumentException(e), interpreter.getContext(), interpreter.getErrorsCopy());
+    }
+    catch (Exception e) {
       return new RenderResult(TemplateError.fromException(e), interpreter.getContext(), interpreter.getErrorsCopy());
     } finally {
       globalContext.reset();

--- a/src/main/java/com/hubspot/jinjava/doc/annotations/JinjavaDoc.java
+++ b/src/main/java/com/hubspot/jinjava/doc/annotations/JinjavaDoc.java
@@ -11,6 +11,8 @@ public @interface JinjavaDoc {
 
   String value() default "";
 
+  JinjavaParam input();
+
   JinjavaParam[] params() default {};
 
   JinjavaSnippet[] snippets() default {};

--- a/src/main/java/com/hubspot/jinjava/doc/annotations/JinjavaDoc.java
+++ b/src/main/java/com/hubspot/jinjava/doc/annotations/JinjavaDoc.java
@@ -11,7 +11,7 @@ public @interface JinjavaDoc {
 
   String value() default "";
 
-  JinjavaParam input();
+  JinjavaParam[] input() default {};
 
   JinjavaParam[] params() default {};
 

--- a/src/main/java/com/hubspot/jinjava/doc/annotations/JinjavaParam.java
+++ b/src/main/java/com/hubspot/jinjava/doc/annotations/JinjavaParam.java
@@ -17,4 +17,6 @@ public @interface JinjavaParam {
 
   String defaultValue() default "";
 
+  boolean required() default false;
+
 }

--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -13,8 +13,11 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.el.ext.NamedParameter;
+import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.DisabledException;
 import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
+import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
@@ -23,7 +26,6 @@ import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.interpret.UnknownTokenException;
 import com.hubspot.jinjava.interpret.errorcategory.BasicTemplateErrorCategory;
-import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.lib.fn.ELFunctionDefinition;
 
 import de.odysseus.el.tree.TreeBuilderException;
@@ -97,6 +99,10 @@ public class ExpressionResolver {
     } catch (DeferredValueException e) {
       // Re-throw so that it can be handled in JinjavaInterpreter
       throw e;
+    } catch (InvalidInputException e) {
+      interpreter.addError(TemplateError.fromInvalidInputException(e));
+    } catch (InvalidArgumentException e) {
+      interpreter.addError(TemplateError.fromInvalidArgumentException(e));
     } catch (Exception e) {
       interpreter.addError(TemplateError.fromException(new InterpretException(
           String.format("Error resolving expression [%s]: " + getRootCauseMessage(e), expression), e, interpreter.getLineNumber(), interpreter.getPosition())));

--- a/src/main/java/com/hubspot/jinjava/interpret/InvalidArgumentException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/InvalidArgumentException.java
@@ -36,28 +36,17 @@ public class InvalidArgumentException extends RuntimeException {
   }
 
   private static String formatArgumentNumber(int argumentNumber) {
-    switch (argumentNumber){
-      case 1:
-        return "1st";
-      case 2:
-        return "2nd";
-      case 3:
-        return "3rd";
-      case 4:
-        return "4th";
-      case 5:
-        return "5th";
-      case 6:
-        return "6th";
-      case 7:
-        return "7th";
-      case 8:
-        return "8th";
-      case 9:
-        return "9th";
-      default:
-        return String.valueOf(argumentNumber);
 
+    String base = "th";
+    int remainder = argumentNumber % 10;
+    if (remainder == 1) {
+      base = "st";
+    } else if (remainder == 2) {
+      base = "nd";
+    } else if (remainder == 3) {
+      base = "rd";
     }
+
+    return String.format("%d%s", argumentNumber, base);
   }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/InvalidArgumentException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/InvalidArgumentException.java
@@ -1,21 +1,20 @@
 package com.hubspot.jinjava.interpret;
 
+import com.hubspot.jinjava.lib.Importable;
+
 public class InvalidArgumentException extends RuntimeException {
 
   private final int lineNumber;
   private final int startPosition;
   private final String message;
-  private final String fieldName;
 
-  public InvalidArgumentException(JinjavaInterpreter interpreter, String code, String message, String fieldName) {
-    this.fieldName = fieldName;
-    this.message = String.format("Invalid argument in %s: %s", code, message);
+  public InvalidArgumentException(JinjavaInterpreter interpreter, Importable importable, InvalidReason invalidReason, int argumentNumber, Object... errorMessageArgs) {
+    this.message = String.format("Invalid argument in '%s': %s",
+        importable.getName(),
+        String.format("%s %s", formatArgumentNumber(argumentNumber + 1), String.format(invalidReason.getErrorMessage(), errorMessageArgs)));
+
     this.lineNumber = interpreter.getLineNumber();
     this.startPosition = interpreter.getPosition();
-  }
-
-  public String getFieldName() {
-    return fieldName;
   }
 
   public String getMessage() {
@@ -28,5 +27,31 @@ public class InvalidArgumentException extends RuntimeException {
 
   public int getStartPosition() {
     return startPosition;
+  }
+
+  private static String formatArgumentNumber(int argumentNumber) {
+    switch (argumentNumber){
+      case 1:
+        return "1st";
+      case 2:
+        return "2nd";
+      case 3:
+        return "3rd";
+      case 4:
+        return "4th";
+      case 5:
+        return "5th";
+      case 6:
+        return "6th";
+      case 7:
+        return "7th";
+      case 8:
+        return "8th";
+      case 9:
+        return "9th";
+      default:
+        return String.valueOf(argumentNumber);
+
+    }
   }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/InvalidArgumentException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/InvalidArgumentException.java
@@ -7,6 +7,7 @@ public class InvalidArgumentException extends RuntimeException {
   private final int lineNumber;
   private final int startPosition;
   private final String message;
+  private final String name;
 
   public InvalidArgumentException(JinjavaInterpreter interpreter, Importable importable, InvalidReason invalidReason, int argumentNumber, Object... errorMessageArgs) {
     this.message = String.format("Invalid argument in '%s': %s",
@@ -15,6 +16,7 @@ public class InvalidArgumentException extends RuntimeException {
 
     this.lineNumber = interpreter.getLineNumber();
     this.startPosition = interpreter.getPosition();
+    this.name = importable.getName();
   }
 
   public String getMessage() {
@@ -27,6 +29,10 @@ public class InvalidArgumentException extends RuntimeException {
 
   public int getStartPosition() {
     return startPosition;
+  }
+
+  public String getName() {
+    return name;
   }
 
   private static String formatArgumentNumber(int argumentNumber) {

--- a/src/main/java/com/hubspot/jinjava/interpret/InvalidArgumentException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/InvalidArgumentException.java
@@ -1,0 +1,32 @@
+package com.hubspot.jinjava.interpret;
+
+public class InvalidArgumentException extends RuntimeException {
+
+  private final int lineNumber;
+  private final int startPosition;
+  private final String message;
+  private final String fieldName;
+
+  public InvalidArgumentException(JinjavaInterpreter interpreter, String code, String message, String fieldName) {
+    this.fieldName = fieldName;
+    this.message = String.format("Invalid argument in %s: %s", code, message);
+    this.lineNumber = interpreter.getLineNumber();
+    this.startPosition = interpreter.getPosition();
+  }
+
+  public String getFieldName() {
+    return fieldName;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public int getLineNumber() {
+    return lineNumber;
+  }
+
+  public int getStartPosition() {
+    return startPosition;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/interpret/InvalidInputException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/InvalidInputException.java
@@ -7,6 +7,7 @@ public class InvalidInputException extends RuntimeException {
   private final int lineNumber;
   private final int startPosition;
   private final String message;
+  private final String name;
 
   public InvalidInputException(JinjavaInterpreter interpreter, Importable importable, InvalidReason invalidReason, Object... errorMessageArgs) {
     this.message = String.format("Invalid input in '%s': input variable %s",
@@ -15,6 +16,7 @@ public class InvalidInputException extends RuntimeException {
 
     this.lineNumber = interpreter.getLineNumber();
     this.startPosition = interpreter.getPosition();
+    this.name = importable.getName();
   }
 
   public String getMessage() {
@@ -27,5 +29,9 @@ public class InvalidInputException extends RuntimeException {
 
   public int getStartPosition() {
     return startPosition;
+  }
+
+  public String getName() {
+    return name;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/InvalidInputException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/InvalidInputException.java
@@ -1,0 +1,31 @@
+package com.hubspot.jinjava.interpret;
+
+import com.hubspot.jinjava.lib.Importable;
+
+public class InvalidInputException extends RuntimeException {
+
+  private final int lineNumber;
+  private final int startPosition;
+  private final String message;
+
+  public InvalidInputException(JinjavaInterpreter interpreter, Importable importable, InvalidReason invalidReason, Object... errorMessageArgs) {
+    this.message = String.format("Invalid input in '%s': input variable %s",
+        importable.getName(),
+        String.format(invalidReason.getErrorMessage(), errorMessageArgs));
+
+    this.lineNumber = interpreter.getLineNumber();
+    this.startPosition = interpreter.getPosition();
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public int getLineNumber() {
+    return lineNumber;
+  }
+
+  public int getStartPosition() {
+    return startPosition;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/interpret/InvalidReason.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/InvalidReason.java
@@ -1,0 +1,23 @@
+package com.hubspot.jinjava.interpret;
+
+public enum InvalidReason {
+  NUMBER_FORMAT("with value '%s' must be a number"),
+  NULL("cannot be null"),
+  STRING("must be a string"),
+  EXPRESSION_TEST("with value %s must be the name of an expression test"),
+  TEMPORAL_UNIT("with value %s must be a valid temporal unit"),
+  JSON_READ("could not be converted to an object"),
+  JSON_WRITE("object could not be written as a string"),
+  REGEX("with value %s must be valid regex")
+  ;
+
+  private final String errorMessage;
+
+  InvalidReason(String errorMessage) {
+    this.errorMessage = errorMessage;
+  }
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -27,6 +27,7 @@ public class TemplateError {
     MISSING,
     DISABLED,
     INVALID_ARGUMENT,
+    INVALID_INPUT,
     OTHER
   }
 
@@ -73,7 +74,18 @@ public class TemplateError {
         ErrorReason.INVALID_ARGUMENT,
         ErrorItem.PROPERTY,
         ex.getMessage(),
-        ex.getFieldName(),
+        ex.getName(),
+        ex.getLineNumber(),
+        ex.getStartPosition(),
+        ex);
+  }
+
+  public static TemplateError fromInvalidInputException(InvalidInputException ex) {
+    return new TemplateError(ErrorType.FATAL,
+        ErrorReason.INVALID_INPUT,
+        ErrorItem.PROPERTY,
+        ex.getMessage(),
+        ex.getName(),
         ex.getLineNumber(),
         ex.getStartPosition(),
         ex);

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -26,6 +26,7 @@ public class TemplateError {
     EXCEPTION,
     MISSING,
     DISABLED,
+    INVALID_ARGUMENT,
     OTHER
   }
 
@@ -65,6 +66,17 @@ public class TemplateError {
   public static TemplateError fromException(TemplateSyntaxException ex) {
     String fieldName = (ex instanceof UnknownTagException) ? ((UnknownTagException) ex).getTag() : ex.getCode();
     return new TemplateError(ErrorType.FATAL, ErrorReason.SYNTAX_ERROR, ErrorItem.OTHER, ExceptionUtils.getMessage(ex), fieldName, ex.getLineNumber(), ex.getStartPosition(), ex);
+  }
+
+  public static TemplateError fromInvalidArgumentException(InvalidArgumentException ex) {
+    return new TemplateError(ErrorType.FATAL,
+        ErrorReason.INVALID_ARGUMENT,
+        ErrorItem.PROPERTY,
+        ex.getMessage(),
+        ex.getFieldName(),
+        ex.getLineNumber(),
+        ex.getStartPosition(),
+        ex);
   }
 
   public static TemplateError fromException(Exception ex) {

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateSyntaxException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateSyntaxException.java
@@ -5,22 +5,30 @@ public class TemplateSyntaxException extends InterpretException {
 
   private final String code;
 
+  @Deprecated
   public TemplateSyntaxException(String code, String message, int lineNumber, int startPosition) {
     super("Syntax error in '" + code + "': " + message, lineNumber, startPosition);
     this.code = code;
   }
 
+  @Deprecated
   public TemplateSyntaxException(String code, String message, int lineNumber) {
     this(code, message, lineNumber, -1);
   }
 
+  @Deprecated
   public TemplateSyntaxException(String code, String message, int lineNumber, int startPosition, Throwable t) {
     super(message, t, lineNumber, startPosition);
     this.code = code;
   }
 
+  @Deprecated
   public TemplateSyntaxException(String code, String message, int lineNumber, Throwable t) {
     this(code, message, lineNumber, -1, t);
+  }
+
+  public TemplateSyntaxException(JinjavaInterpreter interpreter, String code, String message) {
+    this(code, message, interpreter.getLineNumber(), interpreter.getPosition());
   }
 
   public String getCode() {

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateSyntaxException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateSyntaxException.java
@@ -7,7 +7,7 @@ public class TemplateSyntaxException extends InterpretException {
 
   @Deprecated
   public TemplateSyntaxException(String code, String message, int lineNumber, int startPosition) {
-    super("Syntax error in '" + code + "': " + message, lineNumber, startPosition);
+    super(String.format("Syntax error in '%s': %s", code, message), lineNumber, startPosition);
     this.code = code;
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsContainingAllExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsContainingAllExpTest.java
@@ -11,8 +11,8 @@ import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Returns true if a list contains all values in a second list",
-    input = @JinjavaParam(value = "list", type="list"),
-    params = @JinjavaParam(value = "list_two", type="list", desc = "The second list to check if every element is in the first list"),
+    input = @JinjavaParam(value = "list", type="list", required = true),
+    params = @JinjavaParam(value = "list_two", type="list", desc = "The second list to check if every element is in the first list", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{{ [1, 2, 3] is containingall [2, 3] }}")

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsContainingAllExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsContainingAllExpTest.java
@@ -2,10 +2,21 @@ package com.hubspot.jinjava.lib.exptest;
 
 import java.util.Objects;
 
+import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
+import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.util.ForLoop;
 import com.hubspot.jinjava.util.ObjectIterator;
 
+@JinjavaDoc(
+    value = "Returns true if a list contains all values in a second list",
+    input = @JinjavaParam(value = "list", type="list"),
+    params = @JinjavaParam(value = "list_two", type="list", desc = "The second list to check if every element is in the first list"),
+    snippets = {
+        @JinjavaSnippet(
+            code = "{{ [1, 2, 3] is containingall [2, 3] }}")
+    })
 public class IsContainingAllExpTest implements ExpTest {
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsContainingExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsContainingExpTest.java
@@ -11,8 +11,8 @@ import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Returns true if a list contains a value",
-    input = @JinjavaParam(value = "list", type = "list"),
-    params = @JinjavaParam(value = "value", type = "object", desc = "The value to check is in the list"),
+    input = @JinjavaParam(value = "list", type = "list", required = true),
+    params = @JinjavaParam(value = "value", type = "object", desc = "The value to check is in the list", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{{ [1, 2, 3] is containing 2 }}")

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsContainingExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsContainingExpTest.java
@@ -2,10 +2,21 @@ package com.hubspot.jinjava.lib.exptest;
 
 import java.util.Objects;
 
+import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
+import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.util.ForLoop;
 import com.hubspot.jinjava.util.ObjectIterator;
 
+@JinjavaDoc(
+    value = "Returns true if a list contains a value",
+    input = @JinjavaParam(value = "list", type = "list"),
+    params = @JinjavaParam(value = "value", type = "object", desc = "The value to check is in the list"),
+    snippets = {
+        @JinjavaSnippet(
+            code = "{{ [1, 2, 3] is containing 2 }}")
+    })
 public class IsContainingExpTest implements ExpTest {
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsDefinedExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsDefinedExpTest.java
@@ -7,7 +7,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return true if the variable is defined",
-    input = @JinjavaParam(value = "value", type = "object"),
+    input = @JinjavaParam(value = "value", type = "object", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is defined %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsDefinedExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsDefinedExpTest.java
@@ -1,11 +1,13 @@
 package com.hubspot.jinjava.lib.exptest;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return true if the variable is defined",
+    input = @JinjavaParam(value = "value", type = "object"),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is defined %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsDivisibleByExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsDivisibleByExpTest.java
@@ -4,13 +4,14 @@ import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.InvalidArgumentException;
+import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
-@JinjavaDoc(value = "Check if a variable is divisible by a number",
-    params = {
-        @JinjavaParam(value = "num", type = "number", desc = "The number to check whether a number is divisble by")
-    },
+@JinjavaDoc(
+    value = "Returns true if a variable is divisible by a number",
+    input = @JinjavaParam(value = "num", type = "number"),
+    params = @JinjavaParam(value = "divisor", type = "number", desc = "The number to check whether a number is divisible by"),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is divisbleby 5 %}\n" +
@@ -44,10 +45,7 @@ public class IsDivisibleByExpTest implements ExpTest {
     }
 
     if (!Number.class.isAssignableFrom(args[0].getClass())) {
-      throw new InvalidArgumentException(interpreter,
-          getName(),
-          String.format(InvalidArgumentException.NUMBER_FORMAT_EXCEPTION_TEMPLATE, "num", args[0].toString()),
-          "num");
+      throw new InvalidArgumentException(interpreter, this, InvalidReason.NUMBER_FORMAT, 0, args[0].toString());
     }
 
     return ((Number) var).intValue() % ((Number) args[0]).intValue() == 0;

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsDivisibleByExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsDivisibleByExpTest.java
@@ -10,8 +10,8 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 @JinjavaDoc(
     value = "Returns true if a variable is divisible by a number",
-    input = @JinjavaParam(value = "num", type = "number"),
-    params = @JinjavaParam(value = "divisor", type = "number", desc = "The number to check whether a number is divisible by"),
+    input = @JinjavaParam(value = "num", type = "number", required = true),
+    params = @JinjavaParam(value = "divisor", type = "number", desc = "The number to check whether a number is divisible by", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is divisbleby 5 %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsDivisibleByExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsDivisibleByExpTest.java
@@ -3,8 +3,9 @@ package com.hubspot.jinjava.lib.exptest;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 @JinjavaDoc(value = "Check if a variable is divisible by a number",
     params = {
@@ -34,8 +35,19 @@ public class IsDivisibleByExpTest implements ExpTest {
       return false;
     }
 
-    if (args.length == 0 || args[0] == null || !Number.class.isAssignableFrom(args[0].getClass())) {
-      throw new InterpretException(getName() + " test requires a numeric argument");
+    if (args.length == 0) {
+      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (name of expression test to filter by)");
+    }
+
+    if (args[0] == null) {
+      return false;
+    }
+
+    if (!Number.class.isAssignableFrom(args[0].getClass())) {
+      throw new InvalidArgumentException(interpreter,
+          getName(),
+          String.format(InvalidArgumentException.NUMBER_FORMAT_EXCEPTION_TEMPLATE, "num", args[0].toString()),
+          "num");
     }
 
     return ((Number) var).intValue() % ((Number) args[0]).intValue() == 0;

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTest.java
@@ -12,9 +12,9 @@ import de.odysseus.el.misc.TypeConverter;
 
 @JinjavaDoc(
     value = "Returns true if an object has the same value as another object",
-    input = @JinjavaParam(value = "first", type = "object"),
+    input = @JinjavaParam(value = "first", type = "object", required = true),
     params = {
-        @JinjavaParam(value = "other", type = "object", desc = "Another object to check equality against")
+        @JinjavaParam(value = "other", type = "object", desc = "Another object to check equality against", required = true)
     },
     snippets = {
         @JinjavaSnippet(

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTest.java
@@ -4,8 +4,8 @@ import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.el.TruthyTypeConverter;
-import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 import de.odysseus.el.misc.BooleanOperations;
 import de.odysseus.el.misc.TypeConverter;
@@ -36,7 +36,7 @@ public class IsEqualToExpTest implements ExpTest {
   @Override
   public boolean evaluate(Object var, JinjavaInterpreter interpreter, Object... args) {
     if (args.length == 0) {
-      throw new InterpretException(getName() + " test requires 1 argument");
+      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (other object to check equality against)");
     }
 
     return BooleanOperations.eq(TYPE_CONVERTER, var, args[0]);

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTest.java
@@ -11,7 +11,8 @@ import de.odysseus.el.misc.BooleanOperations;
 import de.odysseus.el.misc.TypeConverter;
 
 @JinjavaDoc(
-    value = "Check if an object has the same value as another object",
+    value = "Returns true if an object has the same value as another object",
+    input = @JinjavaParam(value = "first", type = "object"),
     params = {
         @JinjavaParam(value = "other", type = "object", desc = "Another object to check equality against")
     },

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsEvenExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsEvenExpTest.java
@@ -1,11 +1,13 @@
 package com.hubspot.jinjava.lib.exptest;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
-    value = "Return true if the value is even",
+    value = "Returns true if the value is even",
+    input = @JinjavaParam(value = "num", type = "number"),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is even %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsEvenExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsEvenExpTest.java
@@ -24,6 +24,7 @@ public class IsEvenExpTest implements ExpTest {
   @Override
   public boolean evaluate(Object var, JinjavaInterpreter interpreter,
       Object... args) {
+
     if (var == null || !Number.class.isAssignableFrom(var.getClass())) {
       return false;
     }

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsEvenExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsEvenExpTest.java
@@ -7,7 +7,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Returns true if the value is even",
-    input = @JinjavaParam(value = "num", type = "number"),
+    input = @JinjavaParam(value = "num", type = "number", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is even %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsIterableExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsIterableExpTest.java
@@ -1,11 +1,13 @@
 package com.hubspot.jinjava.lib.exptest;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return true if the object is iterable (sequence, dict, etc)",
+    input = @JinjavaParam(value = "object", type = "object"),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is iterable %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsIterableExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsIterableExpTest.java
@@ -7,7 +7,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return true if the object is iterable (sequence, dict, etc)",
-    input = @JinjavaParam(value = "object", type = "object"),
+    input = @JinjavaParam(value = "object", type = "object", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is iterable %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsLowerExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsLowerExpTest.java
@@ -9,7 +9,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return true if the given string is all lowercase",
-    input = @JinjavaParam(value = "string", type = "string"),
+    input = @JinjavaParam(value = "string", type = "string", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is lower %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsLowerExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsLowerExpTest.java
@@ -3,11 +3,13 @@ package com.hubspot.jinjava.lib.exptest;
 import org.apache.commons.lang3.StringUtils;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
-    value = "Return true if the given string is all lowercased",
+    value = "Return true if the given string is all lowercase",
+    input = @JinjavaParam(value = "string", type = "string"),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is lower %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsMappingExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsMappingExpTest.java
@@ -3,11 +3,13 @@ package com.hubspot.jinjava.lib.exptest;
 import java.util.Map;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return true if the given object is a dict",
+    input = @JinjavaParam(value = "object", type = "object"),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is mapping %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsMappingExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsMappingExpTest.java
@@ -9,7 +9,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return true if the given object is a dict",
-    input = @JinjavaParam(value = "object", type = "object"),
+    input = @JinjavaParam(value = "object", type = "object", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is mapping %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsNoneExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsNoneExpTest.java
@@ -7,7 +7,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return true if the given object is null / none",
-    input = @JinjavaParam(value = "object", type = "object"),
+    input = @JinjavaParam(value = "object", type = "object", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% unless variable is none %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsNoneExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsNoneExpTest.java
@@ -1,11 +1,13 @@
 package com.hubspot.jinjava.lib.exptest;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return true if the given object is null / none",
+    input = @JinjavaParam(value = "object", type = "object"),
     snippets = {
         @JinjavaSnippet(
             code = "{% unless variable is none %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsNumberExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsNumberExpTest.java
@@ -7,7 +7,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return true if the object is a number",
-    input = @JinjavaParam(value = "object", type = "object"),
+    input = @JinjavaParam(value = "object", type = "object", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is number %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsNumberExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsNumberExpTest.java
@@ -1,11 +1,13 @@
 package com.hubspot.jinjava.lib.exptest;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return true if the object is a number",
+    input = @JinjavaParam(value = "object", type = "object"),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is number %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsOddExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsOddExpTest.java
@@ -7,7 +7,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return true if a number is an odd number",
-    input = @JinjavaParam(value = "num", type = "number"),
+    input = @JinjavaParam(value = "num", type = "number", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is odd %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsOddExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsOddExpTest.java
@@ -1,11 +1,13 @@
 package com.hubspot.jinjava.lib.exptest;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
-    value = "Return true if the object is an odd number",
+    value = "Return true if a number is an odd number",
+    input = @JinjavaParam(value = "num", type = "number"),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is odd %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsSameAsExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsSameAsExpTest.java
@@ -8,8 +8,8 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 @JinjavaDoc(
     value = "Return true if variable is pointing at same object as other variable",
-    input = @JinjavaParam(value = "object", type = "object"),
-    params = @JinjavaParam(value = "other", type = "object", desc = "A second object to check the variables value against"),
+    input = @JinjavaParam(value = "object", type = "object", required = true),
+    params = @JinjavaParam(value = "other", type = "object", desc = "A second object to check the variables value against", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% if var_one is sameas var_two %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsSameAsExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsSameAsExpTest.java
@@ -6,7 +6,9 @@ import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
-@JinjavaDoc(value = "Return true if variable is pointing at same object as other variable",
+@JinjavaDoc(
+    value = "Return true if variable is pointing at same object as other variable",
+    input = @JinjavaParam(value = "object", type = "object"),
     params = @JinjavaParam(value = "other", type = "object", desc = "A second object to check the variables value against"),
     snippets = {
         @JinjavaSnippet(

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsSameAsExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsSameAsExpTest.java
@@ -3,8 +3,8 @@ package com.hubspot.jinjava.lib.exptest;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 @JinjavaDoc(value = "Return true if variable is pointing at same object as other variable",
     params = @JinjavaParam(value = "other", type = "object", desc = "A second object to check the variables value against"),
@@ -24,8 +24,9 @@ public class IsSameAsExpTest implements ExpTest {
   @Override
   public boolean evaluate(Object var, JinjavaInterpreter interpreter,
       Object... args) {
+
     if (args.length == 0) {
-      throw new InterpretException(getName() + " test requires 1 argument");
+      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (other object to check the variables value against)");
     }
 
     return var == args[0];

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsSequenceExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsSequenceExpTest.java
@@ -1,11 +1,13 @@
 package com.hubspot.jinjava.lib.exptest;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return true if the variable is a sequence. Sequences are variables that are iterable.",
+    input = @JinjavaParam(value = "object", type = "object"),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is sequence %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsSequenceExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsSequenceExpTest.java
@@ -7,7 +7,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return true if the variable is a sequence. Sequences are variables that are iterable.",
-    input = @JinjavaParam(value = "object", type = "object"),
+    input = @JinjavaParam(value = "object", type = "object", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is sequence %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringContainingExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringContainingExpTest.java
@@ -8,8 +8,8 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 @JinjavaDoc(
     value = "Return true if object is a string which contains a specified other string",
-    input =  @JinjavaParam(value = "string", type = "string"),
-    params = @JinjavaParam(value = "check", type = "string", desc = "A second string to check is contained in the first string"),
+    input =  @JinjavaParam(value = "string", type = "string", required = true),
+    params = @JinjavaParam(value = "check", type = "string", desc = "A second string to check is contained in the first string", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is string_containing 'foo' %}\n" +
@@ -30,7 +30,7 @@ public class IsStringContainingExpTest extends IsStringExpTest {
     }
 
     if (args.length == 0) {
-      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (a second string)");
+      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (other string to compare to)");
     }
 
     if (args[0] == null) {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringContainingExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringContainingExpTest.java
@@ -1,12 +1,14 @@
 package com.hubspot.jinjava.lib.exptest;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 @JinjavaDoc(
     value = "Return true if object is a string which contains a specified other string",
+    params = @JinjavaParam(value = "string", type = "string", desc = "A second string to check is contained in the first string"),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is string_containing 'foo' %}\n" +
@@ -27,7 +29,7 @@ public class IsStringContainingExpTest extends IsStringExpTest {
     }
 
     if (args.length == 0) {
-      throw new InterpretException(getName() + " test requires an argument");
+      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (a second string)");
     }
 
     if (args[0] == null) {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringContainingExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringContainingExpTest.java
@@ -8,7 +8,8 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 @JinjavaDoc(
     value = "Return true if object is a string which contains a specified other string",
-    params = @JinjavaParam(value = "string", type = "string", desc = "A second string to check is contained in the first string"),
+    input =  @JinjavaParam(value = "string", type = "string"),
+    params = @JinjavaParam(value = "check", type = "string", desc = "A second string to check is contained in the first string"),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is string_containing 'foo' %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringExpTest.java
@@ -7,7 +7,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return true if object is a string",
-    input = @JinjavaParam(value = "value", type = "object"),
+    input = @JinjavaParam(value = "value", type = "object", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is string %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringExpTest.java
@@ -1,11 +1,13 @@
 package com.hubspot.jinjava.lib.exptest;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return true if object is a string",
+    input = @JinjavaParam(value = "value", type = "object"),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is string %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringStartingWithExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringStartingWithExpTest.java
@@ -3,13 +3,13 @@ package com.hubspot.jinjava.lib.exptest;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 @JinjavaDoc(
     value = "Return true if object is a string which starts with a specified other string",
-    input =  @JinjavaParam(value = "string", type = "string"),
-    params = @JinjavaParam(value = "check", type = "string", desc = "A second string to check is the start of the first string"),
+    input = @JinjavaParam(value = "value", type = "string", required = true),
+    params = @JinjavaParam(value = "check", type = "string", desc = "A second string to check is the start of the first string", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is string_startingwith 'foo' %}\n" +
@@ -30,7 +30,7 @@ public class IsStringStartingWithExpTest extends IsStringExpTest {
     }
 
     if (args.length == 0) {
-      throw new InterpretException(getName() + " test requires an argument");
+      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (other string to compare to)");
     }
 
     if (args[0] == null) {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringStartingWithExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringStartingWithExpTest.java
@@ -1,12 +1,15 @@
 package com.hubspot.jinjava.lib.exptest;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return true if object is a string which starts with a specified other string",
+    input =  @JinjavaParam(value = "string", type = "string"),
+    params = @JinjavaParam(value = "check", type = "string", desc = "A second string to check is the start of the first string"),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is string_startingwith 'foo' %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsTruthyExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsTruthyExpTest.java
@@ -1,12 +1,14 @@
 package com.hubspot.jinjava.lib.exptest;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.util.ObjectTruthValue;
 
 @JinjavaDoc(
     value = "Return true if object is 'truthy'",
+    input = @JinjavaParam(value = "value", type = "object"),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is truthy %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsTruthyExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsTruthyExpTest.java
@@ -8,7 +8,7 @@ import com.hubspot.jinjava.util.ObjectTruthValue;
 
 @JinjavaDoc(
     value = "Return true if object is 'truthy'",
-    input = @JinjavaParam(value = "value", type = "object"),
+    input = @JinjavaParam(value = "value", type = "object", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is truthy %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsUndefinedExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsUndefinedExpTest.java
@@ -7,7 +7,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return true if object is undefined",
-    input = @JinjavaParam(value = "value", type = "object"),
+    input = @JinjavaParam(value = "value", type = "object", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is undefined %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsUndefinedExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsUndefinedExpTest.java
@@ -1,11 +1,13 @@
 package com.hubspot.jinjava.lib.exptest;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return true if object is undefined",
+    input = @JinjavaParam(value = "value", type = "object"),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is undefined %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsUpperExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsUpperExpTest.java
@@ -3,11 +3,13 @@ package com.hubspot.jinjava.lib.exptest;
 import org.apache.commons.lang3.StringUtils;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return true if string is all uppercased",
+    input = @JinjavaParam(value = "value", type = "string"),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is upper %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsUpperExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsUpperExpTest.java
@@ -9,7 +9,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return true if string is all uppercased",
-    input = @JinjavaParam(value = "value", type = "string"),
+    input = @JinjavaParam(value = "value", type = "string", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% if variable is upper %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsWithinExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsWithinExpTest.java
@@ -11,8 +11,8 @@ import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Returns true if a value is within a list",
-    input = @JinjavaParam(value = "value", type="object"),
-    params = @JinjavaParam(value = "list", type="list", desc = "A list to check if the value is in."),
+    input = @JinjavaParam(value = "value", type = "object", required = true),
+    params = @JinjavaParam(value = "list", type = "list", desc = "A list to check if the value is in.", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{{ 2 is within [1, 2, 3] }}")

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsWithinExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsWithinExpTest.java
@@ -2,10 +2,21 @@ package com.hubspot.jinjava.lib.exptest;
 
 import java.util.Objects;
 
+import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
+import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.util.ForLoop;
 import com.hubspot.jinjava.util.ObjectIterator;
 
+@JinjavaDoc(
+    value = "Returns true if a value is within a list",
+    input = @JinjavaParam(value = "value", type="object"),
+    params = @JinjavaParam(value = "list", type="list", desc = "A list to check if the value is in."),
+    snippets = {
+        @JinjavaSnippet(
+            code = "{{ 2 is within [1, 2, 3] }}")
+    })
 public class IsWithinExpTest implements ExpTest {
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/AbsFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AbsFilter.java
@@ -21,7 +21,7 @@ import java.math.BigInteger;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
@@ -38,38 +38,37 @@ public class AbsFilter implements Filter {
 
   @Override
   public Object filter(Object object, JinjavaInterpreter interpreter, String... arg) {
+
+    if (object == null) {
+      return null;
+    }
+
     if (object instanceof Integer) {
       return Math.abs((Integer) object);
-    }
-    if (object instanceof Float) {
+    } else if (object instanceof Float) {
       return Math.abs((Float) object);
-    }
-    if (object instanceof Long) {
+    } else if (object instanceof Long) {
       return Math.abs((Long) object);
-    }
-    if (object instanceof Short) {
+    } else if (object instanceof Short) {
       return Math.abs((Short) object);
-    }
-    if (object instanceof Double) {
+    } else if (object instanceof Double) {
       return Math.abs((Double) object);
-    }
-    if (object instanceof BigDecimal) {
+    } else if (object instanceof BigDecimal) {
       return ((BigDecimal) object).abs();
-    }
-    if (object instanceof BigInteger) {
+    } else if (object instanceof BigInteger) {
       return ((BigInteger) object).abs();
-    }
-    if (object instanceof Byte) {
+    } else if (object instanceof Byte) {
       return Math.abs((Byte) object);
-    }
-    if (object instanceof String) {
+    } else {
       try {
-        return new BigDecimal((String) object).abs();
+        return new BigDecimal(object.toString()).abs();
       } catch (Exception e) {
-        throw new InterpretException(object + " can't be handled by abs filter", e);
+        throw new InvalidArgumentException(interpreter,
+            getName(),
+            String.format("Input %s must be a number", getName(), object.toString()),
+            "number");
       }
     }
-    return object;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/AbsFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AbsFilter.java
@@ -21,14 +21,13 @@ import java.math.BigInteger;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InvalidArgumentException;
+import com.hubspot.jinjava.interpret.InvalidInputException;
+import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return the absolute value of the argument.",
-    params = {
-        @JinjavaParam(value = "number", type = "number", desc = "The number that you want to get the absolute value of")
-    },
+    input = @JinjavaParam(value = "number", type = "number", desc = "The number that you want to get the absolute value of"),
     snippets = {
         @JinjavaSnippet(
             code = "{% set my_number = -53 %}\n" +
@@ -63,10 +62,7 @@ public class AbsFilter implements Filter {
       try {
         return new BigDecimal(object.toString()).abs();
       } catch (Exception e) {
-        throw new InvalidArgumentException(interpreter,
-            getName(),
-            String.format("Input %s must be a number", getName(), object.toString()),
-            "number");
+        throw new InvalidInputException(interpreter, this, InvalidReason.NUMBER_FORMAT, object.toString());
       }
     }
   }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/AbsFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AbsFilter.java
@@ -27,7 +27,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return the absolute value of the argument.",
-    input = @JinjavaParam(value = "number", type = "number", desc = "The number that you want to get the absolute value of"),
+    input = @JinjavaParam(value = "number", type = "number", desc = "The number that you want to get the absolute value of", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% set my_number = -53 %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/AbstractSetFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AbstractSetFilter.java
@@ -3,13 +3,19 @@ package com.hubspot.jinjava.lib.filter;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.util.ForLoop;
 import com.hubspot.jinjava.util.ObjectIterator;
 
 public abstract class AbstractSetFilter implements AdvancedFilter {
 
-  protected Object parseArgs(Object[] args) {
-    return args.length > 0 ? args[0] : null;
+  protected Object parseArgs(JinjavaInterpreter interpreter, Object[] args) {
+    if (args.length < 1) {
+      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (a list to perform set function)");
+    }
+
+    return args[0];
   }
 
   protected Set<Object> objectToSet(Object var) {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/AddFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AddFilter.java
@@ -28,9 +28,9 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 @JinjavaDoc(
     value = "adds a number to the existing value",
-    input = @JinjavaParam(value = "number", type = "number", desc = "Number or numeric variable to add to"),
+    input = @JinjavaParam(value = "number", type = "number", desc = "Number or numeric variable to add to", required = true),
     params = {
-        @JinjavaParam(value = "addend", type = "number", desc = "The number added to the base number")
+        @JinjavaParam(value = "addend", type = "number", desc = "The number added to the base number", required = true)
     },
     snippets = {
         @JinjavaSnippet(
@@ -40,13 +40,13 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 public class AddFilter implements Filter {
 
   @Override
-  public Object filter(Object object, JinjavaInterpreter interpreter, String... arg) {
+  public Object filter(Object object, JinjavaInterpreter interpreter, String... args) {
 
     if (object == null) {
       return null;
     }
 
-    if (arg.length != 1) {
+    if (args.length < 1) {
       throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (number to add to base)");
     }
 
@@ -57,15 +57,15 @@ public class AddFilter implements Filter {
       throw new InvalidInputException(interpreter, this, InvalidReason.NUMBER_FORMAT, object.toString());
     }
 
-    if (arg[0] == null) {
+    if (args[0] == null) {
       return base;
     }
 
     BigDecimal addend;
     try {
-      addend = new BigDecimal(arg[0]);
+      addend = new BigDecimal(args[0]);
     } catch (NumberFormatException e) {
-      throw new InvalidArgumentException(interpreter, this, InvalidReason.NUMBER_FORMAT, 0, arg[0]);
+      throw new InvalidArgumentException(interpreter, this, InvalidReason.NUMBER_FORMAT, 0, args[0]);
     }
 
     return base.add(addend);

--- a/src/main/java/com/hubspot/jinjava/lib/filter/AddFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AddFilter.java
@@ -16,19 +16,20 @@ limitations under the License.
 package com.hubspot.jinjava.lib.filter;
 
 import java.math.BigDecimal;
-import java.util.Objects;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
+import com.hubspot.jinjava.interpret.InvalidInputException;
+import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 @JinjavaDoc(
     value = "adds a number to the existing value",
+    input = @JinjavaParam(value = "number", type = "number", desc = "Number or numeric variable to add to"),
     params = {
-        @JinjavaParam(value = "number", type = "number", desc = "Number or numeric variable to add to"),
         @JinjavaParam(value = "addend", type = "number", desc = "The number added to the base number")
     },
     snippets = {
@@ -46,17 +47,28 @@ public class AddFilter implements Filter {
     }
 
     if (arg.length != 1) {
-      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument");
+      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (number to add to base)");
     }
 
+    BigDecimal base;
     try {
-      BigDecimal base = new BigDecimal(Objects.toString(object));
-      BigDecimal addend = new BigDecimal(Objects.toString(arg[0]));
-
-      return base.add(addend);
-    } catch (Exception e) {
-      throw new InterpretException("filter add error", e);
+      base = new BigDecimal(object.toString());
+    } catch (NumberFormatException e) {
+      throw new InvalidInputException(interpreter, this, InvalidReason.NUMBER_FORMAT, object.toString());
     }
+
+    if (arg[0] == null) {
+      return base;
+    }
+
+    BigDecimal addend;
+    try {
+      addend = new BigDecimal(arg[0]);
+    } catch (NumberFormatException e) {
+      throw new InvalidArgumentException(interpreter, this, InvalidReason.NUMBER_FORMAT, 0, arg[0]);
+    }
+
+    return base.add(addend);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/AddFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AddFilter.java
@@ -23,6 +23,7 @@ import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 @JinjavaDoc(
     value = "adds a number to the existing value",
@@ -39,8 +40,13 @@ public class AddFilter implements Filter {
 
   @Override
   public Object filter(Object object, JinjavaInterpreter interpreter, String... arg) {
+
+    if (object == null) {
+      return null;
+    }
+
     if (arg.length != 1) {
-      throw new InterpretException("filter add expects 1 arg >>> " + arg.length);
+      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument");
     }
 
     try {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/AttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AttrFilter.java
@@ -3,13 +3,13 @@ package com.hubspot.jinjava.lib.filter;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 @JinjavaDoc(
     value = "Renders the attribute of a dictionary",
+    input = @JinjavaParam(value = "obj", desc = "The dictionary containing the attribute"),
     params = {
-        @JinjavaParam(value = "obj", desc = "The dictionary containing the attribute"),
         @JinjavaParam(value = "name", desc = "The dictionary attribute name to access")
     },
     snippets = {
@@ -26,8 +26,9 @@ public class AttrFilter implements Filter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
-    if (args.length == 0) {
-      throw new InterpretException(getName() + " requires an attr name to use", interpreter.getLineNumber());
+
+    if (args.length != 1) {
+      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (attribute name to use)");
     }
 
     return interpreter.resolveProperty(var, args[0]);

--- a/src/main/java/com/hubspot/jinjava/lib/filter/AttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AttrFilter.java
@@ -8,9 +8,9 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 @JinjavaDoc(
     value = "Renders the attribute of a dictionary",
-    input = @JinjavaParam(value = "obj", desc = "The dictionary containing the attribute"),
+    input = @JinjavaParam(value = "obj", desc = "The dictionary containing the attribute", required = true),
     params = {
-        @JinjavaParam(value = "name", desc = "The dictionary attribute name to access")
+        @JinjavaParam(value = "name", desc = "The dictionary attribute name to access", required = true)
     },
     snippets = {
         @JinjavaSnippet(
@@ -27,7 +27,7 @@ public class AttrFilter implements Filter {
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
 
-    if (args.length != 1) {
+    if (args.length < 1) {
       throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (attribute name to use)");
     }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/BaseDateFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/BaseDateFilter.java
@@ -6,42 +6,53 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.google.common.primitives.Longs;
-import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
+import com.hubspot.jinjava.interpret.InvalidReason;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
-public abstract class BaseDateFilter implements Filter {
+public abstract class BaseDateFilter implements AdvancedFilter {
 
   private static final Map<String, ChronoUnit> unitMap = Arrays.stream(ChronoUnit.values())
       .collect(Collectors.toMap(u -> u.toString().toLowerCase(), u -> u));
 
-  protected long parseDiffAmount(String... args) {
+  protected long parseDiffAmount(JinjavaInterpreter interpreter, Object... args) {
 
-    if (args.length < 2) {
-      throw new InterpretException(String.format("%s filter requires a number and a string parameter", getName()));
+    if (args.length != 2) {
+      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 number (diff amount) and 1 string (diff unit) argument");
     }
 
-    String firstArg = args[0];
-    Long diff = Longs.tryParse(firstArg);
+    Object firstArg = args[0];
+    if (firstArg == null) {
+      firstArg = 0;
+    }
+
+    Long diff = Longs.tryParse(firstArg.toString());
     if (diff == null) {
-      throw new InterpretException(String.format("%s filter requires a number parameter as first arg", getName()));
+      throw new InvalidArgumentException(interpreter, this, InvalidReason.NUMBER_FORMAT, 0, firstArg.toString());
     }
     return diff;
   }
 
-  protected ChronoUnit parseChronoUnit(String... args) {
+  protected ChronoUnit parseChronoUnit(JinjavaInterpreter interpreter, Object... args) {
 
-    if (args.length < 2) {
-      throw new InterpretException(String.format("%s filter requires a number and a string parameter", getName()));
+    if (args.length != 2) {
+      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 number (diff amount) and 1 string (diff unit) argument");
     }
 
-    String secondArg = args[1].toLowerCase();
-    return getTemporalUnit(secondArg);
+    Object unitString = args[1];
+    if (unitString == null) {
+      throw new InvalidArgumentException(interpreter, this, InvalidReason.NULL, 1);
+    }
+
+    return getTemporalUnit(interpreter, unitString.toString());
   }
 
-  protected static ChronoUnit getTemporalUnit(String temporalUnit) {
+  protected ChronoUnit getTemporalUnit(JinjavaInterpreter interpreter, String temporalUnit) {
 
     String lowercase = temporalUnit.toLowerCase();
-    if (!unitMap.containsKey(temporalUnit)) {
-      throw new InterpretException(String.format("%s is not a valid temporal unit", lowercase));
+    if (!unitMap.containsKey(lowercase)) {
+      throw new InvalidArgumentException(interpreter, this, InvalidReason.TEMPORAL_UNIT, 1, lowercase);
     }
     return unitMap.get(lowercase);
   }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/BaseDateFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/BaseDateFilter.java
@@ -18,7 +18,7 @@ public abstract class BaseDateFilter implements AdvancedFilter {
 
   protected long parseDiffAmount(JinjavaInterpreter interpreter, Object... args) {
 
-    if (args.length != 2) {
+    if (args.length < 2) {
       throw new TemplateSyntaxException(interpreter, getName(), "requires 1 number (diff amount) and 1 string (diff unit) argument");
     }
 
@@ -36,7 +36,7 @@ public abstract class BaseDateFilter implements AdvancedFilter {
 
   protected ChronoUnit parseChronoUnit(JinjavaInterpreter interpreter, Object... args) {
 
-    if (args.length != 2) {
+    if (args.length < 2) {
       throw new TemplateSyntaxException(interpreter, getName(), "requires 1 number (diff amount) and 1 string (diff unit) argument");
     }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/BatchFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/BatchFilter.java
@@ -15,8 +15,8 @@ import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "A filter that groups up items within a sequence",
+    input = @JinjavaParam(value = "value", desc = "The sequence or dict that the filter is applied to"),
     params = {
-        @JinjavaParam(value = "value", desc = "The sequence or dict that the filter is applied to"),
         @JinjavaParam(value = "linecount", type = "number", desc = "Number of items to include in the batch", defaultValue = "0"),
         @JinjavaParam(value = "fill_with", desc = "Value used to fill up missing items")
     },

--- a/src/main/java/com/hubspot/jinjava/lib/filter/BatchFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/BatchFilter.java
@@ -15,7 +15,7 @@ import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "A filter that groups up items within a sequence",
-    input = @JinjavaParam(value = "value", desc = "The sequence or dict that the filter is applied to"),
+    input = @JinjavaParam(value = "value", desc = "The sequence or dict that the filter is applied to", required = true),
     params = {
         @JinjavaParam(value = "linecount", type = "number", desc = "Number of items to include in the batch", defaultValue = "0"),
         @JinjavaParam(value = "fill_with", desc = "Value used to fill up missing items")

--- a/src/main/java/com/hubspot/jinjava/lib/filter/BetweenTimesFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/BetweenTimesFilter.java
@@ -9,8 +9,10 @@ import java.util.Map;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
+import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.fn.Functions;
 import com.hubspot.jinjava.objects.date.PyishDate;
 
@@ -19,32 +21,32 @@ import com.hubspot.jinjava.objects.date.PyishDate;
  */
 @JinjavaDoc(
     value = "Calculates the time between two datetime objects",
+    input = @JinjavaParam(value = "begin", desc = "Datetime object or timestamp at the beginning of the period"),
     params = {
-        @JinjavaParam(value = "begin", desc = "Datetime object or timestamp at the beginning of the period"),
         @JinjavaParam(value = "end", desc = "Datetime object or timestamp at the end of the period"),
         @JinjavaParam(value = "unit", desc = "Which temporal unit to use"),
     },
     snippets = {
         @JinjavaSnippet(code = "{% begin|between_times(end, 'hours') %}"),
     })
-public class BetweenTimesFilter implements AdvancedFilter {
+public class BetweenTimesFilter extends BaseDateFilter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs) {
 
-    if (args.length < 2) {
-      throw new InterpretException(String.format("%s filter requires a datetime and a string parameter", getName()));
+    if (args.length != 2) {
+      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 datetime (end date) and 1 string (diff unit) argument");
     }
 
     ZonedDateTime start = getZonedDateTime(var);
     ZonedDateTime end = getZonedDateTime(args[0]);
 
     Object args1 = args[1];
-    if (!(args1 instanceof String)) {
-      throw new InterpretException(String.format("%s filter requires a string as the second parameter", getName()));
+    if (args1 == null) {
+      throw new InvalidArgumentException(interpreter, this, InvalidReason.NULL, 1);
     }
 
-    TemporalUnit temporalUnit = BaseDateFilter.getTemporalUnit((String) args[1]);
+    TemporalUnit temporalUnit = getTemporalUnit(interpreter, args[1].toString());
     return temporalUnit.between(start, end);
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/BetweenTimesFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/BetweenTimesFilter.java
@@ -21,10 +21,10 @@ import com.hubspot.jinjava.objects.date.PyishDate;
  */
 @JinjavaDoc(
     value = "Calculates the time between two datetime objects",
-    input = @JinjavaParam(value = "begin", desc = "Datetime object or timestamp at the beginning of the period"),
+    input = @JinjavaParam(value = "begin", desc = "Datetime object or timestamp at the beginning of the period", required = true),
     params = {
-        @JinjavaParam(value = "end", desc = "Datetime object or timestamp at the end of the period"),
-        @JinjavaParam(value = "unit", desc = "Which temporal unit to use"),
+        @JinjavaParam(value = "end", desc = "Datetime object or timestamp at the end of the period", required = true),
+        @JinjavaParam(value = "unit", desc = "Which temporal unit to use", required = true),
     },
     snippets = {
         @JinjavaSnippet(code = "{% begin|between_times(end, 'hours') %}"),
@@ -34,7 +34,7 @@ public class BetweenTimesFilter extends BaseDateFilter {
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs) {
 
-    if (args.length != 2) {
+    if (args.length < 2) {
       throw new TemplateSyntaxException(interpreter, getName(), "requires 1 datetime (end date) and 1 string (diff unit) argument");
     }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/BoolFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/BoolFilter.java
@@ -13,20 +13,19 @@
  */
 package com.hubspot.jinjava.lib.filter;
 
+import org.apache.commons.lang3.BooleanUtils;
+
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import org.apache.commons.lang3.BooleanUtils;
 
 /**
  * bool(value) Convert value to boolean.
  */
 @JinjavaDoc(
         value = "Convert value into a boolean.",
-        params = {
-                @JinjavaParam(value = "value", desc = "The value to convert to a boolean"),
-        },
+        input = @JinjavaParam(value = "value", desc = "The value to convert to a boolean"),
         snippets = {
                 @JinjavaSnippet(
                         desc = "This example converts a text string value to a boolean",

--- a/src/main/java/com/hubspot/jinjava/lib/filter/BoolFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/BoolFilter.java
@@ -25,7 +25,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
  */
 @JinjavaDoc(
         value = "Convert value into a boolean.",
-        input = @JinjavaParam(value = "value", desc = "The value to convert to a boolean"),
+        input = @JinjavaParam(value = "value", desc = "The value to convert to a boolean", required = true),
         snippets = {
                 @JinjavaSnippet(
                         desc = "This example converts a text string value to a boolean",

--- a/src/main/java/com/hubspot/jinjava/lib/filter/CapitalizeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/CapitalizeFilter.java
@@ -9,9 +9,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Capitalize a value. The first character will be uppercase, all others lowercase.",
-    params = {
-        @JinjavaParam(value = "string", desc = "String to capitalize the first letter of")
-    },
+    input = @JinjavaParam(value = "string", desc = "String to capitalize the first letter of"),
     snippets = {
         @JinjavaSnippet(
             code = "{% set sentence = \"the first letter of a sentence should always be capitalized.\" %}\n" +
@@ -26,6 +24,11 @@ public class CapitalizeFilter implements Filter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+
+    if (var == null) {
+      return null;
+    }
+
     if (var instanceof String) {
       String value = (String) var;
       return StringUtils.capitalize(value);

--- a/src/main/java/com/hubspot/jinjava/lib/filter/CapitalizeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/CapitalizeFilter.java
@@ -9,7 +9,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Capitalize a value. The first character will be uppercase, all others lowercase.",
-    input = @JinjavaParam(value = "string", desc = "String to capitalize the first letter of"),
+    input = @JinjavaParam(value = "string", desc = "String to capitalize the first letter of", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% set sentence = \"the first letter of a sentence should always be capitalized.\" %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/CenterFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/CenterFilter.java
@@ -1,7 +1,5 @@
 package com.hubspot.jinjava.lib.filter;
 
-import java.util.Objects;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 
@@ -12,8 +10,8 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Uses whitespace to center the value in a field of a given width.",
+    input = @JinjavaParam(value = "value", desc = "Value to center"),
     params = {
-        @JinjavaParam(value = "value", desc = "Value to center"),
         @JinjavaParam(value = "width", type = "number", defaultValue = "80", desc = "Width of field to center value in")
     },
     snippets = {
@@ -33,14 +31,17 @@ public class CenterFilter implements Filter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
-    String str = Objects.toString(var, "");
+
+    if (var == null) {
+      return null;
+    }
 
     int size = 80;
     if (args.length > 0) {
       size = NumberUtils.toInt(args[0], 80);
     }
 
-    return StringUtils.center(str, size);
+    return StringUtils.center(var.toString(), size);
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/CenterFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/CenterFilter.java
@@ -10,7 +10,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Uses whitespace to center the value in a field of a given width.",
-    input = @JinjavaParam(value = "value", desc = "Value to center"),
+    input = @JinjavaParam(value = "value", desc = "Value to center", required = true),
     params = {
         @JinjavaParam(value = "width", type = "number", defaultValue = "80", desc = "Width of field to center value in")
     },

--- a/src/main/java/com/hubspot/jinjava/lib/filter/CutFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/CutFilter.java
@@ -22,13 +22,13 @@ import org.apache.commons.lang3.StringUtils;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 @JinjavaDoc(
     value = "Removes a string from the value from another string",
+    input = @JinjavaParam(value = "value", desc = "The original string"),
     params = {
-        @JinjavaParam(value = "value", desc = "The original string"),
         @JinjavaParam(value = "to_remove", desc = "String to remove from the original string")
     },
     snippets = {
@@ -40,8 +40,9 @@ public class CutFilter implements Filter {
 
   @Override
   public Object filter(Object object, JinjavaInterpreter interpreter, String... arg) {
+
     if (arg.length != 1) {
-      throw new InterpretException("filter cut expects 1 arg >>> " + arg.length);
+      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (string to remove from target)");
     }
     String cutee = arg[0];
     String origin = Objects.toString(object, "");

--- a/src/main/java/com/hubspot/jinjava/lib/filter/CutFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/CutFilter.java
@@ -27,9 +27,9 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 @JinjavaDoc(
     value = "Removes a string from the value from another string",
-    input = @JinjavaParam(value = "value", desc = "The original string"),
+    input = @JinjavaParam(value = "value", desc = "The original string", required = true),
     params = {
-        @JinjavaParam(value = "to_remove", desc = "String to remove from the original string")
+        @JinjavaParam(value = "to_remove", desc = "String to remove from the original string", required = true)
     },
     snippets = {
         @JinjavaSnippet(
@@ -41,7 +41,7 @@ public class CutFilter implements Filter {
   @Override
   public Object filter(Object object, JinjavaInterpreter interpreter, String... arg) {
 
-    if (arg.length != 1) {
+    if (arg.length < 1) {
       throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (string to remove from target)");
     }
     String cutee = arg[0];

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilter.java
@@ -9,8 +9,8 @@ import com.hubspot.jinjava.objects.date.StrftimeFormatter;
 
 @JinjavaDoc(
     value = "Formats a date object",
+    input = @JinjavaParam(value = "value", defaultValue = "current time", desc = "The date variable or UNIX timestamp to format"),
     params = {
-        @JinjavaParam(value = "value", defaultValue = "current time", desc = "The date variable or UNIX timestamp to format"),
         @JinjavaParam(value = "format", defaultValue = StrftimeFormatter.DEFAULT_DATE_FORMAT, desc = "The format of the date determined by the directives added to this parameter"),
         @JinjavaParam(value = "timezone", defaultValue = "utc", desc = "Time zone of output date")
     },

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilter.java
@@ -9,7 +9,7 @@ import com.hubspot.jinjava.objects.date.StrftimeFormatter;
 
 @JinjavaDoc(
     value = "Formats a date object",
-    input = @JinjavaParam(value = "value", defaultValue = "current time", desc = "The date variable or UNIX timestamp to format"),
+    input = @JinjavaParam(value = "value", defaultValue = "current time", desc = "The date variable or UNIX timestamp to format", required = true),
     params = {
         @JinjavaParam(value = "format", defaultValue = StrftimeFormatter.DEFAULT_DATE_FORMAT, desc = "The format of the date determined by the directives added to this parameter"),
         @JinjavaParam(value = "timezone", defaultValue = "utc", desc = "Time zone of output date")

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DefaultFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DefaultFilter.java
@@ -20,14 +20,14 @@ import org.apache.commons.lang3.BooleanUtils;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.util.ObjectTruthValue;
 
 @JinjavaDoc(
     value = "If the value is undefined it will return the passed default value, otherwise the value of the variable",
+    input = @JinjavaParam(value = "value", desc = "The variable or value to test"),
     params = {
-        @JinjavaParam(value = "value", desc = "The variable or value to test"),
         @JinjavaParam(value = "default_value", desc = "Value to print when variable is not defined"),
         @JinjavaParam(value = "boolean", type = "boolean", defaultValue = "False", desc = "Set to True to use with variables which evaluate to false")
     },
@@ -42,15 +42,15 @@ import com.hubspot.jinjava.util.ObjectTruthValue;
 public class DefaultFilter implements Filter {
 
   @Override
-  public Object filter(Object object, JinjavaInterpreter interpreter, String... arg) {
+  public Object filter(Object object, JinjavaInterpreter interpreter, String... args) {
     boolean truthy = false;
 
-    if (arg.length == 0) {
-      throw new InterpretException("default filter requires 1 or 2 args");
+    if (args.length != 1 && args.length != 2) {
+      throw new TemplateSyntaxException(interpreter, getName(), "requires either 1 (default value to use) or 2 (default value to use, ) arguments");
     }
 
-    if (arg.length == 2) {
-      truthy = BooleanUtils.toBoolean(arg[1]);
+    if (args.length == 2) {
+      truthy = BooleanUtils.toBoolean(args[1]);
     }
 
     if (truthy) {
@@ -62,7 +62,7 @@ public class DefaultFilter implements Filter {
       return object;
     }
 
-    return arg[0];
+    return args[0];
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DefaultFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DefaultFilter.java
@@ -26,9 +26,9 @@ import com.hubspot.jinjava.util.ObjectTruthValue;
 
 @JinjavaDoc(
     value = "If the value is undefined it will return the passed default value, otherwise the value of the variable",
-    input = @JinjavaParam(value = "value", desc = "The variable or value to test"),
+    input = @JinjavaParam(value = "value", desc = "The variable or value to test", required = true),
     params = {
-        @JinjavaParam(value = "default_value", desc = "Value to print when variable is not defined"),
+        @JinjavaParam(value = "default_value", desc = "Value to print when variable is not defined", required = true),
         @JinjavaParam(value = "boolean", type = "boolean", defaultValue = "False", desc = "Set to True to use with variables which evaluate to false")
     },
     snippets = {
@@ -45,11 +45,11 @@ public class DefaultFilter implements Filter {
   public Object filter(Object object, JinjavaInterpreter interpreter, String... args) {
     boolean truthy = false;
 
-    if (args.length != 1 && args.length != 2) {
-      throw new TemplateSyntaxException(interpreter, getName(), "requires either 1 (default value to use) or 2 (default value to use, ) arguments");
+    if (args.length < 1) {
+      throw new TemplateSyntaxException(interpreter, getName(), "requires either 1 (default value to use) or 2 (default value to use, default with variables that evaluate to false) arguments");
     }
 
-    if (args.length == 2) {
+    if (args.length > 2) {
       truthy = BooleanUtils.toBoolean(args[1]);
     }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DictSortFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DictSortFilter.java
@@ -16,8 +16,8 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Sort a dict and yield (key, value) pairs.",
+    input = @JinjavaParam(value = "value", desc = "Dict to sort"),
     params = {
-        @JinjavaParam(value = "value", desc = "Dict to sort"),
         @JinjavaParam(value = "case_sensitive", type = "boolean", defaultValue = "False", desc = "Determines whether or not the sorting is case sensitive"),
         @JinjavaParam(value = "by", type = "enum key|value", defaultValue = "key", desc = "Sort by dict key or value")
     },

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DictSortFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DictSortFilter.java
@@ -16,7 +16,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Sort a dict and yield (key, value) pairs.",
-    input = @JinjavaParam(value = "value", desc = "Dict to sort"),
+    input = @JinjavaParam(value = "value", desc = "Dict to sort", required = true),
     params = {
         @JinjavaParam(value = "case_sensitive", type = "boolean", defaultValue = "False", desc = "Determines whether or not the sorting is case sensitive"),
         @JinjavaParam(value = "by", type = "enum key|value", defaultValue = "key", desc = "Sort by dict key or value")

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DifferenceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DifferenceFilter.java
@@ -11,9 +11,9 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Returns a list containing elements present in the first list but not the second list",
-    input = @JinjavaParam(value = "value", type = "sequence", desc = "The first list"),
+    input = @JinjavaParam(value = "value", type = "sequence", desc = "The first list", required = true),
     params = {
-        @JinjavaParam(value = "list", type = "sequence", desc = "The second list")
+        @JinjavaParam(value = "list", type = "sequence", desc = "The second list", required = true)
     },
     snippets = {
         @JinjavaSnippet(
@@ -23,7 +23,7 @@ public class DifferenceFilter extends AbstractSetFilter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs) {
-    return new ArrayList<>(Sets.difference(objectToSet(var), objectToSet(parseArgs(args))));
+    return new ArrayList<>(Sets.difference(objectToSet(var), objectToSet(parseArgs(interpreter, args))));
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DifferenceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DifferenceFilter.java
@@ -11,8 +11,8 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Returns a list containing elements present in the first list but not the second list",
+    input = @JinjavaParam(value = "value", type = "sequence", desc = "The first list"),
     params = {
-        @JinjavaParam(value = "value", type = "sequence", desc = "The first list"),
         @JinjavaParam(value = "list", type = "sequence", desc = "The second list")
     },
     snippets = {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DivideFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DivideFilter.java
@@ -29,9 +29,9 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 @JinjavaDoc(
     value = "Divides the current value by a divisor",
-    input = @JinjavaParam(value = "value", type = "number", desc = "The numerator to be divided"),
+    input = @JinjavaParam(value = "value", type = "number", desc = "The numerator to be divided", required = true),
     params = {
-        @JinjavaParam(value = "divisor", type = "number", desc = "The divisor to divide the value")
+        @JinjavaParam(value = "divisor", type = "number", desc = "The divisor to divide the value", required = true)
     },
     snippets = {
         @JinjavaSnippet(
@@ -42,7 +42,7 @@ public class DivideFilter implements Filter {
 
   @Override
   public Object filter(Object object, JinjavaInterpreter interpreter, String... arg) {
-    if (arg.length != 1) {
+    if (arg.length < 1) {
       throw new TemplateSyntaxException(interpreter, getName(), "requires 1 number (divisor) argument");
     }
     String toMul = arg[0];

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DivisibleFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DivisibleFilter.java
@@ -23,9 +23,9 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 @JinjavaDoc(
     value = "Evaluates to true if the value is divisible by the given number",
-    input = @JinjavaParam(value = "value", type = "number", desc = "The value to be divided"),
+    input = @JinjavaParam(value = "value", type = "number", desc = "The value to be divided", required = true),
     params = {
-        @JinjavaParam(value = "divisor", type = "number", desc = "The divisor to check if the value is divisible by")
+        @JinjavaParam(value = "divisor", type = "number", desc = "The divisor to check if the value is divisible by", required = true)
     },
     snippets = {
         @JinjavaSnippet(
@@ -43,7 +43,7 @@ public class DivisibleFilter implements Filter {
       return false;
     }
     if (object instanceof Number) {
-      if (arg.length != 1) {
+      if (arg.length < 1) {
         throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (number to divide by)");
       }
       long factor = Long.parseLong(arg[0]);

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DivisibleFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DivisibleFilter.java
@@ -18,13 +18,13 @@ package com.hubspot.jinjava.lib.filter;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 @JinjavaDoc(
     value = "Evaluates to true if the value is divisible by the given number",
+    input = @JinjavaParam(value = "value", type = "number", desc = "The value to be divided"),
     params = {
-        @JinjavaParam(value = "value", type = "number", desc = "The value to be divided"),
         @JinjavaParam(value = "divisor", type = "number", desc = "The divisor to check if the value is divisible by")
     },
     snippets = {
@@ -44,7 +44,7 @@ public class DivisibleFilter implements Filter {
     }
     if (object instanceof Number) {
       if (arg.length != 1) {
-        throw new InterpretException("filter divisible expects 1 arg >>> " + arg.length);
+        throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (number to divide by)");
       }
       long factor = Long.parseLong(arg[0]);
       long value = ((Number) object).longValue();

--- a/src/main/java/com/hubspot/jinjava/lib/filter/EscapeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/EscapeFilter.java
@@ -28,7 +28,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
     value = "Converts the characters &, <, >, ‘, and ” in string s to HTML-safe sequences. "
         + "Use this filter if you need to display text that might contain such characters in HTML. "
         + "Marks return value as markup string.",
-    input = @JinjavaParam(value = "s", desc = "String to escape"),
+    input = @JinjavaParam(value = "s", desc = "String to escape", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% set escape_string = \"<div>This markup is printed as text</div>\" %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/EscapeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/EscapeFilter.java
@@ -28,9 +28,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
     value = "Converts the characters &, <, >, ‘, and ” in string s to HTML-safe sequences. "
         + "Use this filter if you need to display text that might contain such characters in HTML. "
         + "Marks return value as markup string.",
-    params = {
-        @JinjavaParam(value = "s", desc = "String to escape")
-    },
+    input = @JinjavaParam(value = "s", desc = "String to escape"),
     snippets = {
         @JinjavaSnippet(
             code = "{% set escape_string = \"<div>This markup is printed as text</div>\" %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilter.java
@@ -29,7 +29,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
     value = "Converts the characters { and } in string s to Jinjava-safe sequences. "
         + "Use this filter if you need to display text that might contain such characters in Jinjava. "
         + "Marks return value as markup string.",
-    input = @JinjavaParam(value = "s", desc = "String to escape"),
+    input = @JinjavaParam(value = "s", desc = "String to escape", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% set escape_string = \"{{This markup is printed as text}}\" %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilter.java
@@ -29,9 +29,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
     value = "Converts the characters { and } in string s to Jinjava-safe sequences. "
         + "Use this filter if you need to display text that might contain such characters in Jinjava. "
         + "Marks return value as markup string.",
-    params = {
-        @JinjavaParam(value = "s", desc = "String to escape")
-    },
+    input = @JinjavaParam(value = "s", desc = "String to escape"),
     snippets = {
         @JinjavaSnippet(
             code = "{% set escape_string = \"{{This markup is printed as text}}\" %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJsFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJsFilter.java
@@ -26,9 +26,7 @@ import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 
 @JinjavaDoc(
     value = "Escapes strings so that they can be safely inserted into a JavaScript variable declaration",
-    params = {
-        @JinjavaParam(value = "s", desc = "String to escape")
-    },
+    input = @JinjavaParam(value = "s", desc = "String to escape"),
     snippets = {
         @JinjavaSnippet(
             code = "{% set escape_string = \"This string can safely be inserted into JavaScript\" %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJsFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJsFilter.java
@@ -26,7 +26,7 @@ import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 
 @JinjavaDoc(
     value = "Escapes strings so that they can be safely inserted into a JavaScript variable declaration",
-    input = @JinjavaParam(value = "s", desc = "String to escape"),
+    input = @JinjavaParam(value = "s", desc = "String to escape", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% set escape_string = \"This string can safely be inserted into JavaScript\" %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJsonFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJsonFilter.java
@@ -11,9 +11,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Escapes strings so that they can be used as JSON values",
-    params = {
-        @JinjavaParam(value = "s", desc = "String to escape")
-    },
+    input = @JinjavaParam(value = "s", desc = "String to escape"),
     snippets = {
         @JinjavaSnippet(
             code = "{{String that contains JavaScript|escapejson}}"

--- a/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJsonFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJsonFilter.java
@@ -11,7 +11,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Escapes strings so that they can be used as JSON values",
-    input = @JinjavaParam(value = "s", desc = "String to escape"),
+    input = @JinjavaParam(value = "s", desc = "String to escape", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{{String that contains JavaScript|escapejson}}"

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FileSizeFormatFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FileSizeFormatFilter.java
@@ -12,7 +12,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Format the value like a ‘human-readable’ file size (i.e. 13 kB, 4.1 MB, 102 Bytes, etc).",
-    input = @JinjavaParam(value = "value", desc = "The value to convert to filesize format"),
+    input = @JinjavaParam(value = "value", desc = "The value to convert to filesize format", required = true),
     params = {
         @JinjavaParam(value = "binary", type = "boolean", defaultValue = "False", desc = "Use binary prefixes (Mebi, Gibi)")
     },

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FileSizeFormatFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FileSizeFormatFilter.java
@@ -12,8 +12,8 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Format the value like a ‘human-readable’ file size (i.e. 13 kB, 4.1 MB, 102 Bytes, etc).",
+    input = @JinjavaParam(value = "value", desc = "The value to convert to filesize format"),
     params = {
-        @JinjavaParam(value = "value", desc = "The value to convert to filesize format"),
         @JinjavaParam(value = "binary", type = "boolean", defaultValue = "False", desc = "Use binary prefixes (Mebi, Gibi)")
     },
     snippets = {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FirstFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FirstFilter.java
@@ -9,7 +9,7 @@ import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Return the first item of a sequence.",
-    input = @JinjavaParam(value = "seq", type = "sequence", desc = "Sequence to return first item from"),
+    input = @JinjavaParam(value = "seq", type = "sequence", desc = "Sequence to return first item from", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% set my_sequence = ['Item 1', 'Item 2', 'Item 3'] %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FirstFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FirstFilter.java
@@ -9,9 +9,7 @@ import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Return the first item of a sequence.",
-    params = {
-        @JinjavaParam(value = "seq", type = "sequence", desc = "Sequence to return first item from")
-    },
+    input = @JinjavaParam(value = "seq", type = "sequence", desc = "Sequence to return first item from"),
     snippets = {
         @JinjavaSnippet(
             code = "{% set my_sequence = ['Item 1', 'Item 2', 'Item 3'] %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FloatFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FloatFilter.java
@@ -13,7 +13,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Convert the value into a floating point number.",
-    input = @JinjavaParam(value = "value", desc = "Value to convert to a float"),
+    input = @JinjavaParam(value = "value", desc = "Value to convert to a float", required = true),
     params = {
         @JinjavaParam(value = "default", type = "float", defaultValue = "0.0", desc = "Value to return if conversion fails")
     },

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FloatFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FloatFilter.java
@@ -13,8 +13,8 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Convert the value into a floating point number.",
+    input = @JinjavaParam(value = "value", desc = "Value to convert to a float"),
     params = {
-        @JinjavaParam(value = "value", desc = "Value to convert to a float"),
         @JinjavaParam(value = "default", type = "float", defaultValue = "0.0", desc = "Value to return if conversion fails")
     },
     snippets = {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ForceEscapeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ForceEscapeFilter.java
@@ -11,7 +11,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Enforce HTML escaping. This will probably double escape variables.",
-    input = @JinjavaParam(value = "value", desc = "Value to escape"),
+    input = @JinjavaParam(value = "value", desc = "Value to escape", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% set escape_string = \"<div>This markup is printed as text</div>\" %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ForceEscapeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ForceEscapeFilter.java
@@ -11,7 +11,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Enforce HTML escaping. This will probably double escape variables.",
-    params = @JinjavaParam(value = "value", desc = "Value to escape"),
+    input = @JinjavaParam(value = "value", desc = "Value to escape"),
     snippets = {
         @JinjavaSnippet(
             code = "{% set escape_string = \"<div>This markup is printed as text</div>\" %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FormatFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FormatFilter.java
@@ -10,7 +10,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Apply Python string formatting to an object.",
-    input = @JinjavaParam(value = "value", desc = "String value to reformat"),
+    input = @JinjavaParam(value = "value", desc = "String value to reformat", required = true),
     params = {
         @JinjavaParam(value = "args", type = "String...", desc = "Values to insert into string")
     },

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FormatFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FormatFilter.java
@@ -10,8 +10,8 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Apply Python string formatting to an object.",
+    input = @JinjavaParam(value = "value", desc = "String value to reformat"),
     params = {
-        @JinjavaParam(value = "value", desc = "String value to reformat"),
         @JinjavaParam(value = "args", type = "String...", desc = "Values to insert into string")
     },
     snippets = {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FromJsonFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FromJsonFilter.java
@@ -13,7 +13,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Converts JSON string to Object",
-    input = @JinjavaParam(value = "string", desc = "JSON String to write to object"),
+    input = @JinjavaParam(value = "string", desc = "JSON String to write to object", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{{object|fromJson}}"

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FromJsonFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FromJsonFilter.java
@@ -7,14 +7,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.InvalidInputException;
+import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Converts JSON string to Object",
-    params = {
-        @JinjavaParam(value = "s", desc = "JSON String to write to object")
-    },
+    input = @JinjavaParam(value = "string", desc = "JSON String to write to object"),
     snippets = {
         @JinjavaSnippet(
             code = "{{object|fromJson}}"
@@ -26,16 +25,20 @@ public class FromJsonFilter implements Filter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+
+    if (var == null) {
+      return null;
+    }
+
     try {
 
       if (var instanceof String) {
         return OBJECT_MAPPER.readValue((String) var, HashMap.class);
       } else {
-        throw new InterpretException(String.format("%s filter requires a string parameter", getName()));
+        throw new InvalidInputException(interpreter, this, InvalidReason.STRING);
       }
-
     } catch (IOException e) {
-      throw new InterpretException("Could not convert JSON string to object in `fromjson` filter.", e, interpreter.getLineNumber());
+      throw new InvalidInputException(interpreter, this, InvalidReason.JSON_READ);
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/GroupByFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/GroupByFilter.java
@@ -19,9 +19,9 @@ import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Group a sequence of objects by a common attribute.",
-    input = @JinjavaParam(value = "value", desc = "The dict to iterate through and group by a common attribute"),
+    input = @JinjavaParam(value = "value", desc = "The dict to iterate through and group by a common attribute", required = true),
     params = {
-        @JinjavaParam(value = "attribute", desc = "The common attribute to group by")
+        @JinjavaParam(value = "attribute", desc = "The common attribute to group by", required = true)
     },
     snippets = {
         @JinjavaSnippet(
@@ -45,7 +45,7 @@ public class GroupByFilter implements Filter {
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
 
-    if (args.length != 1) {
+    if (args.length < 1) {
       throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (attr name to group by)");
     }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/GroupByFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/GroupByFilter.java
@@ -12,15 +12,15 @@ import com.google.common.collect.Multimap;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.util.ForLoop;
 import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Group a sequence of objects by a common attribute.",
+    input = @JinjavaParam(value = "value", desc = "The dict to iterate through and group by a common attribute"),
     params = {
-        @JinjavaParam(value = "value", desc = "The dict to iterate through and group by a common attribute"),
         @JinjavaParam(value = "attribute", desc = "The common attribute to group by")
     },
     snippets = {
@@ -44,8 +44,9 @@ public class GroupByFilter implements Filter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
-    if (args.length == 0) {
-      throw new InterpretException(getName() + " requires an attr name to group on", interpreter.getLineNumber());
+
+    if (args.length != 1) {
+      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (attr name to group by)");
     }
 
     String attr = args[0];

--- a/src/main/java/com/hubspot/jinjava/lib/filter/IndentFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IndentFilter.java
@@ -17,7 +17,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Uses whitespace to indent a string.",
-    input = @JinjavaParam(value = "string", desc = "The string to indent"),
+    input = @JinjavaParam(value = "string", desc = "The string to indent", required = true),
     params = {
         @JinjavaParam(value = "width", type = "number", defaultValue = "4", desc = "Amount of whitespace to indent"),
         @JinjavaParam(value = "indentfirst", type = "boolean", defaultValue = "False", desc = "If True, first line will be indented")

--- a/src/main/java/com/hubspot/jinjava/lib/filter/IndentFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IndentFilter.java
@@ -17,8 +17,8 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Uses whitespace to indent a string.",
+    input = @JinjavaParam(value = "string", desc = "The string to indent"),
     params = {
-        @JinjavaParam(value = "s", desc = "The string to indent"),
         @JinjavaParam(value = "width", type = "number", defaultValue = "4", desc = "Amount of whitespace to indent"),
         @JinjavaParam(value = "indentfirst", type = "boolean", defaultValue = "False", desc = "If True, first line will be indented")
     },

--- a/src/main/java/com/hubspot/jinjava/lib/filter/IntFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IntFilter.java
@@ -1,6 +1,5 @@
 package com.hubspot.jinjava.lib.filter;
 
-import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.text.ParsePosition;
 import java.util.Locale;
@@ -17,8 +16,8 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
  */
 @JinjavaDoc(
     value = "Convert the value into an integer.",
+    input = @JinjavaParam(value = "value", desc = "The value to convert to an integer"),
     params = {
-        @JinjavaParam(value = "value", desc = "The value to convert to an integer"),
         @JinjavaParam(value = "default", type = "number", defaultValue = "0", desc = "Value to return if the conversion fails")
     },
     snippets = {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/IntFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IntFilter.java
@@ -16,7 +16,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
  */
 @JinjavaDoc(
     value = "Convert the value into an integer.",
-    input = @JinjavaParam(value = "value", desc = "The value to convert to an integer"),
+    input = @JinjavaParam(value = "value", desc = "The value to convert to an integer", required = true),
     params = {
         @JinjavaParam(value = "default", type = "number", defaultValue = "0", desc = "Value to return if the conversion fails")
     },

--- a/src/main/java/com/hubspot/jinjava/lib/filter/IntersectFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IntersectFilter.java
@@ -11,9 +11,9 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Returns a list containing elements present in both lists",
-    input = @JinjavaParam(value = "value", type = "sequence", desc = "The first list"),
+    input = @JinjavaParam(value = "value", type = "sequence", desc = "The first list", required = true),
     params = {
-        @JinjavaParam(value = "list", type = "sequence", desc = "The second list")
+        @JinjavaParam(value = "list", type = "sequence", desc = "The second list", required = true)
     },
     snippets = {
         @JinjavaSnippet(
@@ -23,7 +23,7 @@ public class IntersectFilter extends AbstractSetFilter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs) {
-    return new ArrayList<>(Sets.intersection(objectToSet(var), objectToSet(parseArgs(args))));
+    return new ArrayList<>(Sets.intersection(objectToSet(var), objectToSet(parseArgs(interpreter, args))));
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/IntersectFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IntersectFilter.java
@@ -11,8 +11,8 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Returns a list containing elements present in both lists",
+    input = @JinjavaParam(value = "value", type = "sequence", desc = "The first list"),
     params = {
-        @JinjavaParam(value = "value", type = "sequence", desc = "The first list"),
         @JinjavaParam(value = "list", type = "sequence", desc = "The second list")
     },
     snippets = {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/IpAddrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IpAddrFilter.java
@@ -11,9 +11,9 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Evaluates to true if the value is a valid IPv4 or IPv6 address",
-    input = @JinjavaParam(value = "value", type = "string", desc = "String to check IP Address"),
+    input = @JinjavaParam(value = "value", type = "string", desc = "String to check IP Address", required = true),
     params = {
-        @JinjavaParam(value = "function", type = "string", desc = "Optional name of function. Supported functions: 'prefix'"),
+        @JinjavaParam(value = "function", type = "string", defaultValue = "prefix", desc = "Name of function. Supported functions: 'prefix'"),
     },
     snippets = {
         @JinjavaSnippet(

--- a/src/main/java/com/hubspot/jinjava/lib/filter/IpAddrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IpAddrFilter.java
@@ -11,8 +11,8 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Evaluates to true if the value is a valid IPv4 or IPv6 address",
+    input = @JinjavaParam(value = "value", type = "string", desc = "String to check IP Address"),
     params = {
-        @JinjavaParam(value = "value", type = "string", desc = "String to check IP Address"),
         @JinjavaParam(value = "function", type = "string", desc = "Optional name of function. Supported functions: 'prefix'"),
     },
     snippets = {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/JoinFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/JoinFilter.java
@@ -17,9 +17,9 @@ import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Return a string which is the concatenation of the strings in the sequence.",
-    input = @JinjavaParam(value = "value", desc = "The values to join"),
+    input = @JinjavaParam(value = "value", desc = "The values to join", required = true),
     params = {
-        @JinjavaParam(value = "d", desc = "The separator string used to join the items"),
+        @JinjavaParam(value = "d", desc = "The separator string used to join the items", defaultValue = "(empty String)"),
         @JinjavaParam(value = "attr", desc = "Optional dict object attribute to use in joining")
     },
     snippets = {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/JoinFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/JoinFilter.java
@@ -17,8 +17,8 @@ import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Return a string which is the concatenation of the strings in the sequence.",
+    input = @JinjavaParam(value = "value", desc = "The values to join"),
     params = {
-        @JinjavaParam(value = "value", desc = "The values to join"),
         @JinjavaParam(value = "d", desc = "The separator string used to join the items"),
         @JinjavaParam(value = "attr", desc = "Optional dict object attribute to use in joining")
     },

--- a/src/main/java/com/hubspot/jinjava/lib/filter/LastFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/LastFilter.java
@@ -9,9 +9,7 @@ import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Return the last item of a sequence",
-    params = {
-        @JinjavaParam(value = "seq", type = "sequence", desc = "Sequence to return last item from")
-    },
+    input = @JinjavaParam(value = "seq", type = "sequence", desc = "Sequence to return last item from"),
     snippets = {
         @JinjavaSnippet(
             code = "{% set my_sequence = ['Item 1', 'Item 2', 'Item 3'] %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/LastFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/LastFilter.java
@@ -9,7 +9,7 @@ import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Return the last item of a sequence",
-    input = @JinjavaParam(value = "seq", type = "sequence", desc = "Sequence to return last item from"),
+    input = @JinjavaParam(value = "seq", type = "sequence", desc = "Sequence to return last item from", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% set my_sequence = ['Item 1', 'Item 2', 'Item 3'] %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/LengthFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/LengthFilter.java
@@ -27,7 +27,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return the number of items of a sequence or mapping",
-    input = @JinjavaParam(value = "object", desc = "The sequence to count"),
+    input = @JinjavaParam(value = "object", desc = "The sequence to count", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% set services = ['Web design', 'SEO', 'Inbound Marketing', 'PPC'] %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/LengthFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/LengthFilter.java
@@ -27,7 +27,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return the number of items of a sequence or mapping",
-    params = @JinjavaParam(value = "object", desc = "The sequence to count"),
+    input = @JinjavaParam(value = "object", desc = "The sequence to count"),
     snippets = {
         @JinjavaSnippet(
             code = "{% set services = ['Web design', 'SEO', 'Inbound Marketing', 'PPC'] %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ListFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ListFilter.java
@@ -12,7 +12,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Convert the value into a list. If it was a string the returned list will be a list of characters.",
-    params = @JinjavaParam(value = "value", desc = "Value to add to a sequence"),
+    input = @JinjavaParam(value = "value", desc = "Value to add to a sequence"),
     snippets = {
         @JinjavaSnippet(
             code = "{% set one = 1 %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ListFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ListFilter.java
@@ -12,7 +12,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Convert the value into a list. If it was a string the returned list will be a list of characters.",
-    input = @JinjavaParam(value = "value", desc = "Value to add to a sequence"),
+    input = @JinjavaParam(value = "value", desc = "Value to add to a sequence", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% set one = 1 %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/LowerFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/LowerFilter.java
@@ -22,7 +22,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Convert a value to lowercase",
-    input = @JinjavaParam(value = "s", desc = "String to make lowercase"),
+    input = @JinjavaParam(value = "s", desc = "String to make lowercase", required = true),
     snippets = {
         @JinjavaSnippet(code = "{{ \"Text to MAKE Lowercase\"|lowercase }}")
     })

--- a/src/main/java/com/hubspot/jinjava/lib/filter/LowerFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/LowerFilter.java
@@ -22,7 +22,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Convert a value to lowercase",
-    params = @JinjavaParam(value = "s", desc = "String to make lowercase"),
+    input = @JinjavaParam(value = "s", desc = "String to make lowercase"),
     snippets = {
         @JinjavaSnippet(code = "{{ \"Text to MAKE Lowercase\"|lowercase }}")
     })

--- a/src/main/java/com/hubspot/jinjava/lib/filter/MapFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/MapFilter.java
@@ -6,15 +6,15 @@ import java.util.List;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.util.ForLoop;
 import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Applies a filter on a sequence of objects or looks up an attribute.",
+    input = @JinjavaParam(value = "value", type = "object", desc = "Sequence to apply filter or dict to lookup attribute"),
     params = {
-        @JinjavaParam(value = "value", type = "object", desc = "Sequence to apply filter or dict to lookup attribute"),
         @JinjavaParam(value = "attribute", desc = "Filter to apply to an object or dict attribute to lookup")
     },
     snippets = {
@@ -38,7 +38,7 @@ public class MapFilter implements Filter {
     ForLoop loop = ObjectIterator.getLoop(var);
 
     if (args.length == 0) {
-      throw new InterpretException(getName() + " filter requires name of filter or attribute to apply to given sequence");
+      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (name of filter or attribute to apply to given sequence)");
     }
 
     String attr = args[0];

--- a/src/main/java/com/hubspot/jinjava/lib/filter/MapFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/MapFilter.java
@@ -13,9 +13,9 @@ import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Applies a filter on a sequence of objects or looks up an attribute.",
-    input = @JinjavaParam(value = "value", type = "object", desc = "Sequence to apply filter or dict to lookup attribute"),
+    input = @JinjavaParam(value = "value", type = "object", desc = "Sequence to apply filter or dict to lookup attribute", required = true),
     params = {
-        @JinjavaParam(value = "attribute", desc = "Filter to apply to an object or dict attribute to lookup")
+        @JinjavaParam(value = "attribute", desc = "Filter to apply to an object or dict attribute to lookup", required = true)
     },
     snippets = {
         @JinjavaSnippet(
@@ -37,7 +37,7 @@ public class MapFilter implements Filter {
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
     ForLoop loop = ObjectIterator.getLoop(var);
 
-    if (args.length == 0) {
+    if (args.length < 1) {
       throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (name of filter or attribute to apply to given sequence)");
     }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/Md5Filter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/Md5Filter.java
@@ -28,7 +28,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Calculates the md5 hash of the given object",
-    input = @JinjavaParam(value = "value", desc = "Value to get MD5 hash of"),
+    input = @JinjavaParam(value = "value", desc = "Value to get MD5 hash of", required = true),
     snippets = {
         @JinjavaSnippet(code = "{{ content.absolute_url|md5 }}")
     })

--- a/src/main/java/com/hubspot/jinjava/lib/filter/Md5Filter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/Md5Filter.java
@@ -28,7 +28,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Calculates the md5 hash of the given object",
-    params = @JinjavaParam(value = "value", desc = "Value to get MD5 hash of"),
+    input = @JinjavaParam(value = "value", desc = "Value to get MD5 hash of"),
     snippets = {
         @JinjavaSnippet(code = "{{ content.absolute_url|md5 }}")
     })

--- a/src/main/java/com/hubspot/jinjava/lib/filter/MinusTimeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/MinusTimeFilter.java
@@ -17,10 +17,10 @@ import com.hubspot.jinjava.objects.date.PyishDate;
  */
 @JinjavaDoc(
     value = "Subtracts a specified amount of time to a datetime object",
-    input = @JinjavaParam(value = "var", desc = "Datetime object or timestamp"),
+    input = @JinjavaParam(value = "var", desc = "Datetime object or timestamp", required = true),
     params = {
-        @JinjavaParam(value = "diff", desc = "The amount to subtract from the datetime"),
-        @JinjavaParam(value = "unit", desc = "Which temporal unit to use"),
+        @JinjavaParam(value = "diff", desc = "The amount to subtract from the datetime", required = true),
+        @JinjavaParam(value = "unit", desc = "Which temporal unit to use", required = true),
     },
     snippets = {
         @JinjavaSnippet(code = "{% mydatetime|minus_time(3, 'days') %}"),

--- a/src/main/java/com/hubspot/jinjava/lib/filter/MinusTimeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/MinusTimeFilter.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.lib.filter;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Map;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
@@ -16,8 +17,8 @@ import com.hubspot.jinjava.objects.date.PyishDate;
  */
 @JinjavaDoc(
     value = "Subtracts a specified amount of time to a datetime object",
+    input = @JinjavaParam(value = "var", desc = "Datetime object or timestamp"),
     params = {
-        @JinjavaParam(value = "var", desc = "Datetime object or timestamp"),
         @JinjavaParam(value = "diff", desc = "The amount to subtract from the datetime"),
         @JinjavaParam(value = "unit", desc = "Which temporal unit to use"),
     },
@@ -27,10 +28,9 @@ import com.hubspot.jinjava.objects.date.PyishDate;
 public class MinusTimeFilter extends BaseDateFilter {
 
   @Override
-  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
-
-    long diff = parseDiffAmount(args);
-    ChronoUnit chronoUnit = parseChronoUnit(args);
+  public Object filter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs) {
+    long diff = parseDiffAmount(interpreter, args);
+    ChronoUnit chronoUnit = parseChronoUnit(interpreter, args);
 
     if (var instanceof ZonedDateTime) {
       ZonedDateTime dateTime = (ZonedDateTime) var;

--- a/src/main/java/com/hubspot/jinjava/lib/filter/MultiplyFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/MultiplyFilter.java
@@ -29,9 +29,9 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 @JinjavaDoc(
     value = "Multiplies the current object with the given multiplier",
-    input = @JinjavaParam(value = "value", type = "number", desc = "Base number to be multiplied"),
+    input = @JinjavaParam(value = "value", type = "number", desc = "Base number to be multiplied", required = true),
     params = {
-        @JinjavaParam(value = "multiplier", type = "number", desc = "The multiplier")
+        @JinjavaParam(value = "multiplier", type = "number", desc = "The multiplier", required = true)
     },
     snippets = {
         @JinjavaSnippet(
@@ -43,7 +43,7 @@ public class MultiplyFilter implements Filter {
   @Override
   public Object filter(Object object, JinjavaInterpreter interpreter, String... arg) {
 
-    if (arg.length != 1) {
+    if (arg.length < 1) {
       throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (number to multiply by)");
     }
     String toMul = arg[0];

--- a/src/main/java/com/hubspot/jinjava/lib/filter/PlusTimeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/PlusTimeFilter.java
@@ -17,10 +17,10 @@ import com.hubspot.jinjava.objects.date.PyishDate;
  */
 @JinjavaDoc(
     value = "Adds a specified amount of time to a datetime object",
-    input = @JinjavaParam(value = "var", desc = "Datetime object or timestamp"),
+    input = @JinjavaParam(value = "var", desc = "Datetime object or timestamp", required = true),
     params = {
-        @JinjavaParam(value = "diff", desc = "The amount to add to the datetime"),
-        @JinjavaParam(value = "unit", desc = "Which temporal unit to use"),
+        @JinjavaParam(value = "diff", desc = "The amount to add to the datetime", required = true),
+        @JinjavaParam(value = "unit", desc = "Which temporal unit to use", required = true),
     },
     snippets = {
         @JinjavaSnippet(code = "{% mydatetime|plus_time(3, 'days') %}"),

--- a/src/main/java/com/hubspot/jinjava/lib/filter/PlusTimeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/PlusTimeFilter.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.lib.filter;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Map;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
@@ -16,8 +17,8 @@ import com.hubspot.jinjava.objects.date.PyishDate;
  */
 @JinjavaDoc(
     value = "Adds a specified amount of time to a datetime object",
+    input = @JinjavaParam(value = "var", desc = "Datetime object or timestamp"),
     params = {
-        @JinjavaParam(value = "var", desc = "Datetime object or timestamp"),
         @JinjavaParam(value = "diff", desc = "The amount to add to the datetime"),
         @JinjavaParam(value = "unit", desc = "Which temporal unit to use"),
     },
@@ -27,10 +28,9 @@ import com.hubspot.jinjava.objects.date.PyishDate;
 public class PlusTimeFilter extends BaseDateFilter {
 
   @Override
-  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
-
-    long diff = parseDiffAmount(args);
-    ChronoUnit chronoUnit = parseChronoUnit(args);
+  public Object filter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs) {
+    long diff = parseDiffAmount(interpreter, args);
+    ChronoUnit chronoUnit = parseChronoUnit(interpreter, args);
 
     if (var instanceof ZonedDateTime) {
       ZonedDateTime dateTime = (ZonedDateTime) var;

--- a/src/main/java/com/hubspot/jinjava/lib/filter/PrettyPrintFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/PrettyPrintFilter.java
@@ -23,7 +23,7 @@ import com.hubspot.jinjava.objects.date.PyishDate;
 
 @JinjavaDoc(
     value = "Pretty print a variable. Useful for debugging.",
-    params = @JinjavaParam(value = "value", type = "object", desc = "Object to Pretty Print"),
+    input = @JinjavaParam(value = "value", type = "object", desc = "Object to Pretty Print"),
     snippets = {
         @JinjavaSnippet(
             code = "{% set this_var =\"Variable that I want to debug\" %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/PrettyPrintFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/PrettyPrintFilter.java
@@ -23,7 +23,7 @@ import com.hubspot.jinjava.objects.date.PyishDate;
 
 @JinjavaDoc(
     value = "Pretty print a variable. Useful for debugging.",
-    input = @JinjavaParam(value = "value", type = "object", desc = "Object to Pretty Print"),
+    input = @JinjavaParam(value = "value", type = "object", desc = "Object to Pretty Print", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% set this_var =\"Variable that I want to debug\" %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RandomFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RandomFilter.java
@@ -28,7 +28,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return a random item from the sequence.",
-    params = @JinjavaParam(value = "seq", type = "sequence", desc = "Sequence to return a random item from"),
+    input = @JinjavaParam(value = "seq", type = "sequence", desc = "Sequence to return a random item from"),
     snippets = {
         @JinjavaSnippet(
             desc = "The example below is a standard blog loop that returns a single random post.",

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RandomFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RandomFilter.java
@@ -28,7 +28,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return a random item from the sequence.",
-    input = @JinjavaParam(value = "seq", type = "sequence", desc = "Sequence to return a random item from"),
+    input = @JinjavaParam(value = "seq", type = "sequence", desc = "Sequence to return a random item from", required = true),
     snippets = {
         @JinjavaSnippet(
             desc = "The example below is a standard blog loop that returns a single random post.",

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilter.java
@@ -16,10 +16,10 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
         value = "Return a copy of the value with all occurrences of a matched regular expression (Java RE2 syntax) " +
                 "replaced with a new one. The first argument is the regular expression to be matched, the second " +
                 "is the replacement string",
-        input = @JinjavaParam(value = "s", desc = "Base string to find and replace within"),
+        input = @JinjavaParam(value = "s", desc = "Base string to find and replace within", required = true),
         params = {
-                @JinjavaParam(value = "regex", desc = "The regular expression that you want to match and replace"),
-                @JinjavaParam(value = "new", desc = "The new string that you replace the matched substring")
+                @JinjavaParam(value = "regex", desc = "The regular expression that you want to match and replace", required = true),
+                @JinjavaParam(value = "new", desc = "The new string that you replace the matched substring", required = true)
         },
         snippets = {
                 @JinjavaSnippet(
@@ -37,7 +37,7 @@ public class RegexReplaceFilter implements Filter {
     public Object filter(Object var, JinjavaInterpreter interpreter,
                          String... args) {
 
-        if (args.length != 2) {
+        if (args.length < 2) {
             throw new TemplateSyntaxException(interpreter, getName(), "requires 2 arguments (regex string, replacement string)");
         }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilter.java
@@ -3,19 +3,21 @@ package com.hubspot.jinjava.lib.filter;
 import com.google.re2j.Matcher;
 import com.google.re2j.Pattern;
 import com.google.re2j.PatternSyntaxException;
-
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
+import com.hubspot.jinjava.interpret.InvalidInputException;
+import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 @JinjavaDoc(
         value = "Return a copy of the value with all occurrences of a matched regular expression (Java RE2 syntax) " +
                 "replaced with a new one. The first argument is the regular expression to be matched, the second " +
                 "is the replacement string",
+        input = @JinjavaParam(value = "s", desc = "Base string to find and replace within"),
         params = {
-                @JinjavaParam(value = "s", desc = "Base string to find and replace within"),
                 @JinjavaParam(value = "regex", desc = "The regular expression that you want to match and replace"),
                 @JinjavaParam(value = "new", desc = "The new string that you replace the matched substring")
         },
@@ -35,12 +37,14 @@ public class RegexReplaceFilter implements Filter {
     public Object filter(Object var, JinjavaInterpreter interpreter,
                          String... args) {
 
+        if (args.length != 2) {
+            throw new TemplateSyntaxException(interpreter, getName(), "requires 2 arguments (regex string, replacement string)");
+        }
+
         if (var == null) {
             return null;
         }
-        if (args.length < 2) {
-            throw new InterpretException("filter " + getName() + " requires two string args");
-        }
+
         if (var instanceof String) {
             String s = (String) var;
             String toReplace = args[0];
@@ -51,11 +55,11 @@ public class RegexReplaceFilter implements Filter {
                 Matcher matcher = p.matcher(s);
 
                 return matcher.replaceAll(replaceWith);
-            } catch(PatternSyntaxException e) {
-                throw new InterpretException(getName() + " filter requires a valid regular expression");
+            } catch (PatternSyntaxException e) {
+                throw new InvalidArgumentException(interpreter, this, InvalidReason.REGEX, 0, toReplace);
             }
         } else {
-            throw new InterpretException(getName() + " filter requires a string parameter");
+            throw new InvalidInputException(interpreter, this, InvalidReason.STRING);
         }
     }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RejectAttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RejectAttrFilter.java
@@ -10,9 +10,9 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 @JinjavaDoc(
     value = "Filters a sequence of objects by applying a test to an attribute of an object or the attribute and "
         + "rejecting the ones with the test succeeding.",
-    input = @JinjavaParam(value = "seq", type = "sequence", desc = "Sequence to test"),
+    input = @JinjavaParam(value = "seq", type = "sequence", desc = "Sequence to test", required = true),
     params = {
-        @JinjavaParam(value = "attribute", desc = "Attribute to test for and reject items that contain it"),
+        @JinjavaParam(value = "attribute", desc = "Attribute to test for and reject items that contain it", required = true),
         @JinjavaParam(value = "exp_test", type = "name of expression test", defaultValue = "truthy", desc = "Specify which expression test to run for making the rejection")
     },
     snippets = {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RejectAttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RejectAttrFilter.java
@@ -10,8 +10,8 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 @JinjavaDoc(
     value = "Filters a sequence of objects by applying a test to an attribute of an object or the attribute and "
         + "rejecting the ones with the test succeeding.",
+    input = @JinjavaParam(value = "seq", type = "sequence", desc = "Sequence to test"),
     params = {
-        @JinjavaParam(value = "seq", type = "sequence", desc = "Sequence to test"),
         @JinjavaParam(value = "attribute", desc = "Attribute to test for and reject items that contain it"),
         @JinjavaParam(value = "exp_test", type = "name of expression test", defaultValue = "truthy", desc = "Specify which expression test to run for making the rejection")
     },

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RejectFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RejectFilter.java
@@ -16,9 +16,9 @@ import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Filters a sequence of objects by applying a test to the object and rejecting the ones with the test succeeding.",
-    input = @JinjavaParam(value = "seq", type = "Sequence to test"),
+    input = @JinjavaParam(value = "seq", type = "Sequence to test", required = true),
     params = {
-        @JinjavaParam(value = "exp_test", type = "name of expression test", desc = "Specify which expression test to run for making the selection")
+        @JinjavaParam(value = "exp_test", type = "name of expression test", desc = "Specify which expression test to run for making the selection", required = true)
     },
     snippets = {
         @JinjavaSnippet(
@@ -36,7 +36,7 @@ public class RejectFilter implements Filter {
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
     List<Object> result = new ArrayList<>();
 
-    if (args.length == 0) {
+    if (args.length < 1) {
       throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (name of expression test to filter by)");
     }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RejectFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RejectFilter.java
@@ -6,17 +6,19 @@ import java.util.List;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
+import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.exptest.ExpTest;
 import com.hubspot.jinjava.util.ForLoop;
 import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Filters a sequence of objects by applying a test to the object and rejecting the ones with the test succeeding.",
+    input = @JinjavaParam(value = "seq", type = "Sequence to test"),
     params = {
-        @JinjavaParam(value = "seq", type = "Sequence to test"),
-        @JinjavaParam(value = "exp_test", type = "name of expression test", defaultValue = "truthy", desc = "Specify which expression test to run for making the selection")
+        @JinjavaParam(value = "exp_test", type = "name of expression test", desc = "Specify which expression test to run for making the selection")
     },
     snippets = {
         @JinjavaSnippet(
@@ -35,12 +37,16 @@ public class RejectFilter implements Filter {
     List<Object> result = new ArrayList<>();
 
     if (args.length == 0) {
-      throw new InterpretException(getName() + " requires an exp test to filter on", interpreter.getLineNumber());
+      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (name of expression test to filter by)");
+    }
+
+    if (args[0] == null) {
+      throw new InvalidArgumentException(interpreter, this, InvalidReason.NULL, 0);
     }
 
     ExpTest expTest = interpreter.getContext().getExpTest(args[0]);
     if (expTest == null) {
-      throw new InterpretException("No exp test defined for name '" + args[0] + "'", interpreter.getLineNumber());
+      throw new InvalidArgumentException(interpreter, this, InvalidReason.EXPRESSION_TEST, 0, args[0]);
     }
 
     ForLoop loop = ObjectIterator.getLoop(var);

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ReplaceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ReplaceFilter.java
@@ -13,10 +13,10 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
     value = "Return a copy of the value with all occurrences of a substring replaced with a new one. " +
         "The first argument is the substring that should be replaced, the second is the replacement " +
         "string. If the optional third argument count is given, only the first count occurrences are replaced",
-    input = @JinjavaParam(value = "s", desc = "Base string to find and replace within"),
+    input = @JinjavaParam(value = "s", desc = "Base string to find and replace within", required = true),
     params = {
-        @JinjavaParam(value = "old", desc = "The old substring that you want to match and replace"),
-        @JinjavaParam(value = "new", desc = "The new string that you replace the matched substring"),
+        @JinjavaParam(value = "old", desc = "The old substring that you want to match and replace", required = true),
+        @JinjavaParam(value = "new", desc = "The new string that you replace the matched substring", required = true),
         @JinjavaParam(value = "count", type = "number", desc = "Replace only the first N occurrences")
     },
     snippets = {
@@ -41,7 +41,7 @@ public class ReplaceFilter implements Filter {
     if (var == null) {
       return null;
     }
-    if (args.length != 2 && args.length != 3) {
+    if (args.length < 2) {
       throw new TemplateSyntaxException(interpreter,
           getName(),
           "requires 2 arguments (substring to replace, replacement string) or 3 arguments (substring to replace, replacement string, number of occurrences to replace)");

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ReplaceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ReplaceFilter.java
@@ -6,15 +6,15 @@ import org.apache.commons.lang3.math.NumberUtils;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 @JinjavaDoc(
     value = "Return a copy of the value with all occurrences of a substring replaced with a new one. " +
         "The first argument is the substring that should be replaced, the second is the replacement " +
         "string. If the optional third argument count is given, only the first count occurrences are replaced",
+    input = @JinjavaParam(value = "s", desc = "Base string to find and replace within"),
     params = {
-        @JinjavaParam(value = "s", desc = "Base string to find and replace within"),
         @JinjavaParam(value = "old", desc = "The old substring that you want to match and replace"),
         @JinjavaParam(value = "new", desc = "The new string that you replace the matched substring"),
         @JinjavaParam(value = "count", type = "number", desc = "Replace only the first N occurrences")
@@ -41,8 +41,10 @@ public class ReplaceFilter implements Filter {
     if (var == null) {
       return null;
     }
-    if (args.length < 2) {
-      throw new InterpretException("filter " + getName() + " requires two string args");
+    if (args.length != 2 && args.length != 3) {
+      throw new TemplateSyntaxException(interpreter,
+          getName(),
+          "requires 2 arguments (substring to replace, replacement string) or 3 arguments (substring to replace, replacement string, number of occurrences to replace)");
     }
 
     String s = (String) var;

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ReverseFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ReverseFilter.java
@@ -15,8 +15,6 @@ limitations under the License.
  **********************************************************************/
 package com.hubspot.jinjava.lib.filter;
 
-import static com.hubspot.jinjava.util.Logging.ENGINE_LOG;
-
 import java.lang.reflect.Array;
 import java.util.Collection;
 
@@ -27,7 +25,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Reverse the object or return an iterator the iterates over it the other way round.",
-    params = @JinjavaParam(value = "value", type = "object", desc = "The sequence or dict to reverse the iteration order"),
+    input = @JinjavaParam(value = "value", type = "object", desc = "The sequence or dict to reverse the iteration order"),
     snippets = {
         @JinjavaSnippet(
             code = "{% set nums = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] %}\n" +
@@ -74,7 +72,7 @@ public class ReverseFilter implements Filter {
       }
       return String.valueOf(res);
     }
-    ENGINE_LOG.warn("filter contain can't be applied to >>> " + object.getClass().getName());
+
     return object;
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ReverseFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ReverseFilter.java
@@ -25,7 +25,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Reverse the object or return an iterator the iterates over it the other way round.",
-    input = @JinjavaParam(value = "value", type = "object", desc = "The sequence or dict to reverse the iteration order"),
+    input = @JinjavaParam(value = "value", type = "object", desc = "The sequence or dict to reverse the iteration order", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% set nums = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RoundFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RoundFilter.java
@@ -2,17 +2,19 @@ package com.hubspot.jinjava.lib.filter;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.Objects;
 
 import org.apache.commons.lang3.math.NumberUtils;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.interpret.InvalidInputException;
+import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Round the number to a given precision.",
+    input = @JinjavaParam(value = "value", type = "number", desc = "The number to round"),
     params = {
         @JinjavaParam(value = "value", type = "number", desc = "The number to round"),
         @JinjavaParam(value = "precision", type = "number", defaultValue = "0", desc = "Specifies the precision of rounding"),
@@ -32,10 +34,16 @@ public class RoundFilter implements Filter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+
+    if (var == null) {
+      return null;
+    }
+
     BigDecimal result = BigDecimal.ZERO;
     try {
-      result = new BigDecimal(Objects.toString(var));
+      result = new BigDecimal(var.toString());
     } catch (NumberFormatException e) {
+      throw new InvalidInputException(interpreter, this, InvalidReason.NUMBER_FORMAT, var.toString());
     }
 
     int precision = 0;

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RoundFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RoundFilter.java
@@ -14,9 +14,8 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Round the number to a given precision.",
-    input = @JinjavaParam(value = "value", type = "number", desc = "The number to round"),
+    input = @JinjavaParam(value = "value", type = "number", desc = "The number to round", required = true),
     params = {
-        @JinjavaParam(value = "value", type = "number", desc = "The number to round"),
         @JinjavaParam(value = "precision", type = "number", defaultValue = "0", desc = "Specifies the precision of rounding"),
         @JinjavaParam(value = "method", type = "enum common|ceil|floor", defaultValue = "common", desc = "Method of rounding: 'common' rounds either up or down, 'ceil' always rounds up, and 'floor' always rounds down.")
     },
@@ -39,7 +38,7 @@ public class RoundFilter implements Filter {
       return null;
     }
 
-    BigDecimal result = BigDecimal.ZERO;
+    BigDecimal result;
     try {
       result = new BigDecimal(var.toString());
     } catch (NumberFormatException e) {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SafeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SafeFilter.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.lib.filter;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
@@ -12,6 +13,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
  */
 @JinjavaDoc(
     value = "Mark the value as safe, which means that in an environment with automatic escaping enabled this variable will not be escaped.",
+    input = @JinjavaParam(value = "value", desc = "Value to mark as safe"),
     snippets = {
         @JinjavaSnippet(code = "{{ content.post_list_content|safe }}")
     })

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SafeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SafeFilter.java
@@ -13,7 +13,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
  */
 @JinjavaDoc(
     value = "Mark the value as safe, which means that in an environment with automatic escaping enabled this variable will not be escaped.",
-    input = @JinjavaParam(value = "value", desc = "Value to mark as safe"),
+    input = @JinjavaParam(value = "value", desc = "Value to mark as safe", required = true),
     snippets = {
         @JinjavaSnippet(code = "{{ content.post_list_content|safe }}")
     })

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
@@ -19,9 +19,9 @@ import com.hubspot.jinjava.util.Variable;
 
 @JinjavaDoc(
     value = "Filters a sequence of objects by applying a test to an attribute of an object and only selecting the ones with the test succeeding.",
-    input = @JinjavaParam(value = "sequence", type = "sequence", desc = "Sequence to test"),
+    input = @JinjavaParam(value = "sequence", type = "sequence", desc = "Sequence to test", required = true),
     params = {
-        @JinjavaParam(value = "attr", desc = "Attribute to test for and select items that contain it"),
+        @JinjavaParam(value = "attr", desc = "Attribute to test for and select items that contain it", required = true),
         @JinjavaParam(value = "exp_test", type = "name of expression test", defaultValue = "truthy", desc = "Specify which expression test to run for making the selection")
     },
     snippets = {
@@ -46,7 +46,7 @@ public class SelectAttrFilter implements AdvancedFilter {
   protected Object applyFilter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs, boolean acceptObjects) {
     List<Object> result = new ArrayList<>();
 
-    if (args.length == 0) {
+    if (args.length < 1) {
       throw new TemplateSyntaxException(interpreter, getName(), "requires at least 1 argument (attr to filter on)");
     }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SelectFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SelectFilter.java
@@ -18,9 +18,8 @@ import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Filters a sequence of objects by applying a test to the object and only selecting the ones with the test succeeding.",
-    input = @JinjavaParam(value = "sequence", type = "sequence", desc = "Sequence to test"),
+    input = @JinjavaParam(value = "sequence", type = "sequence", desc = "Sequence to test", required = true),
     params = {
-        @JinjavaParam(value = "value", type = "sequence"),
         @JinjavaParam(value = "exp_test", type = "name of expression test", defaultValue = "truthy", desc = "Specify which expression test to run for making the selection")
     },
     snippets = {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SelectFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SelectFilter.java
@@ -8,14 +8,17 @@ import java.util.Map;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
+import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.exptest.ExpTest;
 import com.hubspot.jinjava.util.ForLoop;
 import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Filters a sequence of objects by applying a test to the object and only selecting the ones with the test succeeding.",
+    input = @JinjavaParam(value = "sequence", type = "sequence", desc = "Sequence to test"),
     params = {
         @JinjavaParam(value = "value", type = "sequence"),
         @JinjavaParam(value = "exp_test", type = "name of expression test", defaultValue = "truthy", desc = "Specify which expression test to run for making the selection")
@@ -37,7 +40,7 @@ public class SelectFilter implements AdvancedFilter {
     List<Object> result = new ArrayList<>();
 
     if (args.length == 0) {
-      throw new InterpretException(getName() + " requires an exp test to filter on", interpreter.getLineNumber());
+      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (name of expression test to filter by)");
     }
 
     Object[] expArgs = new Object[]{};
@@ -48,7 +51,7 @@ public class SelectFilter implements AdvancedFilter {
 
     ExpTest expTest = interpreter.getContext().getExpTest(args[0].toString());
     if (expTest == null) {
-      throw new InterpretException("No exp test defined for name '" + args[0] + "'", interpreter.getLineNumber());
+      throw new InvalidArgumentException(interpreter, this, InvalidReason.EXPRESSION_TEST, 0, args[0].toString());
     }
 
     ForLoop loop = ObjectIterator.getLoop(var);

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ShuffleFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ShuffleFilter.java
@@ -12,7 +12,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Randomly shuffle a given list, returning a new list with all of the items of the original list in a random order",
-    input = @JinjavaParam(value = "sequence", type = "sequence", desc = "Sequence to shuffle"),
+    input = @JinjavaParam(value = "sequence", type = "sequence", desc = "Sequence to shuffle", required = true),
     snippets = {
         @JinjavaSnippet(
             desc = "The example below is a standard blog loop that's order is randomized on page load",

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ShuffleFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ShuffleFilter.java
@@ -6,11 +6,13 @@ import java.util.Collections;
 import java.util.List;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Randomly shuffle a given list, returning a new list with all of the items of the original list in a random order",
+    input = @JinjavaParam(value = "sequence", type = "sequence", desc = "Sequence to shuffle"),
     snippets = {
         @JinjavaSnippet(
             desc = "The example below is a standard blog loop that's order is randomized on page load",

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
@@ -6,17 +6,16 @@ import com.google.common.collect.Iterators;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.util.ForLoop;
 import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Slice an iterator and return a list of lists containing those items.",
+    input = @JinjavaParam(value = "value", type = "sequence", desc = "The sequence or dict that the filter is applied to"),
     params = {
-        @JinjavaParam(value = "value", type = "sequence", desc = "The sequence or dict that the filter is applied to"),
         @JinjavaParam(value = "slices", type = "number", desc = "Specifies how many items will be sliced"),
-        @JinjavaParam(value = "fill_with", desc = "Used to fill missing values on the last iteration")
     },
     snippets = {
         @JinjavaSnippet(
@@ -44,7 +43,7 @@ public class SliceFilter implements Filter {
     ForLoop loop = ObjectIterator.getLoop(var);
 
     if (args.length == 0) {
-      throw new InterpretException(getName() + " requires number of slices argument", interpreter.getLineNumber());
+      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (number of slices)");
     }
 
     int slices = NumberUtils.toInt(args[0], 3);

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
@@ -13,9 +13,9 @@ import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Slice an iterator and return a list of lists containing those items.",
-    input = @JinjavaParam(value = "value", type = "sequence", desc = "The sequence or dict that the filter is applied to"),
+    input = @JinjavaParam(value = "value", type = "sequence", desc = "The sequence or dict that the filter is applied to", required = true),
     params = {
-        @JinjavaParam(value = "slices", type = "number", desc = "Specifies how many items will be sliced"),
+        @JinjavaParam(value = "slices", type = "number", desc = "Specifies how many items will be sliced", required = true),
     },
     snippets = {
         @JinjavaSnippet(
@@ -42,7 +42,7 @@ public class SliceFilter implements Filter {
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
     ForLoop loop = ObjectIterator.getLoop(var);
 
-    if (args.length == 0) {
+    if (args.length < 1) {
       throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (number of slices)");
     }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SortFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SortFilter.java
@@ -15,8 +15,8 @@ import com.hubspot.jinjava.util.Variable;
 
 @JinjavaDoc(
     value = "Sort an iterable.",
+    input = @JinjavaParam(value = "value", type = "iterable", desc = "The sequence or dict to sort through iteration"),
     params = {
-        @JinjavaParam(value = "value", type = "iterable", desc = "The sequence or dict to sort through iteration"),
         @JinjavaParam(value = "reverse", type = "boolean", defaultValue = "False", desc = "Boolean to reverse the sort order"),
         @JinjavaParam(value = "case_sensitive", type = "boolean", defaultValue = "False", desc = "Determines whether or not the sorting is case sensitive"),
         @JinjavaParam(value = "attribute", desc = "Specifies an attribute to sort by")
@@ -43,7 +43,7 @@ public class SortFilter implements Filter {
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
     if (var == null) {
-      return var;
+      return null;
     }
 
     boolean reverse = false;

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SortFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SortFilter.java
@@ -15,7 +15,7 @@ import com.hubspot.jinjava.util.Variable;
 
 @JinjavaDoc(
     value = "Sort an iterable.",
-    input = @JinjavaParam(value = "value", type = "iterable", desc = "The sequence or dict to sort through iteration"),
+    input = @JinjavaParam(value = "value", type = "iterable", desc = "The sequence or dict to sort through iteration", required = true),
     params = {
         @JinjavaParam(value = "reverse", type = "boolean", defaultValue = "False", desc = "Boolean to reverse the sort order"),
         @JinjavaParam(value = "case_sensitive", type = "boolean", defaultValue = "False", desc = "Determines whether or not the sorting is case sensitive"),

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SplitFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SplitFilter.java
@@ -23,8 +23,8 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
  */
 @JinjavaDoc(
     value = "Splits the input string into a list on the given separator",
+    input = @JinjavaParam(value = "string", desc = "The string to split"),
     params = {
-        @JinjavaParam(value = "s", desc = "The string to split"),
         @JinjavaParam(value = "separator", defaultValue = " ", desc = "Specifies the separator to split the variable by"),
         @JinjavaParam(value = "limit", type = "number", defaultValue = "0", desc = "Limits resulting list by putting remainder of string into last list item")
     },

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SplitFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SplitFilter.java
@@ -23,7 +23,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
  */
 @JinjavaDoc(
     value = "Splits the input string into a list on the given separator",
-    input = @JinjavaParam(value = "string", desc = "The string to split"),
+    input = @JinjavaParam(value = "string", desc = "The string to split", required = true),
     params = {
         @JinjavaParam(value = "separator", defaultValue = " ", desc = "Specifies the separator to split the variable by"),
         @JinjavaParam(value = "limit", type = "number", defaultValue = "0", desc = "Limits resulting list by putting remainder of string into last list item")
@@ -53,7 +53,7 @@ public class SplitFilter implements Filter {
       splitter = Splitter.on(args[0]);
     }
     else {
-      splitter = Splitter.on(CharMatcher.WHITESPACE);
+      splitter = Splitter.on(CharMatcher.whitespace());
     }
 
     if (args.length > 1) {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/StringFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/StringFilter.java
@@ -3,11 +3,13 @@ package com.hubspot.jinjava.lib.filter;
 import java.util.Objects;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Returns string value of object",
+    input = @JinjavaParam(value = "value", desc = "The value to turn into a string"),
     snippets = {
         @JinjavaSnippet(
             code = "{% set number_to_string = 45 %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/StringFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/StringFilter.java
@@ -9,7 +9,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Returns string value of object",
-    input = @JinjavaParam(value = "value", desc = "The value to turn into a string"),
+    input = @JinjavaParam(value = "value", desc = "The value to turn into a string", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% set number_to_string = 45 %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/StringToTimeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/StringToTimeFilter.java
@@ -11,9 +11,9 @@ import com.hubspot.jinjava.lib.fn.Functions;
 
 @JinjavaDoc(
     value = "Converts a datetime string and datetime format to a datetime object",
-    input = @JinjavaParam(value = "datetimeString", desc = "Datetime string"),
+    input = @JinjavaParam(value = "datetimeString", desc = "Datetime string", required = true),
     params = {
-        @JinjavaParam(value = "datetimeFormat", desc = "Format of the datetime string"),
+        @JinjavaParam(value = "datetimeFormat", desc = "Format of the datetime string", required = true),
     },
     snippets = {
         @JinjavaSnippet(code = "{% mydatetime|unixtimestamp %}"),
@@ -23,7 +23,7 @@ public class StringToTimeFilter implements Filter {
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
 
-    if (args.length != 1) {
+    if (args.length < 1) {
       throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (datetime format string)");
     }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/StringToTimeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/StringToTimeFilter.java
@@ -3,14 +3,16 @@ package com.hubspot.jinjava.lib.filter;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.InvalidInputException;
+import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.fn.Functions;
 
 @JinjavaDoc(
     value = "Converts a datetime string and datetime format to a datetime object",
+    input = @JinjavaParam(value = "datetimeString", desc = "Datetime string"),
     params = {
-        @JinjavaParam(value = "datetimeString", desc = "Datetime string"),
         @JinjavaParam(value = "datetimeFormat", desc = "Format of the datetime string"),
     },
     snippets = {
@@ -21,12 +23,16 @@ public class StringToTimeFilter implements Filter {
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
 
-    if (!(var instanceof String)) {
-      throw new InterpretException(String.format("%s filter requires a string as input", getName()));
+    if (args.length != 1) {
+      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (datetime format string)");
     }
 
-    if (args.length < 1) {
-      throw new InterpretException(String.format("%s filter requires a datetime format parameter", getName()));
+    if (var == null) {
+      return null;
+    }
+
+    if (!(var instanceof String)) {
+      throw new InvalidInputException(interpreter, this, InvalidReason.STRING);
     }
 
     return Functions.stringToTime((String) var, args[0]);

--- a/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java
@@ -14,7 +14,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
  */
 @JinjavaDoc(
     value = "Strip SGML/XML tags and replace adjacent whitespace by one space.",
-    input = @JinjavaParam(value = "string", desc = "string to strip tags from"),
+    input = @JinjavaParam(value = "string", desc = "string to strip tags from", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{% set some_html = \"<div><strong>Some text</strong></div>\" %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java
@@ -5,6 +5,7 @@ import java.util.regex.Pattern;
 import org.jsoup.Jsoup;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
@@ -13,6 +14,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
  */
 @JinjavaDoc(
     value = "Strip SGML/XML tags and replace adjacent whitespace by one space.",
+    input = @JinjavaParam(value = "string", desc = "string to strip tags from"),
     snippets = {
         @JinjavaSnippet(
             code = "{% set some_html = \"<div><strong>Some text</strong></div>\" %}\n" +
@@ -24,6 +26,7 @@ public class StripTagsFilter implements Filter {
 
   @Override
   public Object filter(Object object, JinjavaInterpreter interpreter, String... arg) {
+
     if (!(object instanceof String)) {
       return object;
     }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SumFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SumFilter.java
@@ -13,8 +13,8 @@ import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Returns the sum of a sequence of numbers plus the value of parameter ‘start’ (which defaults to 0). When the sequence is empty it returns start.",
+    input = @JinjavaParam(value = "value", type = "iterable", desc = "Selects the sequence or dict to sum values from"),
     params = {
-        @JinjavaParam(value = "value", type = "iterable", desc = "Selects the sequence or dict to sum values from"),
         @JinjavaParam(value = "attribute", desc = "Specify an optional attribute of dict to sum"),
         @JinjavaParam(value = "start", type = "number", defaultValue = "0", desc = "Sets a value to return, if there is nothing in the variable to sum")
     },

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SumFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SumFilter.java
@@ -13,10 +13,10 @@ import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Returns the sum of a sequence of numbers plus the value of parameter ‘start’ (which defaults to 0). When the sequence is empty it returns start.",
-    input = @JinjavaParam(value = "value", type = "iterable", desc = "Selects the sequence or dict to sum values from"),
+    input = @JinjavaParam(value = "value", type = "iterable", desc = "Selects the sequence or dict to sum values from", required = true),
     params = {
+        @JinjavaParam(value = "start", type = "number", defaultValue = "0", desc = "Sets a value to return, if there is nothing in the variable to sum"),
         @JinjavaParam(value = "attribute", desc = "Specify an optional attribute of dict to sum"),
-        @JinjavaParam(value = "start", type = "number", defaultValue = "0", desc = "Sets a value to return, if there is nothing in the variable to sum")
     },
     snippets = {
         @JinjavaSnippet(

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SymmetricDifferenceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SymmetricDifferenceFilter.java
@@ -11,9 +11,9 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Returns a list containing elements present in only one list.",
-    input =  @JinjavaParam(value = "value", type = "sequence", desc = "The first list"),
+    input =  @JinjavaParam(value = "value", type = "sequence", desc = "The first list", required = true),
     params = {
-        @JinjavaParam(value = "list", type = "sequence", desc = "The second list")
+        @JinjavaParam(value = "list", type = "sequence", desc = "The second list", required = true)
     },
     snippets = {
         @JinjavaSnippet(
@@ -23,7 +23,7 @@ public class SymmetricDifferenceFilter extends AbstractSetFilter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs) {
-    return new ArrayList<>(Sets.symmetricDifference(objectToSet(var), objectToSet(parseArgs(args))));
+    return new ArrayList<>(Sets.symmetricDifference(objectToSet(var), objectToSet(parseArgs(interpreter, args))));
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SymmetricDifferenceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SymmetricDifferenceFilter.java
@@ -11,8 +11,8 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Returns a list containing elements present in only one list.",
+    input =  @JinjavaParam(value = "value", type = "sequence", desc = "The first list"),
     params = {
-        @JinjavaParam(value = "value", type = "sequence", desc = "The first list"),
         @JinjavaParam(value = "list", type = "sequence", desc = "The second list")
     },
     snippets = {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TitleFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TitleFilter.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.lib.filter;
 import org.apache.commons.lang3.text.WordUtils;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
@@ -13,6 +14,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
  */
 @JinjavaDoc(
     value = "Return a titlecased version of the value. I.e. words will start with uppercase letters, all remaining characters are lowercase.",
+    input = @JinjavaParam(value = "string", type = "string", desc = "the string to titlecase"),
     snippets = {
         @JinjavaSnippet(
             code = "{{ \"My title should be titlecase\"|title }} "

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TitleFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TitleFilter.java
@@ -14,7 +14,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
  */
 @JinjavaDoc(
     value = "Return a titlecased version of the value. I.e. words will start with uppercase letters, all remaining characters are lowercase.",
-    input = @JinjavaParam(value = "string", type = "string", desc = "the string to titlecase"),
+    input = @JinjavaParam(value = "string", type = "string", desc = "the string to titlecase", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{{ \"My title should be titlecase\"|title }} "

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ToJsonFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ToJsonFilter.java
@@ -5,15 +5,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.InvalidInputException;
+import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 
 @JinjavaDoc(
     value = "Writes object as a JSON string",
-    params = {
-        @JinjavaParam(value = "o", desc = "Object to write to JSON")
-    },
+    input = @JinjavaParam(value = "object", desc = "Object to write to JSON"),
     snippets = {
         @JinjavaSnippet(
             code = "{{object|tojson}}"
@@ -28,7 +27,7 @@ public class ToJsonFilter implements Filter {
     try {
       return OBJECT_MAPPER.writeValueAsString(var);
     } catch (JsonProcessingException e) {
-      throw new InterpretException("Could not write object as string for `tojson` filter.", e, interpreter.getLineNumber());
+      throw new InvalidInputException(interpreter, this, InvalidReason.JSON_WRITE);
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ToJsonFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ToJsonFilter.java
@@ -12,7 +12,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Writes object as a JSON string",
-    input = @JinjavaParam(value = "object", desc = "Object to write to JSON"),
+    input = @JinjavaParam(value = "object", desc = "Object to write to JSON", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{{object|tojson}}"

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TrimFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TrimFilter.java
@@ -14,7 +14,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
  */
 @JinjavaDoc(
     value = "Strip leading and trailing whitespace.",
-    input = @JinjavaParam(value = "string", type = "string", desc = "the string to strip whitespace from"),
+    input = @JinjavaParam(value = "string", type = "string", desc = "the string to strip whitespace from", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{{ \" remove whitespace \"|trim }}")

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TrimFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TrimFilter.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
@@ -13,6 +14,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
  */
 @JinjavaDoc(
     value = "Strip leading and trailing whitespace.",
+    input = @JinjavaParam(value = "string", type = "string", desc = "the string to strip whitespace from"),
     snippets = {
         @JinjavaSnippet(
             code = "{{ \" remove whitespace \"|trim }}")

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TruncateFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TruncateFilter.java
@@ -26,8 +26,8 @@ import com.hubspot.jinjava.lib.fn.Functions;
         "If the second parameter is true the filter will cut the text at length. Otherwise it will discard the last word. " +
         "If the text was in fact truncated it will append an ellipsis sign (\"...\"). If you want a different ellipsis sign " +
         "than \"...\" you can specify it using the third parameter.",
+    input = @JinjavaParam(value = "string", desc = "The string to truncate"),
     params = {
-        @JinjavaParam(value = "s", desc = "The string to truncate"),
         @JinjavaParam(value = "length", type = "number", defaultValue = "255", desc = "Specifies the length at which to truncate the text (includes HTML characters)"),
         @JinjavaParam(value = "killwords", type = "boolean", defaultValue = "False", desc = "If true, the string will cut text at length"),
         @JinjavaParam(value = "end", defaultValue = "...", desc = "The characters that will be added to indicate where the text was truncated")

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TruncateFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TruncateFilter.java
@@ -26,7 +26,7 @@ import com.hubspot.jinjava.lib.fn.Functions;
         "If the second parameter is true the filter will cut the text at length. Otherwise it will discard the last word. " +
         "If the text was in fact truncated it will append an ellipsis sign (\"...\"). If you want a different ellipsis sign " +
         "than \"...\" you can specify it using the third parameter.",
-    input = @JinjavaParam(value = "string", desc = "The string to truncate"),
+    input = @JinjavaParam(value = "string", desc = "The string to truncate", required = true),
     params = {
         @JinjavaParam(value = "length", type = "number", defaultValue = "255", desc = "Specifies the length at which to truncate the text (includes HTML characters)"),
         @JinjavaParam(value = "killwords", type = "boolean", defaultValue = "False", desc = "If true, the string will cut text at length"),

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
@@ -19,12 +19,15 @@ import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.fn.Functions;
 
-@JinjavaDoc(value = "Truncates a given string, respecting html markup (i.e. will properly close all nested tags)", params = {
-    @JinjavaParam(value = "html", desc = "HTML to truncate"),
-    @JinjavaParam(value = "length", type = "number", defaultValue = "255", desc = "Length at which to truncate text (HTML characters not included)"),
-    @JinjavaParam(value = "end", defaultValue = "...", desc = "The characters that will be added to indicate where the text was truncated"),
-    @JinjavaParam(value = "breakword", type = "boolean", defaultValue = "false", desc = "If set to true, text will be truncated in the middle of words")
-}, snippets = {
+@JinjavaDoc(
+    value = "Truncates a given string, respecting html markup (i.e. will properly close all nested tags)",
+    input = @JinjavaParam(value = "html", desc = "HTML to truncate"),
+    params = {
+      @JinjavaParam(value = "length", type = "number", defaultValue = "255", desc = "Length at which to truncate text (HTML characters not included)"),
+      @JinjavaParam(value = "end", defaultValue = "...", desc = "The characters that will be added to indicate where the text was truncated"),
+      @JinjavaParam(value = "breakword", type = "boolean", defaultValue = "false", desc = "If set to true, text will be truncated in the middle of words")
+    },
+    snippets = {
     @JinjavaSnippet(code = "{{ \"<p>I want to truncate this text without breaking my HTML<p>\"|truncatehtml(28, '..', false) }}", output = "<p>I want to truncate this text without breaking my HTML</p>")
 })
 public class TruncateHtmlFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
@@ -21,7 +21,7 @@ import com.hubspot.jinjava.lib.fn.Functions;
 
 @JinjavaDoc(
     value = "Truncates a given string, respecting html markup (i.e. will properly close all nested tags)",
-    input = @JinjavaParam(value = "html", desc = "HTML to truncate"),
+    input = @JinjavaParam(value = "html", desc = "HTML to truncate", required = true),
     params = {
       @JinjavaParam(value = "length", type = "number", defaultValue = "255", desc = "Length at which to truncate text (HTML characters not included)"),
       @JinjavaParam(value = "end", defaultValue = "...", desc = "The characters that will be added to indicate where the text was truncated"),

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UnionFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UnionFilter.java
@@ -11,8 +11,8 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Returns a list containing elements present in either list",
+    input = @JinjavaParam(value = "value", type = "sequence", desc = "The first list"),
     params = {
-        @JinjavaParam(value = "value", type = "sequence", desc = "The first list"),
         @JinjavaParam(value = "list", type = "sequence", desc = "The second list")
     },
     snippets = {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UnionFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UnionFilter.java
@@ -11,9 +11,9 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Returns a list containing elements present in either list",
-    input = @JinjavaParam(value = "value", type = "sequence", desc = "The first list"),
+    input = @JinjavaParam(value = "value", type = "sequence", desc = "The first list", required = true),
     params = {
-        @JinjavaParam(value = "list", type = "sequence", desc = "The second list")
+        @JinjavaParam(value = "list", type = "sequence", desc = "The second list", required = true)
     },
     snippets = {
         @JinjavaSnippet(
@@ -23,7 +23,7 @@ public class UnionFilter extends AbstractSetFilter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, Object[] args, Map<String, Object> kwargs) {
-    return new ArrayList<>(Sets.union(objectToSet(var), objectToSet(parseArgs(args))));
+    return new ArrayList<>(Sets.union(objectToSet(var), objectToSet(parseArgs(interpreter, args))));
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UniqueFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UniqueFilter.java
@@ -12,8 +12,8 @@ import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Extract a unique set from a sequence of objects",
+    input = @JinjavaParam(value = "sequence", type = "sequence", desc = "Sequence to filter"),
     params = {
-        @JinjavaParam(value = "sequence", type = "sequence", desc = "Sequence to filter"),
         @JinjavaParam(value = "attr", type = "Optional attribute on object to use as unique identifier")
     },
     snippets = {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UniqueFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UniqueFilter.java
@@ -12,7 +12,7 @@ import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Extract a unique set from a sequence of objects",
-    input = @JinjavaParam(value = "sequence", type = "sequence", desc = "Sequence to filter"),
+    input = @JinjavaParam(value = "sequence", type = "sequence", desc = "Sequence to filter", required = true),
     params = {
         @JinjavaParam(value = "attr", type = "Optional attribute on object to use as unique identifier")
     },

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilter.java
@@ -8,7 +8,7 @@ import com.hubspot.jinjava.lib.fn.Functions;
 
 @JinjavaDoc(
     value = "Gets the UNIX timestamp value (in milliseconds) of a date object",
-    input = @JinjavaParam(value = "value", defaultValue = "current time", desc = "The date variable"),
+    input = @JinjavaParam(value = "value", defaultValue = "current time", desc = "The date variable", required = true),
     snippets = {
         @JinjavaSnippet(code = "{% mydatetime|unixtimestamp %}"),
     })

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilter.java
@@ -8,9 +8,7 @@ import com.hubspot.jinjava.lib.fn.Functions;
 
 @JinjavaDoc(
     value = "Gets the UNIX timestamp value (in milliseconds) of a date object",
-    params = {
-        @JinjavaParam(value = "value", defaultValue = "current time", desc = "The date variable"),
-    },
+    input = @JinjavaParam(value = "value", defaultValue = "current time", desc = "The date variable"),
     snippets = {
         @JinjavaSnippet(code = "{% mydatetime|unixtimestamp %}"),
     })

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UpperFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UpperFilter.java
@@ -16,11 +16,13 @@ limitations under the License.
 package com.hubspot.jinjava.lib.filter;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Convert a value to uppercase",
+    input = @JinjavaParam(value = "string", type = "string", desc = "the string to uppercase"),
     snippets = {
         @JinjavaSnippet(code = "{{ \"text to make uppercase\"|uppercase }}")
     })

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UpperFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UpperFilter.java
@@ -22,7 +22,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Convert a value to uppercase",
-    input = @JinjavaParam(value = "string", type = "string", desc = "the string to uppercase"),
+    input = @JinjavaParam(value = "string", type = "string", desc = "the string to uppercase", required = true),
     snippets = {
         @JinjavaSnippet(code = "{{ \"text to make uppercase\"|uppercase }}")
     })

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UrlEncodeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UrlEncodeFilter.java
@@ -10,11 +10,13 @@ import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Escape strings for use in URLs (uses UTF-8 encoding). It accepts both dictionaries and regular strings as well as pairwise iterables.",
+    input = @JinjavaParam(value = "url", type = "string", desc = "the url to escape"),
     snippets = {
         @JinjavaSnippet(code = "{{ \"Escape & URL encode this string\"|urlencode }}")
     })

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UrlEncodeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UrlEncodeFilter.java
@@ -16,7 +16,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Escape strings for use in URLs (uses UTF-8 encoding). It accepts both dictionaries and regular strings as well as pairwise iterables.",
-    input = @JinjavaParam(value = "url", type = "string", desc = "the url to escape"),
+    input = @JinjavaParam(value = "url", type = "string", desc = "the url to escape", required = true),
     snippets = {
         @JinjavaSnippet(code = "{{ \"Escape & URL encode this string\"|urlencode }}")
     })

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UrlizeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UrlizeFilter.java
@@ -15,8 +15,8 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Converts URLs in plain text into clickable links.",
+    input = @JinjavaParam(value = "value", type="string", desc = "string URL to convert to an anchor"),
     params = {
-        @JinjavaParam(value = "value", desc = "string URL to convert to an anchor"),
         @JinjavaParam(value = "trim_url_limit", type = "number", desc = "Sets a character limit"),
         @JinjavaParam(value = "nofollow", type = "boolean", defaultValue = "False", desc = "Adds nofollow to generated link tag"),
         @JinjavaParam(value = "target", desc = "Adds target attr to generated link tag")

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UrlizeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UrlizeFilter.java
@@ -15,7 +15,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Converts URLs in plain text into clickable links.",
-    input = @JinjavaParam(value = "value", type="string", desc = "string URL to convert to an anchor"),
+    input = @JinjavaParam(value = "value", type="string", desc = "string URL to convert to an anchor", required = true),
     params = {
         @JinjavaParam(value = "trim_url_limit", type = "number", desc = "Sets a character limit"),
         @JinjavaParam(value = "nofollow", type = "boolean", defaultValue = "False", desc = "Adds nofollow to generated link tag"),

--- a/src/main/java/com/hubspot/jinjava/lib/filter/WordCountFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/WordCountFilter.java
@@ -5,11 +5,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Counts the words in the given string",
+    input = @JinjavaParam(value = "string", type = "string", desc = "string to count the words from"),
     snippets = {
         @JinjavaSnippet(
             code = "{%  set count_words = \"Count the number of words in this variable\" %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/WordCountFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/WordCountFilter.java
@@ -11,7 +11,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Counts the words in the given string",
-    input = @JinjavaParam(value = "string", type = "string", desc = "string to count the words from"),
+    input = @JinjavaParam(value = "string", type = "string", desc = "string to count the words from", required = true),
     snippets = {
         @JinjavaSnippet(
             code = "{%  set count_words = \"Count the number of words in this variable\" %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/filter/WordWrapFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/WordWrapFilter.java
@@ -13,8 +13,8 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return a copy of the string passed to the filter wrapped after 79 characters.",
+    input = @JinjavaParam(value = "s", type = "string", desc = "String to wrap after a certain number of characters"),
     params = {
-        @JinjavaParam(value = "s", desc = "String to wrap after a certain number of chracters"),
         @JinjavaParam(value = "width", type = "number", defaultValue = "79", desc = "Sets the width of spaces at which to wrap the text"),
         @JinjavaParam(value = "break_long_words", type = "boolean", defaultValue = "True", desc = "If true, long words will be broken when wrapped")
     },

--- a/src/main/java/com/hubspot/jinjava/lib/filter/WordWrapFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/WordWrapFilter.java
@@ -13,7 +13,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Return a copy of the string passed to the filter wrapped after 79 characters.",
-    input = @JinjavaParam(value = "s", type = "string", desc = "String to wrap after a certain number of characters"),
+    input = @JinjavaParam(value = "s", type = "string", desc = "String to wrap after a certain number of characters", required = true),
     params = {
         @JinjavaParam(value = "width", type = "number", defaultValue = "79", desc = "Sets the width of spaces at which to wrap the text"),
         @JinjavaParam(value = "break_long_words", type = "boolean", defaultValue = "True", desc = "If true, long words will be broken when wrapped")

--- a/src/main/java/com/hubspot/jinjava/lib/filter/XmlAttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/XmlAttrFilter.java
@@ -16,7 +16,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Create an HTML/XML attribute string based on the items in a dict.",
-    input = @JinjavaParam(value = "dict", type = "dict", desc = "Dict to filter"),
+    input = @JinjavaParam(value = "dict", type = "dict", desc = "Dict to filter", required = true),
     params = {
         @JinjavaParam(value = "autospace", type = "boolean", defaultValue = "True", desc = "Automatically prepend a space in front of the item")
     },

--- a/src/main/java/com/hubspot/jinjava/lib/filter/XmlAttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/XmlAttrFilter.java
@@ -16,8 +16,8 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 @JinjavaDoc(
     value = "Create an HTML/XML attribute string based on the items in a dict.",
+    input = @JinjavaParam(value = "dict", type = "dict", desc = "Dict to filter"),
     params = {
-        @JinjavaParam(value = "d", type = "dict", desc = "Dict to filter"),
         @JinjavaParam(value = "autospace", type = "boolean", defaultValue = "True", desc = "Automatically prepend a space in front of the item")
     },
     snippets = {

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -63,7 +63,7 @@ public class Functions {
   }
 
   @JinjavaDoc(value = "return datetime of beginning of the day", params = {
-      @JinjavaParam(value = "timezone", type = "string", defaultValue = "utc", desc = "Optional timezone"),
+      @JinjavaParam(value = "timezone", type = "string", defaultValue = "utc", desc = "timezone"),
   })
   public static ZonedDateTime today(String... var) {
 
@@ -156,8 +156,8 @@ public class Functions {
   }
 
   @JinjavaDoc(value = "converts a string and datetime format into a datetime object", params = {
-      @JinjavaParam(value = "var", type = "datetimeString", defaultValue = "datetime as string"),
-      @JinjavaParam(value = "var", type = "datetimeFormat", defaultValue = "format of the datetime string")
+      @JinjavaParam(value = "var", type = "datetimeString", desc = "datetime as string"),
+      @JinjavaParam(value = "var", type = "datetimeFormat", desc = "format of the datetime string")
   })
   public static PyishDate stringToTime(String datetimeString, String datetimeFormat) {
 

--- a/src/main/java/com/hubspot/jinjava/tree/TagNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TagNode.java
@@ -16,6 +16,8 @@
 package com.hubspot.jinjava.tree;
 
 import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
+import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.lib.tag.Tag;
@@ -57,7 +59,7 @@ public class TagNode extends Node {
       return tag.interpretOutput(this, interpreter);
     } catch (DeferredValueException e) {
       return new RenderedOutputNode(reconstructImage());
-    } catch (InterpretException e) {
+    } catch (InterpretException|InvalidInputException| InvalidArgumentException e) {
       throw e;
     } catch (Exception e) {
       throw new InterpretException("Error rendering tag", e, master.getLineNumber(), master.getStartPosition());

--- a/src/test/java/com/hubspot/jinjava/lib/filter/FromJsonFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FromJsonFilterTest.java
@@ -9,7 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 
@@ -37,7 +37,7 @@ public class FromJsonFilterTest {
     assertThat(nested.get("third")).isEqualTo(4);
   }
 
-  @Test(expected = InterpretException.class)
+  @Test(expected = InvalidArgumentException.class)
   public void itFailsWhenStringIsNotJson() {
 
     String nestedJson = "blah";
@@ -45,7 +45,7 @@ public class FromJsonFilterTest {
     filter.filter(nestedJson, interpreter);
   }
 
-  @Test(expected = InterpretException.class)
+  @Test(expected = InvalidArgumentException.class)
   public void itFailsWhenParameterIsNotString() {
 
     Integer nestedJson = 456;

--- a/src/test/java/com/hubspot/jinjava/lib/filter/FromJsonFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FromJsonFilterTest.java
@@ -9,7 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.InvalidArgumentException;
+import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 
@@ -37,7 +37,7 @@ public class FromJsonFilterTest {
     assertThat(nested.get("third")).isEqualTo(4);
   }
 
-  @Test(expected = InvalidArgumentException.class)
+  @Test(expected = InvalidInputException.class)
   public void itFailsWhenStringIsNotJson() {
 
     String nestedJson = "blah";
@@ -45,7 +45,7 @@ public class FromJsonFilterTest {
     filter.filter(nestedJson, interpreter);
   }
 
-  @Test(expected = InvalidArgumentException.class)
+  @Test(expected = InvalidInputException.class)
   public void itFailsWhenParameterIsNotString() {
 
     Integer nestedJson = 456;

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilterTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 public class RegexReplaceFilterTest {
@@ -34,7 +35,7 @@ public class RegexReplaceFilterTest {
         assertThat(filter.filter("It costs $300", interpreter, "[^a-zA-Z]", "")).isEqualTo("Itcosts");
     }
 
-    @Test(expected = InterpretException.class)
+    @Test(expected = InvalidArgumentException.class)
     public void isThrowsExceptionOnInvalidRegex() {
         filter.filter("It costs $300", interpreter, "[", "");
     }


### PR DESCRIPTION
This is a work in progress attempt to make error messaging consistent and improve documentation. On the documentation side I have split the `input` into a filter/expression test from the arguments for that filter/test. When the input is invalid (for example passing a string into a numeric function), we throw a `InvalidInputException`. When an argument is invalid we throw an `InvalidArgumentException`. If the number of arguments do not match the required number of arguments for the function, we throw an `TemplateSyntaxException`. 

For invalid inputs and arguments, we specify one of the `InvalidReason` enum values and allow the exceptions to automatically handle building a consistent error message. For example, getting the absolute value of a string `'test'|abs` would result in `throw new InvalidInputException(interpreter, this, InvalidReason.NUMBER_FORMAT, object.toString());`. The exception will automatically craft a nice error message: 

`Invalid input in 'abs': input with value 'test' must be a number`. 

For an invalid argument like (`10|add('test')`), we also pass in the argument number: `throw new InvalidArgumentException(interpreter, this, InvalidReason.NUMBER_FORMAT, 0, arg[0]);` which will automatically craft a message:

`Invalid argument in 'add': 1st argument with value 'test' must be a number.`