### PR TITLE
Use type converter when evaulting 'in'

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
@@ -34,10 +34,10 @@ public class CollectionMembershipOperator extends SimpleOperator {
           if (o1 == null) {
             return Boolean.TRUE;
           }
-          continue;
+        } else {
+          convertedObject = converter.convert(o1, value.getClass());
+          return collection.contains(convertedObject);
         }
-        convertedObject = converter.convert(o1, value.getClass());
-        return collection.contains(convertedObject);
       }
     }
 

--- a/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
@@ -26,7 +26,18 @@ public class CollectionMembershipOperator extends SimpleOperator {
     }
 
     if (Collection.class.isAssignableFrom(o2.getClass())) {
-      return ((Collection<?>) o2).contains(o1);
+      Collection<?> collection = (Collection<?>) o2;
+
+      Object convertedObject = null;
+      for (Object value : collection) {
+        if (convertedObject == null) {
+          convertedObject = converter.convert(o1, value.getClass());
+        }
+
+        if (convertedObject.equals(value)) {
+          return Boolean.TRUE;
+        }
+      }
     }
 
     return Boolean.FALSE;

--- a/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
@@ -3,6 +3,8 @@ package com.hubspot.jinjava.el.ext;
 import java.util.Collection;
 import java.util.Objects;
 
+import javax.el.ELException;
+
 import org.apache.commons.lang3.StringUtils;
 
 import de.odysseus.el.misc.TypeConverter;
@@ -28,15 +30,17 @@ public class CollectionMembershipOperator extends SimpleOperator {
     if (Collection.class.isAssignableFrom(o2.getClass())) {
       Collection<?> collection = (Collection<?>) o2;
 
-      Object convertedObject = null;
       for (Object value : collection) {
         if (value == null) {
           if (o1 == null) {
             return Boolean.TRUE;
           }
         } else {
-          convertedObject = converter.convert(o1, value.getClass());
-          return collection.contains(convertedObject);
+          try {
+            return collection.contains(converter.convert(o1, value.getClass()));
+          } catch (ELException e) {
+            return Boolean.FALSE;
+          }
         }
       }
     }

--- a/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
@@ -30,6 +30,13 @@ public class CollectionMembershipOperator extends SimpleOperator {
 
       Object convertedObject = null;
       for (Object value : collection) {
+        if (value == null) {
+          if (o1 == null) {
+            return Boolean.TRUE;
+          }
+          continue;
+        }
+
         if (convertedObject == null) {
           convertedObject = converter.convert(o1, value.getClass());
         }

--- a/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
@@ -36,14 +36,8 @@ public class CollectionMembershipOperator extends SimpleOperator {
           }
           continue;
         }
-
-        if (convertedObject == null) {
-          convertedObject = converter.convert(o1, value.getClass());
-        }
-
-        if (convertedObject.equals(value)) {
-          return Boolean.TRUE;
-        }
+        convertedObject = converter.convert(o1, value.getClass());
+        return collection.contains(convertedObject);
       }
     }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/IntFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/IntFilterTest.java
@@ -118,4 +118,9 @@ public class IntFilterTest {
     assertThat(interpreter.render("{{ '3'|int in [null, 4, 5, 6, null, 3] }}")).isEqualTo("true");
   }
 
+  @Test
+  public void itConvertsProperlyInExpressionTestWithWrongType() {
+    assertThat(interpreter.render("{{ 'test' in [null, 4, 5, 6, null, 3] }}")).isEqualTo("true");
+  }
+
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/IntFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/IntFilterTest.java
@@ -115,7 +115,7 @@ public class IntFilterTest {
 
   @Test
   public void itConvertsProperlyInExpressionTest() {
-    assertThat(interpreter.render("{{ '3'|int in [3, 4, 5] }}")).isEqualTo("true");
+    assertThat(interpreter.render("{{ '3'|int in [null, 4, 5, 6, null, 3] }}")).isEqualTo("true");
   }
 
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/IntFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/IntFilterTest.java
@@ -120,7 +120,6 @@ public class IntFilterTest {
 
   @Test
   public void itConvertsProperlyInExpressionTestWithWrongType() {
-    assertThat(interpreter.render("{{ 'test' in [null, 4, 5, 6, null, 3] }}")).isEqualTo("true");
+    assertThat(interpreter.render("{{ 'test' in [null, 4, 5, 6, null, 3] }}")).isEqualTo("false");
   }
-
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/IntFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/IntFilterTest.java
@@ -6,7 +6,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
 import java.util.Locale;
 
-import org.apache.commons.lang3.math.NumberUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -113,4 +112,10 @@ public class IntFilterTest {
     interpreter = new Jinjava(FRENCH_LOCALE_CONFIG).newInterpreter();
     assertThat(filter.filter("123\u00A0123,12", interpreter)).isEqualTo(123123);
   }
+
+  @Test
+  public void itConvertsProperlyInExpressionTest() {
+    assertThat(interpreter.render("{{ '3'|int in [3, 4, 5] }}")).isEqualTo("true");
+  }
+
 }


### PR DESCRIPTION
When evaluating `in` (for example `{{ 3 in [1, 2, 3] }}` we should use the type converter to compare `3` to the list values.