### PR TITLE
check for null config too

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
@@ -90,7 +90,10 @@ public abstract class Token implements Serializable {
   public abstract int getType();
 
   public TokenScannerSymbols getOrDefaultTokens() {
-    if (JinjavaInterpreter.getCurrent() == null) {
+    if (
+      JinjavaInterpreter.getCurrent() == null ||
+      JinjavaInterpreter.getCurrent().getConfig() == null
+    ) {
       return new DefaultTokenScannerSymbols();
     }
     return JinjavaInterpreter.getCurrent().getConfig().getTokenScannerSymbols();


### PR DESCRIPTION
The check added in https://github.com/HubSpot/jinjava/pull/410 checked for a null interpreter, but not a null config, a situation that exists in some of our unit tests.

@gabru-md 