### PR TITLE
Add dummy object for validation mode.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/TruthyTypeConverter.java
+++ b/src/main/java/com/hubspot/jinjava/el/TruthyTypeConverter.java
@@ -1,5 +1,9 @@
 package com.hubspot.jinjava.el;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import com.hubspot.jinjava.objects.DummyObject;
 import com.hubspot.jinjava.util.ObjectTruthValue;
 
 import de.odysseus.el.misc.TypeConverterImpl;
@@ -12,4 +16,103 @@ public class TruthyTypeConverter extends TypeConverterImpl {
     return Boolean.valueOf(ObjectTruthValue.evaluate(value));
   }
 
+  @Override
+  protected Character coerceToCharacter(Object value) {
+    if (value instanceof DummyObject) {
+      return '0';
+    }
+    return super.coerceToCharacter(value);
+  }
+
+  @Override
+  protected BigDecimal coerceToBigDecimal(Object value) {
+    if (value instanceof DummyObject) {
+      return BigDecimal.ZERO;
+    }
+    return super.coerceToBigDecimal(value);
+  }
+
+  @Override
+  protected BigInteger coerceToBigInteger(Object value) {
+    if (value instanceof DummyObject) {
+      return BigInteger.ZERO;
+    }
+    return super.coerceToBigInteger(value);
+  }
+
+  @Override
+  protected Double coerceToDouble(Object value) {
+    if (value instanceof DummyObject) {
+      return 0d;
+    }
+    return super.coerceToDouble(value);
+  }
+
+  @Override
+  protected Float coerceToFloat(Object value) {
+    if (value instanceof DummyObject) {
+      return 0f;
+    }
+    return super.coerceToFloat(value);
+  }
+
+  @Override
+  protected Long coerceToLong(Object value) {
+    if (value instanceof DummyObject) {
+      return 0L;
+    }
+    return super.coerceToLong(value);
+  }
+
+  @Override
+  protected Integer coerceToInteger(Object value) {
+    if (value instanceof DummyObject) {
+      return 0;
+    }
+    return super.coerceToInteger(value);
+  }
+
+  @Override
+  protected Short coerceToShort(Object value) {
+    if (value instanceof DummyObject) {
+      return 0;
+    }
+    return super.coerceToShort(value);
+  }
+
+  @Override
+  protected Byte coerceToByte(Object value) {
+    if (value instanceof DummyObject) {
+      return 0;
+    }
+    return super.coerceToByte(value);
+  }
+
+  @Override
+  protected String coerceToString(Object value) {
+    if (value instanceof DummyObject) {
+      return "";
+    }
+    return super.coerceToString(value);
+  }
+
+  @Override
+  protected <T extends Enum<T>> T coerceToEnum(Object value, Class<T> type) {
+    if (value instanceof DummyObject) {
+      if (type.getEnumConstants().length > 0) {
+        return type.getEnumConstants()[0];
+      }
+    }
+    return super.coerceToEnum(value, type);
+  }
+
+  @Override
+  protected Object coerceStringToType(String value, Class<?> type) {
+    return super.coerceStringToType(value, type);
+  }
+
+  @Override
+  protected Object coerceToType(Object value, Class<?> type) {
+    return super.coerceToType(value, type);
+  }
 }

--- a/src/main/java/com/hubspot/jinjava/el/TruthyTypeConverter.java
+++ b/src/main/java/com/hubspot/jinjava/el/TruthyTypeConverter.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.el;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.EnumSet;
 
 import com.hubspot.jinjava.objects.DummyObject;
 import com.hubspot.jinjava.util.ObjectTruthValue;
@@ -99,8 +100,9 @@ public class TruthyTypeConverter extends TypeConverterImpl {
   @Override
   protected <T extends Enum<T>> T coerceToEnum(Object value, Class<T> type) {
     if (value instanceof DummyObject) {
-      if (type.getEnumConstants().length > 0) {
-        return type.getEnumConstants()[0];
+      EnumSet<T> enumSet = EnumSet.allOf(type);
+      if (!enumSet.isEmpty()) {
+        return enumSet.iterator().next();
       }
     }
     return super.coerceToEnum(value, type);

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -31,6 +31,7 @@ import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
+import com.hubspot.jinjava.objects.DummyObject;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.util.ForLoop;
@@ -133,7 +134,7 @@ public class ForTag implements Tag {
     try (InterpreterScopeClosable c = interpreter.enterScope()) {
 
       if (interpreter.isValidationMode() && !loop.hasNext()) {
-        loop = ObjectIterator.getLoop(0);
+        loop = ObjectIterator.getLoop(new DummyObject());
         interpreter.getContext().setValidationMode(true);
       }
 

--- a/src/main/java/com/hubspot/jinjava/objects/DummyObject.java
+++ b/src/main/java/com/hubspot/jinjava/objects/DummyObject.java
@@ -1,0 +1,70 @@
+package com.hubspot.jinjava.objects;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableList;
+
+public class DummyObject implements Map<String, Object> {
+
+  @Override
+  public int size() {
+    return 1;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return false;
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return true;
+  }
+
+  @Override
+  public boolean containsValue(Object value) {
+    return true;
+  }
+
+  @Override
+  public Object get(Object key) {
+    return new DummyObject();
+  }
+
+  @Override
+  public Object put(String key, Object value) {
+    return new DummyObject();
+  }
+
+  @Override
+  public Object remove(Object key) {
+    return new DummyObject();
+  }
+
+  @Override
+  public void putAll(Map<? extends String, ?> m) {
+
+  }
+
+  @Override
+  public void clear() {
+
+  }
+
+  @Override
+  public Set<String> keySet() {
+    return null;
+  }
+
+  @Override
+  public Collection<Object> values() {
+    return ImmutableList.of(new DummyObject());
+  }
+
+  @Override
+  public Set<Entry<String, Object>> entrySet() {
+    return null;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/objects/DummyObject.java
+++ b/src/main/java/com/hubspot/jinjava/objects/DummyObject.java
@@ -6,7 +6,7 @@ import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
 
-public class DummyObject implements Map<String, Object> {
+public class DummyObject implements Map<String, Object>, PyWrapper {
 
   @Override
   public int size() {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ValidationModeTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ValidationModeTest.java
@@ -153,6 +153,19 @@ public class ValidationModeTest {
   }
 
   @Test
+  public void itAllowsPropertyReferenceInForLoopInValidationMode() {
+
+    String output = validatingInterpreter.render(
+            "{% for i in [] %}" +
+            "{{ i.test }}" +
+            "{% endfor %}" +
+            "hi");
+
+    assertThat(validatingInterpreter.getErrors().size()).isEqualTo(0);
+    assertThat(output.trim()).isEqualTo("hi");
+  }
+
+  @Test
   public void itResolvesZeroLoopTupleForExpressionsInValidationMode() {
 
     String output = validatingInterpreter.render(

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ValidationModeTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ValidationModeTest.java
@@ -166,6 +166,20 @@ public class ValidationModeTest {
   }
 
   @Test
+  public void itAllowsPropertyReferenceAndTypeCoercionInForLoopInValidationMode() {
+
+    String output = validatingInterpreter.render(
+        "{% for i in [] %}" +
+            "{{ i.test + 100 }}" +
+            "{{ i.nope ~ 'hello' }}" +
+            "{% endfor %}" +
+            "hi");
+
+    assertThat(validatingInterpreter.getErrors().size()).isEqualTo(0);
+    assertThat(output.trim()).isEqualTo("hi");
+  }
+
+  @Test
   public void itResolvesZeroLoopTupleForExpressionsInValidationMode() {
 
     String output = validatingInterpreter.render(


### PR DESCRIPTION
If we are in validation mode and we have a zero-size loop, we used to convert `[]` to `[0]` so we can validate the for loop body by resolving it. The issue is as so looking at some typical code:
```
{% for test in get_objects() %}
 {{ test.property }}
 {{ test.numProperty + 10 }}
{% endfor %}
```
If `get_objects()` returns an empty list, we force `test` to be `0` which will cause validation errors in the for loop body where it expects a different object type returned from `get_objects()`.

The best solution I can think of is to return a `DummyObject` instead of `0`. The dummy object will resolve all properties (so they don't throw errors in cases like `{{ test.property.evenDeeperProperty }}`) and can be coerced to any type (so they don't throw errors in cases like `{{ test.numProperty + 100 }}`). 
