### PR TITLE
defer variables containing deferred vals & track deferred nodes in context

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -144,6 +144,7 @@ public class Context extends ScopeMap<String, Object> {
     resolvedValues.clear();
     resolvedFunctions.clear();
     dependencies = HashMultimap.create();
+    deferredNodes.clear();
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -28,7 +28,6 @@ import java.util.Stack;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;
 import com.hubspot.jinjava.lib.Importable;
@@ -78,7 +77,7 @@ public class Context extends ScopeMap<String, Object> {
   private final Set<String> resolvedValues = new HashSet<>();
   private final Set<String> resolvedFunctions = new HashSet<>();
 
-  private List<Node> deferredNodes = new ArrayList<>();
+  private Set<Node> deferredNodes = new HashSet<>();
 
   private final ExpTestLibrary expTestLibrary;
   private final FilterLibrary filterLibrary;
@@ -144,7 +143,7 @@ public class Context extends ScopeMap<String, Object> {
     resolvedValues.clear();
     resolvedFunctions.clear();
     dependencies = HashMultimap.create();
-    deferredNodes = new ArrayList<>();
+    deferredNodes = new HashSet<>();
   }
 
   @Override
@@ -250,8 +249,8 @@ public class Context extends ScopeMap<String, Object> {
     }
   }
 
-  public List<Node> getDeferredNodes() {
-    return ImmutableList.copyOf(deferredNodes);
+  public Set<Node> getDeferredNodes() {
+    return ImmutableSet.copyOf(deferredNodes);
   }
 
   public List<? extends Node> getSuperBlock() {

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -28,6 +28,7 @@ import java.util.Stack;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;
 import com.hubspot.jinjava.lib.Importable;
@@ -76,6 +77,8 @@ public class Context extends ScopeMap<String, Object> {
   private final Set<String> resolvedExpressions = new HashSet<>();
   private final Set<String> resolvedValues = new HashSet<>();
   private final Set<String> resolvedFunctions = new HashSet<>();
+
+  private final List<Node> deferredNodes = new ArrayList<>();
 
   private final ExpTestLibrary expTestLibrary;
   private final FilterLibrary filterLibrary;
@@ -237,6 +240,17 @@ public class Context extends ScopeMap<String, Object> {
     if (getParent() != null) {
       getParent().addResolvedFunction(function);
     }
+  }
+
+  public void addDeferredNode(Node node) {
+    deferredNodes.add(node);
+    if (getParent() != null) {
+      getParent().addDeferredNode(node);
+    }
+  }
+
+  public List<Node> getDeferredNodes() {
+    return ImmutableList.copyOf(deferredNodes);
   }
 
   public List<? extends Node> getSuperBlock() {

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -78,7 +78,7 @@ public class Context extends ScopeMap<String, Object> {
   private final Set<String> resolvedValues = new HashSet<>();
   private final Set<String> resolvedFunctions = new HashSet<>();
 
-  private final List<Node> deferredNodes = new ArrayList<>();
+  private List<Node> deferredNodes = new ArrayList<>();
 
   private final ExpTestLibrary expTestLibrary;
   private final FilterLibrary filterLibrary;
@@ -144,7 +144,7 @@ public class Context extends ScopeMap<String, Object> {
     resolvedValues.clear();
     resolvedFunctions.clear();
     dependencies = HashMultimap.create();
-    deferredNodes.clear();
+    deferredNodes = new ArrayList<>();
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -245,6 +245,7 @@ public class JinjavaInterpreter {
         try {
           out = node.render(this);
         } catch (DeferredValueException e) {
+          context.addDeferredNode(node);
           out = new RenderedOutputNode(node.getMaster().getImage());
         }
         context.popRenderStack();

--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -44,6 +44,7 @@ public class ExpressionNode extends Node {
     try {
       var = interpreter.resolveELExpression(master.getExpr(), getLineNumber());
     } catch (DeferredValueException e){
+      interpreter.getContext().addDeferredNode(this);
       var = master.getImage();
     }
 

--- a/src/main/java/com/hubspot/jinjava/tree/TagNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TagNode.java
@@ -59,6 +59,7 @@ public class TagNode extends Node {
     try {
       return tag.interpretOutput(this, interpreter);
     } catch (DeferredValueException e) {
+      interpreter.getContext().addDeferredNode(this);
       return new RenderedOutputNode(reconstructImage());
     } catch (InterpretException|InvalidInputException| InvalidArgumentException e) {
       throw e;

--- a/src/main/java/com/hubspot/jinjava/tree/TagNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TagNode.java
@@ -97,15 +97,17 @@ public class TagNode extends Node {
       builder.append(n.getMaster().getImage());
     }
 
-    String endTag = String.format(
-        "%s%s %s %s%s",
-        TokenScannerSymbols.TOKEN_EXPR_START_CHAR,
-        TokenScannerSymbols.TOKEN_TAG_CHAR,
-        getEndName(),
-        TokenScannerSymbols.TOKEN_TAG_CHAR,
-        TokenScannerSymbols.TOKEN_EXPR_END_CHAR
-    );
-    builder.append(endTag);
+    if (getEndName() != null) {
+      String endTag = String.format(
+          "%s%s %s %s%s",
+          TokenScannerSymbols.TOKEN_EXPR_START_CHAR,
+          TokenScannerSymbols.TOKEN_TAG_CHAR,
+          getEndName(),
+          TokenScannerSymbols.TOKEN_TAG_CHAR,
+          TokenScannerSymbols.TOKEN_EXPR_END_CHAR
+      );
+      builder.append(endTag);
+    }
 
     return builder.toString();
   }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/SetTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/SetTagTest.java
@@ -199,7 +199,9 @@ public class SetTagTest {
   @Test
   public void itThrowsAndDefersVarWhenValContainsDeferred() {
     context.put("primary_font_size_num", DeferredValue.instance());
+
     TagNode tagNode = (TagNode) fixture("set-var-exp");
+
     assertThatThrownBy(() -> tag.interpret(tagNode, interpreter)).isInstanceOf(DeferredValueException.class);
     assertThat(context).contains(entry("primary_line_height", DeferredValue.instance()));
   }


### PR DESCRIPTION
Following https://github.com/HubSpot/jinjava/pull/282

1. **Make deferred infectious for variables**
It's possible that variables contain deferred values, in that case the assigned variable(s) should be deferred too, since expressions depending on variables containing deferred values can't and shouldn't be evaluated & rendered.

Example:

Input: 

```
<html>
{% set some_var = "email:" + contact.email %} {% if contact.email  %}{{ contact.email }}{% endif %}
<head></head>
<body></body>
</html>
```

Render before the change:

```
<html>
{% set some_var = "email:" + contact.email %}
<head></head>
<body></body>
</html>
```

After the change:

```
<html>
{% set some_var = "email:" + contact.email %}
{% if contact.email  %}
{{ contact.email }}
{% endif %}
<head></head>
<body></body>
</html>
```

2. **Add list to the context to track deferred nodes**
We need some way of tracking which nodes were deferred so that we can escape them before post-processing the rendered template with Jsoup. If Jsoup encounters these kinds of tags in a place where no characters are allowed it changes the template and even ignores following tags inside of that tag.

Example: 

Input:

```
<html>
{% set some_var = "email:" + contact.email %}
{% if contact.email  %}
{{ contact.email }}
{% endif %}
<head>
<meta name="description" content="some content">
</head>
<body></body>
</html>
```

Jsoup output:
```
<html>
 <head></head>
 <body>
{% set some_var = "email:" + contact.email %}
{% if contact.email %}
{{ contact.email }}
{% endif %}
  <meta name="description" content="some content">
 </body>
</html>
```

In order to escape these tags properly we need to know which tags were deferred. 

We also want to handle the case where a deferred tag contains not-deferred variables. We need to be able to take these out of the context later for further processing.

Example:

Input:

```
<html>
{% set defined_var = "defined" %}
{% set some_var = "email:" + contact.email + defined_var  %} 
{% if contact.email  %}
{{ contact.email }}
{% endif %}
<head>
<meta name="description" content="some content">
</head>
<body></body>
</html>
```

Output:

```
<html>
{% set some_var = "email:" + contact.email + defined_var  %} 
{% if contact.email  %}
{{ contact.email }}
{% endif %}
<head>
<meta name="description" content="some content">
</head>
<body></body>
</html>
```

`defined_var` disappears but `some_var` will not be rendered since it contains a deferred value. If we know which tags have been deferred after the render we can take the vars out of the context and pass them along for a second render.

**Considerations:** I've tried a couple of different approaches, including partial evaluation and extracting variables of deferred tags. Both are a lot more complex than I initially thought and too specific to our use-case, especially given the fact that we don't own `ExpressionFactoryImpl` and all the code that this class depends on. IMO this is the most flexible solution, since users can decide what to do with the deferred nodes after rendering is done.