### PR TITLE
Return long value from int filter if over max int length.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/IntFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IntFilter.java
@@ -37,33 +37,40 @@ public class IntFilter implements Filter {
   public Object filter(Object var, JinjavaInterpreter interpreter,
       String... args) {
 
-    int defaultVal = 0;
+    Long defaultVal = 0L;
     if (args.length > 0) {
-      defaultVal = NumberUtils.toInt(args[0], 0);
+      defaultVal = NumberUtils.toLong(args[0], 0);
     }
 
     if (var == null) {
-      return defaultVal;
+      return convertResult(defaultVal);
     }
 
     if (Number.class.isAssignableFrom(var.getClass())) {
-      return ((Number) var).intValue();
+      return convertResult(((Number) var).longValue());
     }
 
     String input = var.toString().trim();
     Locale locale = interpreter.getConfig().getLocale();
     NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
     ParsePosition pp = new ParsePosition(0);
-    int result;
+    Long result;
     try {
-      result = numberFormat.parse(input, pp).intValue();
+      result = numberFormat.parse(input, pp).longValue();
     } catch (Exception e) {
       result = defaultVal;
     }
     if (pp.getErrorIndex() != -1 || pp.getIndex() != input.length()) {
       result = defaultVal;
     }
-    return result;
+    return convertResult(result);
+  }
+
+  private Object convertResult(Long result) {
+    if (result > Integer.MAX_VALUE) {
+      return result;
+    }
+    return result.intValue();
   }
 
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/IntFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/IntFilterTest.java
@@ -6,7 +6,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
 import java.util.Locale;
 
-import org.apache.commons.lang3.math.NumberUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -112,5 +111,15 @@ public class IntFilterTest {
   public void itInterpretsFrenchCommasAndPeriodsWithFrenchLocale() {
     interpreter = new Jinjava(FRENCH_LOCALE_CONFIG).newInterpreter();
     assertThat(filter.filter("123\u00A0123,12", interpreter)).isEqualTo(123123);
+  }
+
+  @Test
+  public void itUsesLongsForLargeValues() {
+    assertThat(filter.filter("1000000000001", interpreter)).isEqualTo(1000000000001L);
+  }
+
+  @Test
+  public void itUsesLongsForLargeValueDefaults() {
+    assertThat(filter.filter("not a number", interpreter, "1000000000001")).isEqualTo(1000000000001L);
   }
 }


### PR DESCRIPTION
Int is unbounded in python so trying to come up with a solution to bring Jinjava `|int` closer to parity with Jinja. Here we are returning a long value instead of a int if the value is above the maximum allowed for ints. This should fix most issues where people are trying to convert long IDs into numbers using the `|int` filter. Some thought is needed to figure out a better long term solution for higher values than what long supports.