### PR TITLE
Allow ability to set a max recursion depth in config.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -41,6 +41,7 @@ public class JinjavaConfig {
 
   private final boolean readOnlyResolver;
   private final boolean enableRecursiveMacroCalls;
+  private final int maxMacroRecursionDepth;
 
   private Map<Context.Library, Set<String>> disabled;
   private final boolean failOnUnknownTokens;
@@ -54,11 +55,11 @@ public class JinjavaConfig {
   }
 
   public JinjavaConfig() {
-    this(StandardCharsets.UTF_8, Locale.ENGLISH, ZoneOffset.UTC, 10, new HashMap<>(), false, false, true, false, false, 0, true, RandomNumberGeneratorStrategy.THREAD_LOCAL, false, 0);
+    this(StandardCharsets.UTF_8, Locale.ENGLISH, ZoneOffset.UTC, 10, new HashMap<>(), false, false, true, false, 0, false, 0, true, RandomNumberGeneratorStrategy.THREAD_LOCAL, false, 0);
   }
 
   public JinjavaConfig(Charset charset, Locale locale, ZoneId timeZone, int maxRenderDepth) {
-    this(charset, locale, timeZone, maxRenderDepth, new HashMap<>(), false, false, true, false, false, 0, true, RandomNumberGeneratorStrategy.THREAD_LOCAL, false, 0);
+    this(charset, locale, timeZone, maxRenderDepth, new HashMap<>(), false, false, true, false, 0, false, 0, true, RandomNumberGeneratorStrategy.THREAD_LOCAL, false, 0);
   }
 
   private JinjavaConfig(Charset charset,
@@ -70,6 +71,7 @@ public class JinjavaConfig {
                         boolean lstripBlocks,
                         boolean readOnlyResolver,
                         boolean enableRecursiveMacroCalls,
+                        int maxMacroRecursionDepth,
                         boolean failOnUnknownTokens,
                         long maxOutputSize,
                         boolean nestedInterpretationEnabled,
@@ -85,6 +87,7 @@ public class JinjavaConfig {
     this.lstripBlocks = lstripBlocks;
     this.readOnlyResolver = readOnlyResolver;
     this.enableRecursiveMacroCalls = enableRecursiveMacroCalls;
+    this.maxMacroRecursionDepth = maxMacroRecursionDepth;
     this.failOnUnknownTokens = failOnUnknownTokens;
     this.maxOutputSize = maxOutputSize;
     this.nestedInterpretationEnabled = nestedInterpretationEnabled;
@@ -133,6 +136,10 @@ public class JinjavaConfig {
     return enableRecursiveMacroCalls;
   }
 
+  public int getMaxMacroRecursionDepth() {
+    return maxMacroRecursionDepth;
+  }
+
   public Map<Library, Set<String>> getDisabled() {
     return disabled;
   }
@@ -166,6 +173,7 @@ public class JinjavaConfig {
 
     private boolean readOnlyResolver = true;
     private boolean enableRecursiveMacroCalls;
+    private int maxMacroRecursionDepth;
     private boolean failOnUnknownTokens;
     private boolean nestedInterpretationEnabled = true;
     private RandomNumberGeneratorStrategy randomNumberGeneratorStrategy = RandomNumberGeneratorStrategy.THREAD_LOCAL;
@@ -220,6 +228,11 @@ public class JinjavaConfig {
       return this;
     }
 
+    public Builder withMaxMacroRecursionDepth(int maxMacroRecursionDepth) {
+      this.maxMacroRecursionDepth = maxMacroRecursionDepth;
+      return this;
+    }
+
     public Builder withReadOnlyResolver(boolean readOnlyResolver) {
       this.readOnlyResolver = readOnlyResolver;
       return this;
@@ -260,6 +273,7 @@ public class JinjavaConfig {
           lstripBlocks,
           readOnlyResolver,
           enableRecursiveMacroCalls,
+          maxMacroRecursionDepth,
           failOnUnknownTokens,
           maxOutputSize,
           nestedInterpretationEnabled,

--- a/src/main/java/com/hubspot/jinjava/el/ext/AstMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstMacroFunction.java
@@ -45,12 +45,10 @@ public class AstMacroFunction extends AstFunction {
         } catch (MacroTagCycleException e) {
 
           int maxDepth = interpreter.getConfig().getMaxMacroRecursionDepth();
-          String message;
-          if (maxDepth == 0) {
-            message = String.format("Cycle detected for macro '%s'", getName());
-          } else {
-            message = String.format("Max recursion limit of %d reached for macro '%s'", maxDepth, getName());
-          }
+          String message = maxDepth == 0
+              ? String.format("Cycle detected for macro '%s'", getName())
+              : String.format("Max recursion limit of %d reached for macro '%s'", maxDepth, getName());
+
           interpreter.addError(new TemplateError(TemplateError.ErrorType.WARNING,
                                                  TemplateError.ErrorReason.EXCEPTION,
                                                  TemplateError.ErrorItem.TAG,

--- a/src/main/java/com/hubspot/jinjava/interpret/CallStack.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/CallStack.java
@@ -8,10 +8,17 @@ public class CallStack {
   private final CallStack parent;
   private final Class<? extends TagCycleException> exceptionClass;
   private final Stack<String> stack = new Stack<>();
+  private final int depth;
 
   public CallStack(CallStack parent, Class<? extends TagCycleException> exceptionClass) {
     this.parent = parent;
     this.exceptionClass = exceptionClass;
+
+    if (parent == null) {
+      this.depth = 0;
+    } else {
+      this.depth = parent.depth + 1;
+    }
   }
 
   public boolean contains(String path) {
@@ -33,6 +40,14 @@ public class CallStack {
    */
   public void pushWithoutCycleCheck(String path) {
     stack.push(path);
+  }
+
+  public void pushWithMaxDepth(String path, int maxDepth, int lineNumber, int startPosition) {
+    if (depth < maxDepth) {
+      stack.push(path);
+    } else {
+      throw TagCycleException.create(exceptionClass, path, Optional.of(lineNumber), Optional.of(startPosition));
+    }
   }
 
   public void push(String path, int lineNumber, int startPosition) {

--- a/src/main/java/com/hubspot/jinjava/interpret/CallStack.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/CallStack.java
@@ -14,11 +14,7 @@ public class CallStack {
     this.parent = parent;
     this.exceptionClass = exceptionClass;
 
-    if (parent == null) {
-      this.depth = 0;
-    } else {
-      this.depth = parent.depth + 1;
-    }
+    this.depth = parent == null ? 0 : parent.depth + 1;
   }
 
   public boolean contains(String path) {


### PR DESCRIPTION
This is a middle ground option for https://github.com/HubSpot/jinjava/issues/91. You can now set `enableRecursiveMacroCalls` to `true` and `maxMacroRecursionDepth` to a reasonable value to prevent a template from killing your thread due to stack overflows.