### PR TITLE
add a config option to turn off expression tracking

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -41,6 +41,7 @@ public class JinjavaConfig {
   private final boolean trimBlocks;
   private final boolean lstripBlocks;
 
+  private final boolean trackResolved;
   private final boolean readOnlyResolver;
   private final boolean enableRecursiveMacroCalls;
   private final int maxMacroRecursionDepth;
@@ -62,11 +63,11 @@ public class JinjavaConfig {
   }
 
   public JinjavaConfig(InterpreterFactory interpreterFactory) {
-    this(StandardCharsets.UTF_8, Locale.ENGLISH, ZoneOffset.UTC, 10, new HashMap<>(), false, false, true, false, 0, false, 0, true, RandomNumberGeneratorStrategy.THREAD_LOCAL, false, 0, interpreterFactory);
+    this(StandardCharsets.UTF_8, Locale.ENGLISH, ZoneOffset.UTC, 10, new HashMap<>(), false, false, true, false, 0, false, 0, true, RandomNumberGeneratorStrategy.THREAD_LOCAL, false, 0, true, interpreterFactory);
   }
 
   public JinjavaConfig(Charset charset, Locale locale, ZoneId timeZone, int maxRenderDepth) {
-    this(charset, locale, timeZone, maxRenderDepth, new HashMap<>(), false, false, true, false, 0, false, 0, true, RandomNumberGeneratorStrategy.THREAD_LOCAL, false, 0, new JinjavaInterpreterFactory());
+    this(charset, locale, timeZone, maxRenderDepth, new HashMap<>(), false, false, true, false, 0, false, 0, true, RandomNumberGeneratorStrategy.THREAD_LOCAL, false, 0, true, new JinjavaInterpreterFactory());
   }
 
   private JinjavaConfig(Charset charset,
@@ -85,6 +86,7 @@ public class JinjavaConfig {
                         RandomNumberGeneratorStrategy randomNumberGenerator,
                         boolean validationMode,
                         long maxStringLength,
+                        boolean trackResolved,
                         InterpreterFactory interpreterFactory) {
     this.charset = charset;
     this.locale = locale;
@@ -101,6 +103,7 @@ public class JinjavaConfig {
     this.nestedInterpretationEnabled = nestedInterpretationEnabled;
     this.randomNumberGenerator = randomNumberGenerator;
     this.validationMode = validationMode;
+    this.trackResolved = trackResolved;
     this.maxStringLength = maxStringLength;
     this.interpreterFactory = interpreterFactory;
   }
@@ -169,6 +172,8 @@ public class JinjavaConfig {
     return maxStringLength;
   }
 
+  public boolean isTrackResolved() { return trackResolved; }
+
   public InterpreterFactory getInterpreterFactory() {
     return interpreterFactory;
   }
@@ -192,6 +197,7 @@ public class JinjavaConfig {
     private RandomNumberGeneratorStrategy randomNumberGeneratorStrategy = RandomNumberGeneratorStrategy.THREAD_LOCAL;
     private boolean validationMode = false;
     private long maxStringLength = 0;
+    private boolean trackResolved = true;
     private InterpreterFactory interpreterFactory = new JinjavaInterpreterFactory();
 
     private Builder() {
@@ -226,7 +232,6 @@ public class JinjavaConfig {
       this.randomNumberGeneratorStrategy = randomNumberGeneratorStrategy;
       return this;
     }
-
 
     public Builder withTrimBlocks(boolean trimBlocks) {
       this.trimBlocks = trimBlocks;
@@ -278,8 +283,13 @@ public class JinjavaConfig {
       return this;
     }
 
-    public Builder withInterperterFactory(InterpreterFactory interperterFactory) {
-      this.interpreterFactory = interperterFactory;
+    public Builder withTrackResolved(boolean trackResolved) {
+      this.trackResolved = trackResolved;
+      return this;
+    }
+
+    public Builder withInterpreterFactory(InterpreterFactory interpreterFactory) {
+      this.interpreterFactory = interpreterFactory;
       return this;
     }
 
@@ -300,6 +310,7 @@ public class JinjavaConfig {
           randomNumberGeneratorStrategy,
           validationMode,
           maxStringLength,
+          trackResolved,
           interpreterFactory);
     }
 

--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -66,7 +66,9 @@ public class ExpressionResolver {
       return null;
     }
 
-    interpreter.getContext().addResolvedExpression(expression.trim());
+    if (interpreter.getConfig().isTrackResolved()) {
+      interpreter.getContext().addResolvedExpression(expression.trim());
+    }
 
     try {
       String elExpression = EXPRESSION_START_TOKEN + expression.trim() + EXPRESSION_END_TOKEN;

--- a/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
@@ -146,7 +146,9 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
     String propertyName = Objects.toString(property, "");
     Object value = null;
 
-    interpreter.getContext().addResolvedValue(propertyName);
+    if (interpreter.getConfig().isTrackResolved()) {
+      interpreter.getContext().addResolvedValue(propertyName);
+    }
     ErrorItem item = ErrorItem.PROPERTY;
 
     try {

--- a/src/main/java/com/hubspot/jinjava/el/MacroFunctionMapper.java
+++ b/src/main/java/com/hubspot/jinjava/el/MacroFunctionMapper.java
@@ -23,7 +23,8 @@ public class MacroFunctionMapper extends FunctionMapper {
 
   @Override
   public Method resolveFunction(String prefix, String localName) {
-    final Context context = JinjavaInterpreter.getCurrent().getContext();
+    JinjavaInterpreter interpreter = JinjavaInterpreter.getCurrent();
+    final Context context = interpreter.getContext();
     MacroFunction macroFunction = context.getGlobalMacro(localName);
 
     if (macroFunction != null) {
@@ -36,7 +37,7 @@ public class MacroFunctionMapper extends FunctionMapper {
       throw new DisabledException(functionName);
     }
 
-    if (map.containsKey(functionName)) {
+    if (map.containsKey(functionName) && interpreter.getConfig().isTrackResolved()) {
       context.addResolvedFunction(functionName);
     }
 

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -57,6 +57,32 @@ public class JinjavaInterpreterTest {
   }
 
   @Test
+  public void itTracksResolvedExpressions() {
+    String testName = "itTracksResolvedExpressions";
+    assertThat(interpreter.getConfig().isTrackResolved()).isTrue();
+    assertThat(interpreter.getContext().getResolvedExpressions()).doesNotContain(testName);
+
+    interpreter.render("{{" + testName + "}}");
+
+    assertThat(interpreter.getContext().getResolvedExpressions()).contains(testName);
+  }
+
+  @Test
+  public void itDoesNotTrackResolvedExpressionsWhenDisabled() {
+    String testName = "itDoesNotTrackResolvedExpressionsWhenDisabled";
+
+    jinjava = new Jinjava(JinjavaConfig.newBuilder().withTrackResolved(false).build());
+    interpreter = jinjava.newInterpreter();
+
+    assertThat(interpreter.getConfig().isTrackResolved()).isFalse();
+    assertThat(interpreter.getContext().getResolvedExpressions()).doesNotContain(testName);
+
+    interpreter.render("{{" + testName + "}}");
+
+    assertThat(interpreter.getContext().getResolvedExpressions()).doesNotContain(testName);
+  }
+
+  @Test
   public void resolveBlockStubsWithCycle() {
     String content = interpreter.render("{% block foo %}{% block foo %}{% endblock %}{% endblock %}");
     assertThat(content).isEmpty();


### PR DESCRIPTION
For large templates, tracking which functions, expressions, and filters that were used during execution can use a lot of CPU and memory, especially since they are copied all the way up the context tree. 

This adds an option to disable tracking unless it is needed.

For a sufficiently large template, this can be called a lot.

![image](https://user-images.githubusercontent.com/152548/74576845-b1fcb100-4f5a-11ea-81ef-c0e67c368d45.png)
