### PR TITLE
Implement safe filter as SafeString and handle SafeString in filters, functions and expressions

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringExpTest.java
@@ -4,6 +4,7 @@ import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.objects.SafeString;
 
 @JinjavaDoc(
     value = "Return true if object is a string",
@@ -24,7 +25,7 @@ public class IsStringExpTest implements ExpTest {
   @Override
   public boolean evaluate(Object var, JinjavaInterpreter interpreter,
       Object... args) {
-    return var != null && var instanceof String;
+    return var != null && (var instanceof String || var instanceof SafeString);
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsUpperExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsUpperExpTest.java
@@ -6,6 +6,7 @@ import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.objects.SafeString;
 
 @JinjavaDoc(
     value = "Return true if string is all uppercased",
@@ -26,11 +27,11 @@ public class IsUpperExpTest implements ExpTest {
   @Override
   public boolean evaluate(Object var, JinjavaInterpreter interpreter,
       Object... args) {
-    if (!(var instanceof String)) {
+    if (!(var instanceof String || var instanceof SafeString)) {
       return false;
     }
 
-    return StringUtils.isAllUpperCase((String) var);
+    return StringUtils.isAllUpperCase(var.toString());
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/Filter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/Filter.java
@@ -1,17 +1,17 @@
 /**********************************************************************
-Copyright (c) 2014 HubSpot Inc.
+ Copyright (c) 2014 HubSpot Inc.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+ http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
  **********************************************************************/
 package com.hubspot.jinjava.lib.filter;
 
@@ -31,12 +31,9 @@ public interface Filter extends Importable {
   /**
    * Filter the specified template variable within the context of a render process. {{ myvar|myfiltername(arg1,arg2) }}
    *
-   * @param var
-   *          the variable which this filter should operate on
-   * @param interpreter
-   *          current interpreter context
-   * @param args
-   *          any arguments passed to this filter invocation
+   * @param var         the variable which this filter should operate on
+   * @param interpreter current interpreter context
+   * @param args        any arguments passed to this filter invocation
    * @return the filtered form of the given variable
    */
   Object filter(Object var, JinjavaInterpreter interpreter, String... args);
@@ -63,15 +60,26 @@ public interface Filter extends Importable {
     for (int i = 0; i < stringArgs.size(); i++) {
       filterArgs[i] = stringArgs.get(i);
     }
+    if (var instanceof SafeString){
+      return filter((SafeString) var, interpreter, filterArgs);
+    }
 
     return filter(var, interpreter, filterArgs);
   }
-  default Object filter(SafeString var, JinjavaInterpreter interpreter, String... args) {
 
-    Object result = filter(var.toString(), interpreter, args);
-    if (result instanceof String) {
-      return new SafeString(result.toString());
+  default boolean preserveSafeString() {
+    return true;
+  }
+
+
+  default Object filter(SafeString var, JinjavaInterpreter interpreter, String... args) {
+    if (var == null) {
+      return filter((Object) null, interpreter, args);
     }
-    return result;
+    Object filteredValue = filter(var.toString(), interpreter, args);
+    if (preserveSafeString() && filteredValue instanceof String) {
+      return new SafeString(filteredValue.toString());
+    }
+    return filteredValue;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/Filter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/Filter.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.Importable;
+import com.hubspot.jinjava.objects.SafeString;
 
 public interface Filter extends Importable {
 
@@ -64,5 +65,13 @@ public interface Filter extends Importable {
     }
 
     return filter(var, interpreter, filterArgs);
+  }
+  default Object filter(SafeString var, JinjavaInterpreter interpreter, String... args) {
+
+    Object result = filter(var.toString(), interpreter, args);
+    if (result instanceof String) {
+      return new SafeString(result.toString());
+    }
+    return result;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/Filter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/Filter.java
@@ -60,7 +60,8 @@ public interface Filter extends Importable {
     for (int i = 0; i < stringArgs.size(); i++) {
       filterArgs[i] = stringArgs.get(i);
     }
-    if (var instanceof SafeString){
+
+    if (var instanceof SafeString) {
       return filter((SafeString) var, interpreter, filterArgs);
     }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/IpAddrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IpAddrFilter.java
@@ -64,6 +64,11 @@ public class IpAddrFilter implements Filter {
     return false;
   }
 
+  @Override
+  public boolean preserveSafeString() {
+    return false;
+  }
+
   private Object getFunctionValue(JinjavaInterpreter interpreter, String function, Object object) {
 
     if (!(object instanceof String)) {
@@ -123,5 +128,4 @@ public class IpAddrFilter implements Filter {
   public String getName() {
     return "ipaddr";
   }
-
 }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/LengthFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/LengthFilter.java
@@ -80,6 +80,11 @@ public class LengthFilter implements Filter {
   }
 
   @Override
+  public boolean preserveSafeString(){
+    return false;
+  }
+
+  @Override
   public String getName() {
     return "length";
   }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/LengthFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/LengthFilter.java
@@ -80,7 +80,7 @@ public class LengthFilter implements Filter {
   }
 
   @Override
-  public boolean preserveSafeString(){
+  public boolean preserveSafeString() {
     return false;
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/Md5Filter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/Md5Filter.java
@@ -77,6 +77,11 @@ public class Md5Filter implements Filter {
   }
 
   @Override
+  public boolean preserveSafeString() {
+    return false;
+  }
+
+  @Override
   public String getName() {
     return "md5";
   }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SafeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SafeFilter.java
@@ -3,7 +3,10 @@ package com.hubspot.jinjava.lib.filter;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.interpret.InvalidInputException;
+import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.objects.SafeString;
 
 /**
  * Mark the value as safe which means that in an environment with automatic escaping enabled this variable will not be escaped.
@@ -25,9 +28,15 @@ public class SafeFilter implements Filter {
   }
 
   @Override
-  public Object filter(Object var, JinjavaInterpreter interpreter,
-      String... args) {
-    return var;
-  }
+  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+    if (var == null) {
+      return null;
+    }
 
+    if (!(var instanceof String)) {
+      throw new InvalidInputException(interpreter, this, InvalidReason.STRING);
+    }
+
+    return new SafeString((String) var);
+  }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SafeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SafeFilter.java
@@ -3,8 +3,6 @@ package com.hubspot.jinjava.lib.filter;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InvalidInputException;
-import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.objects.SafeString;
 
@@ -31,7 +29,7 @@ public class SafeFilter implements Filter {
     }
 
     if (!(var instanceof String)) {
-      throw new InvalidInputException(interpreter, this, InvalidReason.STRING);
+      return var;
     }
 
     return new SafeString((String) var);

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SafeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SafeFilter.java
@@ -10,9 +10,6 @@ import com.hubspot.jinjava.objects.SafeString;
 
 /**
  * Mark the value as safe which means that in an environment with automatic escaping enabled this variable will not be escaped.
- *
- * This is currently implemented as a pass-through for the given variable.
- *
  */
 @JinjavaDoc(
     value = "Mark the value as safe, which means that in an environment with automatic escaping enabled this variable will not be escaped.",

--- a/src/main/java/com/hubspot/jinjava/lib/fn/TypeFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/TypeFunction.java
@@ -10,6 +10,7 @@ import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.el.ext.AstDict;
 import com.hubspot.jinjava.el.ext.AstList;
 import com.hubspot.jinjava.el.ext.AstTuple;
+import com.hubspot.jinjava.objects.SafeString;
 import com.hubspot.jinjava.objects.date.PyishDate;
 
 
@@ -35,6 +36,7 @@ public class TypeFunction {
       .put(Long.class, "long")
       .put(Map.class, "dict")
       .put(String.class, "str")
+      .put(SafeString.class, "str")
       .build();
 
   public static String type(Object var) {

--- a/src/main/java/com/hubspot/jinjava/objects/SafeString.java
+++ b/src/main/java/com/hubspot/jinjava/objects/SafeString.java
@@ -1,0 +1,19 @@
+package com.hubspot.jinjava.objects;
+
+public class SafeString {
+
+  private final String value;
+
+  public SafeString(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.filter.EscapeFilter;
+import com.hubspot.jinjava.objects.SafeString;
 import com.hubspot.jinjava.tree.output.OutputNode;
 import com.hubspot.jinjava.tree.output.RenderedOutputNode;
 import com.hubspot.jinjava.tree.parse.ExpressionToken;
@@ -61,7 +62,7 @@ public class ExpressionNode extends Node {
       }
     }
 
-    if (interpreter.getContext().isAutoEscape()) {
+    if (interpreter.getContext().isAutoEscape() && !(var instanceof SafeString)) {
       result = EscapeFilter.escapeHtmlEntities(result);
     }
 

--- a/src/main/java/com/hubspot/jinjava/util/ObjectTruthValue.java
+++ b/src/main/java/com/hubspot/jinjava/util/ObjectTruthValue.java
@@ -19,6 +19,8 @@ import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.Map;
 
+import com.hubspot.jinjava.objects.SafeString;
+
 public final class ObjectTruthValue {
 
   private ObjectTruthValue() {
@@ -41,6 +43,10 @@ public final class ObjectTruthValue {
 
     if (object instanceof String) {
       return !"".equals(object) && !"false".equalsIgnoreCase((String) object);
+    }
+
+    if (object instanceof SafeString) {
+      return !"".equals(object.toString()) && !"false".equalsIgnoreCase(object.toString());
     }
 
     if (object.getClass().isArray()) {

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsStringContainingExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsStringContainingExpTestTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.objects.SafeString;
 
 public class IsStringContainingExpTestTest {
 
@@ -34,5 +35,10 @@ public class IsStringContainingExpTestTest {
   @Test
   public void itReturnsFalseForNull() {
     assertThat(jinjava.render(CONTAINING_TEMPLATE, ImmutableMap.of("var", "testing"))).isEqualTo("false");
+  }
+
+  @Test
+  public void itWorksForSafeString() {
+    assertThat(jinjava.render(CONTAINING_TEMPLATE, ImmutableMap.of("var", "testing", "arg", new SafeString("testing")))).isEqualTo("true");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsStringStartingWithExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsStringStartingWithExpTestTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.objects.SafeString;
 
 public class IsStringStartingWithExpTestTest {
   private static final String STARTING_TEMPLATE = "{{ var is string_startingwith arg }}";
@@ -33,5 +34,10 @@ public class IsStringStartingWithExpTestTest {
   @Test
   public void itReturnsFalseForNull() {
     assertThat(jinjava.render(STARTING_TEMPLATE, ImmutableMap.of("var", "testing"))).isEqualTo("false");
+  }
+
+  @Test
+  public void itWorksForSafeString() {
+    assertThat(jinjava.render(STARTING_TEMPLATE, ImmutableMap.of("var", "testing", "arg", new SafeString("tes")))).isEqualTo("true");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsUpperExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsUpperExpTestTest.java
@@ -1,0 +1,38 @@
+package com.hubspot.jinjava.lib.exptest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.objects.SafeString;
+
+public class IsUpperExpTestTest {
+  private static final String STARTING_TEMPLATE = "{{ var is upper }}";
+  private static final String SAFE_TEMPLATE = "{{ (var|safe) is upper }}";
+
+  private Jinjava jinjava;
+
+  @Before
+  public void setup() {
+    jinjava = new Jinjava();
+  }
+
+  @Test
+  public void itReturnsTrueForUpperString() {
+    assertThat(jinjava.render(STARTING_TEMPLATE, ImmutableMap.of("var", "UPPER"))).isEqualTo("true");
+  }
+
+  @Test
+  public void itReturnsFalseForLowerString() {
+    assertThat(jinjava.render(STARTING_TEMPLATE, ImmutableMap.of("var", "lower"))).isEqualTo("false");
+  }
+
+  @Test
+  public void itWorksForSafeStrings() {
+    assertThat(jinjava.render(STARTING_TEMPLATE, ImmutableMap.of("var", new SafeString("UPPER")))).isEqualTo("true");
+    assertThat(jinjava.render(SAFE_TEMPLATE, ImmutableMap.of("var", "UPPER"))).isEqualTo("true");
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/lib/filter/EscapeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/EscapeFilterTest.java
@@ -1,12 +1,13 @@
 package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.objects.SafeString;
 
 public class EscapeFilterTest {
 
@@ -27,4 +28,9 @@ public class EscapeFilterTest {
     assertThat(f.filter(1, interpreter)).isEqualTo("1");
   }
 
+  @Test
+  public void testSafeStringCanBeEscaped() {
+    assertThat(f.filter(new SafeString("<a>Previously marked as safe<a/>"), interpreter).toString()).isEqualTo("&lt;a&gt;Previously marked as safe&lt;a/&gt;");
+    assertThat(f.filter(new SafeString("<a>Previously marked as safe<a/>"), interpreter)).isInstanceOf(SafeString.class);
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilterTest.java
@@ -1,12 +1,13 @@
 package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.objects.SafeString;
 
 public class EscapeJinjavaFilterTest {
 
@@ -25,4 +26,10 @@ public class EscapeJinjavaFilterTest {
     assertThat(f.filter("{{ me & you }}", interpreter)).isEqualTo("&lbrace;&lbrace; me & you &rbrace;&rbrace;");
   }
 
+  @Test
+  public void testSafeStringCanBeEscaped() {
+    assertThat(f.filter("", interpreter)).isEqualTo("");
+    assertThat(f.filter(new SafeString("{{ me & you }}"), interpreter).toString()).isEqualTo("&lbrace;&lbrace; me & you &rbrace;&rbrace;");
+    assertThat(f.filter(new SafeString("{{ me & you }}"), interpreter)).isInstanceOf(SafeString.class);
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJsFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJsFilterTest.java
@@ -45,4 +45,8 @@ public class EscapeJsFilterTest {
     assertThat(jinjava.render("{{ 'Testing a \"quote for the week\"'|escapejs }}", new HashMap<>())).isEqualTo("Testing a \\\"quote for the week\\\"");
   }
 
+  @Test
+  public void testSafeStringCanBeEscaped() {
+    assertThat(jinjava.render("{{ 'Testing\nlineb\"reak\n'|safe|escapejs }}", new HashMap<>())).isEqualTo("Testing\\nlineb\\\"reak\\n");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJsonFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJsonFilterTest.java
@@ -50,4 +50,9 @@ public class EscapeJsonFilterTest {
     Map<String, String> vars = ImmutableMap.of("string", "Testing a 'single quote' for the week");
     assertThat(jinjava.render("{{ string|escapejson }}", vars)).isEqualTo("Testing a 'single quote' for the week");
   }
+
+  @Test
+  public void testSafeStringCanBeEscaped() {
+    assertThat(jinjava.render("{{ 'Testing\nlineb\"reak\n'|safe|escapejs }}", new HashMap<>())).isEqualTo("Testing\\nlineb\\\"reak\\n");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/FromJsonFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FromJsonFilterTest.java
@@ -11,10 +11,12 @@ import org.junit.Test;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.objects.SafeString;
 
 
 public class FromJsonFilterTest {
 
+  private static final String NESTED_JSON = "{\"first\":[1,2,3],\"nested\":{\"second\":\"string\",\"third\":4}}";
   private JinjavaInterpreter interpreter;
   private FromJsonFilter filter;
 
@@ -26,15 +28,8 @@ public class FromJsonFilterTest {
 
   @Test
   public void itReadsStringAsObject() {
-
-    String nestedJson = "{\"first\":[1,2,3],\"nested\":{\"second\":\"string\",\"third\":4}}";
-
-    HashMap<String, Object> node = (HashMap<String, Object>) filter.filter(nestedJson, interpreter);
-    assertThat(node.get("first")).isEqualTo(Arrays.asList(1, 2, 3));
-
-    HashMap<String, Object> nested = (HashMap<String, Object>) node.get("nested");
-    assertThat(nested.get("second")).isEqualTo("string");
-    assertThat(nested.get("third")).isEqualTo(4);
+    HashMap<String, Object> node = (HashMap<String, Object>) filter.filter(NESTED_JSON, interpreter);
+    checkedNestJson(node);
   }
 
   @Test(expected = InvalidInputException.class)
@@ -51,5 +46,20 @@ public class FromJsonFilterTest {
     Integer nestedJson = 456;
 
     filter.filter(nestedJson, interpreter);
+  }
+
+  @Test
+  public void itReadsSafeStringAsObject() {
+    SafeString nestedJson = new SafeString(NESTED_JSON);
+    HashMap<String, Object> node = (HashMap<String, Object>) filter.filter(nestedJson, interpreter);
+    checkedNestJson(node);
+  }
+
+  private void checkedNestJson(HashMap<String, Object> node) {
+    assertThat(node.get("first")).isEqualTo(Arrays.asList(1, 2, 3));
+
+    HashMap<String, Object> nested = (HashMap<String, Object>) node.get("nested");
+    assertThat(nested.get("second")).isEqualTo("string");
+    assertThat(nested.get("third")).isEqualTo(4);
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/IpAddrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/IpAddrFilterTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.objects.SafeString;
 
 public class IpAddrFilterTest {
 
@@ -87,5 +88,13 @@ public class IpAddrFilterTest {
   public void itAddsErrorOnInvalidFunctionName() {
     assertThatThrownBy(() -> ipAddrFilter.filter("192.168.0.1/20", interpreter, "notAFunction"))
         .hasMessageContaining("must be one of");
+  }
+
+  @Test
+  public void itWorksWithSafeString() throws Exception {
+    assertThat(ipAddrFilter.filter(new SafeString("1200:0000:AB00:1234:0000:2552:7777:1313"), interpreter)).isEqualTo(true);
+    assertThat(ipAddrFilter.filter(new SafeString("255.182.100.abc"), interpreter)).isEqualTo(false);
+    assertThat(ipAddrFilter.filter(new SafeString("   128.0.0.1   "), interpreter)).isEqualTo(true);
+    assertThat(ipAddrFilter.filter(new SafeString("255.182.100.1/10"), interpreter, "netmask")).isEqualTo("255.192.0.0");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilterTest.java
@@ -9,6 +9,7 @@ import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.objects.SafeString;
 
 public class RegexReplaceFilterTest {
 
@@ -38,5 +39,10 @@ public class RegexReplaceFilterTest {
     @Test(expected = InvalidArgumentException.class)
     public void isThrowsExceptionOnInvalidRegex() {
         filter.filter("It costs $300", interpreter, "[", "");
+    }
+
+    @Test
+    public void itMatchesRegexAndReplacesStringForSafeString() {
+        assertThat(filter.filter(new SafeString("It costs $300"), interpreter, "[^a-zA-Z]", "").toString()).isEqualTo("Itcosts");
     }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/ReplaceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/ReplaceFilterTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.objects.SafeString;
 
 public class ReplaceFilterTest {
 
@@ -39,4 +40,8 @@ public class ReplaceFilterTest {
     assertThat(filter.filter("aaaaargh", interpreter, "a", "d'oh, ", "2")).isEqualTo("d'oh, d'oh, aaargh");
   }
 
+  @Test
+  public void replaceSafeStringWithCount() {
+    assertThat(filter.filter(new SafeString("aaaaargh"), interpreter, "a", "d'oh, ", "2").toString()).isEqualTo("d'oh, d'oh, aaargh");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SafeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SafeFilterTest.java
@@ -19,7 +19,6 @@ public class SafeFilterTest {
   public void setup() {
     interpreter = new Jinjava().newInterpreter();
     interpreter.getContext().setAutoEscape(true);
-    interpreter.getContext().put("v", HTML);
   }
 
   @After
@@ -29,7 +28,13 @@ public class SafeFilterTest {
 
   @Test
   public void itDoesNotEscapeStringMarkedAsSafe() throws Exception {
-    assertThat(interpreter.renderFlat("{{ v|safe }}")).isEqualTo(HTML);
+    interpreter.getContext().put("html", HTML);
+    assertThat(interpreter.renderFlat("{{ html|safe }}")).isEqualTo(HTML);
   }
 
+  @Test
+  public void itPassesVarThroughIfNotInstanceOfString() throws Exception {
+    interpreter.getContext().put("number", -3);
+    assertThat(interpreter.renderFlat("{{ number|safe|abs }}")).isEqualTo("3");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SafeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SafeFilterTest.java
@@ -2,18 +2,25 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 
 public class SafeFilterTest {
 
   private static final String HTML = "<a>Link</a>";
+  private static final List<Integer> TEST_NUMBERS = ImmutableList.of(43, 1, 24);
+  private static final List<String> TEST_STRINGS = ImmutableList.of("-100","1000", "short", "WeIrD", "The quick Brown fox Jumped Over The Lazy Dog.", "  some whitespace here  ");
+  private static final List<String> STRING_FILTERS = ImmutableList.of("ipaddr", "length", "lower", "upper", "md5", "reverse", "trim", "capitalize", "cut('a')", "center");
+  private static final List<String> NUMBER_FILTERS = ImmutableList.of("divide('5')", "ipaddr", "length", "log", "lower", "upper", "md5", "multiply('9')", "reverse", "root");
 
-  JinjavaInterpreter interpreter;
+  private JinjavaInterpreter interpreter;
 
   @Before
   public void setup() {
@@ -36,5 +43,34 @@ public class SafeFilterTest {
   public void itPassesVarThroughIfNotInstanceOfString() throws Exception {
     interpreter.getContext().put("number", -3);
     assertThat(interpreter.renderFlat("{{ number|safe|abs }}")).isEqualTo("3");
+  }
+
+  @Test
+  public void itWorksWhenChainingFilters() throws Exception {
+    interpreter.getContext().put("safe_html", HTML);
+    assertThat(interpreter.renderFlat("{{ safe_html|safe|upper }}")).isEqualTo(HTML.toUpperCase());
+    assertThat(interpreter.renderFlat("{{ safe_html|upper|safe }}")).isEqualTo(HTML.toUpperCase());
+    assertThat(interpreter.renderFlat("{{ safe_html|safe|length }}")).isEqualTo(String.valueOf(HTML.length()));
+    assertThat(interpreter.renderFlat("{{ safe_html|safe|length|safe }}")).isEqualTo(String.valueOf(HTML.length()));
+    assertThat(interpreter.renderFlat("{{ safe_html|length }}")).isEqualTo(String.valueOf(HTML.length()));
+  }
+
+  @Test
+  public void itWorksForAllRelevantFilters() throws Exception {
+    for (String testFilter : STRING_FILTERS) {
+      for (String testString : TEST_STRINGS ) {
+        interpreter.getContext().put("string_under_test", testString);
+        assertThat(interpreter.renderFlat("{{ string_under_test|safe|" + testFilter + "|safe }}")).as("Testing behaviour of filter with and without safe filter: " + testFilter + " on string " + testString)
+            .isEqualTo(interpreter.renderFlat("{{ string_under_test|" + testFilter + " }}"));
+      }
+    }
+    for (String testFilter : NUMBER_FILTERS) {
+      for (Integer testInt : TEST_NUMBERS ) {
+        interpreter.getContext().put("string_under_test", testInt);
+        assertThat(interpreter.renderFlat("{{ string_under_test|safe|" + testFilter + " }}")).as("Testing behaviour of filter with and without safe filter: " + testFilter + " on string " + testInt)
+            .isEqualTo(interpreter.renderFlat("{{ string_under_test|" + testFilter + " }}"));
+      }
+    }
+    assertThat(interpreter.renderFlat("{{ 1|safe|random }}")).isEqualTo("0");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SafeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SafeFilterTest.java
@@ -1,0 +1,35 @@
+package com.hubspot.jinjava.lib.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+
+public class SafeFilterTest {
+
+  private static final String HTML = "<a>Link</a>";
+
+  JinjavaInterpreter interpreter;
+
+  @Before
+  public void setup() {
+    interpreter = new Jinjava().newInterpreter();
+    interpreter.getContext().setAutoEscape(true);
+    interpreter.getContext().put("v", HTML);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    assertThat(interpreter.getErrorsCopy()).isEmpty();
+  }
+
+  @Test
+  public void itDoesNotEscapeStringMarkedAsSafe() throws Exception {
+    assertThat(interpreter.renderFlat("{{ v|safe }}")).isEqualTo(HTML);
+  }
+
+}

--- a/src/test/java/com/hubspot/jinjava/lib/filter/TrimFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/TrimFilterTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.objects.SafeString;
 
 public class TrimFilterTest {
 
@@ -24,4 +25,21 @@ public class TrimFilterTest {
     assertThat(filter.filter(" foo  ", interpreter)).isEqualTo("foo");
   }
 
+  @Test
+  public void testTrimSafeString() {
+    assertThat(filter.filter(new SafeString(" foo  "), interpreter).toString()).isEqualTo("foo");
+    assertThat(filter.filter(new SafeString(" foo  "), interpreter)).isInstanceOf(SafeString.class);
+  }
+
+  @Test
+  public void itTrimsObject() {
+    assertThat(filter.filter(new TestObject(), interpreter)).isEqualTo("hello");
+  }
+
+  private class TestObject {
+    @Override
+    public String toString() {
+      return "    hello   ";
+    }
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/UpperFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/UpperFilterTest.java
@@ -1,0 +1,32 @@
+package com.hubspot.jinjava.lib.filter;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.objects.SafeString;
+
+public class UpperFilterTest {
+  private UpperFilter filter;
+  private JinjavaInterpreter interpreter;
+
+  @Before
+  public void setup() {
+    interpreter = new Jinjava().newInterpreter();
+    filter = new UpperFilter();
+  }
+
+  @Test
+  public void testUpper() {
+    Assertions.assertThat(filter.filter("lower", interpreter)).isEqualTo("LOWER");
+  }
+
+  @Test
+  public void testUpperSafeString() {
+    Assertions.assertThat(filter.filter(new SafeString("lower"), interpreter).toString()).isEqualTo("LOWER");
+    Assertions.assertThat(filter.filter(new SafeString("lower"), interpreter)).isInstanceOf(SafeString.class);
+  }
+
+}

--- a/src/test/java/com/hubspot/jinjava/lib/fn/TypeFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/TypeFunctionTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.objects.SafeString;
 
 public class TypeFunctionTest {
 
@@ -60,4 +61,10 @@ public class TypeFunctionTest {
   public void testBool() {
     assertThat(TypeFunction.type(Boolean.FALSE)).isEqualTo("bool");
   }
+
+  @Test
+  public void testSafeString() {
+    assertThat(TypeFunction.type(new SafeString("foo"))).isEqualTo("str");
+  }
+
 }


### PR DESCRIPTION
# Safe filter:

Replacement for reverted PR: https://github.com/HubSpot/jinjava/pull/385
Implemenetation is much simplier than previous PR. Any filter which is receiving a SafeString object will now be handled without any changes to the underlying filter. If a function filter receives a SafeString and returns a String it will be wrapped in a SafeString. This is undesirable in some cases such as the ipAddr filter which does not return some direct version of the input. An override has been added to disable this wrapping for such filters. `preserveSafeString` can be set to false to disable the wrapping.

## Documentation

> Marks the value as safe which means that in an environment with automatic escaping enabled the variable will not be escaped.

Jinja docs: http://jinja.palletsprojects.com/en/2.10.x/templates/#working-with-automatic-escaping

## Approach: 

Wrap String with new class `SafeString` when the `|safe` filter is applied to the value. This way we can check the type in `ExpressionNode` and not escape it. I overwrote `toString` to make it work as expected here: https://github.com/HubSpot/jinjava/blob/16679771bf9b81a2435d9140a574ab0d15a05603/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java#L52

## Considerations: 

Since I introduce a new type here we might need to add some implementation for this in `ExpressionResolver` or `JinjavaInterpreterResolver`. The implementation is currently only tested with `|safe` being used at the end of an expression.
