### PR TITLE
Create new class that lazily resolves

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.el;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import javax.el.ELException;
 import javax.el.ExpressionFactory;
@@ -74,6 +75,12 @@ public class ExpressionResolver {
       if (result == null && interpreter.getConfig().isFailOnUnknownTokens()) {
         throw new UnknownTokenException(expression, interpreter.getLineNumber(), interpreter.getPosition());
       }
+
+      // automatically convert suppliers into their values on resolution
+      if (result instanceof Supplier) {
+        result = ((Supplier) result).get();
+      }
+
       validateResult(result);
 
       return result;

--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -3,7 +3,6 @@ package com.hubspot.jinjava.el;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
 
 import java.util.List;
-import java.util.function.Supplier;
 
 import javax.el.ELException;
 import javax.el.ExpressionFactory;
@@ -20,6 +19,7 @@ import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.LazyExpression;
 import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
@@ -77,8 +77,8 @@ public class ExpressionResolver {
       }
 
       // automatically convert suppliers into their values on resolution
-      if (result instanceof Supplier) {
-        result = ((Supplier) result).get();
+      if (result instanceof LazyExpression) {
+        result = ((LazyExpression) result).get();
       }
 
       validateResult(result);

--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -76,7 +76,7 @@ public class ExpressionResolver {
         throw new UnknownTokenException(expression, interpreter.getLineNumber(), interpreter.getPosition());
       }
 
-      // automatically convert suppliers into their values on resolution
+      // resolve the LazyExpression supplier automatically
       if (result instanceof LazyExpression) {
         result = ((LazyExpression) result).get();
       }

--- a/src/main/java/com/hubspot/jinjava/interpret/LazyExpression.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/LazyExpression.java
@@ -1,0 +1,21 @@
+package com.hubspot.jinjava.interpret;
+
+import java.util.function.Supplier;
+
+public class LazyExpression implements Supplier {
+
+  private final Supplier supplier;
+
+  private LazyExpression(Supplier supplier) {
+    this.supplier = supplier;
+  }
+
+  public static LazyExpression of(Supplier supplier) {
+    return new LazyExpression(supplier);
+  }
+
+  @Override
+  public Object get() {
+    return supplier.get();
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
@@ -26,6 +26,7 @@ import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.Context.Library;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.LazyExpression;
 import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
@@ -526,12 +527,12 @@ public class ExpressionResolverTest {
 
 
   @Test
-  public void itResolvesSuppliersToTheirUnderlyingValue() {
+  public void itResolvesLazyExpressionsToTheirUnderlyingValue() {
 
     TestClass testClass = new TestClass();
     Supplier<String> lazyString = () -> result("hallelujah", testClass);
 
-    context.put("myobj", ImmutableMap.of("test", lazyString));
+    context.put("myobj", ImmutableMap.of("test", LazyExpression.of(lazyString)));
 
     assertThat(Objects.toString(interpreter.resolveELExpression("myobj.test", -1))).isEqualTo(
         "hallelujah");
@@ -545,7 +546,7 @@ public class ExpressionResolverTest {
     TestClass testClass = new TestClass();
     Supplier<String> lazyString = () -> result("hallelujah", testClass);
 
-    context.put("myobj", ImmutableMap.of("test", lazyString, "nope", "test"));
+    context.put("myobj", ImmutableMap.of("test", LazyExpression.of(lazyString), "nope", "test"));
 
     assertThat(Objects.toString(interpreter.resolveELExpression("myobj.nope", -1))).isEqualTo(
         "test");

--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -521,6 +522,52 @@ public class ExpressionResolverTest {
     assertThat(Objects.toString(interpreter.resolveELExpression("myobj.nested.nested.date", -1))).isEqualTo(
         "1970-01-01 00:00:00");
     assertThat(interpreter.getErrorsCopy()).isEmpty();
+  }
+
+
+  @Test
+  public void itResolvesSuppliersToTheirUnderlyingValue() {
+
+    TestClass testClass = new TestClass();
+    Supplier<String> lazyString = () -> result("hallelujah", testClass);
+
+    context.put("myobj", ImmutableMap.of("test", lazyString));
+
+    assertThat(Objects.toString(interpreter.resolveELExpression("myobj.test", -1))).isEqualTo(
+        "hallelujah");
+    assertThat(interpreter.getErrorsCopy()).isEmpty();
+    assertThat(testClass.isTouched()).isTrue();
+  }
+
+  @Test
+  public void itResolvesSuppliersOnlyIfResolved() {
+
+    TestClass testClass = new TestClass();
+    Supplier<String> lazyString = () -> result("hallelujah", testClass);
+
+    context.put("myobj", ImmutableMap.of("test", lazyString, "nope", "test"));
+
+    assertThat(Objects.toString(interpreter.resolveELExpression("myobj.nope", -1))).isEqualTo(
+        "test");
+    assertThat(interpreter.getErrorsCopy()).isEmpty();
+    assertThat(testClass.isTouched()).isFalse();
+  }
+
+  public String result(String value, TestClass testClass) {
+    testClass.touch();
+    return value;
+  }
+
+  public class TestClass {
+    private boolean touched = false;
+
+    public boolean isTouched() {
+      return touched;
+    }
+
+    public void touch() {
+      this.touched = true;
+    }
   }
 
   public static final class MyClass {


### PR DESCRIPTION
This could be controversial.
Suppliers are nice to use when a variable that is set in the context that is expensive to calculate may not end up being used. Instead of handling each case individually, we can allow suppliers to be used and automatically call the `get()` function when we resolve an expression that returns a supplier.
As an example use case, if you are currently building a context map (`Map<String, Object>`) and want to lazily generate some of the values, you can replace them with suppliers, and due to this PR, the suppliers will auto-resolve.
