### PR TITLE
adds PyList support to ForTag

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -19,7 +19,6 @@ import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Map.Entry;
 
 import org.apache.commons.lang3.StringUtils;
@@ -165,10 +164,10 @@ public class ForTag implements Tag {
               interpreter.getContext().put(loopVar, entryVal);
             } else if (List.class.isAssignableFrom(val.getClass())) {
               List<Object> entries = ((PyList) val).toList();
-              String entryVal = null;
+              Object entryVal = null;
               // safety check for size
               if (entries.size() >= loopVarIndex) {
-                entryVal = Objects.toString(entries.get(loopVarIndex));
+                entryVal = entries.get(loopVarIndex);
               }
               interpreter.getContext().put(loopVar, entryVal);
             } else {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -19,6 +19,7 @@ import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Map.Entry;
 
 import org.apache.commons.lang3.StringUtils;
@@ -32,6 +33,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.objects.DummyObject;
+import com.hubspot.jinjava.objects.collections.PyList;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.util.ForLoop;
@@ -148,7 +150,8 @@ public class ForTag implements Tag {
         if (loopVars.size() == 1) {
           interpreter.getContext().put(loopVars.get(0), val);
         } else {
-          for (String loopVar : loopVars) {
+          for (int loopVarIndex = 0; loopVarIndex < loopVars.size(); loopVarIndex++) {
+            String loopVar = loopVars.get(loopVarIndex);
             if (Map.Entry.class.isAssignableFrom(val.getClass())) {
               Map.Entry<String, Object> entry = (Entry<String, Object>) val;
               Object entryVal = null;
@@ -159,6 +162,14 @@ public class ForTag implements Tag {
                 entryVal = entry.getValue();
               }
 
+              interpreter.getContext().put(loopVar, entryVal);
+            } else if (List.class.isAssignableFrom(val.getClass())) {
+              List<Object> entries = ((PyList) val).toList();
+              String entryVal = null;
+              // safety check for size
+              if (entries.size() >= loopVarIndex) {
+                entryVal = Objects.toString(entries.get(loopVarIndex));
+              }
               interpreter.getContext().put(loopVar, entryVal);
             } else {
               try {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
@@ -205,6 +205,27 @@ public class ForTagTest {
     assertEquals(new PyishDate(testDate).toString(), rendered);
   }
 
+  @Test
+  public void testTuplesWithPyList() {
+	  String template = "{% for href, caption in [('index.html', 'Index'), ('downloads.html', 'Downloads'), ('products.html', 'Products')] %}" + 
+	  		"<li><a href=\"{{href|e}}\">{{caption|e}}</a></li>\n" + 
+	  		"{% endfor %}";
+	  String expected = "<li><a href=\"index.html\">Index</a></li>\n" +
+	  		"<li><a href=\"downloads.html\">Downloads</a></li>\n" +
+	  		"<li><a href=\"products.html\">Products</a></li>\n";
+	  
+	  String rendered = jinjava.render(template, context);
+	  assertEquals(rendered, expected);
+	  
+	  template = "{% for a, b, c in [(1,2,3), (4,5,6)] %}"
+	  		+ "<p>{{a}} {{b}} {{c}}</p>\n"
+	  		+ "{% endfor %}";
+	  expected = "<p>1 2 3</p>\n"
+	  		+ "<p>4 5 6</p>\n";
+	  rendered = jinjava.render(template, context);
+	  assertEquals(rendered, expected);
+  }
+  
   private Node fixture(String name) {
     try {
       return new TreeParser(interpreter, Resources.toString(

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
@@ -210,7 +210,7 @@ public class ForTagTest {
   @Test
   public void testTuplesWithPyList() {
 	String template = "{% for href, caption in [('index.html', 'Index'), ('downloads.html', 'Downloads'), ('products.html', 'Products')] %}" + 
-	  		"<li><a href=\"{{href|e}}\">{{caption|e}}</a></li>\n" + 
+	  		"<li><a href=\"{{href}}\">{{caption}}</a></li>\n" + 
 	  		"{% endfor %}";
 	String expected = "<li><a href=\"index.html\">Index</a></li>\n" +
 	  		"<li><a href=\"downloads.html\">Downloads</a></li>\n" +


### PR DESCRIPTION
Fixes #321 

This pull request is wrt the above-mentioned Issue.
The support for For-Tag was limited to Maps and the else block in ForTag.java file could not handle tuples(list of tuples) types. This PR adds the needed code as well as the supporting tests.

Cheers!