### PR TITLE
Fix implementation for slice filter

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
@@ -1,8 +1,10 @@
 package com.hubspot.jinjava.lib.filter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.commons.lang3.math.NumberUtils;
 
-import com.google.common.collect.Iterators;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
@@ -47,7 +49,27 @@ public class SliceFilter implements Filter {
     }
 
     int slices = NumberUtils.toInt(args[0], 3);
-    return Iterators.paddedPartition(loop, slices);
+    List<List<Object>> result = new ArrayList<>();
+
+    List<Object> currentList = null;
+    int i = 0;
+    while(loop.hasNext()) {
+      Object next = loop.next();
+      if (i % slices == 0) {
+        currentList = new ArrayList<>(slices);
+        result.add(currentList);
+      }
+      currentList.add(next);
+      i++;
+    }
+
+    if (args.length > 1 && currentList != null) {
+      while (currentList.size() < slices) {
+        currentList.add(args[1]);
+      }
+    }
+
+    return result;
   }
 
 }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
@@ -8,6 +8,8 @@ import org.apache.commons.lang3.math.NumberUtils;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
+import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.util.ForLoop;
@@ -49,6 +51,9 @@ public class SliceFilter implements Filter {
     }
 
     int slices = NumberUtils.toInt(args[0], 3);
+    if (slices <= 0) {
+      throw new InvalidArgumentException(interpreter, this, InvalidReason.POSITIVE_NUMBER, 0, args[0]);
+    }
     List<List<Object>> result = new ArrayList<>();
 
     List<Object> currentList = null;

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
@@ -20,6 +20,7 @@ import com.hubspot.jinjava.util.ObjectIterator;
     input = @JinjavaParam(value = "value", type = "sequence", desc = "The sequence or dict that the filter is applied to", required = true),
     params = {
         @JinjavaParam(value = "slices", type = "number", desc = "Specifies how many items will be sliced", required = true),
+        @JinjavaParam(value = "fillWith", type = "object", desc = "Specifies which object to use to fill missing values on final iteration", required = false),
     },
     snippets = {
         @JinjavaSnippet(

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
@@ -58,7 +58,7 @@ public class SliceFilter implements Filter {
 
     List<Object> currentList = null;
     int i = 0;
-    while(loop.hasNext()) {
+    while (loop.hasNext()) {
       Object next = loop.next();
       if (i % slices == 0) {
         currentList = new ArrayList<>(slices);

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
@@ -69,8 +69,9 @@ public class SliceFilter implements Filter {
     }
 
     if (args.length > 1 && currentList != null) {
+      Object fillWith = args[1];
       while (currentList.size() < slices) {
-        currentList.add(args[1]);
+        currentList.add(fillWith);
       }
     }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SliceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SliceFilterTest.java
@@ -33,7 +33,35 @@ public class SliceFilterTest {
     assertThat(dom.select(".columwrapper ul")).hasSize(3);
     assertThat(dom.select(".columwrapper .column-1 li")).hasSize(3);
     assertThat(dom.select(".columwrapper .column-2 li")).hasSize(3);
-    assertThat(dom.select(".columwrapper .column-3 li")).hasSize(3);
+    assertThat(dom.select(".columwrapper .column-3 li")).hasSize(1);
+  }
+
+  @Test
+  public void testSliceWithReplacement() throws Exception {
+    String result = jinjava.render(
+        Resources.toString(Resources.getResource("filter/slice-filter-replacement.jinja"), StandardCharsets.UTF_8),
+        ImmutableMap.of("items", (Object) Lists.newArrayList("a", "b", "c", "d", "e")));
+
+    assertThat(result).isEqualTo("\n" +
+        "  1\n" +
+        "    a\n" +
+        "    b\n" +
+        "  2\n" +
+        "    c\n" +
+        "    d\n" +
+        "  3\n" +
+        "    e\n" +
+        "    hello\n" +
+        "");
+  }
+
+  @Test
+  public void testSliceWithEmptyList() throws Exception {
+    String result = jinjava.render(
+        Resources.toString(Resources.getResource("filter/slice-filter-empty.jinja"), StandardCharsets.UTF_8),
+        ImmutableMap.of("items", (Object) Lists.newArrayList()));
+
+    assertThat(result).isEqualTo("\n");
   }
 
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SliceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SliceFilterTest.java
@@ -13,6 +13,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
 import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.interpret.RenderResult;
 
 public class SliceFilterTest {
 
@@ -24,7 +25,7 @@ public class SliceFilterTest {
   }
 
   @Test
-  public void testSimpleSlice() throws Exception {
+  public void itSlicesLists() throws Exception {
     Document dom = Jsoup.parseBodyFragment(
         jinjava.render(
             Resources.toString(Resources.getResource("filter/slice-filter.jinja"), StandardCharsets.UTF_8),
@@ -37,7 +38,7 @@ public class SliceFilterTest {
   }
 
   @Test
-  public void testSliceWithReplacement() throws Exception {
+  public void itSlicesListWithReplacement() throws Exception {
     String result = jinjava.render(
         Resources.toString(Resources.getResource("filter/slice-filter-replacement.jinja"), StandardCharsets.UTF_8),
         ImmutableMap.of("items", (Object) Lists.newArrayList("a", "b", "c", "d", "e")));
@@ -56,12 +57,51 @@ public class SliceFilterTest {
   }
 
   @Test
-  public void testSliceWithEmptyList() throws Exception {
+  public void itSlicesListWithReplacementButDivisibleSlices() throws Exception {
+    String result = jinjava.render(
+        Resources.toString(Resources.getResource("filter/slice-filter-replacement.jinja"), StandardCharsets.UTF_8),
+        ImmutableMap.of("items", (Object) Lists.newArrayList("a", "b", "c", "d", "e", "f")));
+
+    assertThat(result).isEqualTo("\n" +
+        "  1\n" +
+        "    a\n" +
+        "    b\n" +
+        "  2\n" +
+        "    c\n" +
+        "    d\n" +
+        "  3\n" +
+        "    e\n" +
+        "    f\n" +
+        "");
+  }
+
+  @Test
+  public void itSlicesEmptyList() throws Exception {
     String result = jinjava.render(
         Resources.toString(Resources.getResource("filter/slice-filter-empty.jinja"), StandardCharsets.UTF_8),
         ImmutableMap.of("items", (Object) Lists.newArrayList()));
 
     assertThat(result).isEqualTo("\n");
+  }
+
+  @Test
+  public void itAddsErrorOnNegativeSlice() throws Exception {
+    RenderResult result = jinjava.renderForResult(
+        Resources.toString(Resources.getResource("filter/slice-filter-negative.jinja"), StandardCharsets.UTF_8),
+        ImmutableMap.of("items", (Object) Lists.newArrayList()));
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("with value -1 must be a positive number");
+  }
+
+  @Test
+  public void itAddsErrorOnZeroSlice() throws Exception {
+    RenderResult result = jinjava.renderForResult(
+        Resources.toString(Resources.getResource("filter/slice-filter-zero.jinja"), StandardCharsets.UTF_8),
+        ImmutableMap.of("items", (Object) Lists.newArrayList()));
+
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage()).contains("with value 0 must be a positive number");
   }
 
 }

--- a/src/test/resources/filter/slice-filter-empty.jinja
+++ b/src/test/resources/filter/slice-filter-empty.jinja
@@ -1,0 +1,6 @@
+{%- for column in items|slice(2, 'hello') %}
+  {{ loop.index }}
+ {%- for item in column %}
+    {{ item }}
+  {%- endfor %}
+{%- endfor %}

--- a/src/test/resources/filter/slice-filter-negative.jinja
+++ b/src/test/resources/filter/slice-filter-negative.jinja
@@ -1,0 +1,6 @@
+{%- for column in items|slice(-1, 'hello') %}
+  {{ loop.index }}
+ {%- for item in column %}
+    {{ item }}
+  {%- endfor %}
+{%- endfor %}

--- a/src/test/resources/filter/slice-filter-replacement.jinja
+++ b/src/test/resources/filter/slice-filter-replacement.jinja
@@ -1,0 +1,6 @@
+{%- for column in items|slice(2, 'hello') %}
+  {{ loop.index }}
+ {%- for item in column %}
+    {{ item }}
+  {%- endfor %}
+{%- endfor %}

--- a/src/test/resources/filter/slice-filter-zero.jinja
+++ b/src/test/resources/filter/slice-filter-zero.jinja
@@ -1,0 +1,6 @@
+{%- for column in items|slice(0, 'hello') %}
+  {{ loop.index }}
+ {%- for item in column %}
+    {{ item }}
+  {%- endfor %}
+{%- endfor %}


### PR DESCRIPTION
Slice filter was not implemented as according to spec. When doing `list|slice(3)` we should not be padding non-divisible slices with null values. When using `list|slice(3, 'value')` we should pad non-divisible slices with `value`. https://jinja.palletsprojects.com/en/2.11.x/templates/#slice