### PR TITLE
Return image when calling toString for LazyExpression.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/LazyExpression.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/LazyExpression.java
@@ -21,12 +21,8 @@ public class LazyExpression implements Supplier {
     return supplier.get();
   }
 
-  public String getImage() {
-    return image;
-  }
-
   @Override
   public String toString() {
-    return super.toString();
+    return image;
   }
 }


### PR DESCRIPTION
Rather than print some generic `LazyExpression@...`, let's return the original image of the expression.