### PR TITLE
Add type conversion to collection expression tests.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
@@ -18,7 +18,7 @@ import de.odysseus.el.tree.impl.ast.AstNode;
 public class CollectionMembershipOperator extends SimpleOperator {
 
   @Override
-  protected Object apply(TypeConverter converter, Object o1, Object o2) {
+  public Object apply(TypeConverter converter, Object o1, Object o2) {
     if (o2 == null) {
       return Boolean.FALSE;
     }

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/CollectionExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/CollectionExpTest.java
@@ -1,0 +1,11 @@
+package com.hubspot.jinjava.lib.exptest;
+
+import com.hubspot.jinjava.el.TruthyTypeConverter;
+import com.hubspot.jinjava.el.ext.CollectionMembershipOperator;
+
+public abstract class CollectionExpTest implements ExpTest {
+
+  protected static final TruthyTypeConverter TYPE_CONVERTER = new TruthyTypeConverter();
+  protected static final CollectionMembershipOperator COLLECTION_MEMBERSHIP_OPERATOR = new CollectionMembershipOperator();
+
+}

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsContainingAllExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsContainingAllExpTest.java
@@ -1,7 +1,5 @@
 package com.hubspot.jinjava.lib.exptest;
 
-import java.util.Objects;
-
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
@@ -17,7 +15,7 @@ import com.hubspot.jinjava.util.ObjectIterator;
         @JinjavaSnippet(
             code = "{{ [1, 2, 3] is containingall [2, 3] }}")
     })
-public class IsContainingAllExpTest implements ExpTest {
+public class IsContainingAllExpTest extends CollectionExpTest {
 
   @Override
   public boolean evaluate(Object var, JinjavaInterpreter interpreter, Object... args) {
@@ -29,15 +27,7 @@ public class IsContainingAllExpTest implements ExpTest {
     ForLoop loop = ObjectIterator.getLoop(args[0]);
     while (loop.hasNext()) {
       Object matchValue = loop.next();
-      ForLoop varLoop = ObjectIterator.getLoop(var);
-      boolean matches = false;
-      while (varLoop.hasNext()) {
-        if (Objects.equals(matchValue, varLoop.next())) {
-          matches = true;
-          break;
-        }
-      }
-      if (!matches) {
+      if (!(Boolean) COLLECTION_MEMBERSHIP_OPERATOR.apply(TYPE_CONVERTER, matchValue, var)) {
         return false;
       }
     }

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsContainingExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsContainingExpTest.java
@@ -1,13 +1,9 @@
 package com.hubspot.jinjava.lib.exptest;
 
-import java.util.Objects;
-
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.util.ForLoop;
-import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Returns true if a list contains a value",
@@ -17,23 +13,16 @@ import com.hubspot.jinjava.util.ObjectIterator;
         @JinjavaSnippet(
             code = "{{ [1, 2, 3] is containing 2 }}")
     })
-public class IsContainingExpTest implements ExpTest {
+public class IsContainingExpTest extends CollectionExpTest {
 
   @Override
   public boolean evaluate(Object var, JinjavaInterpreter interpreter, Object... args) {
 
-    if (null == var || args.length == 0) {
+    if (args == null || args.length == 0) {
       return false;
     }
 
-    ForLoop loop = ObjectIterator.getLoop(var);
-    while (loop.hasNext()) {
-      if (Objects.equals(loop.next(), args[0])) {
-        return true;
-      }
-    }
-
-    return false;
+    return (Boolean) COLLECTION_MEMBERSHIP_OPERATOR.apply(TYPE_CONVERTER, args[0], var);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsWithinExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsWithinExpTest.java
@@ -1,13 +1,9 @@
 package com.hubspot.jinjava.lib.exptest;
 
-import java.util.Objects;
-
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.util.ForLoop;
-import com.hubspot.jinjava.util.ObjectIterator;
 
 @JinjavaDoc(
     value = "Returns true if a value is within a list",
@@ -17,7 +13,7 @@ import com.hubspot.jinjava.util.ObjectIterator;
         @JinjavaSnippet(
             code = "{{ 2 is within [1, 2, 3] }}")
     })
-public class IsWithinExpTest implements ExpTest {
+public class IsWithinExpTest extends CollectionExpTest {
 
   @Override
   public boolean evaluate(Object var, JinjavaInterpreter interpreter, Object... args) {
@@ -26,14 +22,7 @@ public class IsWithinExpTest implements ExpTest {
       return false;
     }
 
-    ForLoop loop = ObjectIterator.getLoop(args[0]);
-    while (loop.hasNext()) {
-      if (Objects.equals(loop.next(), var)) {
-        return true;
-      }
-    }
-
-    return false;
+    return (Boolean) COLLECTION_MEMBERSHIP_OPERATOR.apply(TYPE_CONVERTER, var, args[0]);
   }
 
   @Override

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsContainingAllExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsContainingAllExpTestTest.java
@@ -44,4 +44,9 @@ public class IsContainingAllExpTestTest {
   public void itFailsOnNullValues() {
     assertThat(jinjava.render(String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "null"), new HashMap<>())).isEqualTo("fail");
   }
+
+  @Test
+  public void itPerformsTypeConversion() {
+    assertThat(jinjava.render(String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "['2', '3']"), new HashMap<>())).isEqualTo("pass");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsContainingExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsContainingExpTestTest.java
@@ -26,8 +26,8 @@ public class IsContainingExpTestTest {
   }
 
   @Test
-  public void itPassesOnNullContainedValue() {
-    assertThat(jinjava.render(String.format(CONTAINING_TEMPLATE, "[1, 2, null]", "null"), new HashMap<>())).isEqualTo("pass");
+  public void itFailsOnNullContainedValue() {
+    assertThat(jinjava.render(String.format(CONTAINING_TEMPLATE, "[1, 2, null]", "null"), new HashMap<>())).isEqualTo("fail");
   }
 
   @Test
@@ -48,5 +48,10 @@ public class IsContainingExpTestTest {
   @Test
   public void itFailsOnNullSequence() {
     assertThat(jinjava.render(String.format(CONTAINING_TEMPLATE, "null", "2"), new HashMap<>())).isEqualTo("fail");
+  }
+
+  @Test
+  public void itPerformsTypeConversion() {
+    assertThat(jinjava.render(String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "'2'"), new HashMap<>())).isEqualTo("pass");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsWithinExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsWithinExpTestTest.java
@@ -26,8 +26,8 @@ public class IsWithinExpTestTest {
   }
 
   @Test
-  public void itPassesOnNullValueInSequence() {
-    assertThat(jinjava.render(String.format(IN_TEMPLATE, "null", "[1, 2, null]"), new HashMap<>())).isEqualTo("pass");
+  public void itFailsOnNullValueInSequence() {
+    assertThat(jinjava.render(String.format(IN_TEMPLATE, "null", "[1, 2, null]"), new HashMap<>())).isEqualTo("fail");
   }
 
   @Test
@@ -43,5 +43,10 @@ public class IsWithinExpTestTest {
   @Test
   public void itFailsOnNullSequence() {
     assertThat(jinjava.render(String.format(IN_TEMPLATE, "2", "null"), new HashMap<>())).isEqualTo("fail");
+  }
+
+  @Test
+  public void itPerformsTypeConversion() {
+    assertThat(jinjava.render(String.format(IN_TEMPLATE, "'1'", "[100000000000, 1]"), new HashMap<>())).isEqualTo("pass");
   }
 }


### PR DESCRIPTION
The collection expression tests `containing`, `containingall`, and `within` should be functionally equivalent to the `in` operator. A previous PR added type conversion to the `in` operator (https://github.com/HubSpot/jinjava/pull/314) so that `in` would be equivalent with the equality (`=`) operator. This expands that functionality to these expression tests so they can be functionality equivalent to `in` and `=`.

To make these equivalent, I had to change how we handle `null` values in the collections in these tests.