### PR TITLE
Refactor tags to use static strings for tag names.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/AutoEscapeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/AutoEscapeTag.java
@@ -23,18 +23,12 @@ import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 public class AutoEscapeTag implements Tag {
 
   public static final String TAG_NAME = "autoescape";
-  public static final String END_TAG_NAME = "endautoescape";
 
   private static final long serialVersionUID = 786006577642541285L;
 
   @Override
   public String getName() {
     return TAG_NAME;
-  }
-
-  @Override
-  public String getEndTagName() {
-    return END_TAG_NAME;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/AutoEscapeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/AutoEscapeTag.java
@@ -21,16 +21,20 @@ import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
                 "{% endautoescape %}")
     })
 public class AutoEscapeTag implements Tag {
+
+  public static final String TAG_NAME = "autoescape";
+  public static final String END_TAG_NAME = "endautoescape";
+
   private static final long serialVersionUID = 786006577642541285L;
 
   @Override
   public String getName() {
-    return "autoescape";
+    return TAG_NAME;
   }
 
   @Override
   public String getEndTagName() {
-    return "endautoescape";
+    return END_TAG_NAME;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/BlockTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/BlockTag.java
@@ -45,7 +45,6 @@ import com.hubspot.jinjava.util.WhitespaceUtils;
 public class BlockTag implements Tag {
 
   public static final String TAG_NAME = "block";
-  public static final String END_TAG_NAME = "endblock";
 
   private static final long serialVersionUID = -2362317415797088108L;
 
@@ -66,11 +65,6 @@ public class BlockTag implements Tag {
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     throw new UnsupportedOperationException("BlockTag must be rendered directly via interpretOutput() method");
-  }
-
-  @Override
-  public String getEndTagName() {
-    return END_TAG_NAME;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/BlockTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/BlockTag.java
@@ -43,6 +43,10 @@ import com.hubspot.jinjava.util.WhitespaceUtils;
                 "{% endblock %}"),
     })
 public class BlockTag implements Tag {
+
+  public static final String TAG_NAME = "block";
+  public static final String END_TAG_NAME = "endblock";
+
   private static final long serialVersionUID = -2362317415797088108L;
 
   @Override
@@ -66,12 +70,12 @@ public class BlockTag implements Tag {
 
   @Override
   public String getEndTagName() {
-    return "endblock";
+    return END_TAG_NAME;
   }
 
   @Override
   public String getName() {
-    return "block";
+    return TAG_NAME;
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/CallTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/CallTag.java
@@ -51,18 +51,12 @@ import com.hubspot.jinjava.tree.TagNode;
 public class CallTag implements Tag {
 
   public static final String TAG_NAME = "call";
-  public static final String END_TAG_NAME = "endcall";
 
   private static final long serialVersionUID = 7231253469979314727L;
 
   @Override
   public String getName() {
     return TAG_NAME;
-  }
-
-  @Override
-  public String getEndTagName() {
-    return END_TAG_NAME;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/CallTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/CallTag.java
@@ -50,16 +50,19 @@ import com.hubspot.jinjava.tree.TagNode;
     })
 public class CallTag implements Tag {
 
+  public static final String TAG_NAME = "call";
+  public static final String END_TAG_NAME = "endcall";
+
   private static final long serialVersionUID = 7231253469979314727L;
 
   @Override
   public String getName() {
-    return "call";
+    return TAG_NAME;
   }
 
   @Override
   public String getEndTagName() {
-    return "endcall";
+    return END_TAG_NAME;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/CycleTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/CycleTag.java
@@ -46,9 +46,10 @@ import com.hubspot.jinjava.util.HelperStringTokenizer;
     })
 public class CycleTag implements Tag {
 
+  public static final String TAG_NAME = "cycle";
+
   private static final long serialVersionUID = 9145890505287556784L;
   private static final String LOOP_INDEX = "loop.index0";
-  private static final String TAGNAME = "cycle";
 
   @Override
   public boolean isRenderedInValidationMode() {
@@ -105,7 +106,7 @@ public class CycleTag implements Tag {
 
   @Override
   public String getName() {
-    return TAGNAME;
+    return TAG_NAME;
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/DoTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/DoTag.java
@@ -16,6 +16,8 @@ import com.hubspot.jinjava.tree.TagNode;
     })
 public class DoTag implements Tag {
 
+  public static final String TAG_NAME = "do";
+
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
 
@@ -34,6 +36,6 @@ public class DoTag implements Tag {
 
   @Override
   public String getName() {
-    return "do";
+    return TAG_NAME;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ElseIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ElseIfTag.java
@@ -7,8 +7,9 @@ import com.hubspot.jinjava.tree.TagNode;
 @JinjavaDoc(value = "", hidden = true)
 public class ElseIfTag implements Tag {
 
+  public static final String TAG_NAME = "elif";
+
   private static final long serialVersionUID = -7988057025956316803L;
-  static final String ELSEIF = "elif";
 
   @Override
   public boolean isRenderedInValidationMode() {
@@ -27,7 +28,7 @@ public class ElseIfTag implements Tag {
 
   @Override
   public String getName() {
-    return ELSEIF;
+    return TAG_NAME;
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ElseTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ElseTag.java
@@ -22,8 +22,9 @@ import com.hubspot.jinjava.tree.TagNode;
 @JinjavaDoc(value = "", hidden = true)
 public class ElseTag implements Tag {
 
+  public static final String TAG_NAME = "else";
+
   private static final long serialVersionUID = 1082768429113702148L;
-  static final String ELSE = "else";
 
   @Override
   public boolean isRenderedInValidationMode() {
@@ -42,7 +43,7 @@ public class ElseTag implements Tag {
 
   @Override
   public String getName() {
-    return ELSE;
+    return TAG_NAME;
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ExtendsTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ExtendsTag.java
@@ -76,6 +76,9 @@ import com.hubspot.jinjava.util.HelperStringTokenizer;
                 "{% endblock %}")
     })
 public class ExtendsTag implements Tag {
+
+  public static final String TAG_NAME = "extends";
+
   private static final long serialVersionUID = 4692863362280761393L;
 
   @Override
@@ -108,7 +111,7 @@ public class ExtendsTag implements Tag {
 
   @Override
   public String getName() {
-    return "extends";
+    return TAG_NAME;
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -74,7 +74,6 @@ import com.hubspot.jinjava.util.ObjectIterator;
 public class ForTag implements Tag {
 
   public static final String TAG_NAME = "for";
-  public static final String END_TAG_NAME = "endfor";
 
   private static final long serialVersionUID = 6175143875754966497L;
   private static final String LOOP = "loop";
@@ -187,11 +186,6 @@ public class ForTag implements Tag {
 
       return buff.toString();
     }
-  }
-
-  @Override
-  public String getEndTagName() {
-    return END_TAG_NAME;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -73,10 +73,11 @@ import com.hubspot.jinjava.util.ObjectIterator;
     })
 public class ForTag implements Tag {
 
+  public static final String TAG_NAME = "for";
+  public static final String END_TAG_NAME = "endfor";
+
   private static final long serialVersionUID = 6175143875754966497L;
   private static final String LOOP = "loop";
-  private static final String TAGNAME = "for";
-  private static final String ENDTAGNAME = "endfor";
 
   @Override
   public boolean isRenderedInValidationMode() {
@@ -190,12 +191,12 @@ public class ForTag implements Tag {
 
   @Override
   public String getEndTagName() {
-    return ENDTAGNAME;
+    return END_TAG_NAME;
   }
 
   @Override
   public String getName() {
-    return TAGNAME;
+    return TAG_NAME;
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/FromTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/FromTag.java
@@ -48,11 +48,13 @@ import com.hubspot.jinjava.util.HelperStringTokenizer;
     })
 public class FromTag implements Tag {
 
+  public static final String TAG_NAME = "from";
+
   private static final long serialVersionUID = 6152691434172265022L;
 
   @Override
   public String getName() {
-    return "from";
+    return TAG_NAME;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IfTag.java
@@ -49,7 +49,6 @@ import com.hubspot.jinjava.util.ObjectTruthValue;
 public class IfTag implements Tag {
 
   public static final String TAG_NAME = "if";
-  public static final String END_TAG_NAME = "endif";
 
   private static final long serialVersionUID = -3784039314941268904L;
 
@@ -110,11 +109,6 @@ public class IfTag implements Tag {
 
   protected boolean isPositiveIfElseNode(TagNode tagNode, JinjavaInterpreter interpreter) {
     return ObjectTruthValue.evaluate(interpreter.resolveELExpression(tagNode.getHelpers(), tagNode.getLineNumber()));
-  }
-
-  @Override
-  public String getEndTagName() {
-    return END_TAG_NAME;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IfTag.java
@@ -48,9 +48,10 @@ import com.hubspot.jinjava.util.ObjectTruthValue;
     })
 public class IfTag implements Tag {
 
+  public static final String TAG_NAME = "if";
+  public static final String END_TAG_NAME = "endif";
+
   private static final long serialVersionUID = -3784039314941268904L;
-  private static final String TAGNAME = "if";
-  private static final String ENDTAGNAME = "endif";
 
   @Override
   public boolean isRenderedInValidationMode() {
@@ -84,10 +85,10 @@ public class IfTag implements Tag {
         Node node = nodeIterator.next();
         if (TagNode.class.isAssignableFrom(node.getClass())) {
           TagNode tag = (TagNode) node;
-          if (tag.getName().equals(ElseIfTag.ELSEIF)) {
+          if (tag.getName().equals(ElseIfTag.TAG_NAME)) {
             execute = !executedAnyBlock && isPositiveIfElseNode(tag, interpreter);
             continue;
-          } else if (tag.getName().equals(ElseTag.ELSE)) {
+          } else if (tag.getName().equals(ElseTag.TAG_NAME)) {
             execute = !executedAnyBlock;
             continue;
           }
@@ -113,12 +114,12 @@ public class IfTag implements Tag {
 
   @Override
   public String getEndTagName() {
-    return ENDTAGNAME;
+    return END_TAG_NAME;
   }
 
   @Override
   public String getName() {
-    return TAGNAME;
+    return TAG_NAME;
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IfchangedTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IfchangedTag.java
@@ -36,7 +36,6 @@ import com.hubspot.jinjava.tree.TagNode;
 public class IfchangedTag implements Tag {
 
   public static final String TAG_NAME = "ifchanged";
-  public static final String END_TAG_NAME = "endifchanged";
 
   private static final long serialVersionUID = 3567908136629704724L;
   private static final String LASTKEY = "'IF\"CHG";
@@ -66,11 +65,6 @@ public class IfchangedTag implements Tag {
       return sb.toString();
     }
     return "";
-  }
-
-  @Override
-  public String getEndTagName() {
-    return END_TAG_NAME;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IfchangedTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IfchangedTag.java
@@ -35,10 +35,11 @@ import com.hubspot.jinjava.tree.TagNode;
     })
 public class IfchangedTag implements Tag {
 
+  public static final String TAG_NAME = "ifchanged";
+  public static final String END_TAG_NAME = "endifchanged";
+
   private static final long serialVersionUID = 3567908136629704724L;
   private static final String LASTKEY = "'IF\"CHG";
-  private static final String TAGNAME = "ifchanged";
-  private static final String ENDTAGNAME = "endifchanged";
 
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
@@ -69,12 +70,12 @@ public class IfchangedTag implements Tag {
 
   @Override
   public String getEndTagName() {
-    return ENDTAGNAME;
+    return END_TAG_NAME;
   }
 
   @Override
   public String getName() {
-    return TAGNAME;
+    return TAG_NAME;
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -54,11 +54,14 @@ import com.hubspot.jinjava.util.HelperStringTokenizer;
                 "{{ header_footer.footer('h3', 'Company footer info') }}")
     })
 public class ImportTag implements Tag {
+
+  public static final String TAG_NAME = "import";
+
   private static final long serialVersionUID = 8433638845398005260L;
 
   @Override
   public String getName() {
-    return "import";
+    return TAG_NAME;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IncludeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IncludeTag.java
@@ -47,6 +47,9 @@ import com.hubspot.jinjava.util.HelperStringTokenizer;
         @JinjavaSnippet(code = "{% include \"hubspot/styles/patches/recommended.css\" %}")
     })
 public class IncludeTag implements Tag {
+
+  public static final String TAG_NAME = "include";
+
   private static final long serialVersionUID = -8391753639874726854L;
 
   @Override
@@ -91,7 +94,7 @@ public class IncludeTag implements Tag {
 
   @Override
   public String getName() {
-    return "include";
+    return TAG_NAME;
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
@@ -48,7 +48,6 @@ import com.hubspot.jinjava.tree.TagNode;
 public class MacroTag implements Tag {
 
   public static final String TAG_NAME = "macro";
-  public static final String END_TAG_NAME = "endmacro";
 
   private static final long serialVersionUID = 8397609322126956077L;
 
@@ -58,11 +57,6 @@ public class MacroTag implements Tag {
   @Override
   public String getName() {
     return TAG_NAME;
-  }
-
-  @Override
-  public String getEndTagName() {
-    return END_TAG_NAME;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
@@ -47,6 +47,9 @@ import com.hubspot.jinjava.tree.TagNode;
     })
 public class MacroTag implements Tag {
 
+  public static final String TAG_NAME = "macro";
+  public static final String END_TAG_NAME = "endmacro";
+
   private static final long serialVersionUID = 8397609322126956077L;
 
   private static final Pattern MACRO_PATTERN = Pattern.compile("([a-zA-Z_][\\w_]*)[^(]*\\(([^)]*)\\)");
@@ -54,12 +57,12 @@ public class MacroTag implements Tag {
 
   @Override
   public String getName() {
-    return "macro";
+    return TAG_NAME;
   }
 
   @Override
   public String getEndTagName() {
-    return "endmacro";
+    return END_TAG_NAME;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/PrintTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/PrintTag.java
@@ -18,11 +18,13 @@ import com.hubspot.jinjava.tree.TagNode;
     })
 public class PrintTag implements Tag {
 
+  public static final String TAG_NAME = "print";
+
   private static final long serialVersionUID = -8613906103187594569L;
 
   @Override
   public String getName() {
-    return "print";
+    return TAG_NAME;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/RawTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/RawTag.java
@@ -19,16 +19,20 @@ import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
         ),
     })
 public class RawTag implements Tag {
+
+  public static final String TAG_NAME = "raw";
+  public static final String END_TAG_NAME = "endraw";
+
   private static final long serialVersionUID = -6963360187396753883L;
 
   @Override
   public String getName() {
-    return "raw";
+    return TAG_NAME;
   }
 
   @Override
   public String getEndTagName() {
-    return "endraw";
+    return END_TAG_NAME;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/RawTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/RawTag.java
@@ -21,18 +21,12 @@ import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 public class RawTag implements Tag {
 
   public static final String TAG_NAME = "raw";
-  public static final String END_TAG_NAME = "endraw";
 
   private static final long serialVersionUID = -6963360187396753883L;
 
   @Override
   public String getName() {
     return TAG_NAME;
-  }
-
-  @Override
-  public String getEndTagName() {
-    return END_TAG_NAME;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
@@ -53,12 +53,13 @@ import com.hubspot.jinjava.tree.TagNode;
     })
 public class SetTag implements Tag {
 
+  public static final String TAG_NAME = "set";
+
   private static final long serialVersionUID = -8558479410226781539L;
-  private static final String TAGNAME = "set";
 
   @Override
   public String getName() {
-    return TAGNAME;
+    return TAG_NAME;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/Tag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/Tag.java
@@ -34,10 +34,11 @@ public interface Tag extends Importable, Serializable {
   /**
    * @return Get name of end tag (lowerCase). Null if it's a single tag without content.
    */
-  String getEndTagName();
+  default String getEndTagName() {
+    return String.format("end%s", getName());
+  }
 
   default boolean isRenderedInValidationMode() {
     return false;
   }
-
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/UnlessTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/UnlessTag.java
@@ -22,16 +22,19 @@ import com.hubspot.jinjava.util.ObjectTruthValue;
     snippets = @JinjavaSnippet(code = "{% unless x < 0 %} x is greater than zero {% endunless %}"))
 public class UnlessTag extends IfTag {
 
+  public static final String TAG_NAME = "unless";
+  public static final String END_TAG_NAME = "endunless";
+
   private static final long serialVersionUID = 1562284758153763419L;
 
   @Override
   public String getName() {
-    return "unless";
+    return TAG_NAME;
   }
 
   @Override
   public String getEndTagName() {
-    return "endunless";
+    return END_TAG_NAME;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/UnlessTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/UnlessTag.java
@@ -23,18 +23,12 @@ import com.hubspot.jinjava.util.ObjectTruthValue;
 public class UnlessTag extends IfTag {
 
   public static final String TAG_NAME = "unless";
-  public static final String END_TAG_NAME = "endunless";
 
   private static final long serialVersionUID = 1562284758153763419L;
 
   @Override
   public String getName() {
     return TAG_NAME;
-  }
-
-  @Override
-  public String getEndTagName() {
-    return END_TAG_NAME;
   }
 
   @Override


### PR DESCRIPTION
This makes it a lot easier to build tag exclusion lists for interpreters.