### PR TITLE
Track Java method invocations, start whitelist

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/JinjavaBeanELResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/JinjavaBeanELResolver.java
@@ -33,6 +33,16 @@ public class JinjavaBeanELResolver extends BeanELResolver {
     .add("wait")
     .build();
 
+  private static final Set<String> UNTRACKED_METHODS = ImmutableSet.of(
+    "filter",
+    "evaluate",
+    "evaluateNegated",
+    "append",
+    "cycle",
+    "items",
+    "count"
+  );
+
   /**
    * Creates a new read/write {@link JinjavaBeanELResolver}.
    */
@@ -144,7 +154,12 @@ public class JinjavaBeanELResolver extends BeanELResolver {
   }
 
   private void trackHostUsage(Object base, Object method) {
-    if (base == null || base.getClass() == null || method == null) {
+    if (
+      base == null ||
+      base.getClass() == null ||
+      method == null ||
+      UNTRACKED_METHODS.contains(method.toString())
+    ) {
       return;
     }
 

--- a/src/main/java/com/hubspot/jinjava/el/ext/JinjavaBeanELResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/JinjavaBeanELResolver.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.el.ext;
 
 import com.google.common.base.CaseFormat;
 import com.google.common.collect.ImmutableSet;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -138,5 +139,18 @@ public class JinjavaBeanELResolver extends BeanELResolver {
       o instanceof Field ||
       o instanceof Constructor
     );
+  }
+
+  private void trackHostUsage(Object o, Object method) {
+    if (o == null || method == null) {
+      return;
+    }
+
+    JinjavaInterpreter interpreter = JinjavaInterpreter.getCurrent();
+    if (interpreter != null && interpreter.getContext() != null) {
+      interpreter
+        .getContext()
+        .addHostExpression(o.getClass().getSimpleName(), method.toString());
+    }
   }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/JinjavaBeanELResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/JinjavaBeanELResolver.java
@@ -74,6 +74,8 @@ public class JinjavaBeanELResolver extends BeanELResolver {
     Class<?>[] paramTypes,
     Object[] params
   ) {
+    trackHostUsage(base, method);
+
     if (method == null || RESTRICTED_METHODS.contains(method.toString())) {
       throw new MethodNotFoundException(
         "Cannot find method '" + method + "' in " + base.getClass()
@@ -141,8 +143,8 @@ public class JinjavaBeanELResolver extends BeanELResolver {
     );
   }
 
-  private void trackHostUsage(Object o, Object method) {
-    if (o == null || method == null) {
+  private void trackHostUsage(Object base, Object method) {
+    if (base == null || base.getClass() == null || method == null) {
       return;
     }
 
@@ -150,7 +152,7 @@ public class JinjavaBeanELResolver extends BeanELResolver {
     if (interpreter != null && interpreter.getContext() != null) {
       interpreter
         .getContext()
-        .addHostExpression(o.getClass().getSimpleName(), method.toString());
+        .addHostExpression(base.getClass().getSimpleName(), method.toString());
     }
   }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -18,7 +18,6 @@ package com.hubspot.jinjava.interpret;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
 import com.hubspot.jinjava.lib.Importable;
 import com.hubspot.jinjava.lib.exptest.ExpTest;
@@ -46,6 +45,9 @@ import java.util.stream.Collectors;
 public class Context extends ScopeMap<String, Object> {
   public static final String GLOBAL_MACROS_SCOPE_KEY = "__macros__";
   public static final String IMPORT_RESOURCE_PATH_KEY = "import_resource_path";
+
+  private static final int MAX_TRACKED_CLASSES = 50;
+  private static final int MAX_TRACKED_METHODS = 10;
 
   private SetMultimap<String, String> dependencies = HashMultimap.create();
   private final SetMultimap<String, String> hostExpressions = HashMultimap.create();
@@ -519,10 +521,15 @@ public class Context extends ScopeMap<String, Object> {
   }
 
   public void addHostExpression(String className, String methodName) {
-    this.hostExpressions.put(className, methodName);
+    if (
+      this.hostExpressions.size() <= MAX_TRACKED_CLASSES &&
+      this.hostExpressions.get(className).size() <= MAX_TRACKED_METHODS
+    ) {
+      this.hostExpressions.put(className, methodName);
+    }
   }
 
-  public Multimap<String, String> getHostExpressions() {
+  public SetMultimap<String, String> getHostExpressions() {
     return this.hostExpressions;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -18,6 +18,7 @@ package com.hubspot.jinjava.interpret;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
 import com.hubspot.jinjava.lib.Importable;
 import com.hubspot.jinjava.lib.exptest.ExpTest;
@@ -47,6 +48,7 @@ public class Context extends ScopeMap<String, Object> {
   public static final String IMPORT_RESOURCE_PATH_KEY = "import_resource_path";
 
   private SetMultimap<String, String> dependencies = HashMultimap.create();
+  private final SetMultimap<String, String> hostExpressions = HashMultimap.create();
   private Map<Library, Set<String>> disabled;
 
   public boolean isValidationMode() {
@@ -514,5 +516,13 @@ public class Context extends ScopeMap<String, Object> {
 
   public SetMultimap<String, String> getDependencies() {
     return this.dependencies;
+  }
+
+  public void addHostExpression(String className, String methodName) {
+    this.hostExpressions.put(className, methodName);
+  }
+
+  public Multimap<String, String> getHostExpressions() {
+    return this.hostExpressions;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -522,7 +522,7 @@ public class Context extends ScopeMap<String, Object> {
 
   public void addHostExpression(String className, String methodName) {
     if (
-      this.hostExpressions.size() <= MAX_TRACKED_CLASSES &&
+      this.hostExpressions.keySet().size() <= MAX_TRACKED_CLASSES &&
       this.hostExpressions.get(className).size() <= MAX_TRACKED_METHODS
     ) {
       this.hostExpressions.put(className, methodName);


### PR DESCRIPTION
Tracks usage of `method()` on objects. There are some we should allow (for example `append`), so started a whitelist of allowed methods that skip tracking.