### PR TITLE
Add a warning when there is no matching start tag for an end tag

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -199,11 +199,13 @@ public class TreeParser {
       parent.getMaster().setRightTrimAfterEnd(tagToken.isRightTrim());
     }
 
+    boolean hasMatchingStartTag = false;
     while (!(parent instanceof RootNode)) {
       TagNode parentTag = (TagNode) parent;
       parent = parent.getParent();
 
       if (parentTag.getEndName().equals(tag.getEndTagName())) {
+        hasMatchingStartTag = true;
         break;
       } else {
         interpreter.addError(TemplateError.fromException(
@@ -211,6 +213,18 @@ public class TreeParser {
                                         "Mismatched end tag, expected: " + parentTag.getEndName(),
                                         tagToken.getLineNumber(), tagToken.getStartPosition())));
       }
+    }
+    if (!hasMatchingStartTag) {
+      interpreter.addError(new TemplateError(
+          ErrorType.WARNING,
+          ErrorReason.SYNTAX_ERROR,
+          ErrorItem.TAG,
+          "Missing start tag",
+          tag.getName(),
+          tagToken.getLineNumber(),
+          tagToken.getStartPosition(),
+          null
+      ));
     }
   }
 }

--- a/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
@@ -11,6 +11,7 @@ import com.google.common.io.Resources;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 
 public class TreeParserTest {
 
@@ -84,6 +85,16 @@ public class TreeParserTest {
         .isEqualTo("<div>\n"
             + "        yay\n"
             + "</div>\n");
+  }
+
+  @Test
+  public void itWarnsAgainstMissingStartTags() {
+    String expression = "{% if true %} foo {% endif %} {% endif %}";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.getErrors()).hasSize(1);
+    assertThat(interpreter.getErrors().get(0).getSeverity()).isEqualTo(ErrorType.WARNING);
+    assertThat(interpreter.getErrors().get(0).getMessage()).isEqualTo("Missing start tag");
+    assertThat(interpreter.getErrors().get(0).getFieldName()).isEqualTo("endif");
   }
 
   Node parse(String fixture) {


### PR DESCRIPTION
The following syntax is allowed by Jinjava:
```
{% if true %}
foo
{% endif %}
{% endif %}
```
This causes no issues in isolation, but can result in mismatched end tags when inserted in the middle of a template such as in a generated `module_attribute` tag. Adding a warning will help make this danger more apparent and prevent cases such as this from causing problems.