### PR TITLE
prevent CallStacks from parenting themselves

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/CallStack.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/CallStack.java
@@ -3,7 +3,11 @@ package com.hubspot.jinjava.interpret;
 import java.util.Optional;
 import java.util.Stack;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class CallStack {
+  private static final Logger LOG = LoggerFactory.getLogger(CallStack.class);
 
   private final CallStack parent;
   private final Class<? extends TagCycleException> exceptionClass;
@@ -13,6 +17,10 @@ public class CallStack {
   private int topStartPosition = -1;
 
   public CallStack(CallStack parent, Class<? extends TagCycleException> exceptionClass) {
+    if (parent == this) {
+      LOG.error("Attempt to make this call stack a parent of itself! Ignoring parent.");
+      parent = null;
+    }
     this.parent = parent;
     this.exceptionClass = exceptionClass;
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilter.java
@@ -33,7 +33,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
     snippets = {
         @JinjavaSnippet(
             code = "{% set escape_string = \"{{This markup is printed as text}}\" %}\n" +
-                "{{ escape_string|escapeJinjava }}")
+                "{{ escape_string|escape_jinjava }}")
     })
 
 public class EscapeJinjavaFilter implements Filter {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
@@ -108,7 +108,7 @@ public class MacroTagTest {
   }
 
   @Test
-  public void testMacroUsedInForLoop() throws Exception {
+  public void testMacroUsedInForLoop() {
     Map<String, Object> bindings = new HashMap<>();
     bindings.put("widget_data", ImmutableMap.of(
         "tools_body_1", ImmutableMap.of("html", "body1"),
@@ -126,21 +126,21 @@ public class MacroTagTest {
   }
 
   @Test
-  public void itPreventsDirectMacroRecursion() throws IOException {
+  public void itPreventsDirectMacroRecursion() {
     String template = fixtureText("recursion");
     interpreter.render(template);
     assertThat(interpreter.getErrorsCopy().get(0).getMessage()).contains("Cycle detected for macro 'hello'");
   }
 
   @Test
-  public void itPreventsIndirectMacroRecursion() throws IOException {
+  public void itPreventsIndirectMacroRecursion() {
     String template = fixtureText("recursion_indirect");
     interpreter.render(template);
     assertThat(interpreter.getErrorsCopy().get(0).getMessage()).contains("Cycle detected for macro 'goodbye'");
   }
 
   @Test
-  public void itAllowsMacrosCallingMacrosUsingCall() throws IOException {
+  public void itAllowsMacrosCallingMacrosUsingCall() {
     String template = fixtureText("macros-calling-macros");
     String out = interpreter.render(template);
     assertThat(interpreter.getErrorsCopy()).isEmpty();
@@ -149,7 +149,7 @@ public class MacroTagTest {
   }
 
   @Test
-  public void itAllowsMacroRecursionWhenEnabledInConfiguration() throws IOException {
+  public void itAllowsMacroRecursionWhenEnabledInConfiguration() {
     // I need a different configuration here therefore
     interpreter = new Jinjava(JinjavaConfig.newBuilder().withEnableRecursiveMacroCalls(true).build()).newInterpreter();
     JinjavaInterpreter.pushCurrent(interpreter);
@@ -167,7 +167,7 @@ public class MacroTagTest {
   }
 
   @Test
-  public void itAllowsMacroRecursionWithMaxDepth() throws IOException {
+  public void itAllowsMacroRecursionWithMaxDepth() {
 
     interpreter = new Jinjava(JinjavaConfig.newBuilder()
         .withEnableRecursiveMacroCalls(true)
@@ -187,7 +187,7 @@ public class MacroTagTest {
   }
 
   @Test
-  public void itAllowsMacroRecursionWithMaxDepthInValidationMode() throws IOException {
+  public void itAllowsMacroRecursionWithMaxDepthInValidationMode() {
 
     interpreter = new Jinjava(JinjavaConfig.newBuilder()
         .withEnableRecursiveMacroCalls(true)
@@ -208,7 +208,7 @@ public class MacroTagTest {
   }
 
   @Test
-  public void itEnforcesMacroRecursionWithMaxDepth() throws IOException {
+  public void itEnforcesMacroRecursionWithMaxDepth() {
 
     interpreter = new Jinjava(JinjavaConfig.newBuilder()
         .withEnableRecursiveMacroCalls(true)


### PR DESCRIPTION
We've seen some instances where `CallStack.pop()` gets itself into a cycle. This could only be possible if it were a parent of itself. 

Adding some error logging here to help track it down.