### PR TITLE
[Discussion] Handling variables in deferred scopes

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -18,6 +18,7 @@ package com.hubspot.jinjava.interpret;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;
 import com.hubspot.jinjava.lib.Importable;
 import com.hubspot.jinjava.lib.exptest.ExpTest;
@@ -269,9 +270,21 @@ public class Context extends ScopeMap<String, Object> {
   }
 
   public void addDeferredNode(Node node) {
+    addDeferredNodeAndContext(node, 1);
+  }
+
+  //depth is "height" back up the context tree here
+  private void addDeferredNodeAndContext(Node node, int currentDepth) {
     deferredNodes.add(node);
+
+    if (getParent() != null && currentDepth++ == 0) {
+      Map<String, Object> localDifference = Maps
+        .difference(getParent(), this)
+        .entriesOnlyOnRight();
+      getParent().putAll(localDifference);
+    }
     if (getParent() != null) {
-      getParent().addDeferredNode(node);
+      getParent().addDeferredNodeAndContext(node, currentDepth);
     }
   }
 


### PR DESCRIPTION
I'm working on preserving variables within deferred blocks. Currently, if a variable is used inside of a deferred node then once the first render is finished, the value is no longer in the context at the end of the render. This also presents itself as a bug in our (HubSpot) implementation when using Modules as the modules are rendered in a lower scope.

This POC PR shows that by taking the context at the time of encountering the deferred node and adding it to the parent context we can preserve it for the subsequent render. However, there is an issue with this. If the variable is used in the deferred block and updated, the first pass will resolve the variable with the value ignoring the deferred logic.


Ideally, when encountering a deferred block, we could look at the variables used in that block and add them to the context as a DeferredValue with an original value of the value they have at the time of deferral. This requires continuing to evaluate the node after the exception has been thrown, which is tricky.


## Example template: 
```
{% for item in resolved %}
    {% set varUsedInForScope = 'outside if statement' %}  
    {% if deferred %}
        {{ varUsedInForScope }}
        {% set varUsedInForScope = 'entered if statement' %}
   {% endif %}   
   {{ varUsedInForScope }}
{% endfor %}
```

Context before rendering:
resolved=resolvedValue
deferred=com.hubspot.jinjava.interpret.DeferredValue

## Output when rendering with existing logic:
❌ `{% if deferred %}     {{ varUsedInForScope }}     {% set varUsedInForScope = 'entered if statement' %}   {% endif %}   outside if statement`

### Context after 1st render:
❌ varUsedInForScope is lost
✅ deferred=com.hubspot.jinjava.interpret.DeferredValue
✅ resolved=resolvedValue

Before the 2nd render we set the deferred var to have a non-deferred value to allow the if block to execute.

### Output 2nd render:
❌ `                   outside if statement`

Note the missing first print statement from inside the deferred statement. The second printed statement is simply preserved from the 1st render and should have the value "entered if statement"

### Context after 2nd render: 
✅ varUsedInForScope=entered if statement
✅ deferred=resolved
✅ resolved=resolvedValue

## Output when rendering with proposed logic:
Context before render:
resolved=resolvedValue
deferred=com.hubspot.jinjava.interpret.DeferredValue

❌ `{% if deferred %}     {{ varUsedInForScope }}     {% set varUsedInForScope = 'entered if statement' %}   {% endif %}   outside if statement`
### Context after first render: 
✅ loop=com.hubspot.jinjava.util.ForLoop
✅ item=resolvedValue
❌ varUsedInForScope=outside if statement : we want this to be marked as Deferred with an original value of outside if statement
✅ deferred=com.hubspot.jinjava.interpret.DeferredValue : correct because this is the first pass and we have not resolved the variable yet before the 2nd pass.
✅ resolved=resolvedValue

Again, deferred is set to a resolved value before the 2nd render

## Output 2nd render:
❌ `         outside if statement           outside if statement`

### Context after 2nd render: 
✅ loop=com.hubspot.jinjava.util.ForLoop
✅ item=resolvedValue
❌ varUsedInForScope=entered if statement
✅ deferred=resolved
✅ resolved=resolvedValue

This result is more functional as it allows the var in the if block to be evaluated but it does not have the expected new value for varUsedInForScope

# Desired output

We would like the output of the example template to be the same as if there was only one render stage with the deferred value present and available in the 1st stage.

## Example template:
```
{% for item in resolved %}
    {% set varUsedInForScope = 'outside if statement' %}  
    {% if deferred %}
        {{ varUsedInForScope }}
        {% set varUsedInForScope = 'entered if statement' %}
   {% endif %}   
   {{ varUsedInForScope }}
{% endfor %}
```

The desired output for the example template would be:

`outside if statement    entered if statement`

In order to achieve this we want the following to occur:

Context before rendering:
resolved=resolvedValue
deferred=com.hubspot.jinjava.interpret.DeferredValue

### Output of 1st render: 

✅ `{% if deferred %}     {{ varUsedInForScope }}     {% set varUsedInForScope = 'entered if statement' %}   {% endif %}    {{ varUsedInForScope }} `

The for loop is rendered away with just one iteration occurring as desired. The first rendering stage would mark varUsedInForScope as deferred and store its original value - preventing it from being rendered with the current value in the context. This requires parsing ahead within the deferred block to know that it is used in the deferred if statement. 
### Context after first render: 
✅ varUsedInForScope=com.hubspot.jinjava.interpret.DeferredValue(originalValue=outside if statement)
✅ deferred=com.hubspot.jinjava.interpret.DeferredValue
✅ resolved=resolvedValue

### Output of 2nd render:
✅ `outside if statement    entered if statement`
As desired.



