### PR TITLE
Add a warning for unclosed comments

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -95,6 +95,18 @@ public class TreeParser {
         return tag((TagToken) token);
 
       case TOKEN_NOTE:
+        if (!token.getImage().endsWith("#}")) {
+          interpreter.addError(new TemplateError(
+              ErrorType.WARNING,
+              ErrorReason.SYNTAX_ERROR,
+              ErrorItem.TAG,
+              "Unclosed comment",
+              "comment",
+              token.getLineNumber(),
+              token.getStartPosition(),
+              null
+          ));
+        }
         break;
 
       default:

--- a/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
@@ -97,6 +97,16 @@ public class TreeParserTest {
     assertThat(interpreter.getErrors().get(0).getFieldName()).isEqualTo("endif");
   }
 
+  @Test
+  public void itWarnsAgainstUnclosedComment() {
+    String expression = "foo {# this is an unclosed comment %}";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.getErrors()).hasSize(1);
+    assertThat(interpreter.getErrors().get(0).getSeverity()).isEqualTo(ErrorType.WARNING);
+    assertThat(interpreter.getErrors().get(0).getMessage()).isEqualTo("Unclosed comment");
+    assertThat(interpreter.getErrors().get(0).getFieldName()).isEqualTo("comment");
+  }
+
   Node parse(String fixture) {
     try {
       return new TreeParser(interpreter, Resources.toString(


### PR DESCRIPTION
Similar to #326:

Consider this following template:
```
foo
{# this is a comment %}
```
The comment in the second line is not actually closed due to a typo. 
This is fine on its own, but would wipe out the rest of the template if this snippet was inserted in the middle of a template such as in a generated `module_attribute` tag. Adding a warning will help make this danger more apparent and prevent cases such as this from causing problems.