### PR TITLE
Add millis precision to unixtimestamp function

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/FunctionLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/FunctionLibrary.java
@@ -14,7 +14,7 @@ public class FunctionLibrary extends SimpleLibrary<ELFunctionDefinition> {
   @Override
   protected void registerDefaults() {
     register(new ELFunctionDefinition("", "datetimeformat", Functions.class, "dateTimeFormat", Object.class, String[].class));
-    register(new ELFunctionDefinition("", "unixtimestamp", Functions.class, "unixtimestamp", Object.class));
+    register(new ELFunctionDefinition("", "unixtimestamp", Functions.class, "unixtimestamp", Object[].class));
     register(new ELFunctionDefinition("", "truncate", Functions.class, "truncate", Object.class, Object[].class));
     register(new ELFunctionDefinition("", "range", Functions.class, "range", Object.class, Object[].class));
     register(new ELFunctionDefinition("", "type", TypeFunction.class, "type", Object.class));

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -152,7 +152,7 @@ public class Functions {
       return 0;
     }
 
-    return d.toEpochSecond() * 1000;
+    return d.toEpochSecond() * 1000 + Math.round(d.getNano() / 1_000_000.0);
   }
 
   @JinjavaDoc(value = "converts a string and datetime format into a datetime object", params = {

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -145,8 +145,8 @@ public class Functions {
   @JinjavaDoc(value = "gets the unix timestamp milliseconds value of a datetime", params = {
       @JinjavaParam(value = "var", type = "date", defaultValue = "current time"),
   })
-  public static long unixtimestamp(Object var) {
-    ZonedDateTime d = getDateTimeArg(var, ZoneOffset.UTC);
+  public static long unixtimestamp(Object... var) {
+    ZonedDateTime d = getDateTimeArg(var == null || var.length == 0 ? null : var[0], ZoneOffset.UTC);
 
     if (d == null) {
       return 0;

--- a/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
@@ -29,7 +29,7 @@ public class StrftimeFormatter {
     CONVERSIONS['c'] = "EEE MMM dd HH:mm:ss yyyy";
     CONVERSIONS['d'] = "dd";
     CONVERSIONS['e'] = "d"; // The day of the month like with %d, but padded with blank (range 1 through 31).
-    CONVERSIONS['f'] = "SSSS";
+    CONVERSIONS['f'] = "SSSSSS";
     CONVERSIONS['H'] = "HH";
     CONVERSIONS['h'] = "hh";
     CONVERSIONS['I'] = "hh";

--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
@@ -484,7 +484,7 @@ public class ExpressionResolverTest {
     final JinjavaConfig config = JinjavaConfig.newBuilder().build();
     String template = "{% for i in range(1, 5) %}{{i}} {% endfor %}\n{{ unixtimestamp(datetime) }}";
     final RenderResult renderResult = jinjava.renderForResult(template, context, config);
-    assertThat(renderResult.getOutput()).isEqualTo("1 2 3 4 \n12000");
+    assertThat(renderResult.getOutput()).isEqualTo("1 2 3 4 \n12345");
     assertThat(renderResult.getContext().getResolvedFunctions()).hasSameElementsAs(ImmutableSet.of(":range", ":unixtimestamp"));
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
@@ -13,6 +13,7 @@ public class UnixTimestampFunctionTest {
 
   @Test
   public void itGetsUnixTimestamps() {
+    assertThat(Functions.unixtimestamp()).isGreaterThan(0).isLessThan(System.currentTimeMillis());
     assertThat(Functions.unixtimestamp(epochMilliseconds)).isEqualTo(epochMilliseconds);
     assertThat(Functions.unixtimestamp(d)).isEqualTo(epochMilliseconds);
     assertThat(Math.abs(Functions.unixtimestamp(null) - ZonedDateTime.now().toEpochSecond() * 1000)).isLessThan(1000);

--- a/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
@@ -8,14 +8,14 @@ import org.junit.Test;
 
 public class UnixTimestampFunctionTest {
 
-  private final ZonedDateTime d = ZonedDateTime.parse("2013-11-06T14:22:00.000+00:00[UTC]");
-  private final long epochMilliseconds = d.toEpochSecond() * 1000;
+  private final ZonedDateTime d = ZonedDateTime.parse("2013-11-06T14:22:12.345+00:00[UTC]");
+  private final long epochMilliseconds = d.toEpochSecond() * 1000 + 345;
 
   @Test
   public void itGetsUnixTimestamps() {
     assertThat(Functions.unixtimestamp(epochMilliseconds)).isEqualTo(epochMilliseconds);
     assertThat(Functions.unixtimestamp(d)).isEqualTo(epochMilliseconds);
-    assertThat(Math.abs(Functions.unixtimestamp(null) - ZonedDateTime.now().toEpochSecond() * 1000)).isLessThan(10);
+    assertThat(Math.abs(Functions.unixtimestamp(null) - ZonedDateTime.now().toEpochSecond() * 1000)).isLessThan(1000);
   }
 
 }

--- a/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
@@ -15,7 +15,7 @@ public class StrftimeFormatterTest {
   @Before
   public void setup() {
     Locale.setDefault(Locale.ENGLISH);
-    d = ZonedDateTime.parse("2013-11-06T14:22:00.000+00:00");
+    d = ZonedDateTime.parse("2013-11-06T14:22:00.123+00:00");
   }
 
   @Test
@@ -62,6 +62,11 @@ public class StrftimeFormatterTest {
   @Test
   public void testTime() {
     assertThat(StrftimeFormatter.format(d, "%X")).isEqualTo("14:22:00");
+  }
+
+  @Test
+  public void testMicrosecs() {
+    assertThat(StrftimeFormatter.format(d, "%X %f")).isEqualTo("14:22:00 123000");
   }
 
   @Test


### PR DESCRIPTION
We claimed to provide microsecond formatting options in the `unixtimestamp` filter, but we were rounding to seconds. Millis are now in there. Adding micros would change the return value and break compatibility. 

Separately, the date/time formatter has been updated to return seconds in microseconds but will still be rounded to micros if the source of the date the source is millis precision such as the `unixtimestamp` function.

Also fixed the function to allow no arguments to return the value of `now()`.
