### PR TITLE
defer import tag & improved reconstructImage

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -113,6 +113,8 @@ public class ImportTag implements Tag {
       if (!child.getContext().getDeferredNodes().isEmpty()){
         node.getChildren().forEach(deferredChild -> interpreter.getContext().addDeferredNode(deferredChild));
         if (StringUtils.isBlank(contextVar)) {
+          childBindings.remove(Context.GLOBAL_MACROS_SCOPE_KEY);
+          childBindings.remove(Context.IMPORT_RESOURCE_PATH_KEY);
           childBindings.keySet().forEach(key -> interpreter.getContext().put(key, DeferredValue.instance()));
         } else {
           interpreter.getContext().put(contextVar, DeferredValue.instance());

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -110,6 +110,7 @@ public class ImportTag implements Tag {
 
       Map<String, Object> childBindings = child.getContext().getSessionBindings();
 
+      // If the template depends on deferred values it should not be rendered and all defined variables should be deferred too
       if (!child.getContext().getDeferredNodes().isEmpty()){
         node.getChildren().forEach(deferredChild -> interpreter.getContext().addDeferredNode(deferredChild));
         if (StringUtils.isBlank(contextVar)) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -109,7 +109,7 @@ public class ImportTag implements Tag {
       Map<String, Object> childBindings = child.getContext().getSessionBindings();
 
       if (!child.getContext().getDeferredNodes().isEmpty()){
-        interpreter.getContext().addDeferredNode(node);
+        node.getChildren().forEach(deferredChild -> interpreter.getContext().addDeferredNode(deferredChild));
         if (StringUtils.isBlank(contextVar)) {
           childBindings.keySet().forEach(key -> interpreter.getContext().put(key, DeferredValue.instance()));
         } else {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -106,6 +106,8 @@ public class ImportTag implements Tag {
         JinjavaInterpreter.popCurrent();
       }
 
+      interpreter.addAllErrors(child.getErrorsCopy());
+
       Map<String, Object> childBindings = child.getContext().getSessionBindings();
 
       if (!child.getContext().getDeferredNodes().isEmpty()){
@@ -118,8 +120,6 @@ public class ImportTag implements Tag {
 
         throw new DeferredValueException(templateFile, tagNode.getLineNumber(), tagNode.getStartPosition());
       }
-
-      interpreter.addAllErrors(child.getErrorsCopy());
 
       if (StringUtils.isBlank(contextVar)) {
         for (MacroFunction macro : child.getContext().getGlobalMacros().values()) {

--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -56,6 +56,10 @@ public class ExpressionNode extends Node {
         try {
           result = interpreter.renderFlat(result);
         } catch (Exception e) {
+          if (e instanceof DeferredValueException){
+            interpreter.getContext().addDeferredNode(this);
+            result = master.getImage();
+          }
           Logging.ENGINE_LOG.warn("Error rendering variable node result", e);
         }
       }

--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -56,10 +56,6 @@ public class ExpressionNode extends Node {
         try {
           result = interpreter.renderFlat(result);
         } catch (Exception e) {
-          if (e instanceof DeferredValueException){
-            interpreter.getContext().addDeferredNode(this);
-            result = master.getImage();
-          }
           Logging.ENGINE_LOG.warn("Error rendering variable node result", e);
         }
       }

--- a/src/main/java/com/hubspot/jinjava/tree/Node.java
+++ b/src/main/java/com/hubspot/jinjava/tree/Node.java
@@ -73,6 +73,10 @@ public abstract class Node implements Serializable {
     this.children = children;
   }
 
+  public String reconstructImage(){
+    return master.getImage();
+  }
+
   public abstract OutputNode render(JinjavaInterpreter interpreter);
 
   public abstract String getName();

--- a/src/main/java/com/hubspot/jinjava/tree/TagNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TagNode.java
@@ -90,26 +90,28 @@ public class TagNode extends Node {
     return tag;
   }
 
-  private String reconstructImage() {
+  public String reconstructImage() {
     StringBuilder builder = new StringBuilder().append(master.getImage());
-
     for (Node n : getChildren()) {
-      builder.append(n.getMaster().getImage());
+      builder.append(n.reconstructImage());
     }
 
     if (getEndName() != null) {
-      String endTag = String.format(
-          "%s%s %s %s%s",
-          TokenScannerSymbols.TOKEN_EXPR_START_CHAR,
-          TokenScannerSymbols.TOKEN_TAG_CHAR,
-          getEndName(),
-          TokenScannerSymbols.TOKEN_TAG_CHAR,
-          TokenScannerSymbols.TOKEN_EXPR_END_CHAR
-      );
-      builder.append(endTag);
+      builder.append(reconstructEnd());
     }
 
     return builder.toString();
+  }
+
+  public String reconstructEnd() {
+    return String.format(
+        "%s%s %s %s%s",
+        TokenScannerSymbols.TOKEN_EXPR_START_CHAR,
+        TokenScannerSymbols.TOKEN_TAG_CHAR,
+        getEndName(),
+        TokenScannerSymbols.TOKEN_TAG_CHAR,
+        TokenScannerSymbols.TOKEN_EXPR_END_CHAR
+    );
   }
 
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
@@ -68,6 +68,13 @@ public class DeferredTest {
     assertThat(interpreter.getErrors()).isEmpty();
   }
 
+  @Test
+  public void itPreservesNestedIfTag() {
+    String output = interpreter.render("{% if deferred %}{% if resolved %}{{resolved}}{% endif %}{% else %}b{% endif %}");
+    assertThat(output).isEqualTo("{% if deferred %}{% if resolved %}{{resolved}}{% endif %}{% else %}b{% endif %}");
+    assertThat(interpreter.getErrors()).isEmpty();
+  }
+
   /**
    * This may or may not be desirable behaviour.
    */

--- a/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
@@ -93,6 +93,14 @@ public class DeferredTest {
   }
 
   @Test
+  public void itPreservesNestedExpressions() {
+    interpreter.getContext().put("nested", "some {{deferred}} value");
+    String output = interpreter.render("Test {{nested}}");
+    assertThat(output).isEqualTo("Test some {{deferred}} value");
+    assertThat(interpreter.getErrors()).isEmpty();
+  }
+
+  @Test
   public void itPreservesForTag() {
     String output = interpreter.render("{% for item in deferred %}{{item.name}}{% else %}last{% endfor %}");
     assertThat(output).isEqualTo("{% for item in deferred %}{{item.name}}{% else %}last{% endfor %}");

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
@@ -80,7 +80,7 @@ public class ImportTagTest {
   }
 
   @Test
-  public void itDefersImportedContextEntirely() {
+  public void itDefersImportedVariable() {
     Jinjava jinjava = new Jinjava();
     interpreter = new JinjavaInterpreter(jinjava, context, jinjava.getGlobalConfig());
     interpreter.getContext().put("primary_font_size_num", DeferredValue.instance());
@@ -89,7 +89,7 @@ public class ImportTagTest {
   }
 
   @Test
-  public void itDefersGloballyImportedContextEntirely() {
+  public void itDefersGloballyImportedVariables() {
     Jinjava jinjava = new Jinjava();
     interpreter = new JinjavaInterpreter(jinjava, context, jinjava.getGlobalConfig());
     interpreter.getContext().put("primary_font_size_num", DeferredValue.instance());
@@ -98,20 +98,16 @@ public class ImportTagTest {
   }
 
   @Test
-  public void itDoesNotRenderAnythingDependingOnImportedContext() {
-    try {
-      Jinjava jinjava = new Jinjava();
-      interpreter = new JinjavaInterpreter(jinjava, context, jinjava.getGlobalConfig());
-      interpreter.getContext().put("primary_font_size_num", DeferredValue.instance());
-      String renderedImport = fixture("import-property");
-      assertThat(renderedImport).isEqualTo(Resources.toString(Resources.getResource("tags/macrotag/import-property.jinja"), StandardCharsets.UTF_8));
-    } catch (IOException e) {
-      throw new RuntimeException();
-    }
+  public void itReconstructsDeferredImportTag() {
+    Jinjava jinjava = new Jinjava();
+    interpreter = new JinjavaInterpreter(jinjava, context, jinjava.getGlobalConfig());
+    interpreter.getContext().put("primary_font_size_num", DeferredValue.instance());
+    String renderedImport = fixture("import-property");
+    assertThat(renderedImport).contains("{% import \"tags/settag/set-var-exp.jinja\" as pegasus %}");
   }
 
   @Test
-  public void itDoesNotRenderAnythingDependingOnGloballyImportedContext() {
+  public void itDoesNotRenderTagsDependingOnDeferredImport() {
     try {
       Jinjava jinjava = new Jinjava();
       interpreter = new JinjavaInterpreter(jinjava, context, jinjava.getGlobalConfig());
@@ -124,7 +120,20 @@ public class ImportTagTest {
   }
 
   @Test
-  public void itAddsAllDeferredNodesOfImportedContext() {
+  public void itDoesNotRenderTagsDependingOnDeferredGlobalImport() {
+    try {
+      Jinjava jinjava = new Jinjava();
+      interpreter = new JinjavaInterpreter(jinjava, context, jinjava.getGlobalConfig());
+      interpreter.getContext().put("primary_font_size_num", DeferredValue.instance());
+      String renderedImport = fixture("import-property");
+      assertThat(renderedImport).isEqualTo(Resources.toString(Resources.getResource("tags/macrotag/import-property.jinja"), StandardCharsets.UTF_8));
+    } catch (IOException e) {
+      throw new RuntimeException();
+    }
+  }
+
+  @Test
+  public void itAddsAllDeferredNodesOfImport() {
     Jinjava jinjava = new Jinjava();
     interpreter = new JinjavaInterpreter(jinjava, context, jinjava.getGlobalConfig());
     interpreter.getContext().put("primary_font_size_num", DeferredValue.instance());
@@ -134,7 +143,7 @@ public class ImportTagTest {
   }
 
   @Test
-  public void itAddsAllDeferredNodesOfGloballyImportedContext() {
+  public void itAddsAllDeferredNodesOfGlobalImport() {
     Jinjava jinjava = new Jinjava();
     interpreter = new JinjavaInterpreter(jinjava, context, jinjava.getGlobalConfig());
     interpreter.getContext().put("primary_font_size_num", DeferredValue.instance());

--- a/src/test/resources/tags/macrotag/import-property-global.jinja
+++ b/src/test/resources/tags/macrotag/import-property-global.jinja
@@ -1,0 +1,3 @@
+{% import "tags/settag/set-var-exp.jinja" %}
+
+{{ primary_line_height }}

--- a/src/test/resources/tags/macrotag/import-property.jinja
+++ b/src/test/resources/tags/macrotag/import-property.jinja
@@ -1,0 +1,3 @@
+{% import "tags/settag/set-var-exp.jinja" as pegasus %}
+
+{{ pegasus.primary_line_height }}


### PR DESCRIPTION
### Defer import tag

This change handles the case where an import tag depends on deferred values. In this case the nodes inside of the tags will be added to the deferredNodes list and all created values inside of the SetTag will be deferred. 

Assuming the file `my_properties.html` depends on a deferred value.

Example 1: `{% import 'custom/page/web_page_basic/my_properties.html' as header_footer %}`
`header_footer` will be deferred

Example 2: `{% import 'custom/page/web_page_basic/my_properties.html' %}`
All variables defined (or deferred) inside of the file will be deferred.

After that a DeferredValueException is thrown from inside of the `ImportTag` in order to avoid rendering it and to reconstruct it properly. 

### Improved reconstructImage

This change adds reconstructImage as a public function on the Node base class. This allows the child classes of Node to implement this function, however it will default to `master.getImage()` so that users are not forced to implement it when they extend Node. This way `reconstructImage` can be improved inside of `TagNode` to reconstruct recursively. Before it would only reconstruct at the depth of 1. 

Example (from a test added in `DeferredTest`):

`{% if deferred %}{% if resolved %}{{resolved}}{% endif %}{% else %}b{% endif %}`

Before the change this would have been reconstructed to

`{% if deferred %}{% if resolved %}{% else %}b{% endif %}`

After the change it reconstructs correctly to the original template.

### Considerations

At the moment, macros that are called with/depend on deferred values are not preserved correctly. At the time of rendering the macro definition, it's not possible right now to know if the value it depends on will be defined when the macro is actually called. This is not trivial and I'll need to think more about how to make it work well, but in order to move forward and make progress we've decided to not support this for the time being. 

Also I'm aware of the `FromTag`, which is very similar to the `ImportTag`. I'll add DeferredValue support for it later.