### PR TITLE
Fix template syntax exception error messages

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/InvalidArgumentException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/InvalidArgumentException.java
@@ -10,9 +10,13 @@ public class InvalidArgumentException extends RuntimeException {
   private final String name;
 
   public InvalidArgumentException(JinjavaInterpreter interpreter, Importable importable, InvalidReason invalidReason, int argumentNumber, Object... errorMessageArgs) {
-    this.message = String.format("Invalid argument in '%s': %s",
+    this(interpreter, importable, String.format("Invalid argument in '%s': %s",
         importable.getName(),
-        String.format("%s %s", formatArgumentNumber(argumentNumber + 1), String.format(invalidReason.getErrorMessage(), errorMessageArgs)));
+        String.format("%s %s", formatArgumentNumber(argumentNumber + 1), String.format(invalidReason.getErrorMessage(), errorMessageArgs))));
+  }
+
+  public InvalidArgumentException(JinjavaInterpreter interpreter, Importable importable, String errorMessage) {
+    this.message = String.format("Invalid argument in '%s': %s", importable.getName(), errorMessage);
 
     this.lineNumber = interpreter.getLineNumber();
     this.startPosition = interpreter.getPosition();

--- a/src/main/java/com/hubspot/jinjava/interpret/InvalidArgumentException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/InvalidArgumentException.java
@@ -16,7 +16,7 @@ public class InvalidArgumentException extends RuntimeException {
   }
 
   public InvalidArgumentException(JinjavaInterpreter interpreter, Importable importable, String errorMessage) {
-    this.message = String.format("Invalid argument in '%s': %s", importable.getName(), errorMessage);
+    this.message = errorMessage;
 
     this.lineNumber = interpreter.getLineNumber();
     this.startPosition = interpreter.getPosition();

--- a/src/main/java/com/hubspot/jinjava/interpret/InvalidInputException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/InvalidInputException.java
@@ -10,9 +10,13 @@ public class InvalidInputException extends RuntimeException {
   private final String name;
 
   public InvalidInputException(JinjavaInterpreter interpreter, Importable importable, InvalidReason invalidReason, Object... errorMessageArgs) {
-    this.message = String.format("Invalid input in '%s': input variable %s",
+    this(interpreter, importable, String.format("Invalid input in '%s': input variable %s",
         importable.getName(),
-        String.format(invalidReason.getErrorMessage(), errorMessageArgs));
+        String.format(invalidReason.getErrorMessage(), errorMessageArgs)));
+  }
+
+  public InvalidInputException(JinjavaInterpreter interpreter, Importable importable, String errorMessage) {
+    this.message = errorMessage;
 
     this.lineNumber = interpreter.getLineNumber();
     this.startPosition = interpreter.getPosition();

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -61,12 +61,12 @@ public class TemplateError {
   }
 
   public static TemplateError fromSyntaxError(InterpretException ex) {
-    return new TemplateError(ErrorType.FATAL, ErrorReason.SYNTAX_ERROR, ErrorItem.OTHER, ExceptionUtils.getMessage(ex), null, ex.getLineNumber(), ex.getStartPosition(), ex);
+    return new TemplateError(ErrorType.FATAL, ErrorReason.SYNTAX_ERROR, ErrorItem.OTHER, ex.getMessage(), null, ex.getLineNumber(), ex.getStartPosition(), ex);
   }
 
   public static TemplateError fromException(TemplateSyntaxException ex) {
     String fieldName = (ex instanceof UnknownTagException) ? ((UnknownTagException) ex).getTag() : ex.getCode();
-    return new TemplateError(ErrorType.FATAL, ErrorReason.SYNTAX_ERROR, ErrorItem.OTHER, ExceptionUtils.getMessage(ex), fieldName, ex.getLineNumber(), ex.getStartPosition(), ex);
+    return new TemplateError(ErrorType.FATAL, ErrorReason.SYNTAX_ERROR, ErrorItem.OTHER, ex.getMessage(), fieldName, ex.getLineNumber(), ex.getStartPosition(), ex);
   }
 
   public static TemplateError fromInvalidArgumentException(InvalidArgumentException ex) {

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -61,7 +61,7 @@ public class TemplateError {
   }
 
   public static TemplateError fromSyntaxError(InterpretException ex) {
-    return new TemplateError(ErrorType.FATAL, ErrorReason.SYNTAX_ERROR, ErrorItem.OTHER, ex.getMessage(), null, ex.getLineNumber(), ex.getStartPosition(), ex);
+    return new TemplateError(ErrorType.FATAL, ErrorReason.SYNTAX_ERROR, ErrorItem.OTHER, ExceptionUtils.getMessage(ex), null, ex.getLineNumber(), ex.getStartPosition(), ex);
   }
 
   public static TemplateError fromException(TemplateSyntaxException ex) {

--- a/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
@@ -15,7 +15,7 @@ public class UnixTimestampFunctionTest {
   public void itGetsUnixTimestamps() {
     assertThat(Functions.unixtimestamp(epochMilliseconds)).isEqualTo(epochMilliseconds);
     assertThat(Functions.unixtimestamp(d)).isEqualTo(epochMilliseconds);
-    assertThat(Functions.unixtimestamp(null)).isEqualTo(ZonedDateTime.now().toEpochSecond() * 1000);
+    assertThat(Math.abs(Functions.unixtimestamp(null) - ZonedDateTime.now().toEpochSecond() * 1000)).isLessThan(10);
   }
 
 }


### PR DESCRIPTION
Right now if you have a syntax error we use `ExceptionUtils` to craft the message which leads to a long redundant message: `TemplateSyntaxException: com.hubspot.jinjava.interpret.TemplateSyntaxException: Syntax error in 'add': requires 1 argument (number to add to base)`. This just prints out the relevant message part of it `Syntax error in 'add': requires 1 argument (number to add to base)`.