### PR TITLE
Lower logging level for truncate.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -204,7 +204,8 @@ public class Functions {
         try {
           length = Integer.parseInt(Objects.toString(arg[0]));
         } catch (Exception e) {
-          ENGINE_LOG.info("truncate(): error setting length for {}, using default {}", arg[0], DEFAULT_TRUNCATE_LENGTH);
+          ENGINE_LOG.debug("truncate(): error setting length for {}, using default {}", arg[0],
+              DEFAULT_TRUNCATE_LENGTH);
         }
       }
 


### PR DESCRIPTION
We are seeing this polluting the logs a lot, and there is not actionable way to fix the input.
```
INFO  jinjava - truncate(): error setting length for true, using default 255
``` 