### PR TITLE
Only add max depth error when not in validation mode.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/AstMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstMacroFunction.java
@@ -45,6 +45,11 @@ public class AstMacroFunction extends AstFunction {
         } catch (MacroTagCycleException e) {
 
           int maxDepth = interpreter.getConfig().getMaxMacroRecursionDepth();
+          if (maxDepth != 0 && interpreter.getConfig().isValidationMode()) {
+            // validation mode is only concerned with syntax
+            return "";
+          }
+
           String message = maxDepth == 0
               ? String.format("Cycle detected for macro '%s'", getName())
               : String.format("Max recursion limit of %d reached for macro '%s'", maxDepth, getName());

--- a/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
@@ -189,6 +189,27 @@ public class MacroTagTest {
   }
 
   @Test
+  public void itAllowsMacroRecursionWithMaxDepthInValidationMode() throws IOException {
+
+    interpreter = new Jinjava(JinjavaConfig.newBuilder()
+        .withEnableRecursiveMacroCalls(true)
+        .withMaxMacroRecursionDepth(10)
+        .withValidationMode(true)
+        .build()).newInterpreter();
+    JinjavaInterpreter.pushCurrent(interpreter);
+
+    try {
+      String template = fixtureText("ending-recursion");
+      String out = interpreter.render(template);
+      assertThat(interpreter.getErrorsCopy()).isEmpty();
+      assertThat(out).contains("Hello Hello Hello Hello Hello");
+    }
+    finally {
+      JinjavaInterpreter.popCurrent();
+    }
+  }
+
+  @Test
   public void itEnforcesMacroRecursionWithMaxDepth() throws IOException {
 
     interpreter = new Jinjava(JinjavaConfig.newBuilder()


### PR DESCRIPTION
Validation mode changes how variables are resolved so we should not be exposing the max depth error as it is based on runtime behavior. 