### PR TITLE
Check hasNext instead of check length=0.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -132,7 +132,7 @@ public class ForTag implements Tag {
 
     try (InterpreterScopeClosable c = interpreter.enterScope()) {
 
-      if (interpreter.isValidationMode() && loop.getLength() == 0) {
+      if (interpreter.isValidationMode() && !loop.hasNext()) {
         loop = ObjectIterator.getLoop(0);
         interpreter.getContext().setValidationMode(true);
       }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -132,7 +132,7 @@ public class ForTag implements Tag {
 
     try (InterpreterScopeClosable c = interpreter.enterScope()) {
 
-      if (loop.getLength() == 0 && interpreter.isValidationMode()) {
+      if (interpreter.isValidationMode() && loop.getLength() == 0) {
         loop = ObjectIterator.getLoop(0);
         interpreter.getContext().setValidationMode(true);
       }


### PR DESCRIPTION
We are seeing some pages having
```
 WARN  jinjava - can't compute items' length while looping.
```