### PR TITLE
Fix NPE with lazy expression in intermediate expression resolution.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
@@ -36,6 +36,7 @@ import com.hubspot.jinjava.el.ext.JinjavaListELResolver;
 import com.hubspot.jinjava.el.ext.NamedParameter;
 import com.hubspot.jinjava.interpret.DisabledException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.LazyExpression;
 import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
@@ -216,6 +217,10 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
   Object wrap(Object value) {
     if (value == null) {
       return null;
+    }
+
+    if (value instanceof LazyExpression) {
+      value = ((LazyExpression) value).get();
     }
 
     if (value instanceof PyWrapper) {

--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
@@ -554,13 +554,26 @@ public class ExpressionResolverTest {
     assertThat(testClass.isTouched()).isFalse();
   }
 
+  @Test
+  public void itResolvesLazyExpressionsInNested() {
+
+    Supplier<TestClass> lazyObject = TestClass::new;
+
+    context.put("myobj", ImmutableMap.of("test", LazyExpression.of(lazyObject)));
+
+    assertThat(Objects.toString(interpreter.resolveELExpression("myobj.test.name", -1))).isEqualTo(
+        "Amazing test class");
+    assertThat(interpreter.getErrorsCopy()).isEmpty();
+  }
+
   public String result(String value, TestClass testClass) {
     testClass.touch();
     return value;
   }
 
-  public class TestClass {
+  public static class TestClass {
     private boolean touched = false;
+    private String name = "Amazing test class";
 
     public boolean isTouched() {
       return touched;
@@ -568,6 +581,10 @@ public class ExpressionResolverTest {
 
     public void touch() {
       this.touched = true;
+    }
+
+    public String getName() {
+      return name;
     }
   }
 


### PR DESCRIPTION
Follow up on https://github.com/HubSpot/jinjava/pull/357.
Previously resolving something like `map.lazy.value` would throw a NPE if `lazy` was a LazyExpression because we only mapped it to `get()` at the end of resolving the expression. Here we check every step of the way if a value returned is a LazyExpression and convert it to its underlying value.