### PR TITLE
Create a new one instead of clear.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -47,7 +47,7 @@ public class Context extends ScopeMap<String, Object> {
   public static final String GLOBAL_MACROS_SCOPE_KEY = "__macros__";
   public static final String IMPORT_RESOURCE_PATH_KEY = "import_resource_path";
 
-  private final SetMultimap<String, String> dependencies = HashMultimap.create();
+  private SetMultimap<String, String> dependencies = HashMultimap.create();
   private Map<Library, Set<String>> disabled;
 
   public boolean isValidationMode() {
@@ -140,7 +140,7 @@ public class Context extends ScopeMap<String, Object> {
     resolvedExpressions.clear();
     resolvedValues.clear();
     resolvedFunctions.clear();
-    dependencies.clear();
+    dependencies = HashMultimap.create();
   }
 
   @Override


### PR DESCRIPTION
Since the JinJava is shared globally, so are the global context and its dependencies. Let's create a new one instead clear it.

```
ConcurrentModificationException
 
java.util.HashMap$HashIterator in nextNode at line 1445
java.util.HashMap$ValueIterator in next at line 1474
com.google.common.collect.AbstractMapBasedMultimap in clear at line 273
com.google.common.collect.HashMultimap in clear at line 46
com.hubspot.jinjava.interpret.Context in reset at line 143
```