### PR TITLE
Add python list operations to PyList

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
@@ -26,4 +26,7 @@ public class PyList extends ForwardingList<Object> implements PyWrapper {
     return add(e);
   }
 
+  public void prepend(Object e) {
+    add(0, e);
+  }
 }

--- a/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
@@ -1,6 +1,9 @@
 package com.hubspot.jinjava.objects.collections;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import com.google.common.collect.ForwardingList;
 import com.hubspot.jinjava.objects.PyWrapper;
@@ -26,7 +29,46 @@ public class PyList extends ForwardingList<Object> implements PyWrapper {
     return add(e);
   }
 
-  public void prepend(Object e) {
-    add(0, e);
+  public void insert(int i, Object e) {
+    add(i, e);
+  }
+
+  public boolean extend(PyList e) {
+    return addAll(e.list);
+  }
+
+  public Object pop() {
+    return remove(list.size() - 1);
+  }
+
+  public Object pop(int index) {
+    return remove(index);
+  }
+
+  public long count(Object o) {
+    return stream()
+        .filter(object -> Objects.equals(object, o))
+        .count();
+  }
+
+  public void reverse() {
+    Collections.reverse(list);
+  }
+
+  public PyList copy() {
+    return new PyList(new ArrayList<>(list));
+  }
+
+  public int index(Object o) {
+    return indexOf(o);
+  }
+
+  public int index(Object o, int begin, int end) {
+    for (int i = begin; i < end; i++) {
+      if (Objects.equals(o, get(i))) {
+        return i;
+      }
+    }
+    return -1;
   }
 }

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
@@ -1,0 +1,34 @@
+package com.hubspot.jinjava.objects.collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.hubspot.jinjava.Jinjava;
+
+public class PyListTest {
+
+  private Jinjava jinjava;
+
+  @Before
+  public void setup() {
+    jinjava = new Jinjava();
+  }
+
+  @Test
+  public void itSupportsAppendOperation() {
+    assertThat(jinjava.render("{% set test = [1, 2, 3] %}" +
+        "{% do test.append(4) %}" +
+        "{{ test }}", Collections.emptyMap())).isEqualTo("[1, 2, 3, 4]");
+  }
+
+  @Test
+  public void itSupportsPrependOperation() {
+    assertThat(jinjava.render("{% set test = [1, 2, 3] %}" +
+        "{% do test.prepend(4) %}" +
+        "{{ test }}", Collections.emptyMap())).isEqualTo("[4, 1, 2, 3]");
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
@@ -93,4 +93,16 @@ public class PyListTest {
     assertThat(jinjava.render("{% set test = [10, 20, 30, 10, 20, 30] %}" +
         "{{ test.index(20, 2, 6) }}", Collections.emptyMap())).isEqualTo("4");
   }
+
+  @Test
+  public void itReturnsNegativeOneForMissingObjectForIndex() {
+    assertThat(jinjava.render("{% set test = [10, 20, 30, 10, 20, 30] %}" +
+        "{{ test.index(999) }}", Collections.emptyMap())).isEqualTo("-1");
+  }
+
+  @Test
+  public void itReturnsNegativeOneForMissingObjectForIndexWithinBounds() {
+    assertThat(jinjava.render("{% set test = [10, 20, 30, 10, 20, 30] %}" +
+        "{{ test.index(999, 1, 5) }}", Collections.emptyMap())).isEqualTo("-1");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
@@ -26,9 +26,71 @@ public class PyListTest {
   }
 
   @Test
-  public void itSupportsPrependOperation() {
+  public void itSupportsExtendOperation() {
     assertThat(jinjava.render("{% set test = [1, 2, 3] %}" +
-        "{% do test.prepend(4) %}" +
-        "{{ test }}", Collections.emptyMap())).isEqualTo("[4, 1, 2, 3]");
+        "{% do test.extend([4, 5, 6]) %}" +
+        "{{ test }}", Collections.emptyMap())).isEqualTo("[1, 2, 3, 4, 5, 6]");
+  }
+
+  @Test
+  public void itSupportsInsertOperation() {
+    assertThat(jinjava.render("{% set test = [1, 2, 3] %}" +
+        "{% do test.insert(1, 4) %}" +
+        "{{ test }}", Collections.emptyMap())).isEqualTo("[1, 4, 2, 3]");
+  }
+
+  @Test
+  public void itSupportsPopOperation() {
+    assertThat(jinjava.render("{% set test = [1, 2, 3] %}" +
+        "{{ test.pop() }}" +
+        "{{ test }}", Collections.emptyMap())).isEqualTo("3[1, 2]");
+  }
+
+  @Test
+  public void itSupportsPopAtIndexOperation() {
+    assertThat(jinjava.render("{% set test = [1, 2, 3] %}" +
+        "{{ test.pop(1) }}" +
+        "{{ test }}", Collections.emptyMap())).isEqualTo("2[1, 3]");
+  }
+
+  @Test
+  public void itSupportsClearOperation() {
+    assertThat(jinjava.render("{% set test = [1, 2, 3] %}" +
+        "{% do test.clear() %}" +
+        "{{ test }}", Collections.emptyMap())).isEqualTo("[]");
+  }
+
+  @Test
+  public void itSupportsCountOperation() {
+    assertThat(jinjava.render("{% set test = [1, 1, 2, 2, 2, 3] %}" +
+        "{{ test.count(2) }}" +
+        "{{ test }}", Collections.emptyMap())).isEqualTo("3[1, 1, 2, 2, 2, 3]");
+  }
+
+  @Test
+  public void itSupportsReverseOperation() {
+    assertThat(jinjava.render("{% set test = [1, 2, 3] %}" +
+        "{% do test.reverse() %}" +
+        "{{ test }}", Collections.emptyMap())).isEqualTo("[3, 2, 1]");
+  }
+
+  @Test
+  public void itSupportsCopyOperation() {
+    assertThat(jinjava.render("{% set test = [1, 2, 3] %}" +
+        "{% set test2 = test.copy() %}" +
+        "{% do test.append(4) %}" +
+        "{{ test }}{{test2}}", Collections.emptyMap())).isEqualTo("[1, 2, 3, 4][1, 2, 3]");
+  }
+
+  @Test
+  public void itSupportsIndexOperation() {
+    assertThat(jinjava.render("{% set test = [10, 20, 30, 10, 20, 30] %}" +
+        "{{ test.index(20) }}", Collections.emptyMap())).isEqualTo("1");
+  }
+
+  @Test
+  public void itSupportsIndexWithinBoundsOperation() {
+    assertThat(jinjava.render("{% set test = [10, 20, 30, 10, 20, 30] %}" +
+        "{{ test.index(20, 2, 6) }}", Collections.emptyMap())).isEqualTo("4");
   }
 }


### PR DESCRIPTION
Extended `PyList` to support most of the python list operations (https://docs.python.org/3/tutorial/datastructures.html).

One issue is with the `remove()` function which I cannot overload.
