### PR TITLE
Fix expression resolver in import tag.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -95,7 +95,13 @@ public class ImportTag implements Tag {
         interpreter.render(node);
       } else {
         JinjavaInterpreter child = new JinjavaInterpreter(interpreter);
-        child.render(node);
+        JinjavaInterpreter.pushCurrent(child);
+
+        try {
+          child.render(node);
+        } finally {
+          JinjavaInterpreter.popCurrent();
+        }
 
         interpreter.addAllErrors(child.getErrorsCopy());
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
@@ -101,6 +101,16 @@ public class ImportTagTest {
         .contains("using scoped var: myscopedvar");
   }
 
+  @Test
+  public void itImportsMacroWithCall() throws IOException {
+    Jinjava jinjava = new Jinjava();
+    interpreter = new JinjavaInterpreter(jinjava, context, jinjava.getGlobalConfig());
+
+    String renderResult = interpreter.render(Resources.toString(Resources.getResource("tags/importtag/imports-macro.jinja"), StandardCharsets.UTF_8));
+    assertThat(renderResult.trim()).isEqualTo("");
+    assertThat(interpreter.getErrorsCopy()).hasSize(0);
+  }
+
   private String fixture(String name) {
     try {
       return interpreter.renderFlat(Resources.toString(

--- a/src/test/resources/tags/importtag/imports-macro.jinja
+++ b/src/test/resources/tags/importtag/imports-macro.jinja
@@ -1,0 +1,1 @@
+{% import "tags/macrotag/simple-with-call.jinja" as test %}

--- a/src/test/resources/tags/macrotag/simple-with-call.jinja
+++ b/src/test/resources/tags/macrotag/simple-with-call.jinja
@@ -1,0 +1,5 @@
+{% macro getPath() -%}
+  Hello {{ myname }}
+{%- endmacro %}
+
+{{ getPath() }}


### PR DESCRIPTION
When doing `{% import x as y %}` we create a new child interpreter and use that to render the imported template and then copy over errors/macros. The issue is that the expression resolver uses the static `JinjavaIntepreter.currentIntepreter()` to resolve expressions, meaning that we are using the parent interpreter to resolve expressions in the child interpreter's render.