### PR TITLE
Serialize lazy expression as its underlying value.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,10 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>

--- a/src/main/java/com/hubspot/jinjava/interpret/LazyExpression.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/LazyExpression.java
@@ -2,6 +2,8 @@ package com.hubspot.jinjava.interpret;
 
 import java.util.function.Supplier;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public class LazyExpression implements Supplier {
 
   private final Supplier supplier;
@@ -17,6 +19,7 @@ public class LazyExpression implements Supplier {
   }
 
   @Override
+  @JsonValue
   public Object get() {
     return supplier.get();
   }

--- a/src/test/java/com/hubspot/jinjava/interpret/LazyExpressionTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/LazyExpressionTest.java
@@ -1,0 +1,18 @@
+package com.hubspot.jinjava.interpret;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+
+public class LazyExpressionTest {
+
+  @Test
+  public void itSerializesUnderlyingValue() throws JsonProcessingException {
+    LazyExpression expression = LazyExpression.of(() -> ImmutableMap.of("test", "hello", "test2", "hello2"), "{}");
+    assertThat(new ObjectMapper().writeValueAsString(expression)).isEqualTo("{\"test\":\"hello\",\"test2\":\"hello2\"}");
+  }
+}


### PR DESCRIPTION
Uses `@JsonValue` to make sure if we are serializing this expression anywhere, we use the value that the expression resolves to.