### PR TITLE
Implements equals() and hashCode() methods for TemplateError

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -359,7 +359,7 @@ public class TemplateError {
         item,
         message,
         fieldName,
-        lineno, 
+        lineno,
         startPosition,
         category,
         categoryErrors,

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -354,6 +354,15 @@ public class TemplateError {
 
   @Override
   public int hashCode() {
-    return Objects.hash(severity, reason, item, message, fieldName, lineno, startPosition, category, categoryErrors, scopeDepth);
+    return Objects.hash(severity,
+        reason,
+        item,
+        message,
+        fieldName,
+        lineno, 
+        startPosition,
+        category,
+        categoryErrors,
+        scopeDepth);
   }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.interpret;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -330,5 +331,29 @@ public class TemplateError {
         ", category=" + category +
         ", categoryErrors=" + categoryErrors +
         '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof TemplateError)) {
+      return false;
+    }
+
+    TemplateError other = (TemplateError) o;
+    return Objects.equals(severity, other.severity)
+        && Objects.equals(reason, other.reason)
+        && Objects.equals(item, other.item)
+        && Objects.equals(message, other.message)
+        && Objects.equals(fieldName, other.fieldName)
+        && Objects.equals(lineno, other.lineno)
+        && Objects.equals(startPosition, other.startPosition)
+        && Objects.equals(category, other.category)
+        && Objects.equals(categoryErrors, other.categoryErrors)
+        && Objects.equals(scopeDepth, other.scopeDepth);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(severity, reason, item, message, fieldName, lineno, startPosition, category, categoryErrors, scopeDepth);
   }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/TemplateErrorTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/TemplateErrorTest.java
@@ -6,6 +6,10 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
+import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
+import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
+import com.hubspot.jinjava.interpret.errorcategory.BasicTemplateErrorCategory;
 
 public class TemplateErrorTest {
 
@@ -58,5 +62,46 @@ public class TemplateErrorTest {
     TemplateError e = TemplateError.fromUnknownProperty(ImmutableMap.of("foo", veryLong), "other", 123, 4);
     assertThat(e.getMessage()).startsWith("Cannot resolve property 'other' in '{foo=");
     assertThat(e.getMessage().length()).isLessThan(1500);
+  }
+
+
+  @Test
+  public void itComparesEquality() {
+
+    TemplateError error1 = new TemplateError(ErrorType.WARNING,
+        ErrorReason.SYNTAX_ERROR,
+        ErrorItem.TAG,
+        "error",
+        "badField",
+        10,
+        100,
+        new Exception(),
+        BasicTemplateErrorCategory.FROM_CYCLE_DETECTED,
+        ImmutableMap.of("test1", "test2"));
+
+    TemplateError error2 = new TemplateError(ErrorType.WARNING,
+        ErrorReason.SYNTAX_ERROR,
+        ErrorItem.TAG,
+        "error",
+        "badField",
+        10,
+        100,
+        new Exception(),
+        BasicTemplateErrorCategory.FROM_CYCLE_DETECTED,
+        ImmutableMap.of("test1", "test2"));
+
+    TemplateError error3 = new TemplateError(ErrorType.WARNING,
+        ErrorReason.SYNTAX_ERROR,
+        ErrorItem.TAG,
+        "error",
+        "differentField",
+        10,
+        100,
+        new Exception(),
+        BasicTemplateErrorCategory.FROM_CYCLE_DETECTED,
+        ImmutableMap.of("test1", "test2"));
+
+    assertThat(error1).isEqualTo(error2);
+    assertThat(error1).isNotEqualTo(error3);
   }
 }


### PR DESCRIPTION
This makes it easy to compare error sets for differences.