### PR TITLE
evalulate variables in dict keys

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
@@ -33,7 +33,7 @@ public class AstDict extends AstLiteral {
       if (entry.getKey() instanceof AstString) {
         key = Objects.toString(entry.getKey().eval(bindings, context));
       } else if (entry.getKey() instanceof AstIdentifier) {
-        key = ((AstIdentifier) entry.getKey()).getName();
+        key = entry.getKey().eval(bindings, context).toString();
       } else {
         throw new TemplateStateException("Dict key must be a string or identifier, was: " + entry.getKey());
       }

--- a/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
@@ -28,18 +28,18 @@ public class AstDict extends AstLiteral {
     Map<String, Object> resolved = new LinkedHashMap<>();
 
     for (Map.Entry<AstNode, AstNode> entry : dict.entrySet()) {
+      AstNode entryKey = entry.getKey();
       String key;
 
-      if (entry.getKey() instanceof AstString) {
-        key = Objects.toString(entry.getKey().eval(bindings, context));
-      } else if (entry.getKey() instanceof AstIdentifier) {
-        Object result = entry.getKey().eval(bindings, context);
-        if (result == null) {
-          continue;
-        }
-        key = result.toString();
+      if (entryKey instanceof AstString) {
+        key = Objects.toString(entryKey.eval(bindings, context));
+      } else if (entryKey instanceof AstIdentifier) {
+        Object result = entryKey.eval(bindings, context);
+        key = result == null
+            ? ((AstIdentifier) entryKey).getName() // this is for compatibility with the previous behavior
+            : result.toString();
       } else {
-        throw new TemplateStateException("Dict key must be a string or identifier, was: " + entry.getKey());
+        throw new TemplateStateException("Dict key must be a string or identifier, was: " + entryKey);
       }
 
       resolved.put(key, entry.getValue().eval(bindings, context));
@@ -58,7 +58,7 @@ public class AstDict extends AstLiteral {
     StringBuilder s = new StringBuilder("{");
 
     for (Map.Entry<AstNode, AstNode> entry : dict.entrySet()) {
-      s.append(Objects.toString(entry.getKey())).append(":").append(Objects.toString(entry.getValue()));
+      s.append(entry.getKey()).append(":").append(entry.getValue());
     }
 
     return s.append("}").toString();

--- a/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
@@ -33,7 +33,11 @@ public class AstDict extends AstLiteral {
       if (entry.getKey() instanceof AstString) {
         key = Objects.toString(entry.getKey().eval(bindings, context));
       } else if (entry.getKey() instanceof AstIdentifier) {
-        key = entry.getKey().eval(bindings, context).toString();
+        Object result = entry.getKey().eval(bindings, context);
+        if (result == null) {
+          continue;
+        }
+        key = result.toString();
       } else {
         throw new TemplateStateException("Dict key must be a string or identifier, was: " + entry.getKey());
       }

--- a/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
@@ -160,7 +160,7 @@ public class ExtendedSyntaxBuilderTest {
   public void mapLiteral() {
     context.put("foo", "bar");
     assertThat((Map<String, Object>) val("{}")).isEmpty();
-    Map<String, Object> map = (Map<String, Object>) val("{foo: foo, \"foo2\": foo, foo3: 123, foo4: 'string', foo5: {}, foo6: [1, 2]}");
+    Map<String, Object> map = (Map<String, Object>) val("{\"foo\": foo, \"foo2\": foo, \"foo3\": 123, \"foo4\": 'string', \"foo5\": {}, \"foo6\": [1, 2]}");
     assertThat(map).contains(entry("foo", "bar"), entry("foo2", "bar"), entry("foo3", 123L),
         entry("foo4", "string"), entry("foo6", Arrays.asList(1L, 2L)));
 

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
@@ -105,4 +105,11 @@ public class PyListTest {
     assertThat(jinjava.render("{% set test = [10, 20, 30, 10, 20, 30] %}" +
         "{{ test.index(999, 1, 5) }}", Collections.emptyMap())).isEqualTo("-1");
   }
+
+  @Test
+  public void itInterpretsVariables() {
+    assertThat(jinjava.render("{% set ten = \"10\" %}{% set test = [ten, 20, 30] %}" +
+        "{{ test }}", Collections.emptyMap())).isEqualTo("[10, 20, 30]");
+  }
+
 }

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
@@ -1,0 +1,50 @@
+package com.hubspot.jinjava.objects.collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.hubspot.jinjava.Jinjava;
+
+public class PyMapTest {
+
+  private Jinjava jinjava;
+
+  @Before
+  public void setup() {
+    jinjava = new Jinjava();
+  }
+
+  @Test
+  public void itUpdatesKeysWithStaticName() {
+    assertThat(jinjava.render("{% set test = {\"key1\": \"value1\"} %}" +
+        "{% do test.update({\"key1\": \"value2\"}) %}" +
+        "{{ test[\"key1\"] }}", Collections.emptyMap())).isEqualTo("value2");
+  }
+
+  @Test
+  public void itSetsKeysWithVariableName() {
+    assertThat(jinjava.render("{% set keyName = \"key1\" %}" +
+        "{% set test = {keyName: \"value1\"} %}" +
+        "{{ test[keyName] }}", Collections.emptyMap())).isEqualTo("value1");
+  }
+
+  @Test
+  public void itGetsKeysWithVariableName() {
+    assertThat(jinjava.render("{% set test = {\"key1\": \"value1\"} %}" +
+        "{% set keyName = \"key1\" %}" +
+        "{{ test[keyName] }}", Collections.emptyMap())).isEqualTo("value1");
+  }
+
+  @Test
+  public void itUpdatesKeysWithVariableName() {
+    assertThat(jinjava.render("{% set test = {\"key1\": \"value1\"} %}" +
+        "{% set keyName = \"key1\" %}" +
+        "{% do test.update({keyName: \"value2\"}) %}" +
+        "{{ test[keyName] }}", Collections.emptyMap())).isEqualTo("value2");
+  }
+
+}

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
@@ -40,6 +40,12 @@ public class PyMapTest {
   }
 
   @Test
+  public void itIgnoresKeysWithUnknownVariableName() {
+    assertThat(jinjava.render("{% set test = {keyName: \"value1\"} %}" +
+        "{{ test[\"keyName\"] }}", Collections.emptyMap())).isEqualTo("");
+  }
+
+  @Test
   public void itUpdatesKeysWithVariableName() {
     assertThat(jinjava.render("{% set test = {\"key1\": \"value1\"} %}" +
         "{% set keyName = \"key1\" %}" +

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
@@ -40,9 +40,9 @@ public class PyMapTest {
   }
 
   @Test
-  public void itIgnoresKeysWithUnknownVariableName() {
+  public void itFallsBackUnknownVariableNameToString() {
     assertThat(jinjava.render("{% set test = {keyName: \"value1\"} %}" +
-        "{{ test[\"keyName\"] }}", Collections.emptyMap())).isEqualTo("");
+        "{{ test[\"keyName\"] }}", Collections.emptyMap())).isEqualTo("value1");
   }
 
   @Test


### PR DESCRIPTION
While you could previously add variables as elements in list, this was not possible with dict keys. 

So 
```
{% set keyName = "key1" %}
{% set test = {keyName: "value1"} %}
{{ test[keyName]}}
```

will now return "value1"

This could have adverse side effects. We were liberally accepting unquoted key names for dicts. Now they will be evaluated.

This does work in Jinja 2.11.1 for lists and dicts:
```
>>> Template('Hello {% set key = "key1" %}{% set d = [key, "val"] %}{{ d[0] }}').render()
u'Hello key1'
```

```
>>> Template('Hello {% set d = [key, "val"] %}{{ d[0] }}').render(key="key1")
u'Hello key1'
```

For compatibility, key names that evaluate to `null` (meaning probably undefined) will be treated as strings. 

Fixes https://github.com/HubSpot/jinjava/issues/379