### PR TITLE
Revert "Update expression resolver to return null instead of blank string."

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -63,7 +63,7 @@ public class ExpressionResolver {
    */
   public Object resolveExpression(String expression) {
     if (StringUtils.isBlank(expression)) {
-      return null;
+      return "";
     }
 
     interpreter.getContext().addResolvedExpression(expression.trim());
@@ -121,7 +121,7 @@ public class ExpressionResolver {
           String.format("Error resolving expression [%s]: " + getRootCauseMessage(e), expression), e, interpreter.getLineNumber(), interpreter.getPosition())));
     }
 
-    return null;
+    return "";
   }
 
   private void validateResult(Object result) {

--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
@@ -454,7 +454,7 @@ public class ExpressionResolverTest {
     final JinjavaConfig config = JinjavaConfig.newBuilder().withDisabled(disabled).build();
 
     final RenderResult renderResult = jinjava.renderForResult(template, context, config);
-    assertEquals("hi ", renderResult.getOutput());
+    assertEquals("hi  ", renderResult.getOutput());
     TemplateError e = renderResult.getErrors().get(0);
     assertThat(e.getItem()).isEqualTo(ErrorItem.FUNCTION);
     assertThat(e.getReason()).isEqualTo(ErrorReason.DISABLED);

--- a/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
@@ -274,8 +274,8 @@ public class ExtendedSyntaxBuilderTest {
     assertThat(val("stringToSplit.split('-')")).isEqualTo(new String[]{ "one", "two", "three", "four", "five" });
 
     assertThat(val("stringToSplit.split('-')[-1]")).isEqualTo("five");
-    assertThat(val("stringToSplit.split('-')[1.5]")).isEqualTo(null);
-    assertThat(val("stringToSplit.split('-')[-1.5]")).isEqualTo(null);
+    assertThat(val("stringToSplit.split('-')[1.5]")).isEqualTo("");
+    assertThat(val("stringToSplit.split('-')[-1.5]")).isEqualTo("");
 
     // out of range returns null, as -6 + the length of the array is still
     // negative, and java doesn't support negative array indices.
@@ -287,7 +287,7 @@ public class ExtendedSyntaxBuilderTest {
 
   @Test
   public void invalidNestedAssignmentExpr() {
-    assertThat(val("content.template_path = 'Custom/Email/Responsive/testing.html'")).isEqualTo(null);
+    assertThat(val("content.template_path = 'Custom/Email/Responsive/testing.html'")).isEqualTo("");
     assertThat(interpreter.getErrorsCopy()).isNotEmpty();
     assertThat(interpreter.getErrorsCopy().get(0).getReason()).isEqualTo(ErrorReason.SYNTAX_ERROR);
     assertThat(interpreter.getErrorsCopy().get(0).getMessage()).containsIgnoringCase("identifier");
@@ -295,7 +295,7 @@ public class ExtendedSyntaxBuilderTest {
 
   @Test
   public void invalidIdentifierAssignmentExpr() {
-    assertThat(val("content = 'Custom/Email/Responsive/testing.html'")).isEqualTo(null);
+    assertThat(val("content = 'Custom/Email/Responsive/testing.html'")).isEqualTo("");
     assertThat(interpreter.getErrorsCopy()).isNotEmpty();
     assertThat(interpreter.getErrorsCopy().get(0).getReason()).isEqualTo(ErrorReason.SYNTAX_ERROR);
     assertThat(interpreter.getErrorsCopy().get(0).getMessage()).containsIgnoringCase("'='");
@@ -303,7 +303,7 @@ public class ExtendedSyntaxBuilderTest {
 
   @Test
   public void invalidPipeOperatorExpr() {
-    assertThat(val("topics|1")).isEqualTo(null);
+    assertThat(val("topics|1")).isEqualTo("");
     assertThat(interpreter.getErrorsCopy()).isNotEmpty();
     assertThat(interpreter.getErrorsCopy().get(0).getReason()).isEqualTo(ErrorReason.SYNTAX_ERROR);
   }


### PR DESCRIPTION
Reverts HubSpot/jinjava#296
Issues with handling null values.