### PR TITLE
Fix expression resolver in `include` and `from` tag.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/FromTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/FromTag.java
@@ -93,7 +93,12 @@ public class FromTag implements Tag {
         Node node = interpreter.parse(template);
 
         JinjavaInterpreter child = new JinjavaInterpreter(interpreter);
-        child.render(node);
+        JinjavaInterpreter.pushCurrent(child);
+        try {
+          child.render(node);
+        } finally {
+          JinjavaInterpreter.popCurrent();
+        }
 
         interpreter.addAllErrors(child.getErrorsCopy());
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IncludeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IncludeTag.java
@@ -75,11 +75,15 @@ public class IncludeTag implements Tag {
       interpreter.getContext().addDependency("coded_files", templateFile);
 
       JinjavaInterpreter child = new JinjavaInterpreter(interpreter);
-      String result = child.render(node);
+      JinjavaInterpreter.pushCurrent(child);
 
-      interpreter.addAllErrors(child.getErrorsCopy());
-
-      return result;
+      try {
+        String result = child.render(node);
+        interpreter.addAllErrors(child.getErrorsCopy());
+        return result;
+      } finally {
+        JinjavaInterpreter.popCurrent();
+      }
 
     } catch (IOException e) {
       throw new InterpretException(e.getMessage(), e, tagNode.getLineNumber(), tagNode.getStartPosition());

--- a/src/test/java/com/hubspot/jinjava/lib/tag/FromTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/FromTagTest.java
@@ -69,6 +69,12 @@ public class FromTagTest {
         .anyMatch(e -> e.getCategory() == BasicTemplateErrorCategory.FROM_CYCLE_DETECTED));
   }
 
+  @Test
+  public void itImportsWithMacroTag() {
+    fixture("from-simple-with-call");
+    assertThat(interpreter.getErrorsCopy()).isEmpty();
+  }
+
   private String fixture(String name) {
     try {
       return interpreter.renderFlat(Resources.toString(

--- a/src/test/java/com/hubspot/jinjava/lib/tag/IncludeTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/IncludeTagTest.java
@@ -59,4 +59,13 @@ public class IncludeTagTest {
     assertThat(dependencies.get("coded_files").contains("{% include \"tags/includetag/cat.html\" %}"));
   }
 
+  @Test
+  public void itIncludesFileWithMacroCall() throws IOException {
+
+    RenderResult result = jinjava.renderForResult(Resources.toString(Resources.getResource("tags/includetag/include-with-import.jinja"), StandardCharsets.UTF_8),
+        new HashMap<>());
+
+    assertThat(result.getErrors()).isEmpty();
+  }
+
 }

--- a/src/test/resources/tags/includetag/include-with-import.jinja
+++ b/src/test/resources/tags/includetag/include-with-import.jinja
@@ -1,0 +1,1 @@
+{% include "tags/macrotag/simple-with-call.jinja" %}

--- a/src/test/resources/tags/macrotag/from-simple-with-call.jinja
+++ b/src/test/resources/tags/macrotag/from-simple-with-call.jinja
@@ -1,0 +1,1 @@
+{% from "simple-with-call.jinja" import getPath %}


### PR DESCRIPTION
Similar to https://github.com/HubSpot/jinjava/pull/290 we need to fix the expression resolver for `include` and `from` so included files can call macros without errors.