### PR TITLE
Support empty bracket implicit index syntax.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/AstRangeBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstRangeBracket.java
@@ -41,14 +41,9 @@ public class AstRangeBracket extends AstBracket {
       return evalString((String) base, bindings, context);
     }
 
-    Iterable<?> baseItr;
-
-    if (base.getClass().isArray()) {
-      baseItr = Arrays.asList((Object[]) base);
-    }
-    else {
-      baseItr = (Iterable<?>) base;
-    }
+    Iterable<?> baseItr = base.getClass().isArray()
+        ? Arrays.asList((Object[]) base)
+        : (Iterable<?>) base;
 
     Object start = property == null ? 0 : property.eval(bindings, context);
     if (start == null && strict) {

--- a/src/main/java/com/hubspot/jinjava/el/ext/AstRangeBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstRangeBracket.java
@@ -41,7 +41,16 @@ public class AstRangeBracket extends AstBracket {
       return evalString((String) base, bindings, context);
     }
 
-    Object start = property.eval(bindings, context);
+    Iterable<?> baseItr;
+
+    if (base.getClass().isArray()) {
+      baseItr = Arrays.asList((Object[]) base);
+    }
+    else {
+      baseItr = (Iterable<?>) base;
+    }
+
+    Object start = property == null ? 0 : property.eval(bindings, context);
     if (start == null && strict) {
       return Collections.emptyList();
     }
@@ -49,7 +58,7 @@ public class AstRangeBracket extends AstBracket {
       throw new ELException("Range start is not a number");
     }
 
-    Object end = rangeMax.eval(bindings, context);
+    Object end = rangeMax == null ? (Iterables.size(baseItr)) : rangeMax.eval(bindings, context);
     if (end == null && strict) {
       return Collections.emptyList();
     }
@@ -60,21 +69,13 @@ public class AstRangeBracket extends AstBracket {
     int startNum = ((Number) start).intValue();
     int endNum = ((Number) end).intValue();
 
-    Iterable<?> baseItr;
-
-    if (base.getClass().isArray()) {
-      baseItr = Arrays.asList((Object[]) base);
-    }
-    else {
-      baseItr = (Iterable<?>) base;
-    }
-
     PyList result = new PyList(new ArrayList<>());
     int index = 0;
 
     // Handle negative indices.
     if ((startNum < 0) || (endNum < 0)) {
-       int size = Iterables.size(baseItr);
+      // size may have been calculated already
+       int size = rangeMax == null ? endNum : Iterables.size(baseItr);
        if (startNum < 0) {
           startNum += size;
        }

--- a/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
@@ -286,6 +286,12 @@ public class ExtendedSyntaxBuilderTest {
   }
 
   @Test
+  public void arrayWithMissingIndices() {
+    assertThat(val("[1, 2, 3][1:]")).isEqualTo(Lists.newArrayList(2L, 3L));
+    assertThat(val("[1, 2, 3][:2]")).isEqualTo(Lists.newArrayList(1L, 2L));
+  }
+
+  @Test
   public void invalidNestedAssignmentExpr() {
     assertThat(val("content.template_path = 'Custom/Email/Responsive/testing.html'")).isEqualTo(null);
     assertThat(interpreter.getErrorsCopy()).isNotEmpty();

--- a/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
@@ -286,7 +286,7 @@ public class ExtendedSyntaxBuilderTest {
   }
 
   @Test
-  public void arrayWithMissingIndices() {
+  public void arrayWithImplicitIndices() {
     assertThat(val("[1, 2, 3][1:]")).isEqualTo(Lists.newArrayList(2L, 3L));
     assertThat(val("[1, 2, 3][:2]")).isEqualTo(Lists.newArrayList(1L, 2L));
   }


### PR DESCRIPTION
It was not possible previously do something like `list[3:]` to get the sublist of all elements from index 3 to the end, as well as `list[:3]`, the sublist of all elements from index 0 up to index 3.