### PR TITLE
Handle `OutputTooBigException` in the interpreter.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -270,7 +270,11 @@ public class JinjavaInterpreter {
 
         for (Node node : parentRoot.getChildren()) {
           OutputNode out = node.render(this);
-          output.addNode(out);
+          try {
+            output.addNode(out);
+          } catch (OutputTooBigException ex) {
+            addError(TemplateError.fromException(ex));
+          }
         }
 
         context.getExtendPathStack().pop();

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -237,7 +237,12 @@ public class JinjavaInterpreter {
         addError(new TemplateError(ErrorType.WARNING, ErrorReason.EXCEPTION, ErrorItem.TAG,
             "Rendering cycle detected: '" + renderStr + "'", null, getLineNumber(), node.getStartPosition(),
             null, BasicTemplateErrorCategory.IMPORT_CYCLE_DETECTED, ImmutableMap.of("string", renderStr)));
-        output.addNode(new RenderedOutputNode(renderStr));
+
+        try {
+          output.addNode(new RenderedOutputNode(renderStr));
+        } catch (OutputTooBigException ex) {
+          addError(TemplateError.fromException(ex));
+        }
       } else {
         OutputNode out;
         context.pushRenderStack(renderStr);
@@ -248,7 +253,11 @@ public class JinjavaInterpreter {
           out = new RenderedOutputNode(node.getMaster().getImage());
         }
         context.popRenderStack();
-        output.addNode(out);
+        try {
+          output.addNode(out);
+        } catch (OutputTooBigException ex) {
+          addError(TemplateError.fromException(ex));
+        }
       }
     }
 

--- a/src/main/java/com/hubspot/jinjava/tree/output/OutputList.java
+++ b/src/main/java/com/hubspot/jinjava/tree/output/OutputList.java
@@ -3,7 +3,9 @@ package com.hubspot.jinjava.tree.output;
 import java.util.LinkedList;
 import java.util.List;
 
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.OutputTooBigException;
+import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 
 public class OutputList {
@@ -46,7 +48,11 @@ public class OutputList {
     LengthLimitingStringBuilder val = new LengthLimitingStringBuilder(maxOutputSize);
 
     for (OutputNode node : nodes) {
-      val.append(node.getValue());
+      try {
+        val.append(node.getValue());
+      } catch (OutputTooBigException ex) {
+        JinjavaInterpreter.getCurrent().addError(TemplateError.fromException(ex));
+      }
     }
 
     return val.toString();

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -181,5 +181,6 @@ public class JinjavaInterpreterTest {
     renderResult = new Jinjava(outputSizeLimitedConfig).renderForResult(input, new HashMap<>());
     assertThat(renderResult.hasErrors()).isTrue();
     assertThat(renderResult.getErrors().get(0).getMessage()).contains("OutputTooBigException");
+    assertThat(renderResult.getOutput()).isEqualTo("1234567890");
   }
 }


### PR DESCRIPTION
If one of these exceptions is thrown, we lose all rendered output instead of cutting off at the max size.