### PR TITLE
Catch DeferredValueException in the ExpressionNode

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.filter.EscapeFilter;
 import com.hubspot.jinjava.tree.output.OutputNode;
@@ -39,7 +40,12 @@ public class ExpressionNode extends Node {
 
   @Override
   public OutputNode render(JinjavaInterpreter interpreter) {
-    Object var = interpreter.resolveELExpression(master.getExpr(), getLineNumber());
+    Object var;
+    try {
+      var = interpreter.resolveELExpression(master.getExpr(), getLineNumber());
+    } catch (DeferredValueException e){
+      var = master.getImage();
+    }
 
     String result = Objects.toString(var, "");
 

--- a/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
@@ -78,6 +78,13 @@ public class DeferredTest {
     assertThat(interpreter.getErrors()).isEmpty();
   }
 
+ @Test
+  public void itResolvesIfTagWherePossible() {
+   String output = interpreter.render("{% if true %}{{deferred}}{% endif %}");
+   assertThat(output).isEqualTo("{{deferred}}");
+   assertThat(interpreter.getErrors()).isEmpty();
+ }
+
   @Test
   public void itPreservesForTag() {
     String output = interpreter.render("{% for item in deferred %}{{item.name}}{% else %}last{% endfor %}");

--- a/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
@@ -86,6 +86,13 @@ public class DeferredTest {
  }
 
   @Test
+  public void itResolvesForTagWherePossible() {
+    String output = interpreter.render("{% for i in [1, 2] %}{{i}}{{deferred}}{% endfor %}");
+    assertThat(output).isEqualTo("1{{deferred}}2{{deferred}}");
+    assertThat(interpreter.getErrors()).isEmpty();
+  }
+
+  @Test
   public void itPreservesForTag() {
     String output = interpreter.render("{% for item in deferred %}{{item.name}}{% else %}last{% endfor %}");
     assertThat(output).isEqualTo("{% for item in deferred %}{{item.name}}{% else %}last{% endfor %}");


### PR DESCRIPTION
This fixes a problem where a Tag would not be rendered when it contained a deferred ExpressionNode as a child. I'm not 100% sure if this is sufficient for a fix or if I need to worry about something else in the ExpressionNode (e.g. the config value). Since `StringUtils.equals(result, master.getImage()) == true` it should be fine though.