### PR TITLE
Upgrade map filter to advanced filter, improve error messages, and pass through args for filters

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/InvalidArgumentException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/InvalidArgumentException.java
@@ -15,6 +15,12 @@ public class InvalidArgumentException extends RuntimeException {
         String.format("%s argument %s", formatArgumentNumber(argumentNumber + 1), String.format(invalidReason.getErrorMessage(), errorMessageArgs))));
   }
 
+  public InvalidArgumentException(JinjavaInterpreter interpreter, Importable importable, InvalidReason invalidReason, String argumentName, Object... errorMessageArgs) {
+    this(interpreter, importable.getName(), String.format("Invalid argument in '%s': %s",
+        importable.getName(),
+        String.format("'%s' argument %s", argumentName, String.format(invalidReason.getErrorMessage(), errorMessageArgs))));
+  }
+
   public InvalidArgumentException(JinjavaInterpreter interpreter, String name, String errorMessage) {
     this.message = errorMessage;
 

--- a/src/main/java/com/hubspot/jinjava/interpret/InvalidArgumentException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/InvalidArgumentException.java
@@ -9,19 +9,29 @@ public class InvalidArgumentException extends RuntimeException {
   private final String message;
   private final String name;
 
-  public InvalidArgumentException(JinjavaInterpreter interpreter, Importable importable, InvalidReason invalidReason, int argumentNumber, Object... errorMessageArgs) {
+  public InvalidArgumentException(JinjavaInterpreter interpreter,
+                                  Importable importable,
+                                  InvalidReason invalidReason,
+                                  int argumentNumber,
+                                  Object... errorMessageArgs) {
     this(interpreter, importable.getName(), String.format("Invalid argument in '%s': %s",
         importable.getName(),
         String.format("%s argument %s", formatArgumentNumber(argumentNumber + 1), String.format(invalidReason.getErrorMessage(), errorMessageArgs))));
   }
 
-  public InvalidArgumentException(JinjavaInterpreter interpreter, Importable importable, InvalidReason invalidReason, String argumentName, Object... errorMessageArgs) {
+  public InvalidArgumentException(JinjavaInterpreter interpreter,
+                                  Importable importable,
+                                  InvalidReason invalidReason,
+                                  String argumentName,
+                                  Object... errorMessageArgs) {
     this(interpreter, importable.getName(), String.format("Invalid argument in '%s': %s",
         importable.getName(),
         String.format("'%s' argument %s", argumentName, String.format(invalidReason.getErrorMessage(), errorMessageArgs))));
   }
 
-  public InvalidArgumentException(JinjavaInterpreter interpreter, String name, String errorMessage) {
+  public InvalidArgumentException(JinjavaInterpreter interpreter,
+                                  String name,
+                                  String errorMessage) {
     this.message = errorMessage;
 
     this.lineNumber = interpreter.getLineNumber();

--- a/src/main/java/com/hubspot/jinjava/lib/filter/MapFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/MapFilter.java
@@ -1,6 +1,8 @@
 package com.hubspot.jinjava.lib.filter;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -70,7 +72,7 @@ public class MapFilter implements AdvancedFilter {
     while (loop.hasNext()) {
       Object val = loop.next();
       if (apply != null) {
-        val = apply.filter(val, interpreter);
+        val = apply.filter(val, interpreter, Arrays.copyOfRange(args, 1, args.length), Collections.emptyMap());
       } else {
         val = interpreter.resolveProperty(val, attr);
       }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/MapFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/MapFilter.java
@@ -43,7 +43,9 @@ public class MapFilter implements AdvancedFilter {
     ForLoop loop = ObjectIterator.getLoop(var);
 
     if (args.length < 1 && kwargs.size() < 1) {
-      throw new TemplateSyntaxException(interpreter, getName(), "requires 1 argument (name of filter or attribute to apply to given sequence)");
+      throw new TemplateSyntaxException(interpreter,
+          getName(),
+          "requires 1 argument (name of filter or attribute to apply to given sequence)");
     }
 
     String attr;

--- a/src/test/java/com/hubspot/jinjava/lib/filter/MapFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/MapFilterTest.java
@@ -35,6 +35,13 @@ public class MapFilterTest {
   }
 
   @Test
+  public void itPassesAdditionalArgumentsIntoFilter() {
+    assertThat(jinjava.render("{{ titles|map('truncate', 5, true, '')|join(', ') }}",
+        ImmutableMap.of("titles", (Object) Lists.newArrayList("Happy Day", "FOOBAR", "barfoo"))))
+        .isEqualTo("Happy, FOOBA, barfo");
+  }
+
+  @Test
   public void itUsesAttributeIfAttributeNameClashesWithFilter() {
     assertThat(jinjava.render("{{ titles|map(attribute='date')|join(' ') }}",
         ImmutableMap.of("titles", (Object) Lists.newArrayList(new TestClass(12345)))))

--- a/src/test/java/com/hubspot/jinjava/lib/filter/MapFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/MapFilterTest.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -31,6 +32,40 @@ public class MapFilterTest {
     assertThat(jinjava.render("{{ titles|map('lower')|join(', ') }}",
         ImmutableMap.of("titles", (Object) Lists.newArrayList("Happy Day", "FOO", "bar"))))
         .isEqualTo("happy day, foo, bar");
+  }
+
+  @Test
+  public void itUsesAttributeIfAttributeNameClashesWithFilter() {
+    assertThat(jinjava.render("{{ titles|map(attribute='date')|join(' ') }}",
+        ImmutableMap.of("titles", (Object) Lists.newArrayList(new TestClass(12345)))))
+        .isEqualTo("12345");
+  }
+
+  @Test
+  public void itAddsErrorIfFirstArgumentIsNull() {
+    assertThatThrownBy(() -> jinjava.render("{{ titles|map(null)|join(' ') }}",
+        ImmutableMap.of("titles", (Object) Lists.newArrayList(new TestClass(12345)))))
+        .hasMessageContaining("1st argument cannot be null");
+  }
+
+  @Test
+  public void itAddsErrorIfAttributeArgumentIsNull() {
+    assertThatThrownBy(() -> jinjava.render("{{ titles|map(attribute=null)|join(' ') }}",
+        ImmutableMap.of("titles", (Object) Lists.newArrayList(new TestClass(12345)))))
+        .hasMessageContaining("'attribute' argument cannot be null");
+  }
+
+  public class TestClass {
+
+    private final long date;
+
+    public TestClass(long date) {
+      this.date = date;
+    }
+
+    public long getDate() {
+      return date;
+    }
   }
 
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/MapFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/MapFilterTest.java
@@ -42,6 +42,13 @@ public class MapFilterTest {
   }
 
   @Test
+  public void itMapsFirstArgumentToFilterIfFilterExists() {
+    assertThatThrownBy(() -> jinjava.render("{{ titles|map('date')|join(' ') }}",
+        ImmutableMap.of("titles", (Object) Lists.newArrayList(new TestClass(12345)))))
+        .hasMessageContaining("Input to function must be a date object");
+  }
+
+  @Test
   public void itAddsErrorIfFirstArgumentIsNull() {
     assertThatThrownBy(() -> jinjava.render("{{ titles|map(null)|join(' ') }}",
         ImmutableMap.of("titles", (Object) Lists.newArrayList(new TestClass(12345)))))

--- a/src/test/java/com/hubspot/jinjava/lib/filter/MapFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/MapFilterTest.java
@@ -55,6 +55,13 @@ public class MapFilterTest {
         .hasMessageContaining("'attribute' argument cannot be null");
   }
 
+  @Test
+  public void itAddsErrorIfNoArgumentsAreProvided() {
+    assertThatThrownBy(() -> jinjava.render("{{ titles|map()|join(' ') }}",
+        ImmutableMap.of("titles", (Object) Lists.newArrayList(new TestClass(12345)))))
+        .hasMessageContaining("requires 1 argument");
+  }
+
   public class TestClass {
 
     private final long date;


### PR DESCRIPTION
The `|map` filter supports two usages: mapping to an attribute and mapping to a filter. Since `|map` was a regular filter, it could not use the `attribute=` arg to specify if the argument is an attribute and not a filter if there was ambiguity between the two. This upgrades the map filter to an advanced filter and improves on error messaging by preventing NPEs from surfacing if a null value is passed into the filter.

The docs also say `Alternatively you can let it invoke a filter by passing the name of the filter and the arguments afterwards` which was not true until I added the passthrough of the additional arguments.