### PR TITLE
Expand documentation factory with new fields.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocExpTest.java
@@ -4,8 +4,8 @@ import java.util.Map;
 
 public class JinjavaDocExpTest extends JinjavaDocItem {
 
-  public JinjavaDocExpTest(String name, String desc, String aliasOf, boolean deprecated, JinjavaDocParam[] params, JinjavaDocSnippet[] snippets, Map<String, String> meta) {
-    super(name, desc, aliasOf, deprecated, params, snippets, meta);
+  public JinjavaDocExpTest(String name, String desc, String aliasOf, boolean deprecated, JinjavaDocParam[] inputs, JinjavaDocParam[] params, JinjavaDocSnippet[] snippets, Map<String, String> meta) {
+    super(name, desc, aliasOf, deprecated, inputs, params, snippets, meta);
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
@@ -160,7 +160,7 @@ public class JinjavaDocFactory {
             docAnnotation.value(),
             docAnnotation.aliasOf(),
             docAnnotation.deprecated(),
-            extractParams(docAnnotation.input()), 
+            extractParams(docAnnotation.input()),
             extractParams(docAnnotation.params()),
             extractSnippets(docAnnotation.snippets()),
             extractMeta(docAnnotation.meta())));

--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
@@ -46,11 +46,11 @@ public class JinjavaDocFactory {
 
       if (docAnnotation == null) {
         LOG.warn("Expression Test {} doesn't have a @{} annotation", t.getName(), com.hubspot.jinjava.doc.annotations.JinjavaDoc.class.getName());
-        doc.addExpTest(new JinjavaDocExpTest(t.getName(), "", "", false, new JinjavaDocParam[] {}, new JinjavaDocSnippet[] {}, Collections.emptyMap()));
+        doc.addExpTest(new JinjavaDocExpTest(t.getName(), "", "", false, new JinjavaDocParam[] {}, new JinjavaDocParam[] {}, new JinjavaDocSnippet[] {}, Collections.emptyMap()));
       }
       else if (!docAnnotation.hidden()) {
         doc.addExpTest(new JinjavaDocExpTest(t.getName(), docAnnotation.value(), docAnnotation.aliasOf(), docAnnotation.deprecated(),
-            extractParams(docAnnotation.params()), extractSnippets(docAnnotation.snippets()), extractMeta(docAnnotation.meta())));
+            extractParams(docAnnotation.input()), extractParams(docAnnotation.params()), extractSnippets(docAnnotation.snippets()), extractMeta(docAnnotation.meta())));
       }
     }
   }
@@ -61,11 +61,11 @@ public class JinjavaDocFactory {
 
       if (docAnnotation == null) {
         LOG.warn("Filter {} doesn't have a @{} annotation", f.getClass(), com.hubspot.jinjava.doc.annotations.JinjavaDoc.class.getName());
-        doc.addFilter(new JinjavaDocFilter(f.getName(), "", "", false, new JinjavaDocParam[] {}, new JinjavaDocSnippet[] {}, Collections.emptyMap()));
+        doc.addFilter(new JinjavaDocFilter(f.getName(), "", "", false, new JinjavaDocParam[] {}, new JinjavaDocParam[] {}, new JinjavaDocSnippet[] {}, Collections.emptyMap()));
       }
       else if (!docAnnotation.hidden()) {
         doc.addFilter(new JinjavaDocFilter(f.getName(), docAnnotation.value(), docAnnotation.aliasOf(), docAnnotation.deprecated(),
-            extractParams(docAnnotation.params()), extractSnippets(docAnnotation.snippets()), extractMeta(docAnnotation.meta())));
+            extractParams(docAnnotation.input()), extractParams(docAnnotation.params()), extractSnippets(docAnnotation.snippets()), extractMeta(docAnnotation.meta())));
       }
     }
   }
@@ -86,11 +86,11 @@ public class JinjavaDocFactory {
 
         if (docAnnotation == null) {
           LOG.warn("Function {} doesn't have a @{} annotation", fn.getName(), com.hubspot.jinjava.doc.annotations.JinjavaDoc.class.getName());
-          doc.addFunction(new JinjavaDocFunction(fn.getLocalName(), "", "", false, new JinjavaDocParam[] {}, new JinjavaDocSnippet[] {}, Collections.emptyMap()));
+          doc.addFunction(new JinjavaDocFunction(fn.getLocalName(), "", "", false, new JinjavaDocParam[] {}, new JinjavaDocParam[] {}, new JinjavaDocSnippet[] {}, Collections.emptyMap()));
         }
         else if (!docAnnotation.hidden()) {
           doc.addFunction(new JinjavaDocFunction(fn.getLocalName(), docAnnotation.value(), docAnnotation.aliasOf(), docAnnotation.deprecated(),
-              extractParams(docAnnotation.params()), extractSnippets(docAnnotation.snippets()), extractMeta(docAnnotation.meta())));
+              extractParams(docAnnotation.input()), extractParams(docAnnotation.params()), extractSnippets(docAnnotation.snippets()), extractMeta(docAnnotation.meta())));
         }
       }
     }
@@ -105,11 +105,11 @@ public class JinjavaDocFactory {
 
       if (docAnnotation == null) {
         LOG.warn("Tag {} doesn't have a @{} annotation", t.getName(), com.hubspot.jinjava.doc.annotations.JinjavaDoc.class.getName());
-        doc.addTag(new JinjavaDocTag(t.getName(), StringUtils.isBlank(t.getEndTagName()), "", "", false, new JinjavaDocParam[] {}, new JinjavaDocSnippet[] {}, Collections.emptyMap()));
+        doc.addTag(new JinjavaDocTag(t.getName(), StringUtils.isBlank(t.getEndTagName()), "", "", false, new JinjavaDocParam[] {}, new JinjavaDocParam[] {}, new JinjavaDocSnippet[] {}, Collections.emptyMap()));
       }
       else if (!docAnnotation.hidden()) {
         doc.addTag(new JinjavaDocTag(t.getName(), StringUtils.isBlank(t.getEndTagName()), docAnnotation.value(), docAnnotation.aliasOf(), docAnnotation.deprecated(),
-            extractParams(docAnnotation.params()), extractSnippets(docAnnotation.snippets()), extractMeta(docAnnotation.meta())));
+            extractParams(docAnnotation.input()), extractParams(docAnnotation.params()), extractSnippets(docAnnotation.snippets()), extractMeta(docAnnotation.meta())));
       }
     }
   }
@@ -119,7 +119,7 @@ public class JinjavaDocFactory {
 
     for (int i = 0; i < params.length; i++) {
       JinjavaParam p = params[i];
-      result[i] = new JinjavaDocParam(p.value(), p.type(), p.desc(), p.defaultValue());
+      result[i] = new JinjavaDocParam(p.value(), p.type(), p.desc(), p.defaultValue(), p.required());
     }
 
     return result;

--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
@@ -46,11 +46,24 @@ public class JinjavaDocFactory {
 
       if (docAnnotation == null) {
         LOG.warn("Expression Test {} doesn't have a @{} annotation", t.getName(), com.hubspot.jinjava.doc.annotations.JinjavaDoc.class.getName());
-        doc.addExpTest(new JinjavaDocExpTest(t.getName(), "", "", false, new JinjavaDocParam[] {}, new JinjavaDocParam[] {}, new JinjavaDocSnippet[] {}, Collections.emptyMap()));
+        doc.addExpTest(new JinjavaDocExpTest(t.getName(),
+            "",
+            "",
+            false,
+            new JinjavaDocParam[] {},
+            new JinjavaDocParam[] {},
+            new JinjavaDocSnippet[] {},
+            Collections.emptyMap()));
       }
       else if (!docAnnotation.hidden()) {
-        doc.addExpTest(new JinjavaDocExpTest(t.getName(), docAnnotation.value(), docAnnotation.aliasOf(), docAnnotation.deprecated(),
-            extractParams(docAnnotation.input()), extractParams(docAnnotation.params()), extractSnippets(docAnnotation.snippets()), extractMeta(docAnnotation.meta())));
+        doc.addExpTest(new JinjavaDocExpTest(t.getName(),
+            docAnnotation.value(),
+            docAnnotation.aliasOf(),
+            docAnnotation.deprecated(),
+            extractParams(docAnnotation.input()),
+            extractParams(docAnnotation.params()),
+            extractSnippets(docAnnotation.snippets()),
+            extractMeta(docAnnotation.meta())));
       }
     }
   }
@@ -61,11 +74,24 @@ public class JinjavaDocFactory {
 
       if (docAnnotation == null) {
         LOG.warn("Filter {} doesn't have a @{} annotation", f.getClass(), com.hubspot.jinjava.doc.annotations.JinjavaDoc.class.getName());
-        doc.addFilter(new JinjavaDocFilter(f.getName(), "", "", false, new JinjavaDocParam[] {}, new JinjavaDocParam[] {}, new JinjavaDocSnippet[] {}, Collections.emptyMap()));
+        doc.addFilter(new JinjavaDocFilter(f.getName(),
+            "",
+            "",
+            false,
+            new JinjavaDocParam[] {},
+            new JinjavaDocParam[] {},
+            new JinjavaDocSnippet[] {},
+            Collections.emptyMap()));
       }
       else if (!docAnnotation.hidden()) {
-        doc.addFilter(new JinjavaDocFilter(f.getName(), docAnnotation.value(), docAnnotation.aliasOf(), docAnnotation.deprecated(),
-            extractParams(docAnnotation.input()), extractParams(docAnnotation.params()), extractSnippets(docAnnotation.snippets()), extractMeta(docAnnotation.meta())));
+        doc.addFilter(new JinjavaDocFilter(f.getName(),
+            docAnnotation.value(),
+            docAnnotation.aliasOf(),
+            docAnnotation.deprecated(),
+            extractParams(docAnnotation.input()),
+            extractParams(docAnnotation.params()),
+            extractSnippets(docAnnotation.snippets()),
+            extractMeta(docAnnotation.meta())));
       }
     }
   }
@@ -86,11 +112,24 @@ public class JinjavaDocFactory {
 
         if (docAnnotation == null) {
           LOG.warn("Function {} doesn't have a @{} annotation", fn.getName(), com.hubspot.jinjava.doc.annotations.JinjavaDoc.class.getName());
-          doc.addFunction(new JinjavaDocFunction(fn.getLocalName(), "", "", false, new JinjavaDocParam[] {}, new JinjavaDocParam[] {}, new JinjavaDocSnippet[] {}, Collections.emptyMap()));
+          doc.addFunction(new JinjavaDocFunction(fn.getLocalName(),
+              "",
+              "",
+              false,
+              new JinjavaDocParam[] {},
+              new JinjavaDocParam[] {},
+              new JinjavaDocSnippet[] {},
+              Collections.emptyMap()));
         }
         else if (!docAnnotation.hidden()) {
-          doc.addFunction(new JinjavaDocFunction(fn.getLocalName(), docAnnotation.value(), docAnnotation.aliasOf(), docAnnotation.deprecated(),
-              extractParams(docAnnotation.input()), extractParams(docAnnotation.params()), extractSnippets(docAnnotation.snippets()), extractMeta(docAnnotation.meta())));
+          doc.addFunction(new JinjavaDocFunction(fn.getLocalName(),
+              docAnnotation.value(),
+              docAnnotation.aliasOf(),
+              docAnnotation.deprecated(),
+              extractParams(docAnnotation.input()),
+              extractParams(docAnnotation.params()),
+              extractSnippets(docAnnotation.snippets()),
+              extractMeta(docAnnotation.meta())));
         }
       }
     }
@@ -105,11 +144,26 @@ public class JinjavaDocFactory {
 
       if (docAnnotation == null) {
         LOG.warn("Tag {} doesn't have a @{} annotation", t.getName(), com.hubspot.jinjava.doc.annotations.JinjavaDoc.class.getName());
-        doc.addTag(new JinjavaDocTag(t.getName(), StringUtils.isBlank(t.getEndTagName()), "", "", false, new JinjavaDocParam[] {}, new JinjavaDocParam[] {}, new JinjavaDocSnippet[] {}, Collections.emptyMap()));
+        doc.addTag(new JinjavaDocTag(t.getName(),
+            StringUtils.isBlank(t.getEndTagName()),
+            "",
+            "",
+            false,
+            new JinjavaDocParam[] {},
+            new JinjavaDocParam[] {},
+            new JinjavaDocSnippet[] {},
+            Collections.emptyMap()));
       }
       else if (!docAnnotation.hidden()) {
-        doc.addTag(new JinjavaDocTag(t.getName(), StringUtils.isBlank(t.getEndTagName()), docAnnotation.value(), docAnnotation.aliasOf(), docAnnotation.deprecated(),
-            extractParams(docAnnotation.input()), extractParams(docAnnotation.params()), extractSnippets(docAnnotation.snippets()), extractMeta(docAnnotation.meta())));
+        doc.addTag(new JinjavaDocTag(t.getName(),
+            StringUtils.isBlank(t.getEndTagName()),
+            docAnnotation.value(),
+            docAnnotation.aliasOf(),
+            docAnnotation.deprecated(),
+            extractParams(docAnnotation.input()), 
+            extractParams(docAnnotation.params()),
+            extractSnippets(docAnnotation.snippets()),
+            extractMeta(docAnnotation.meta())));
       }
     }
   }

--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFilter.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFilter.java
@@ -4,8 +4,8 @@ import java.util.Map;
 
 public class JinjavaDocFilter extends JinjavaDocItem {
 
-  public JinjavaDocFilter(String name, String desc, String aliasOf, boolean deprecated, JinjavaDocParam[] params, JinjavaDocSnippet[] snippets, Map<String, String> meta) {
-    super(name, desc, aliasOf, deprecated, params, snippets, meta);
+  public JinjavaDocFilter(String name, String desc, String aliasOf, boolean deprecated, JinjavaDocParam[] inputs, JinjavaDocParam[] params, JinjavaDocSnippet[] snippets, Map<String, String> meta) {
+    super(name, desc, aliasOf, deprecated, inputs, params, snippets, meta);
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFunction.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFunction.java
@@ -4,8 +4,8 @@ import java.util.Map;
 
 public class JinjavaDocFunction extends JinjavaDocItem {
 
-  public JinjavaDocFunction(String name, String desc, String aliasOf, boolean deprecated, JinjavaDocParam[] params, JinjavaDocSnippet[] snippets, Map<String, String> meta) {
-    super(name, desc, aliasOf, deprecated, params, snippets, meta);
+  public JinjavaDocFunction(String name, String desc, String aliasOf, boolean deprecated, JinjavaDocParam[] inputs, JinjavaDocParam[] params, JinjavaDocSnippet[] snippets, Map<String, String> meta) {
+    super(name, desc, aliasOf, deprecated, inputs, params, snippets, meta);
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocItem.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocItem.java
@@ -8,15 +8,17 @@ public abstract class JinjavaDocItem {
   private final String desc;
   private final String aliasOf;
   private final boolean deprecated;
+  private final JinjavaDocParam[] inputs;
   private final JinjavaDocParam[] params;
   private final JinjavaDocSnippet[] snippets;
   private final Map<String, String> meta;
 
-  public JinjavaDocItem(String name, String desc, String aliasOf, boolean deprecated, JinjavaDocParam[] params, JinjavaDocSnippet[] snippets, Map<String, String> meta) {
+  public JinjavaDocItem(String name, String desc, String aliasOf, boolean deprecated, JinjavaDocParam[] inputs, JinjavaDocParam[] params, JinjavaDocSnippet[] snippets, Map<String, String> meta) {
     this.name = name;
     this.desc = desc;
     this.aliasOf = aliasOf;
     this.deprecated = deprecated;
+    this.inputs = inputs.clone();
     this.params = params.clone();
     this.snippets = snippets.clone();
     this.meta = meta;
@@ -36,6 +38,10 @@ public abstract class JinjavaDocItem {
 
   public boolean isDeprecated() {
     return deprecated;
+  }
+
+  public JinjavaDocParam[] getInputs() {
+    return inputs.clone();
   }
 
   public JinjavaDocParam[] getParams() {

--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocParam.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocParam.java
@@ -6,12 +6,14 @@ public class JinjavaDocParam {
   private final String type;
   private final String desc;
   private final String defaultValue;
+  private final boolean required;
 
-  public JinjavaDocParam(String name, String type, String desc, String defaultValue) {
+  public JinjavaDocParam(String name, String type, String desc, String defaultValue, boolean required) {
     this.name = name;
     this.type = type;
     this.desc = desc;
     this.defaultValue = defaultValue;
+    this.required = required;
   }
 
   public String getName() {
@@ -28,6 +30,10 @@ public class JinjavaDocParam {
 
   public String getDefaultValue() {
     return defaultValue;
+  }
+
+  public boolean getRequired() {
+    return required;
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocTag.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocTag.java
@@ -6,8 +6,8 @@ public class JinjavaDocTag extends JinjavaDocItem {
 
   private final boolean empty;
 
-  public JinjavaDocTag(String name, boolean empty, String desc, String aliasOf, boolean deprecated, JinjavaDocParam[] params, JinjavaDocSnippet[] snippets, Map<String, String> meta) {
-    super(name, desc, aliasOf, deprecated, params, snippets, meta);
+  public JinjavaDocTag(String name, boolean empty, String desc, String aliasOf, boolean deprecated, JinjavaDocParam[] inputs, JinjavaDocParam[] params, JinjavaDocSnippet[] snippets, Map<String, String> meta) {
+    super(name, desc, aliasOf, deprecated, inputs, params, snippets, meta);
     this.empty = empty;
   }
 


### PR DESCRIPTION
The new `required` and `input` attributes were not being added to the documentation factory builder. This fixes that.