### PR TITLE
Fix datetime zone output.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
@@ -47,7 +47,7 @@ public class StrftimeFormatter {
     CONVERSIONS['X'] = "HH:mm:ss";
     CONVERSIONS['y'] = "yy";
     CONVERSIONS['Y'] = "yyyy";
-    CONVERSIONS['z'] = "ZZZZ";
+    CONVERSIONS['z'] = "Z";
     CONVERSIONS['Z'] = "z";
     CONVERSIONS['%'] = "%";
 

--- a/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
@@ -47,8 +47,8 @@ public class StrftimeFormatter {
     CONVERSIONS['X'] = "HH:mm:ss";
     CONVERSIONS['y'] = "yy";
     CONVERSIONS['Y'] = "yyyy";
-    CONVERSIONS['z'] = "Z";
-    CONVERSIONS['Z'] = "ZZZZ";
+    CONVERSIONS['z'] = "ZZZZ";
+    CONVERSIONS['Z'] = "z";
     CONVERSIONS['%'] = "%";
 
     NOMINATIVE_CONVERSIONS['B'] = "LLLL";

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
@@ -71,6 +71,11 @@ public class DateTimeFormatFilterTest {
     assertThat(filter.filter(1539277785000L, interpreter, "%l:%M %p %Z", "America/Los_Angeles")).isEqualTo("10:09 AM PDT");
   }
 
+  @Test
+  public void itOutputsTimezoneOffset() {
+    assertThat(filter.filter(1539277785000L, interpreter, "%l:%M %p %z", "America/Los_Angeles")).isEqualTo("10:09 AM -0700");
+  }
+
   @Test(expected = InvalidDateFormatException.class)
   public void itThrowsExceptionOnInvalidTimezone() throws Exception {
     filter.filter(1539277785000L, interpreter, "%B %d, %Y, at %I:%M %p", "Not a timezone");

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
@@ -66,6 +66,11 @@ public class DateTimeFormatFilterTest {
     assertThat(filter.filter(1539277785000L, interpreter, "%B %d, %Y, at %I:%M %p", "UTC+8")).isEqualTo("October 12, 2018, at 01:09 AM");
   }
 
+  @Test
+  public void itOutputsTimezoneName() {
+    assertThat(filter.filter(1539277785000L, interpreter, "%l:%M %p %Z", "America/Los_Angeles")).isEqualTo("10:09 AM PDT");
+  }
+
   @Test(expected = InvalidDateFormatException.class)
   public void itThrowsExceptionOnInvalidTimezone() throws Exception {
     filter.filter(1539277785000L, interpreter, "%B %d, %Y, at %I:%M %p", "Not a timezone");

--- a/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.objects.date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Locale;
 
@@ -85,8 +86,9 @@ public class StrftimeFormatterTest {
 
   @Test
   public void testZoneOutput() {
-    assertThat(StrftimeFormatter.format(d, "%z")).isEqualTo("+0000");
-    assertThat(StrftimeFormatter.format(d, "%Z")).isEqualTo("GMT");
+    d = ZonedDateTime.of(d.toLocalDateTime(), ZoneId.of("America/Los_Angeles"));
+    assertThat(StrftimeFormatter.format(d, "%z")).isEqualTo("-0800");
+    assertThat(StrftimeFormatter.format(d, "%Z")).isEqualTo("PST");
   }
 
   @Test


### PR DESCRIPTION
Comparing http://strftime.org/ and https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html, `%z` should map to `Z` which outputs the offset `+HHMM` or `-HHMM`. `%Z` should map to `z` which outputs the shorthand name fo the timezone (for example `PDT`). 