### PR TITLE
Support nominative date formats.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
@@ -62,10 +62,12 @@ public class StrftimeFormatter {
    */
   public static String toJavaDateTimeFormat(String strftime) {
     if (!StringUtils.contains(strftime, '%')) {
-      return strftime;
+      return replaceL(strftime);
     }
 
     StringBuilder result = new StringBuilder();
+
+    boolean replaceL = true;
     for (int i = 0; i < strftime.length(); i++) {
       char c = strftime.charAt(i);
       if (c == '%') {
@@ -81,6 +83,7 @@ public class StrftimeFormatter {
         if (c == 'O') {
           c = strftime.charAt(++i);
           conversions = NOMINATIVE_CONVERSIONS;
+          replaceL = false;
         }
 
         if (stripLeadingZero) {
@@ -105,7 +108,12 @@ public class StrftimeFormatter {
       }
     }
 
-    return result.toString();
+    String formatResult = result.toString();
+    return replaceL ? replaceL(formatResult) : formatResult;
+  }
+
+  private static String replaceL(String s) {
+    return StringUtils.replaceChars(s, 'L', 'M');
   }
 
   public static DateTimeFormatter formatter(String strftime) {

--- a/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
@@ -19,6 +19,7 @@ public class StrftimeFormatter {
    * Mapped from http://strftime.org/, http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html
    */
   private static final String[] CONVERSIONS = new String[255];
+  private static final String[] NOMINATIVE_CONVERSIONS = new String[255];
 
   static {
     CONVERSIONS['a'] = "EEE";
@@ -49,6 +50,8 @@ public class StrftimeFormatter {
     CONVERSIONS['z'] = "Z";
     CONVERSIONS['Z'] = "ZZZZ";
     CONVERSIONS['%'] = "%";
+
+    NOMINATIVE_CONVERSIONS['B'] = "LLLL";
   }
 
   /**
@@ -59,26 +62,31 @@ public class StrftimeFormatter {
    */
   public static String toJavaDateTimeFormat(String strftime) {
     if (!StringUtils.contains(strftime, '%')) {
-      return replaceL(strftime);
+      return strftime;
     }
 
     StringBuilder result = new StringBuilder();
-
     for (int i = 0; i < strftime.length(); i++) {
       char c = strftime.charAt(i);
       if (c == '%') {
         c = strftime.charAt(++i);
         boolean stripLeadingZero = false;
+        String[] conversions = CONVERSIONS;
 
         if (c == '-') {
           stripLeadingZero = true;
           c = strftime.charAt(++i);
         }
 
+        if (c == 'O') {
+          c = strftime.charAt(++i);
+          conversions = NOMINATIVE_CONVERSIONS;
+        }
+
         if (stripLeadingZero) {
-          result.append(CONVERSIONS[c].substring(1));
+          result.append(conversions[c].substring(1));
         } else {
-          result.append(CONVERSIONS[c]);
+          result.append(conversions[c]);
         }
       } else if (Character.isLetter(c)) {
         result.append("'");
@@ -97,11 +105,7 @@ public class StrftimeFormatter {
       }
     }
 
-    return replaceL(result.toString());
-  }
-
-  private static String replaceL(String s) {
-    return StringUtils.replaceChars(s, 'L', 'M');
+    return result.toString();
   }
 
   public static DateTimeFormatter formatter(String strftime) {

--- a/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
@@ -88,4 +88,12 @@ public class StrftimeFormatterTest {
     assertThat(StrftimeFormatter.format(d, "%z")).isEqualTo("+0000");
     assertThat(StrftimeFormatter.format(d, "%Z")).isEqualTo("GMT");
   }
+
+  @Test
+  public void itConvertsNominativeFormats() {
+    ZonedDateTime zonedDateTime = ZonedDateTime.parse("2019-06-06T14:22:00.000+00:00");
+
+    assertThat(StrftimeFormatter.formatter("%OB").withLocale(Locale.forLanguageTag("ru")).format(zonedDateTime))
+        .isEqualTo("Июнь");
+  }
 }


### PR DESCRIPTION
Some languages have two version of months (nominative and genitive). By default, JDK8 uses genitive format which can cause issues. This allows you to use `%OB` instead of `%B` to get the nominative version of the month name.