### PR TITLE
Rewrite sort filter to address several problems.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/InvalidReason.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/InvalidReason.java
@@ -9,7 +9,9 @@ public enum InvalidReason {
   JSON_READ("could not be converted to an object"),
   JSON_WRITE("object could not be written as a string"),
   REGEX("with value %s must be valid regex"),
-  POSITIVE_NUMBER("with value %s must be a positive number")
+  POSITIVE_NUMBER("with value %s must be a positive number"),
+  NULL_IN_LIST("of type 'list' cannot contain a null item"),
+  NULL_ATTRIBUTE_IN_LIST("with value '%s' must be a valid attribute of every item in the list")
   ;
 
   private final String errorMessage;

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SortFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SortFilter.java
@@ -68,8 +68,7 @@ public class SortFilter implements Filter {
 
     List<String> attr = getAttributeArgument(interpreter, args);
 
-    List<?> result = Lists.newArrayList(ObjectIterator.getLoop(var));
-    return result.stream()
+    return Lists.newArrayList(ObjectIterator.getLoop(var)).stream()
         .sorted(Comparator.comparing((o) -> mapObject(interpreter, o, attr),
             new ObjectComparator(reverse, caseSensitive)))
         .collect(Collectors.toList());

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SortFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SortFilter.java
@@ -1,17 +1,23 @@
 package com.hubspot.jinjava.lib.filter;
 
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.BooleanUtils;
 
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
+import com.hubspot.jinjava.interpret.InvalidInputException;
+import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.util.ObjectIterator;
-import com.hubspot.jinjava.util.Variable;
 
 @JinjavaDoc(
     value = "Sort an iterable.",
@@ -35,6 +41,9 @@ import com.hubspot.jinjava.util.Variable;
     })
 public class SortFilter implements Filter {
 
+  private static final Splitter DOT_SPLITTER = Splitter.on('.').omitEmptyStrings();
+  private static final Joiner DOT_JOINER = Joiner.on('.');
+
   @Override
   public String getName() {
     return "sort";
@@ -56,43 +65,55 @@ public class SortFilter implements Filter {
       caseSensitive = BooleanUtils.toBoolean(args[1]);
     }
 
-    String attr = null;
-    if (args.length > 2) {
-      attr = args[2];
-    }
+    List<String> attr = getAttributeArgument(interpreter, args);
 
     List<?> result = Lists.newArrayList(ObjectIterator.getLoop(var));
-    result.sort(new ObjectComparator(interpreter, reverse, caseSensitive, attr));
+    return result.stream()
+        .sorted(Comparator.comparing((o) -> mapObject(interpreter, o, attr), new ObjectComparator(interpreter, reverse, caseSensitive)))
+        .collect(Collectors.toList());
+  }
 
+  private List<String> getAttributeArgument(JinjavaInterpreter interpreter, String[] args) {
+    if (args.length > 2) {
+      String attrArg = args[2];
+      if (attrArg == null) {
+        throw new InvalidArgumentException(interpreter, this, InvalidReason.NULL, 2);
+      }
+      return DOT_SPLITTER.splitToList(attrArg);
+    }
+    return Collections.emptyList();
+  }
+
+  private Object mapObject(JinjavaInterpreter interpreter, Object o, List<String> propertyChain) {
+
+    if (o == null) {
+      throw new InvalidInputException(interpreter, this, InvalidReason.NULL_IN_LIST);
+    }
+
+    if (propertyChain.isEmpty()) {
+      return o;
+    }
+
+    Object result = interpreter.resolveProperty(o, propertyChain);
+    if (result == null) {
+      throw new InvalidArgumentException(interpreter, this, InvalidReason.NULL_ATTRIBUTE_IN_LIST, 2, DOT_JOINER.join(propertyChain));
+    }
     return result;
   }
 
   private static class ObjectComparator implements Comparator<Object> {
     private final boolean reverse;
     private final boolean caseSensitive;
-    private final Variable variable;
 
-    ObjectComparator(JinjavaInterpreter interpreter, boolean reverse, boolean caseSensitive, String attr) {
+    ObjectComparator(JinjavaInterpreter interpreter, boolean reverse, boolean caseSensitive) {
       this.reverse = reverse;
       this.caseSensitive = caseSensitive;
-
-      if (attr != null) {
-        this.variable = new Variable(interpreter, "o." + attr);
-      }
-      else {
-        this.variable = null;
-      }
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public int compare(Object o1, Object o2) {
       int result = 0;
-
-      if (variable != null) {
-        o1 = variable.resolve(o1);
-        o2 = variable.resolve(o2);
-      }
 
       if (o1 instanceof String && !caseSensitive) {
         result = ((String) o1).compareToIgnoreCase((String) o2);

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SortFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SortFilter.java
@@ -56,33 +56,17 @@ public class SortFilter implements Filter {
       return null;
     }
 
-    boolean reverse = false;
-    if (args.length > 0) {
-      reverse = BooleanUtils.toBoolean(args[0]);
-    }
+    boolean reverse = args.length > 0 && BooleanUtils.toBoolean(args[0]);
+    boolean caseSensitive = args.length > 1 && BooleanUtils.toBoolean(args[1]);
 
-    boolean caseSensitive = false;
-    if (args.length > 1) {
-      caseSensitive = BooleanUtils.toBoolean(args[1]);
-    }
-
-    List<String> attr = getAttributeArgument(interpreter, args);
+    List<String> attr = args.length > 2 && args[2] != null
+        ? DOT_SPLITTER.splitToList(args[2])
+        : Collections.emptyList();
 
     return Lists.newArrayList(ObjectIterator.getLoop(var)).stream()
         .sorted(Comparator.comparing((o) -> mapObject(interpreter, o, attr),
             new ObjectComparator(reverse, caseSensitive)))
         .collect(Collectors.toList());
-  }
-
-  private List<String> getAttributeArgument(JinjavaInterpreter interpreter, String[] args) {
-    if (args.length > 2) {
-      String attrArg = args[2];
-      if (attrArg == null) {
-        throw new InvalidArgumentException(interpreter, this, InvalidReason.NULL, 2);
-      }
-      return DOT_SPLITTER.splitToList(attrArg);
-    }
-    return Collections.emptyList();
   }
 
   private Object mapObject(JinjavaInterpreter interpreter, Object o, List<String> propertyChain) {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SortFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SortFilter.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.filter;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -69,7 +70,8 @@ public class SortFilter implements Filter {
 
     List<?> result = Lists.newArrayList(ObjectIterator.getLoop(var));
     return result.stream()
-        .sorted(Comparator.comparing((o) -> mapObject(interpreter, o, attr), new ObjectComparator(interpreter, reverse, caseSensitive)))
+        .sorted(Comparator.comparing((o) -> mapObject(interpreter, o, attr),
+            new ObjectComparator(reverse, caseSensitive)))
         .collect(Collectors.toList());
   }
 
@@ -101,11 +103,11 @@ public class SortFilter implements Filter {
     return result;
   }
 
-  private static class ObjectComparator implements Comparator<Object> {
+  private static class ObjectComparator implements Comparator<Object>, Serializable {
     private final boolean reverse;
     private final boolean caseSensitive;
 
-    ObjectComparator(JinjavaInterpreter interpreter, boolean reverse, boolean caseSensitive) {
+    ObjectComparator(boolean reverse, boolean caseSensitive) {
       this.reverse = reverse;
       this.caseSensitive = caseSensitive;
     }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SortFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SortFilter.java
@@ -59,10 +59,11 @@ public class SortFilter implements Filter {
     boolean reverse = args.length > 0 && BooleanUtils.toBoolean(args[0]);
     boolean caseSensitive = args.length > 1 && BooleanUtils.toBoolean(args[1]);
 
-    List<String> attr = args.length > 2 && args[2] != null
-        ? DOT_SPLITTER.splitToList(args[2])
-        : Collections.emptyList();
+    if (args.length > 2 && args[2] == null) {
+      throw new InvalidArgumentException(interpreter, this, InvalidReason.NULL, 2);
+    }
 
+    List<String> attr = args.length > 2 ? DOT_SPLITTER.splitToList(args[2]) : Collections.emptyList();
     return Lists.newArrayList(ObjectIterator.getLoop(var)).stream()
         .sorted(Comparator.comparing((o) -> mapObject(interpreter, o, attr),
             new ObjectComparator(reverse, caseSensitive)))
@@ -81,7 +82,11 @@ public class SortFilter implements Filter {
 
     Object result = interpreter.resolveProperty(o, propertyChain);
     if (result == null) {
-      throw new InvalidArgumentException(interpreter, this, InvalidReason.NULL_ATTRIBUTE_IN_LIST, 2, DOT_JOINER.join(propertyChain));
+      throw new InvalidArgumentException(interpreter,
+          this,
+          InvalidReason.NULL_ATTRIBUTE_IN_LIST,
+          2,
+          DOT_JOINER.join(propertyChain));
     }
     return result;
   }


### PR DESCRIPTION
So a few problems with the previous implementation addressed in this PR:

- If an object in the list is null, we would throw an unhelpful NPE.

- If the attribute is null, we just pretend it wasn't passed in in the first place.

- If the attribute resolution is null, we would throw an unhelpful NPE.

- We would do attribute resolution on every object comparison resulting in O(nlogn) resolutions instead of O(n).

To fix we now throw useful error messages. We also use streams and a keyExtractor method for the comparison so attribute resolution only happens once per object.