### PR TITLE
Render node in `include` tag in the same interpreter scope.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/IncludeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IncludeTag.java
@@ -74,17 +74,7 @@ public class IncludeTag implements Tag {
 
       interpreter.getContext().addDependency("coded_files", templateFile);
 
-      JinjavaInterpreter child = new JinjavaInterpreter(interpreter);
-      JinjavaInterpreter.pushCurrent(child);
-
-      try {
-        String result = child.render(node);
-        interpreter.addAllErrors(child.getErrorsCopy());
-        return result;
-      } finally {
-        JinjavaInterpreter.popCurrent();
-      }
-
+      return interpreter.render(node);
     } catch (IOException e) {
       throw new InterpretException(e.getMessage(), e, tagNode.getLineNumber(), tagNode.getStartPosition());
     } finally {


### PR DESCRIPTION
When we include a partial template we should be in the same interpreter scope (should be the functional equivalent of copying and pasting the partial template into the other template).