### PR TITLE
store reference to TokenScannerSymbols in Nodes and Tokens

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -31,10 +31,12 @@ public class ExpressionNode extends Node {
   private static final long serialVersionUID = -6063173739682221042L;
 
   private final ExpressionToken master;
+  private final TokenScannerSymbols symbols;
 
-  public ExpressionNode(ExpressionToken token) {
+  public ExpressionNode(ExpressionToken token, TokenScannerSymbols symbols) {
     super(token, token.getLineNumber(), token.getStartPosition());
     master = token;
+    this.symbols = symbols;
   }
 
   @Override
@@ -48,8 +50,6 @@ public class ExpressionNode extends Node {
     }
 
     String result = Objects.toString(var, "");
-
-    TokenScannerSymbols symbols = interpreter.getConfig().getTokenScannerSymbols();
 
     if (interpreter.getConfig().isNestedInterpretationEnabled()) {
       if (

--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -22,7 +22,6 @@ import com.hubspot.jinjava.objects.SafeString;
 import com.hubspot.jinjava.tree.output.OutputNode;
 import com.hubspot.jinjava.tree.output.RenderedOutputNode;
 import com.hubspot.jinjava.tree.parse.ExpressionToken;
-import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
 import com.hubspot.jinjava.util.Logging;
 import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
@@ -31,12 +30,10 @@ public class ExpressionNode extends Node {
   private static final long serialVersionUID = -6063173739682221042L;
 
   private final ExpressionToken master;
-  private final TokenScannerSymbols symbols;
 
-  public ExpressionNode(ExpressionToken token, TokenScannerSymbols symbols) {
+  public ExpressionNode(ExpressionToken token) {
     super(token, token.getLineNumber(), token.getStartPosition());
     master = token;
-    this.symbols = symbols;
   }
 
   @Override
@@ -55,8 +52,8 @@ public class ExpressionNode extends Node {
       if (
         !StringUtils.equals(result, master.getImage()) &&
         (
-          StringUtils.contains(result, symbols.getExpressionStart()) ||
-          StringUtils.contains(result, symbols.getExpressionStartWithTag())
+          StringUtils.contains(result, getSymbols().getExpressionStart()) ||
+          StringUtils.contains(result, getSymbols().getExpressionStartWithTag())
         )
       ) {
         try {

--- a/src/main/java/com/hubspot/jinjava/tree/Node.java
+++ b/src/main/java/com/hubspot/jinjava/tree/Node.java
@@ -30,7 +30,7 @@ public abstract class Node implements Serializable {
   private final int startPosition;
 
   private Node parent = null;
-  private LinkedList<Node> children = new LinkedList<Node>();
+  private LinkedList<Node> children = new LinkedList<>();
 
   public Node(Token master, int lineNumber) {
     this(master, lineNumber, -1);
@@ -91,7 +91,7 @@ public abstract class Node implements Serializable {
     }
 
     if (getChildren().size() > 0) {
-      t.append(prefix).append("end :: " + toString()).append('\n');
+      t.append(prefix).append("end :: ").append(toString()).append('\n');
     }
 
     return t.toString();

--- a/src/main/java/com/hubspot/jinjava/tree/Node.java
+++ b/src/main/java/com/hubspot/jinjava/tree/Node.java
@@ -18,6 +18,7 @@ package com.hubspot.jinjava.tree;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.tree.output.OutputNode;
 import com.hubspot.jinjava.tree.parse.Token;
+import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
 import java.io.Serializable;
 import java.util.LinkedList;
 import org.apache.commons.lang3.StringUtils;
@@ -31,10 +32,6 @@ public abstract class Node implements Serializable {
 
   private Node parent = null;
   private LinkedList<Node> children = new LinkedList<>();
-
-  public Node(Token master, int lineNumber) {
-    this(master, lineNumber, -1);
-  }
 
   public Node(Token master, int lineNumber, int startPosition) {
     this.master = master;
@@ -72,6 +69,10 @@ public abstract class Node implements Serializable {
 
   public String reconstructImage() {
     return master.getImage();
+  }
+
+  public TokenScannerSymbols getSymbols() {
+    return master.getSymbols();
   }
 
   public abstract OutputNode render(JinjavaInterpreter interpreter);

--- a/src/main/java/com/hubspot/jinjava/tree/RootNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/RootNode.java
@@ -17,11 +17,12 @@ package com.hubspot.jinjava.tree;
 
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.tree.output.OutputNode;
+import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
 
 public class RootNode extends Node {
   private static final long serialVersionUID = 5904181260202954424L;
 
-  RootNode() {
+  RootNode(TokenScannerSymbols symbols) {
     super(null, 0, 0);
   }
 

--- a/src/main/java/com/hubspot/jinjava/tree/TagNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TagNode.java
@@ -32,14 +32,12 @@ public class TagNode extends Node {
   private final Tag tag;
   private final TagToken master;
   private final String endName;
-  private final TokenScannerSymbols symbols;
 
   public TagNode(Tag tag, TagToken token, TokenScannerSymbols symbols) {
     super(token, token.getLineNumber(), token.getStartPosition());
     this.master = token;
     this.tag = tag;
     this.endName = tag.getEndTagName();
-    this.symbols = symbols;
   }
 
   @Override
@@ -104,20 +102,20 @@ public class TagNode extends Node {
 
   public String reconstructEnd() {
     StringBuilder stringBuilder = new StringBuilder();
-    stringBuilder.append(symbols.getExpressionStartWithTag());
+    stringBuilder.append(getSymbols().getExpressionStartWithTag());
     if (
       getChildren() != null &&
       !getChildren().isEmpty() &&
       getChildren().getLast().getMaster().isRightTrim()
     ) {
-      stringBuilder.append(symbols.getTrimChar());
+      stringBuilder.append(getSymbols().getTrimChar());
     }
     stringBuilder.append(" ").append(getEndName()).append(" ");
     if (getMaster().isRightTrimAfterEnd()) {
-      stringBuilder.append(symbols.getTrimChar());
+      stringBuilder.append(getSymbols().getTrimChar());
     }
 
-    stringBuilder.append(symbols.getExpressionEndWithTag());
+    stringBuilder.append(getSymbols().getExpressionEndWithTag());
     return stringBuilder.toString();
   }
 }

--- a/src/main/java/com/hubspot/jinjava/tree/TagNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TagNode.java
@@ -32,19 +32,14 @@ public class TagNode extends Node {
   private final Tag tag;
   private final TagToken master;
   private final String endName;
+  private final TokenScannerSymbols symbols;
 
-  public TagNode(Tag tag, TagToken token) {
+  public TagNode(Tag tag, TagToken token, TokenScannerSymbols symbols) {
     super(token, token.getLineNumber(), token.getStartPosition());
     this.master = token;
     this.tag = tag;
     this.endName = tag.getEndTagName();
-  }
-
-  private TagNode(TagNode n) {
-    super(n.master, n.getLineNumber(), n.getStartPosition());
-    tag = n.tag;
-    master = n.master;
-    endName = n.endName;
+    this.symbols = symbols;
   }
 
   @Override
@@ -108,10 +103,6 @@ public class TagNode extends Node {
   }
 
   public String reconstructEnd() {
-    TokenScannerSymbols symbols = JinjavaInterpreter
-      .getCurrent()
-      .getConfig()
-      .getTokenScannerSymbols();
     StringBuilder stringBuilder = new StringBuilder();
     stringBuilder.append(symbols.getExpressionStartWithTag());
     if (

--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -52,7 +52,7 @@ public class TreeParser {
   }
 
   public Node buildTree() {
-    Node root = new RootNode();
+    Node root = new RootNode(symbols);
 
     parent = root;
 
@@ -166,7 +166,7 @@ public class TreeParser {
   }
 
   private Node expression(ExpressionToken expressionToken) {
-    ExpressionNode n = new ExpressionNode(expressionToken, symbols);
+    ExpressionNode n = new ExpressionNode(expressionToken);
     n.setParent(parent);
     return n;
   }

--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -140,7 +140,8 @@ public class TreeParser {
           new TextToken(
             StringUtils.stripEnd(textToken.getImage(), "\t "),
             textToken.getLineNumber(),
-            textToken.getStartPosition()
+            textToken.getStartPosition(),
+            symbols
           );
       }
     }
@@ -165,7 +166,7 @@ public class TreeParser {
   }
 
   private Node expression(ExpressionToken expressionToken) {
-    ExpressionNode n = new ExpressionNode(expressionToken);
+    ExpressionNode n = new ExpressionNode(expressionToken, symbols);
     n.setParent(parent);
     return n;
   }
@@ -209,7 +210,7 @@ public class TreeParser {
       }
     }
 
-    TagNode node = new TagNode(tag, tagToken);
+    TagNode node = new TagNode(tag, tagToken, symbols);
     node.setParent(parent);
 
     if (node.getEndName() != null) {
@@ -227,7 +228,6 @@ public class TreeParser {
     if (
       parent instanceof TagNode &&
       tagToken.isLeftTrim() &&
-      lastSibling != null &&
       lastSibling instanceof TextNode
     ) {
       lastSibling.getMaster().setRightTrim(true);

--- a/src/main/java/com/hubspot/jinjava/tree/parse/ExpressionToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/ExpressionToken.java
@@ -20,12 +20,15 @@ import org.apache.commons.lang3.StringUtils;
 
 public class ExpressionToken extends Token {
   private static final long serialVersionUID = 6336768632140743908L;
-  private final int tokenExprStart;
   private String expr;
 
-  public ExpressionToken(String image, int lineNumber, int startPosition) {
-    super(image, lineNumber, startPosition);
-    tokenExprStart = getOrDefaultTokens().getExprStart();
+  public ExpressionToken(
+    String image,
+    int lineNumber,
+    int startPosition,
+    TokenScannerSymbols symbols
+  ) {
+    super(image, lineNumber, startPosition, symbols);
   }
 
   @Override
@@ -35,7 +38,7 @@ public class ExpressionToken extends Token {
 
   @Override
   public int getType() {
-    return tokenExprStart;
+    return getSymbols().getExprStart();
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/tree/parse/NoteToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/NoteToken.java
@@ -17,16 +17,19 @@ package com.hubspot.jinjava.tree.parse;
 
 public class NoteToken extends Token {
   private static final long serialVersionUID = -3859011447900311329L;
-  private final int tokenNote;
 
-  public NoteToken(String image, int lineNumber, int startPosition) {
-    super(image, lineNumber, startPosition);
-    tokenNote = getOrDefaultTokens().getNote();
+  public NoteToken(
+    String image,
+    int lineNumber,
+    int startPosition,
+    TokenScannerSymbols symbols
+  ) {
+    super(image, lineNumber, startPosition, symbols);
   }
 
   @Override
   public int getType() {
-    return tokenNote;
+    return getSymbols().getNote();
   }
 
   /**

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TagToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TagToken.java
@@ -20,20 +20,23 @@ import com.hubspot.jinjava.util.WhitespaceUtils;
 
 public class TagToken extends Token {
   private static final long serialVersionUID = -4927751270481832992L;
-  private final int tokenTag;
 
   private String tagName;
   private String rawTagName;
   private String helpers;
 
-  public TagToken(String image, int lineNumber, int startPosition) {
-    super(image, lineNumber, startPosition);
-    tokenTag = getOrDefaultTokens().getTag();
+  public TagToken(
+    String image,
+    int lineNumber,
+    int startPosition,
+    TokenScannerSymbols symbols
+  ) {
+    super(image, lineNumber, startPosition, symbols);
   }
 
   @Override
   public int getType() {
-    return tokenTag;
+    return getSymbols().getTag();
   }
 
   /**

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TextToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TextToken.java
@@ -19,16 +19,19 @@ import org.apache.commons.lang3.StringUtils;
 
 public class TextToken extends Token {
   private static final long serialVersionUID = -6168990984496468543L;
-  private final int tokenFixed;
 
-  public TextToken(String image, int lineNumber, int startPosition) {
-    super(image, lineNumber, startPosition);
-    tokenFixed = getOrDefaultTokens().getFixed();
+  public TextToken(
+    String image,
+    int lineNumber,
+    int startPosition,
+    TokenScannerSymbols symbols
+  ) {
+    super(image, lineNumber, startPosition, symbols);
   }
 
   @Override
   public int getType() {
-    return tokenFixed;
+    return getSymbols().getFixed();
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
@@ -15,7 +15,6 @@ limitations under the License.
  **********************************************************************/
 package com.hubspot.jinjava.tree.parse;
 
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.UnexpectedTokenException;
 import java.io.Serializable;
 
@@ -28,20 +27,23 @@ public abstract class Token implements Serializable {
 
   protected final int lineNumber;
   protected final int startPosition;
+  private final TokenScannerSymbols symbols;
 
   private boolean leftTrim;
   private boolean rightTrim;
   private boolean rightTrimAfterEnd;
 
-  public Token(String image, int lineNumber, int startPosition) {
+  public Token(
+    String image,
+    int lineNumber,
+    int startPosition,
+    TokenScannerSymbols symbols
+  ) {
     this.image = image;
     this.lineNumber = lineNumber;
     this.startPosition = startPosition;
+    this.symbols = symbols;
     parse();
-  }
-
-  public Token(String image, int lineNumber) {
-    this(image, lineNumber, -1);
   }
 
   public String getImage() {
@@ -80,6 +82,10 @@ public abstract class Token implements Serializable {
     return startPosition;
   }
 
+  public TokenScannerSymbols getSymbols() {
+    return symbols;
+  }
+
   @Override
   public String toString() {
     return image;
@@ -89,16 +95,6 @@ public abstract class Token implements Serializable {
 
   public abstract int getType();
 
-  public TokenScannerSymbols getOrDefaultTokens() {
-    if (
-      JinjavaInterpreter.getCurrent() == null ||
-      JinjavaInterpreter.getCurrent().getConfig() == null
-    ) {
-      return new DefaultTokenScannerSymbols();
-    }
-    return JinjavaInterpreter.getCurrent().getConfig().getTokenScannerSymbols();
-  }
-
   static Token newToken(
     int tokenKind,
     TokenScannerSymbols symbols,
@@ -107,13 +103,13 @@ public abstract class Token implements Serializable {
     int startPosition
   ) {
     if (tokenKind == symbols.getFixed()) {
-      return new TextToken(image, lineNumber, startPosition);
+      return new TextToken(image, lineNumber, startPosition, symbols);
     } else if (tokenKind == symbols.getNote()) {
-      return new NoteToken(image, lineNumber, startPosition);
+      return new NoteToken(image, lineNumber, startPosition, symbols);
     } else if (tokenKind == symbols.getExprStart()) {
-      return new ExpressionToken(image, lineNumber, startPosition);
+      return new ExpressionToken(image, lineNumber, startPosition, symbols);
     } else if (tokenKind == symbols.getTag()) {
-      return new TagToken(image, lineNumber, startPosition);
+      return new TagToken(image, lineNumber, startPosition, symbols);
     } else {
       throw new UnexpectedTokenException(
         String.valueOf((char) tokenKind),

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TokenScannerSymbols.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TokenScannerSymbols.java
@@ -77,32 +77,28 @@ public abstract class TokenScannerSymbols {
 
   public String getExpressionStart() {
     if (expressionStart == null) {
-      expressionStart =
-        new StringBuilder().append(getPrefixChar()).append(getExprStartChar()).toString();
+      expressionStart = String.valueOf(getPrefixChar()) + getExprStartChar();
     }
     return expressionStart;
   }
 
   public String getExpressionStartWithTag() {
     if (expressionStartWithTag == null) {
-      expressionStartWithTag =
-        new StringBuilder().append(getPrefixChar()).append(getTagChar()).toString();
+      expressionStartWithTag = String.valueOf(getPrefixChar()) + getTagChar();
     }
     return expressionStartWithTag;
   }
 
   public String getExpressionEndWithTag() {
     if (expressionEndWithTag == null) {
-      expressionEndWithTag =
-        new StringBuilder().append(getTagChar()).append(getPostfixChar()).toString();
+      expressionEndWithTag = String.valueOf(getTagChar()) + getPostfixChar();
     }
     return expressionEndWithTag;
   }
 
   public String getClosingComment() {
     if (closingComment == null) {
-      closingComment =
-        new StringBuilder().append(getNoteChar()).append(getPostfixChar()).toString();
+      closingComment = String.valueOf(getNoteChar()) + getPostfixChar();
     }
     return closingComment;
   }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -10,6 +10,7 @@ import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.tree.TextNode;
 import com.hubspot.jinjava.tree.output.BlockInfo;
 import com.hubspot.jinjava.tree.parse.TextToken;
+import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Optional;
@@ -19,11 +20,13 @@ import org.junit.Test;
 public class JinjavaInterpreterTest {
   private Jinjava jinjava;
   private JinjavaInterpreter interpreter;
+  private TokenScannerSymbols symbols;
 
   @Before
   public void setup() {
     jinjava = new Jinjava();
     interpreter = jinjava.newInterpreter();
+    symbols = interpreter.getConfig().getTokenScannerSymbols();
   }
 
   @Test
@@ -43,7 +46,7 @@ public class JinjavaInterpreterTest {
       "foobar",
       new BlockInfo(
         Lists.newLinkedList(
-          Lists.newArrayList((new TextNode(new TextToken("sparta", -1, -1))))
+          Lists.newArrayList((new TextNode(new TextToken("sparta", -1, -1, symbols))))
         ),
         Optional.empty(),
         0,
@@ -60,7 +63,7 @@ public class JinjavaInterpreterTest {
       "foobar",
       new BlockInfo(
         Lists.newLinkedList(
-          Lists.newArrayList(new TextNode(new TextToken("$150.00", -1, -1)))
+          Lists.newArrayList(new TextNode(new TextToken("$150.00", -1, -1, symbols)))
         ),
         Optional.empty(),
         0,

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ValidationModeTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ValidationModeTest.java
@@ -12,6 +12,7 @@ import com.hubspot.jinjava.lib.fn.ELFunctionDefinition;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.TextNode;
+import com.hubspot.jinjava.tree.parse.DefaultTokenScannerSymbols;
 import com.hubspot.jinjava.tree.parse.TextToken;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -263,7 +264,9 @@ public class ValidationModeTest {
 
   @Test
   public void itDoesNotExecuteMacrosInValidatedBlocks() {
-    TextNode textNode = new TextNode(new TextToken("hello", 1, 1));
+    TextNode textNode = new TextNode(
+      new TextToken("hello", 1, 1, new DefaultTokenScannerSymbols())
+    );
     InstrumentedMacroFunction macro = new InstrumentedMacroFunction(
       ImmutableList.of(textNode),
       "hello",

--- a/src/test/java/com/hubspot/jinjava/tree/parse/TagTokenTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/parse/TagTokenTest.java
@@ -7,23 +7,24 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import org.junit.Test;
 
 public class TagTokenTest {
+  private static final TokenScannerSymbols SYMBOLS = new DefaultTokenScannerSymbols();
 
   @Test
   public void testParseTag() {
-    TagToken t = new TagToken("{% foo %}", 1, 2);
+    TagToken t = new TagToken("{% foo %}", 1, 2, SYMBOLS);
     assertThat(t.getTagName()).isEqualTo("foo");
   }
 
   @Test
   public void testParseTagWithHelpers() {
-    TagToken t = new TagToken("{% foo bar %}", 1, 2);
+    TagToken t = new TagToken("{% foo bar %}", 1, 2, SYMBOLS);
     assertThat(t.getTagName()).isEqualTo("foo");
     assertThat(t.getHelpers().trim()).isEqualTo("bar");
   }
 
   @Test
   public void tagNameIsAllJavaIdentifiers() {
-    TagToken t = new TagToken("{%rich_text\"top_left\"%}", 1, 2);
+    TagToken t = new TagToken("{%rich_text\"top_left\"%}", 1, 2, SYMBOLS);
     assertThat(t.getTagName()).isEqualTo("rich_text");
     assertThat(t.getHelpers()).isEqualTo("\"top_left\"");
   }
@@ -31,7 +32,7 @@ public class TagTokenTest {
   @Test
   public void itThrowsParseErrorWhenMalformed() {
     try {
-      new TagToken("{% ", 1, 2);
+      new TagToken("{% ", 1, 2, SYMBOLS);
       failBecauseExceptionWasNotThrown(TemplateSyntaxException.class);
     } catch (TemplateSyntaxException e) {
       assertThat(e).hasMessageContaining("Malformed");


### PR DESCRIPTION
Before, we would parse nodes and tokens using one set of symbols from the config and potentially use a different set when reconstructing a tag. Instead, let's just store a reference to the symbols on each node so we can use it when rendering.

Follow up to https://github.com/HubSpot/jinjava/pull/410

@gabru-md 