### PR TITLE
Add support for resolving relative paths in separate files

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/CallStack.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/CallStack.java
@@ -64,4 +64,15 @@ public class CallStack {
 
     return Optional.of(stack.pop());
   }
+
+  public Optional<String> peek() {
+    if (stack.isEmpty()) {
+      if (parent != null) {
+        return parent.peek();
+      }
+      return Optional.empty();
+    }
+
+    return Optional.of(stack.peek());
+  }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -45,6 +45,7 @@ import com.hubspot.jinjava.util.ScopeMap;
 
 public class Context extends ScopeMap<String, Object> {
   public static final String GLOBAL_MACROS_SCOPE_KEY = "__macros__";
+  public static final String IMPORT_RESOURCE_PATH_KEY = "import_resource_path";
 
   private final SetMultimap<String, String> dependencies = HashMultimap.create();
   private Map<Library, Set<String>> disabled;
@@ -70,6 +71,7 @@ public class Context extends ScopeMap<String, Object> {
   private final CallStack includePathStack;
   private final CallStack macroStack;
   private final CallStack fromStack;
+  private final CallStack currentPathStack;
 
   private final Set<String> resolvedExpressions = new HashSet<>();
   private final Set<String> resolvedValues = new HashSet<>();
@@ -121,6 +123,7 @@ public class Context extends ScopeMap<String, Object> {
     this.macroStack = new CallStack(parent == null ? null : parent.getMacroStack(), MacroTagCycleException.class);
     this.fromStack = new CallStack(parent == null ? null : parent.getFromStack(),
         FromTagCycleException.class);
+    this.currentPathStack = new CallStack(parent == null ? null : parent.getCurrentPathStack(), TagCycleException.class);
 
     if (disabled == null) {
       disabled = new HashMap<>();
@@ -405,6 +408,10 @@ public class Context extends ScopeMap<String, Object> {
 
   public CallStack getMacroStack() {
     return macroStack;
+  }
+
+  public CallStack getCurrentPathStack() {
+    return currentPathStack;
   }
 
   public void pushFromStack(String path, int lineNumber, int startPosition) {

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -255,6 +255,7 @@ public class JinjavaInterpreter {
     // render all extend parents, keeping the last as the root output
     if (processExtendRoots) {
       while (!extendParentRoots.isEmpty()) {
+        context.getCurrentPathStack().push(context.getExtendPathStack().peek().orElse(""), lineNumber, position);
         Node parentRoot = extendParentRoots.removeFirst();
         output = new OutputList(config.getMaxOutputSize());
 
@@ -264,6 +265,7 @@ public class JinjavaInterpreter {
         }
 
         context.getExtendPathStack().pop();
+        context.getCurrentPathStack().pop();
       }
     }
 

--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.lib.fn;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import com.hubspot.jinjava.el.ext.AbstractCallableMethod;
 import com.hubspot.jinjava.interpret.Context;
@@ -45,6 +46,8 @@ public class MacroFunction extends AbstractCallableMethod {
   @Override
   public Object doEvaluate(Map<String, Object> argMap, Map<String, Object> kwargMap, List<Object> varArgs) {
     JinjavaInterpreter interpreter = JinjavaInterpreter.getCurrent();
+    Optional<String> importFile = Optional.ofNullable((String) localContextScope.get(Context.IMPORT_RESOURCE_PATH_KEY));
+    importFile.ifPresent(path -> interpreter.getContext().getCurrentPathStack().push(path, interpreter.getLineNumber(), interpreter.getPosition()));
 
     try (InterpreterScopeClosable c = interpreter.enterScope()) {
       for (Map.Entry<String, Object> scopeEntry : localContextScope.getScope().entrySet()) {
@@ -70,6 +73,7 @@ public class MacroFunction extends AbstractCallableMethod {
         result.append(node.render(interpreter));
       }
 
+      importFile.ifPresent(path -> interpreter.getContext().getCurrentPathStack().pop());
       return result.toString();
     }
   }

--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -93,4 +93,8 @@ public class MacroFunction extends AbstractCallableMethod {
     return caller;
   }
 
+  public Context getLocalContextScope() {
+    return localContextScope;
+  }
+
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/FromTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/FromTag.java
@@ -93,6 +93,7 @@ public class FromTag implements Tag {
         Node node = interpreter.parse(template);
 
         JinjavaInterpreter child = new JinjavaInterpreter(interpreter);
+        child.getContext().put("import_resource_path", templateFile);
         JinjavaInterpreter.pushCurrent(child);
         try {
           child.render(node);

--- a/src/main/java/com/hubspot/jinjava/lib/tag/FromTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/FromTag.java
@@ -11,6 +11,7 @@ import com.google.common.collect.PeekingIterator;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.FromTagCycleException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -93,7 +94,7 @@ public class FromTag implements Tag {
         Node node = interpreter.parse(template);
 
         JinjavaInterpreter child = new JinjavaInterpreter(interpreter);
-        child.getContext().put("import_resource_path", templateFile);
+        child.getContext().put(Context.IMPORT_RESOURCE_PATH_KEY, templateFile);
         JinjavaInterpreter.pushCurrent(child);
         try {
           child.render(node);

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -95,6 +95,7 @@ public class ImportTag implements Tag {
         interpreter.render(node);
       } else {
         JinjavaInterpreter child = new JinjavaInterpreter(interpreter);
+        child.getContext().put("importResourcePath", templateFile);
         JinjavaInterpreter.pushCurrent(child);
 
         try {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -92,7 +92,7 @@ public class ImportTag implements Tag {
       Node node = interpreter.parse(template);
 
       JinjavaInterpreter child = new JinjavaInterpreter(interpreter);
-      child.getContext().put("import_resource_path", templateFile);
+      child.getContext().put(Context.IMPORT_RESOURCE_PATH_KEY, templateFile);
       JinjavaInterpreter.pushCurrent(child);
 
       try {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IncludeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IncludeTag.java
@@ -73,12 +73,14 @@ public class IncludeTag implements Tag {
       Node node = interpreter.parse(template);
 
       interpreter.getContext().addDependency("coded_files", templateFile);
+      interpreter.getContext().getCurrentPathStack().push(templateFile, interpreter.getLineNumber(), interpreter.getPosition());
 
       return interpreter.render(node);
     } catch (IOException e) {
       throw new InterpretException(e.getMessage(), e, tagNode.getLineNumber(), tagNode.getStartPosition());
     } finally {
       interpreter.getContext().getIncludePathStack().pop();
+      interpreter.getContext().getCurrentPathStack().pop();
     }
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
@@ -55,7 +55,7 @@ public class ImportTagTest {
     interpreter.render(Resources.toString(Resources.getResource("tags/importtag/imports-self.jinja"), StandardCharsets.UTF_8));
     assertThat(context.get("c")).isEqualTo("hello");
 
-    assertThat(interpreter.getErrorsCopy().get(0).getMessage()).contains("Rendering cycle detected:", "imports-self.jinja");
+    assertThat(interpreter.getErrorsCopy().get(0).getMessage()).contains("Import cycle detected", "imports-self.jinja");
   }
 
   @Test
@@ -67,7 +67,7 @@ public class ImportTagTest {
     assertThat(context.get("a")).isEqualTo("foo");
     assertThat(context.get("b")).isEqualTo("bar");
 
-    assertThat(interpreter.getErrorsCopy().get(0).getMessage()).contains("Rendering cycle detected:", "b-imports-a.jinja");
+    assertThat(interpreter.getErrorsCopy().get(0).getMessage()).contains("Import cycle detected", "b-imports-a.jinja");
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
@@ -111,6 +111,17 @@ public class ImportTagTest {
     assertThat(interpreter.getErrorsCopy()).hasSize(0);
   }
 
+  @Test
+  public void itAddsImportResourcePathToMacrosToUseAsCurrentPath() throws IOException {
+    Jinjava jinjava = new Jinjava();
+    interpreter = new JinjavaInterpreter(jinjava, context, jinjava.getGlobalConfig());
+
+    interpreter.render(Resources.toString(Resources.getResource("tags/importtag/imports-global-macro.jinja"), StandardCharsets.UTF_8));
+
+    assertThat(interpreter.getContext().getGlobalMacro("getPath").getLocalContextScope().get(Context.IMPORT_RESOURCE_PATH_KEY))
+        .isEqualTo("tags/macrotag/simple.jinja");
+  }
+
   private String fixture(String name) {
     try {
       return interpreter.renderFlat(Resources.toString(

--- a/src/test/resources/tags/importtag/imports-global-macro.jinja
+++ b/src/test/resources/tags/importtag/imports-global-macro.jinja
@@ -1,0 +1,1 @@
+{% import "tags/macrotag/simple.jinja" %}


### PR DESCRIPTION
This PR is to support resolving relative paths located in a separate file for cases such as HubSpot custom modules.
- It adds a `peek()` method to `CallStack` to allow looking at the top of the include/extend stack in order to determine what file a tag is located in.
- It adds `importResourcePath` to the local context of each macro in `ImportTag` so that the macro will know which file it originated from.

Let me know if additional information is needed.