### PR TITLE
Add codeStyleChecker for jinjava

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: java
 jdk:
   - oraclejdk8
 
+# https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766
+dist: trusty
+
 cache:
   directories:
     - $HOME/.m2
@@ -18,5 +21,6 @@ notifications:
 before_install:
   - pip install --user codecov
 after_success:
+  - mvn validate -e
   - codecov
 

--- a/pom.xml
+++ b/pom.xml
@@ -157,9 +157,29 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <executions>
+          <execution>
+            <id>validate</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <configLocation>${basedir}/src/main/resources/jinjava-checkstyle.xml</configLocation>
+              <encoding>UTF-8</encoding>
+              <consoleOutput>true</consoleOutput>
+              <failsOnError>true</failsOnError>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <!-- Remove basepom's stuff -->
-        <configuration combine.self="override" />
+        <configuration combine.self="override"></configuration>
         <executions>
           <execution>
             <goals>

--- a/src/main/resources/jinjava-checkstyle.xml
+++ b/src/main/resources/jinjava-checkstyle.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!-- This is a checkstyle configuration file. For descriptions of
+what the following rules do, please see the checkstyle configuration
+page at http://checkstyle.sourceforge.net/config.html -->
+
+<!--NOTE: I wish to check the code style automatically, however,
+there too many old codes couldn't apply some of the following rules
+ which are annotated-->
+
+<module name="Checker">
+    <property name="charset" value="UTF-8"/>
+    <property name="fileExtensions" value="java"/>
+
+    <!-- See http://checkstyle.sf.net/config_sizes.html   default : 2000-->
+    <module name="FileLength"/>
+
+    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+    <module name="FileTabCharacter"/>
+
+    <module name="RegexpSingleline">
+        <property name="format" value="\s+$"/>
+        <property name="minimum" value="0"/>
+        <property name="maximum" value="0"/>
+        <property name="message" value="Line has trailing spaces."/>
+    </module>
+
+    <module name="TreeWalker">
+
+        <!-- Checks for imports                              -->
+        <!-- See http://checkstyle.sf.net/config_import.html -->
+        <!-- <module name="AvoidStarImport"/> -->
+        <module name="IllegalImport"/>
+        <!-- defaults to sun.* packages -->
+        <module name="RedundantImport"/>
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="true"/>
+        </module>
+
+        <!-- Checks for Size Violations.                    -->
+        <!-- See http://checkstyle.sf.net/config_sizes.html -->
+        <module name="LineLength">
+            <property name="max" value="300"/>
+        </module>
+        <module name="MethodLength">
+            <property name="max" value="200"/>
+        </module>
+        <module name="ParameterNumber">
+            <property name="max" value="20"/>
+        </module>
+
+        <!-- Checks for whitespace                               -->
+        <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+        <module name="EmptyForIteratorPad"/>
+        <module name="GenericWhitespace"/>
+        <module name="MethodParamPad"/>
+        <module name="ParenPad"/>
+        <module name="TypecastParenPad"/>
+        <!-- <module name="NoWhitespaceAfter"/>-->
+        <!-- <module name="NoWhitespaceBefore"/>-->
+        <!-- <module name="WhitespaceAfter"/>-->
+        <!-- <module name="WhitespaceAround"/>-->
+
+        <!-- Modifier Checks                                    -->
+        <!-- See http://checkstyle.sf.net/config_modifier.html -->
+        <module name="RedundantModifier"/>
+
+        <!-- Checks for blocks. You know, those {}'s         -->
+        <!-- See http://checkstyle.sf.net/config_blocks.html -->
+        <module name="AvoidNestedBlocks"/>
+        <module name="EmptyBlock"/>
+        <!-- <module name="LeftCurly"/>-->
+        <!-- <module name="RightCurly"/>-->
+
+        <!-- Checks for common coding problems               -->
+        <!-- See http://checkstyle.sf.net/config_coding.html -->
+        <module name="EmptyStatement"/>
+        <module name="IllegalInstantiation"/>
+        <!-- <module name="MissingSwitchDefault"/>-->
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
+
+        <!-- Miscellaneous other checks.                   -->
+        <!-- See http://checkstyle.sf.net/config_misc.html -->
+        <module name="TodoComment"/>
+        <module name="UpperEll"/>
+        <!-- <module name="ArrayTypeStyle"/>-->
+
+        <!-- To configure the check so that it matches default Eclipse formatter
+            configuration (tested on Kepler and Luna releases):
+                1. group of static imports is on the top
+                2. groups of non-static imports: "java" and "javax" packages first,
+                    then "org" and then all other imports
+                3. imports will be sorted in the groups
+                4. groups are separated by single blank line -->
+        <module name="CustomImportOrder">
+            <!-- <property name="customImportOrderRules"
+                      value="STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS"/>-->
+            <property name="specialImportsRegExp" value="^org\."/>
+            <property name="separateLineBetweenGroups" value="true"/>
+            <!-- <property name="sortImportsInGroupAlphabetically" value="true"/>-->
+        </module>
+    </module>
+
+</module>


### PR DESCRIPTION
refer to #344 

I think it's inefficient to check the code style manually, then I create a `checkstyle` configuration to cover some scenarios as much as possible.

>  I wish to check the code style automatically, however, there too many old codes couldn't apply some rules