### PR TITLE
Defer variables used in deferred nodes

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -273,15 +273,13 @@ public class Context extends ScopeMap<String, Object> {
     deferredNodes.add(node);
     Set<String> deferredProps = DeferredValueUtils.findAndMarkDeferredProperties(this);
     if (getParent() != null) {
+      Context parent = getParent();
+      //Place deferred values on the parent context
+      deferredProps
+        .stream()
+        .filter(key -> !parent.containsKey(key))
+        .forEach(key -> parent.put(key, this.get(key)));
       getParent().handleDeferredNode(node);
-      if (this.getParent() != null) {
-        Context parent = this.getParent();
-        //Place deferred values on the parent context
-        deferredProps
-          .stream()
-          .filter(key -> !parent.containsKey(key))
-          .forEach(key -> parent.put(key, this.get(key)));
-      }
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -271,9 +271,15 @@ public class Context extends ScopeMap<String, Object> {
 
   public void handleDeferredNode(Node node) {
     deferredNodes.add(node);
-    DeferredValueUtils.findAndMarkDeferredProperties(this);
-
+    Set<String> deferredProps = DeferredValueUtils.getPropertiesUsedInDeferredNodes(this);
+    DeferredValueUtils.markDeferredProperties(this, deferredProps);
     if (getParent() != null) {
+      //Place deferred values on the parent context
+      deferredProps
+        .stream()
+        .filter(key -> !getParent().containsKey(key))
+        .forEach(key -> getParent().put(key, this.get(key)));
+
       getParent().handleDeferredNode(node);
     }
   }

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -30,6 +30,7 @@ import com.hubspot.jinjava.lib.fn.MacroFunction;
 import com.hubspot.jinjava.lib.tag.Tag;
 import com.hubspot.jinjava.lib.tag.TagLibrary;
 import com.hubspot.jinjava.tree.Node;
+import com.hubspot.jinjava.util.DeferredValueUtils;
 import com.hubspot.jinjava.util.ScopeMap;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -268,10 +269,12 @@ public class Context extends ScopeMap<String, Object> {
     }
   }
 
-  public void addDeferredNode(Node node) {
+  public void handleDeferredNode(Node node) {
     deferredNodes.add(node);
+    DeferredValueUtils.findAndMarkDeferredProperties(this);
+
     if (getParent() != null) {
-      getParent().addDeferredNode(node);
+      getParent().handleDeferredNode(node);
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -271,16 +271,17 @@ public class Context extends ScopeMap<String, Object> {
 
   public void handleDeferredNode(Node node) {
     deferredNodes.add(node);
-    Set<String> deferredProps = DeferredValueUtils.getPropertiesUsedInDeferredNodes(this);
-    DeferredValueUtils.markDeferredProperties(this, deferredProps);
+    Set<String> deferredProps = DeferredValueUtils.findAndMarkDeferredProperties(this);
     if (getParent() != null) {
-      //Place deferred values on the parent context
-      deferredProps
-        .stream()
-        .filter(key -> !getParent().containsKey(key))
-        .forEach(key -> getParent().put(key, this.get(key)));
-
       getParent().handleDeferredNode(node);
+      if (this.getParent() != null) {
+        Context parent = this.getParent();
+        //Place deferred values on the parent context
+        deferredProps
+          .stream()
+          .filter(key -> !parent.containsKey(key))
+          .forEach(key -> parent.put(key, this.get(key)));
+      }
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -267,7 +267,7 @@ public class JinjavaInterpreter {
         try {
           out = node.render(this);
         } catch (DeferredValueException e) {
-          context.addDeferredNode(node);
+          context.handleDeferredNode(node);
           out = new RenderedOutputNode(node.getMaster().getImage());
         }
         context.popRenderStack();

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -150,7 +150,7 @@ public class ImportTag implements Tag {
         node
           .getChildren()
           .forEach(
-            deferredChild -> interpreter.getContext().addDeferredNode(deferredChild)
+            deferredChild -> interpreter.getContext().handleDeferredNode(deferredChild)
           );
         if (StringUtils.isBlank(contextVar)) {
           for (MacroFunction macro : child.getContext().getGlobalMacros().values()) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -173,10 +173,7 @@ public class ImportTag implements Tag {
           }
           childBindings.remove(Context.GLOBAL_MACROS_SCOPE_KEY);
           childBindings.remove(Context.IMPORT_RESOURCE_PATH_KEY);
-          for (String key : childBindings.keySet()) {
-            childBindings.put(key, DeferredValue.instance());
-          }
-          interpreter.getContext().put(contextVar, childBindings);
+          interpreter.getContext().put(contextVar, DeferredValue.instance(childBindings));
         }
 
         throw new DeferredValueException(

--- a/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
@@ -126,10 +126,20 @@ public class SetTag implements Tag {
 
         for (int i = 0; i < varTokens.length; i++) {
           String varItem = varTokens[i].trim();
+          if (interpreter.getContext().containsKey(varItem)) {
+            if (interpreter.getContext().get(var) instanceof DeferredValue) {
+              throw new DeferredValueException(var);
+            }
+          }
           interpreter.getContext().put(varItem, exprVals.get(i));
         }
       } else {
         // handle single variable assignment
+        if (interpreter.getContext().containsKey(var)) {
+          if (interpreter.getContext().get(var) instanceof DeferredValue) {
+            throw new DeferredValueException(var);
+          }
+        }
         interpreter
           .getContext()
           .put(var, interpreter.resolveELExpression(expr, tagNode.getLineNumber()));

--- a/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
@@ -127,8 +127,8 @@ public class SetTag implements Tag {
         for (int i = 0; i < varTokens.length; i++) {
           String varItem = varTokens[i].trim();
           if (interpreter.getContext().containsKey(varItem)) {
-            if (interpreter.getContext().get(var) instanceof DeferredValue) {
-              throw new DeferredValueException(var);
+            if (interpreter.getContext().get(varItem) instanceof DeferredValue) {
+              throw new DeferredValueException(varItem);
             }
           }
           interpreter.getContext().put(varItem, exprVals.get(i));

--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -42,7 +42,7 @@ public class ExpressionNode extends Node {
     try {
       var = interpreter.resolveELExpression(master.getExpr(), getLineNumber());
     } catch (DeferredValueException e) {
-      interpreter.getContext().addDeferredNode(this);
+      interpreter.getContext().handleDeferredNode(this);
       var = master.getImage();
     }
 

--- a/src/main/java/com/hubspot/jinjava/tree/TagNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TagNode.java
@@ -51,7 +51,7 @@ public class TagNode extends Node {
     try {
       return tag.interpretOutput(this, interpreter);
     } catch (DeferredValueException e) {
-      interpreter.getContext().addDeferredNode(this);
+      interpreter.getContext().handleDeferredNode(this);
       return new RenderedOutputNode(reconstructImage());
     } catch (InterpretException | InvalidInputException | InvalidArgumentException e) {
       throw e;

--- a/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Sets;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.lib.tag.SetTag;
 import com.hubspot.jinjava.tree.ExpressionNode;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.TagNode;
@@ -26,7 +27,7 @@ public class DeferredValueUtils {
   private static final Pattern TEMPLATE_TAG_PATTERN = Pattern.compile(TEMPLATE_TAG_REGEX);
 
   private static final Pattern SET_TAG_PATTERN = Pattern.compile(
-    "set " + TEMPLATE_TAG_REGEX
+    SetTag.TAG_NAME + " " + TEMPLATE_TAG_REGEX
   );
 
   public static HashMap<String, Object> getDeferredContextWithOriginalValues(

--- a/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
@@ -1,0 +1,174 @@
+package com.hubspot.jinjava.util;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.hubspot.jinjava.interpret.Context;
+import com.hubspot.jinjava.interpret.DeferredValue;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.tree.ExpressionNode;
+import com.hubspot.jinjava.tree.Node;
+import com.hubspot.jinjava.tree.TagNode;
+import com.hubspot.jinjava.tree.TextNode;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class DeferredValueUtils {
+  private static final Pattern TEMPLATE_TAG_PATTERN = Pattern.compile(
+    "(\\w+(?:\\.\\w+)*)"
+  );
+
+  public static HashMap<String, Object> getDeferredContextWithOriginalValues(
+    Context context
+  ) {
+    return getDeferredContextWithOriginalValues(context, ImmutableSet.of());
+  }
+
+  //The context needed for a second render
+  //Ignores deferred properties with no originalValue
+  //Optionally only keep keys in keysToKeep
+  public static HashMap<String, Object> getDeferredContextWithOriginalValues(
+    Context context,
+    Set<String> keysToKeep
+  ) {
+    HashMap<String, Object> deferredContext = new HashMap<>(context.size());
+    context.forEach(
+      (contextKey, contextItem) -> {
+        if (keysToKeep.size() > 0 && !keysToKeep.contains(contextKey)) {
+          return;
+        }
+        if (contextItem instanceof DeferredValue) {
+          if (((DeferredValue) contextItem).getOriginalValue() != null) {
+            deferredContext.put(
+              contextKey,
+              ((DeferredValue) contextItem).getOriginalValue()
+            );
+          }
+        } else {
+          deferredContext.put(contextKey, contextItem);
+        }
+      }
+    );
+    return deferredContext;
+  }
+
+  public static void findAndMarkDeferredProperties(Context context) {
+    Set<String> props = getPropertiesUsedInDeferredNodes(context);
+    props
+      .stream()
+      .filter(prop -> !(context.get(prop) instanceof DeferredValue))
+      .forEach(prop -> context.put(prop, DeferredValue.instance(context.get(prop))));
+  }
+
+  @VisibleForTesting
+  public static Set<String> getPropertiesUsedInDeferredNodes(Context context) {
+    String templateSource = rebuildTemplateForNodes(context.getDeferredNodes());
+    Set<String> propertiesUsed = findUsedProperties(templateSource);
+    return propertiesUsed
+      .stream()
+      .map(prop -> prop.split("[\\[.]", 2)[0]) // split map accesses on .prop or ['prop']
+      .filter(context::containsKey)
+      .collect(Collectors.toSet());
+  }
+
+  private static String rebuildTemplateForNodes(Set<Node> nodes) {
+    StringJoiner joiner = new StringJoiner(" ");
+    getDeferredTags(nodes).stream().map(DeferredTag::getTag).forEach(joiner::add);
+    return joiner.toString();
+  }
+
+  private static Set<String> findUsedProperties(String templateSource) {
+    Matcher matcher = TEMPLATE_TAG_PATTERN.matcher(templateSource);
+    Set<String> tags = Sets.newHashSet();
+    while (matcher.find()) {
+      tags.add(matcher.group(1));
+    }
+    return tags;
+  }
+
+  public static Set<DeferredTag> getDeferredTags(Set<Node> deferredNodes) {
+    return getDeferredTags(new LinkedList<>(deferredNodes), 0);
+  }
+
+  private static Set<DeferredTag> getDeferredTags(List<Node> nodes, int depth) {
+    // precaution - templates are parsed with this render depth so in theory the depth should never be exceeded
+    Set<DeferredTag> deferredTags = new HashSet<>();
+    int maxRenderDepth = JinjavaInterpreter.getCurrent() == null
+      ? 3
+      : JinjavaInterpreter.getCurrent().getConfig().getMaxRenderDepth();
+    if (depth > maxRenderDepth) {
+      return deferredTags;
+    }
+    for (Node node : nodes) {
+      getDeferredTags(node).ifPresent(deferredTags::addAll);
+      deferredTags.addAll(getDeferredTags(node.getChildren(), depth + 1));
+    }
+    return deferredTags;
+  }
+
+  private static Optional<Set<DeferredTag>> getDeferredTags(Node deferredNode) {
+    if (deferredNode instanceof TextNode || deferredNode.getMaster() == null) {
+      return Optional.empty();
+    }
+
+    String nodeImage = deferredNode.getMaster().getImage();
+    if (Strings.nullToEmpty(nodeImage).trim().isEmpty()) {
+      return Optional.empty();
+    }
+
+    Set<DeferredTag> deferredTags = new HashSet<>();
+    deferredTags.add(
+      new DeferredTag().setTag(nodeImage).setNormalizedTag(getNormalizedTag(deferredNode))
+    );
+
+    if (deferredNode instanceof TagNode) {
+      TagNode tagNode = (TagNode) deferredNode;
+      if (tagNode.getEndName() != null) {
+        String endTag = tagNode.reconstructEnd();
+        deferredTags.add(new DeferredTag().setTag(endTag).setNormalizedTag(endTag));
+      }
+    }
+
+    return Optional.of(deferredTags);
+  }
+
+  private static String getNormalizedTag(Node node) {
+    if (node instanceof ExpressionNode) {
+      return node.toString().replaceAll("\\s+", "");
+    }
+
+    return node.getMaster().getImage();
+  }
+
+  private static class DeferredTag {
+    String tag;
+    String normalizedTag;
+
+    public String getTag() {
+      return tag;
+    }
+
+    public DeferredTag setTag(String tag) {
+      this.tag = tag;
+      return this;
+    }
+
+    public String getNormalizedTag() {
+      return normalizedTag;
+    }
+
+    public DeferredTag setNormalizedTag(String normalizedTag) {
+      this.normalizedTag = normalizedTag;
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
@@ -1,6 +1,5 @@
 package com.hubspot.jinjava.util;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -61,15 +60,13 @@ public class DeferredValueUtils {
     return deferredContext;
   }
 
-  public static void findAndMarkDeferredProperties(Context context) {
-    Set<String> props = getPropertiesUsedInDeferredNodes(context);
+  public static void markDeferredProperties(Context context, Set<String> props) {
     props
       .stream()
       .filter(prop -> !(context.get(prop) instanceof DeferredValue))
       .forEach(prop -> context.put(prop, DeferredValue.instance(context.get(prop))));
   }
 
-  @VisibleForTesting
   public static Set<String> getPropertiesUsedInDeferredNodes(Context context) {
     String templateSource = rebuildTemplateForNodes(context.getDeferredNodes());
     Set<String> propertiesUsed = findUsedProperties(templateSource);

--- a/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
@@ -3,10 +3,15 @@ package com.hubspot.jinjava.util;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import com.google.common.collect.Streams;
+import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.lib.tag.SetTag;
+import com.hubspot.jinjava.lib.exptest.ExpTest;
+import com.hubspot.jinjava.lib.filter.Filter;
+import com.hubspot.jinjava.lib.fn.ELFunctionDefinition;
+import com.hubspot.jinjava.lib.tag.Tag;
 import com.hubspot.jinjava.tree.ExpressionNode;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.TagNode;
@@ -21,14 +26,16 @@ import java.util.StringJoiner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class DeferredValueUtils {
   private static final String TEMPLATE_TAG_REGEX = "(\\w+(?:\\.\\w+)*)";
   private static final Pattern TEMPLATE_TAG_PATTERN = Pattern.compile(TEMPLATE_TAG_REGEX);
+  private static final Set<String> JINJAVA_KEYWORDS;
 
-  private static final Pattern SET_TAG_PATTERN = Pattern.compile(
-    SetTag.TAG_NAME + " " + TEMPLATE_TAG_REGEX
-  );
+  static {
+    JINJAVA_KEYWORDS = getJinJavaKeyWords(new Jinjava());
+  }
 
   public static HashMap<String, Object> getDeferredContextWithOriginalValues(
     Context context
@@ -66,31 +73,22 @@ public class DeferredValueUtils {
 
   public static Set<String> findAndMarkDeferredProperties(Context context) {
     String templateSource = rebuildTemplateForNodes(context.getDeferredNodes());
-    Set<String> deferredProps = getPropertiesUsedInDeferredNodes(context, templateSource);
-    Set<String> setProps = getPropertiesSetInDeferredNodes(templateSource);
+    Set<String> deferredProps = getPropertiesUsedInDeferredNodes(templateSource);
 
-    markDeferredProperties(context, Sets.union(deferredProps, setProps));
+    markDeferredProperties(context, deferredProps);
 
     return deferredProps;
-  }
-
-  public static Set<String> getPropertiesSetInDeferredNodes(String templateSource) {
-    return findSetProperties(templateSource);
   }
 
   public static Set<DeferredTag> getDeferredTags(Set<Node> deferredNodes) {
     return getDeferredTags(new LinkedList<>(deferredNodes), 0);
   }
 
-  public static Set<String> getPropertiesUsedInDeferredNodes(
-    Context context,
-    String templateSource
-  ) {
+  public static Set<String> getPropertiesUsedInDeferredNodes(String templateSource) {
     Set<String> propertiesUsed = findUsedProperties(templateSource);
     return propertiesUsed
       .stream()
       .map(prop -> prop.split("\\.", 2)[0]) // split accesses on .prop
-      .filter(context::containsKey)
       .collect(Collectors.toSet());
   }
 
@@ -136,18 +134,27 @@ public class DeferredValueUtils {
     Matcher matcher = TEMPLATE_TAG_PATTERN.matcher(templateSource);
     Set<String> tags = Sets.newHashSet();
     while (matcher.find()) {
-      tags.add(matcher.group(1));
+      String tag = matcher.group(1);
+      if (!JINJAVA_KEYWORDS.contains(tag)) {
+        tags.add(tag);
+      }
     }
     return tags;
   }
 
-  private static Set<String> findSetProperties(String templateSource) {
-    Matcher matcher = SET_TAG_PATTERN.matcher(templateSource);
-    Set<String> tags = Sets.newHashSet();
-    while (matcher.find()) {
-      tags.add(matcher.group(1));
-    }
-    return tags;
+  private static Set<String> getJinJavaKeyWords(Jinjava jinjava) {
+    Stream<Filter> filters = jinjava.getGlobalContext().getAllFilters().stream();
+    Stream<ELFunctionDefinition> functions = (Stream<ELFunctionDefinition>) jinjava
+      .getGlobalContext()
+      .getAllFunctions()
+      .stream();
+    Stream<Tag> tags = jinjava.getGlobalContext().getAllTags().stream();
+    Stream<ExpTest> expTests = jinjava.getGlobalContext().getAllExpTests().stream();
+
+    return Streams
+      .concat(filters, functions, tags, expTests)
+      .map(keyWord -> keyWord.getName().toLowerCase())
+      .collect(Collectors.toSet());
   }
 
   private static Optional<Set<DeferredTag>> getDeferredTags(Node deferredNode) {

--- a/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
@@ -88,7 +88,7 @@ public class DeferredValueUtils {
     Set<String> propertiesUsed = findUsedProperties(templateSource);
     return propertiesUsed
       .stream()
-      .map(prop -> prop.split("\\[\\.]", 2)[0]) // split map accesses on .prop
+      .map(prop -> prop.split("\\.", 2)[0]) // split accesses on .prop
       .filter(context::containsKey)
       .collect(Collectors.toSet());
   }

--- a/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
@@ -228,7 +228,7 @@ public class DeferredTest {
 
   @Test
   public void itPutsDeferredVariablesOnParentScopes() {
-    String template = getFixtureTemplate("for-with-if-and-set.jinja");
+    String template = getFixtureTemplate("set-within-lower-scope.jinja");
     interpreter.getContext().put("deferredValue", DeferredValue.instance("resolved"));
     interpreter.render(template);
     assertThat(interpreter.getContext()).containsKey("varSetInside");
@@ -240,7 +240,7 @@ public class DeferredTest {
 
   @Test
   public void puttingDeferredVariablesOnParentScopesDoesNotBreakSetTag() {
-    String template = getFixtureTemplate("set-within-lower-scope.jinja");
+    String template = getFixtureTemplate("set-within-lower-scope-twice.jinja");
 
     interpreter.getContext().put("deferredValue", DeferredValue.instance("resolved"));
     String output = interpreter.render(template);

--- a/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
@@ -240,4 +240,23 @@ public class DeferredTest {
     DeferredValue varInScopeDeferred = (DeferredValue) varInScope;
     assertThat(varInScopeDeferred.getOriginalValue()).isEqualTo("testvalue");
   }
+
+  @Test
+  public void itPutsDeferredVariablesOnParentScopes() {
+    String template = "";
+    template += "{% for item in resolved %}";
+    template += "   {% set varSetInside = 'inside first scope' %}";
+    template += "   {% if deferredValue %}"; //Deferred Node
+    template += "     {{ varSetInside }}";
+    template += "   {% endif %}"; // end Deferred Node
+    template += "{% endfor %}";
+
+    interpreter.getContext().put("deferredValue", DeferredValue.instance("resolved"));
+    interpreter.render(template);
+    assertThat(interpreter.getContext()).containsKey("varSetInside");
+    Object varSetInside = interpreter.getContext().get("varSetInside");
+    assertThat(varSetInside).isInstanceOf(DeferredValue.class);
+    DeferredValue varSetInsideDeferred = (DeferredValue) varSetInside;
+    assertThat(varSetInsideDeferred.getOriginalValue()).isEqualTo("inside first scope");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
@@ -293,4 +293,22 @@ public class DeferredTest {
     assertThat(secondRender.trim())
       .isEqualTo("inside first scope              inside first scope2".trim());
   }
+
+  @Test
+  public void itMarksVariablesSetInDeferredBlockAsDeferred() {
+    String template = "";
+    template += "   {% set reference = deferredValue %}";
+    template += "   {% if reference == 'resolved' %}"; //Deferred Node
+    template += "     {{ set varSetInside = 'set inside' }}";
+    template += "   {% endif %}"; // end Deferred Node
+    template += "{{ varSetInside }}";
+    JinjavaInterpreter.popCurrent();
+
+    interpreter.getContext().put("deferredValue", DeferredValue.instance("resolved"));
+    String output = interpreter.render(template);
+    assertThat(interpreter.getContext()).containsKey("varSetInside");
+    Object varSetInside = interpreter.getContext().get("varSetInside");
+    assertThat(varSetInside).isInstanceOf(DeferredValue.class);
+    assertThat(output).contains("{{ varSetInside }}");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
@@ -267,10 +267,14 @@ public class DeferredTest {
 
     interpreter.getContext().put("deferredValue", DeferredValue.instance("resolved"));
     String output = interpreter.render(template);
+    Context context = interpreter.getContext();
     assertThat(interpreter.getContext()).containsKey("varSetInside");
     Object varSetInside = interpreter.getContext().get("varSetInside");
     assertThat(varSetInside).isInstanceOf(DeferredValue.class);
     assertThat(output).contains("{{ varSetInside }}");
+    assertThat(context.get("a")).isInstanceOf(DeferredValue.class);
+    assertThat(context.get("b")).isInstanceOf(DeferredValue.class);
+    assertThat(context.get("c")).isInstanceOf(DeferredValue.class);
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
@@ -331,7 +331,9 @@ public class DeferredTest {
     String template = "";
     template += "   {% set reference = deferredValue %}";
     template += "   {% if reference == 'resolved' %}"; //Deferred Node
-    template += "     {% set varSetInside = imported.map[deferredValue2] %}";
+    template +=
+      "     {% set varSetInside = imported.map[deferredValue2.nonexistentprop] %}";
+    template += "   {{ deferredValue2.nonexistentprop }}";
     template += "   {% endif %}"; // end Deferred Node
     template += "{{ varSetInside }}";
     JinjavaInterpreter.popCurrent();
@@ -343,13 +345,14 @@ public class DeferredTest {
       ImmutableMap.of("key", "value")
     );
     interpreter.getContext().put("imported", map);
+
     String output = interpreter.render(template);
-    assertThat(interpreter.getContext()).containsKey("varSetInside");
-    Object varSetInside = interpreter.getContext().get("varSetInside");
+    assertThat(interpreter.getContext()).containsKey("deferredValue2");
+    Object deferredValue2 = interpreter.getContext().get("deferredValue2");
     Set<String> deferredVals = DeferredValueUtils.findAndMarkDeferredProperties(
       interpreter.getContext()
     );
-    assertThat(varSetInside).isInstanceOf(DeferredValue.class);
-    assertThat(output).contains("{{ varSetInside }}");
+    assertThat(deferredValue2).isInstanceOf(DeferredValue.class);
+    assertThat(output).contains("{% set varSetInside = imported.map[deferredValue2] %}");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
@@ -105,14 +105,23 @@ public class ImportTagTest {
       .contains("wrap-padding: padding-left:42px;padding-right:42px");
   }
 
+  // Properties from within the import are deferred too.
+  // The main concern is that the key is deferred so that any
+  // subsequent uses of any variables defined in the imported template are marked as deferred
   @Test
-  public void itDefersImportedVariable() {
+  public void itDefersImportedVariableKey() {
     Jinjava jinjava = new Jinjava();
     interpreter = new JinjavaInterpreter(jinjava, context, jinjava.getGlobalConfig());
     interpreter.getContext().put("primary_font_size_num", DeferredValue.instance());
     fixture("import-property");
-    assertThat(((Map) interpreter.getContext().get("pegasus")).get("primary_line_height"))
+    assertThat(interpreter.getContext().get("pegasus")).isInstanceOf(DeferredValue.class);
+
+    //If pegasus was deferred at the key.prop level instead of key this would resolve to a value
+    assertThat(interpreter.getContext().get("expected_to_be_deferred"))
       .isInstanceOf(DeferredValue.class);
+    DeferredValue deferredValue = (DeferredValue) interpreter.getContext().get("pegasus");
+    Map originalValue = (Map) deferredValue.getOriginalValue();
+    assertThat(originalValue.get("primary_line_height")).isNotNull();
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/util/DeferredValueUtilsTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/DeferredValueUtilsTest.java
@@ -1,0 +1,242 @@
+package com.hubspot.jinjava.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Mockito.*;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.hubspot.jinjava.interpret.Context;
+import com.hubspot.jinjava.interpret.DeferredValue;
+import com.hubspot.jinjava.tree.ExpressionNode;
+import com.hubspot.jinjava.tree.Node;
+import com.hubspot.jinjava.tree.TagNode;
+import com.hubspot.jinjava.tree.parse.Token;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DeferredValueUtilsTest {
+
+  @Test
+  public void itFindsGlobalProperties() {
+    Context context = getContext(
+      Lists.newArrayList(getNodeForClass(TagNode.class, "{% if java_bean %}"))
+    );
+    context.put("java_bean", getPopulatedJavaBean());
+
+    Set<String> deferredProperties = DeferredValueUtils.getPropertiesUsedInDeferredNodes(
+      context
+    );
+
+    assertThat(deferredProperties).contains("java_bean");
+  }
+
+  @Test
+  public void itDefersWholePropertyOnArrayAccess() {
+    Context context = getContext(
+      Lists.newArrayList(getNodeForClass(TagNode.class, "{{ array[0] }}"))
+    );
+    context.put("array", Lists.newArrayList("a", "b", "c"));
+
+    Set<String> deferredProperties = DeferredValueUtils.getPropertiesUsedInDeferredNodes(
+      context
+    );
+    assertThat(deferredProperties).contains("array");
+  }
+
+  @Test
+  public void itDefersWholePropertyOnDictAccess() {
+    Context context = getContext(
+      Lists.newArrayList(getNodeForClass(TagNode.class, "{{ dict['a'] }}"))
+    );
+    context.put("dict", Collections.singletonMap("a", "x"));
+
+    Set<String> deferredProperties = DeferredValueUtils.getPropertiesUsedInDeferredNodes(
+      context
+    );
+    assertThat(deferredProperties).contains("dict");
+  }
+
+  @Test
+  public void itDefersTheCompleteObjectWhenAtLeastOnePropertyIsUsed() {
+    Context context = getContext(
+      Lists.newArrayList(
+        getNodeForClass(
+          TagNode.class,
+          "{% if java_bean.property_one %}",
+          Optional.empty(),
+          Optional.empty()
+        )
+      )
+    );
+    context.put("java_bean", getPopulatedJavaBean());
+
+    DeferredValueUtils.findAndMarkDeferredProperties(context);
+
+    assertThat(context.containsKey("java_bean")).isTrue();
+    assertThat(context.get("java_bean")).isInstanceOf(DeferredValue.class);
+    DeferredValue deferredValue = (DeferredValue) context.get("java_bean");
+    JavaBean originalValue = (JavaBean) deferredValue.getOriginalValue();
+    assertThat(originalValue).hasFieldOrPropertyWithValue("propertyOne", "propertyOne");
+    assertThat(originalValue).hasFieldOrPropertyWithValue("propertyTwo", "propertyTwo");
+  }
+
+  @Test
+  public void itHandlesCaseWhereValueIsNull() {
+    Context context = getContext(
+      Lists.newArrayList(
+        getNodeForClass(
+          TagNode.class,
+          "{% if property.id %}",
+          Optional.empty(),
+          Optional.empty()
+        )
+      )
+    );
+    context.put("property", null);
+
+    DeferredValueUtils.findAndMarkDeferredProperties(context);
+
+    assertThat(context.get("property")).isNull();
+  }
+
+  @Test
+  public void itPreservesNonDeferredProperties() {
+    Context context = getContext(
+      Lists.newArrayList(
+        getNodeForClass(
+          TagNode.class,
+          "{% if deferred %}",
+          Optional.empty(),
+          Optional.empty()
+        )
+      )
+    );
+    context.put("deferred", "deferred");
+    context.put("not_deferred", "test_value");
+
+    DeferredValueUtils.findAndMarkDeferredProperties(context);
+    assertThat(context.get("not_deferred")).isEqualTo("test_value");
+  }
+
+  @Test
+  public void itRestoresContextSuccessfully() {
+    Context context = new Context();
+    ImmutableMap<String, String> simpleMap = ImmutableMap.of("a", "x", "b", "y");
+    ImmutableMap<String, Object> nestedMap = ImmutableMap.of("nested", simpleMap);
+    Integer[] simpleArray = { 1, 2, 3, 4, 5, 6 };
+    JavaBean javaBean = getPopulatedJavaBean();
+    context.put("simple_var", DeferredValue.instance("SimpleVar"));
+    context.put("java_bean", DeferredValue.instance(javaBean));
+    context.put("simple_bool", DeferredValue.instance(true));
+    context.put("simple_array", DeferredValue.instance(simpleArray));
+    context.put("simple_map", DeferredValue.instance(simpleMap));
+    context.put("nested_map", DeferredValue.instance(nestedMap));
+
+    context.put("simple_var_undeferred", "SimpleVarUnDeferred");
+    context.put("java_bean_undeferred", javaBean);
+    context.put("nested_map_undeferred", nestedMap);
+
+    HashMap<String, Object> result = DeferredValueUtils.getDeferredContextWithOriginalValues(
+      context
+    );
+    assertThat(result).contains(entry("simple_var", "SimpleVar"));
+    assertThat(result).contains(entry("java_bean", javaBean));
+    assertThat(result).contains(entry("simple_bool", true));
+    assertThat(result).contains(entry("simple_array", simpleArray));
+    assertThat(result).contains(entry("simple_map", simpleMap));
+    assertThat(result).contains(entry("nested_map", nestedMap));
+
+    assertThat(result).contains(entry("simple_var_undeferred", "SimpleVarUnDeferred"));
+    assertThat(result).contains(entry("java_bean_undeferred", javaBean));
+    assertThat(result).contains(entry("nested_map_undeferred", nestedMap));
+  }
+
+  @Test
+  public void itIgnoresUnrestorableValuesFromDeferredContext() {
+    Context context = new Context();
+    context.put("simple_var", DeferredValue.instance());
+    context.put("java_bean", DeferredValue.instance());
+
+    HashMap<String, Object> result = DeferredValueUtils.getDeferredContextWithOriginalValues(
+      context
+    );
+    assertThat(result).isEmpty();
+  }
+
+  private Context getContext(List<? extends Node> nodes) {
+    Context context = new Context();
+    for (Node node : nodes) {
+      context.handleDeferredNode(node);
+    }
+    return context;
+  }
+
+  private <T extends Node> T getNodeForClass(Class<T> clazz, String image) {
+    return getNodeForClass(clazz, image, Optional.empty(), Optional.empty());
+  }
+
+  private <T extends Node> T getNodeForClass(
+    Class<T> clazz,
+    String image,
+    Optional<List<Node>> childNodes,
+    Optional<String> endName
+  ) {
+    T node = mock(clazz);
+    Token token = mock(Token.class);
+    if (childNodes.isPresent()) {
+      LinkedList<Node> children = new LinkedList<>();
+      children.addAll(childNodes.get());
+      when(node.getChildren()).thenReturn(children);
+    }
+    when(token.getImage()).thenReturn(image);
+    when(node.getMaster()).thenReturn(token);
+    if (node instanceof ExpressionNode) {
+      when(node.toString()).thenReturn(image);
+    }
+    if (node instanceof TagNode && endName.isPresent()) {
+      TagNode tagNode = (TagNode) node;
+      when(tagNode.getEndName()).thenReturn(endName.get());
+      when(tagNode.reconstructEnd()).thenReturn("{% " + endName.get() + " %}");
+    }
+    return node;
+  }
+
+  private JavaBean getPopulatedJavaBean() {
+    JavaBean javaBean = new JavaBean();
+    javaBean.setPropertyOne("propertyOne");
+    javaBean.setPropertyTwo("propertyTwo");
+    return javaBean;
+  }
+
+  private class JavaBean {
+    String propertyOne;
+    String propertyTwo;
+
+    public String getPropertyOne() {
+      return propertyOne;
+    }
+
+    public JavaBean setPropertyOne(String propertyOne) {
+      this.propertyOne = propertyOne;
+      return this;
+    }
+
+    public String getPropertyTwo() {
+      return propertyTwo;
+    }
+
+    public JavaBean setPropertyTwo(String propertyTwo) {
+      this.propertyTwo = propertyTwo;
+      return this;
+    }
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/util/DeferredValueUtilsTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/DeferredValueUtilsTest.java
@@ -32,7 +32,7 @@ public class DeferredValueUtilsTest {
     );
     context.put("java_bean", getPopulatedJavaBean());
 
-    Set<String> deferredProperties = DeferredValueUtils.getPropertiesUsedInDeferredNodes(
+    Set<String> deferredProperties = DeferredValueUtils.findAndMarkDeferredProperties(
       context
     );
 
@@ -46,7 +46,7 @@ public class DeferredValueUtilsTest {
     );
     context.put("array", Lists.newArrayList("a", "b", "c"));
 
-    Set<String> deferredProperties = DeferredValueUtils.getPropertiesUsedInDeferredNodes(
+    Set<String> deferredProperties = DeferredValueUtils.findAndMarkDeferredProperties(
       context
     );
     assertThat(deferredProperties).contains("array");
@@ -59,7 +59,7 @@ public class DeferredValueUtilsTest {
     );
     context.put("dict", Collections.singletonMap("a", "x"));
 
-    Set<String> deferredProperties = DeferredValueUtils.getPropertiesUsedInDeferredNodes(
+    Set<String> deferredProperties = DeferredValueUtils.findAndMarkDeferredProperties(
       context
     );
     assertThat(deferredProperties).contains("dict");
@@ -79,9 +79,7 @@ public class DeferredValueUtilsTest {
     );
     context.put("java_bean", getPopulatedJavaBean());
 
-    Set<String> deferredProps = DeferredValueUtils.getPropertiesUsedInDeferredNodes(
-      context
-    );
+    Set<String> deferredProps = DeferredValueUtils.findAndMarkDeferredProperties(context);
     DeferredValueUtils.markDeferredProperties(context, deferredProps);
     assertThat(context.containsKey("java_bean")).isTrue();
     assertThat(context.get("java_bean")).isInstanceOf(DeferredValue.class);
@@ -104,9 +102,7 @@ public class DeferredValueUtilsTest {
       )
     );
     context.put("property", null);
-    Set<String> deferredProps = DeferredValueUtils.getPropertiesUsedInDeferredNodes(
-      context
-    );
+    Set<String> deferredProps = DeferredValueUtils.findAndMarkDeferredProperties(context);
     DeferredValueUtils.markDeferredProperties(context, deferredProps);
 
     assertThat(context.get("property")).isNull();
@@ -127,10 +123,7 @@ public class DeferredValueUtilsTest {
     context.put("deferred", "deferred");
     context.put("not_deferred", "test_value");
 
-    Set<String> deferredProps = DeferredValueUtils.getPropertiesUsedInDeferredNodes(
-      context
-    );
-    DeferredValueUtils.markDeferredProperties(context, deferredProps);
+    DeferredValueUtils.findAndMarkDeferredProperties(context);
     assertThat(context.get("not_deferred")).isEqualTo("test_value");
   }
 

--- a/src/test/java/com/hubspot/jinjava/util/DeferredValueUtilsTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/DeferredValueUtilsTest.java
@@ -79,8 +79,10 @@ public class DeferredValueUtilsTest {
     );
     context.put("java_bean", getPopulatedJavaBean());
 
-    DeferredValueUtils.findAndMarkDeferredProperties(context);
-
+    Set<String> deferredProps = DeferredValueUtils.getPropertiesUsedInDeferredNodes(
+      context
+    );
+    DeferredValueUtils.markDeferredProperties(context, deferredProps);
     assertThat(context.containsKey("java_bean")).isTrue();
     assertThat(context.get("java_bean")).isInstanceOf(DeferredValue.class);
     DeferredValue deferredValue = (DeferredValue) context.get("java_bean");
@@ -102,8 +104,10 @@ public class DeferredValueUtilsTest {
       )
     );
     context.put("property", null);
-
-    DeferredValueUtils.findAndMarkDeferredProperties(context);
+    Set<String> deferredProps = DeferredValueUtils.getPropertiesUsedInDeferredNodes(
+      context
+    );
+    DeferredValueUtils.markDeferredProperties(context, deferredProps);
 
     assertThat(context.get("property")).isNull();
   }
@@ -123,7 +127,10 @@ public class DeferredValueUtilsTest {
     context.put("deferred", "deferred");
     context.put("not_deferred", "test_value");
 
-    DeferredValueUtils.findAndMarkDeferredProperties(context);
+    Set<String> deferredProps = DeferredValueUtils.getPropertiesUsedInDeferredNodes(
+      context
+    );
+    DeferredValueUtils.markDeferredProperties(context, deferredProps);
     assertThat(context.get("not_deferred")).isEqualTo("test_value");
   }
 

--- a/src/test/resources/deferred/deferred-macro.jinja
+++ b/src/test/resources/deferred/deferred-macro.jinja
@@ -1,0 +1,11 @@
+{%- macro inc_padding(width) -%}
+{%- set padding = padding + width -%}
+{{padding}}
+{%- endmacro -%}
+{{ padding }},
+{%- set padding =  inc_padding(added_padding) | int -%}
+{{ padding }},
+{%- set padding = inc_padding(deferred) | int -%}
+{{ padding}},
+{%- set padding = inc_padding(added_padding) | int -%}
+{{ padding }}

--- a/src/test/resources/deferred/deferred-map-access.jinja
+++ b/src/test/resources/deferred/deferred-map-access.jinja
@@ -1,0 +1,6 @@
+{% set reference = deferredValue %}
+{% if reference == 'resolved' %}
+  {% set varSetInside = imported.map[deferredValue2.nonexistentprop] %}
+{{ deferredValue2.nonexistentprop }}
+{% endif %}
+{{ varSetInside }}

--- a/src/test/resources/deferred/for-with-if-and-set.jinja
+++ b/src/test/resources/deferred/for-with-if-and-set.jinja
@@ -1,6 +1,0 @@
-{% for item in resolved %}
-   {% set varSetInside = 'inside first scope' %}
-   {% if deferredValue %}
-     {{ varSetInside }}
-   {% endif %}
-{% endfor %}

--- a/src/test/resources/deferred/for-with-if-and-set.jinja
+++ b/src/test/resources/deferred/for-with-if-and-set.jinja
@@ -1,0 +1,6 @@
+{% for item in resolved %}
+   {% set varSetInside = 'inside first scope' %}
+   {% if deferredValue %}
+     {{ varSetInside }}
+   {% endif %}
+{% endfor %}

--- a/src/test/resources/deferred/set-in-deferred.jinja
+++ b/src/test/resources/deferred/set-in-deferred.jinja
@@ -1,5 +1,6 @@
 {% set reference = deferredValue %}
 {% if reference == 'resolved' %}
    {% set varSetInside = 'set inside' %}
+   {% set a, b, c = ['x','y','z'] %}
 {% endif %}
 {{ varSetInside }}

--- a/src/test/resources/deferred/set-in-deferred.jinja
+++ b/src/test/resources/deferred/set-in-deferred.jinja
@@ -1,0 +1,5 @@
+{% set reference = deferredValue %}
+{% if reference == 'resolved' %}
+   {% set varSetInside = 'set inside' %}
+{% endif %}
+{{ varSetInside }}

--- a/src/test/resources/deferred/set-within-lower-scope-twice.jinja
+++ b/src/test/resources/deferred/set-within-lower-scope-twice.jinja
@@ -1,0 +1,12 @@
+{%- for item in resolved -%}
+   {%- set varSetInside = 'inside first scope' -%}
+   {%- if deferredValue -%}
+     {{ varSetInside }}
+   {%- endif -%}
+{%- endfor -%}
+{%- for item in resolved -%}
+   {%- set varSetInside = 'inside first scope2' -%}
+   {%- if deferredValue -%}
+     {{ varSetInside }}
+   {%- endif -%}
+{%- endfor -%}

--- a/src/test/resources/deferred/set-within-lower-scope.jinja
+++ b/src/test/resources/deferred/set-within-lower-scope.jinja
@@ -1,0 +1,12 @@
+{%- for item in resolved -%}
+   {%- set varSetInside = 'inside first scope' -%}
+   {%- if deferredValue -%}
+     {{ varSetInside }}
+   {%- endif -%}
+{%- endfor -%}
+{%- for item in resolved -%}
+   {%- set varSetInside = 'inside first scope2' -%}
+   {%- if deferredValue -%}
+     {{ varSetInside }}
+   {%- endif -%}
+{%- endfor -%}

--- a/src/test/resources/deferred/set-within-lower-scope.jinja
+++ b/src/test/resources/deferred/set-within-lower-scope.jinja
@@ -1,12 +1,6 @@
-{%- for item in resolved -%}
-   {%- set varSetInside = 'inside first scope' -%}
-   {%- if deferredValue -%}
+{% for item in resolved %}
+   {% set varSetInside = 'inside first scope' %}
+   {% if deferredValue %}
      {{ varSetInside }}
-   {%- endif -%}
-{%- endfor -%}
-{%- for item in resolved -%}
-   {%- set varSetInside = 'inside first scope2' -%}
-   {%- if deferredValue -%}
-     {{ varSetInside }}
-   {%- endif -%}
-{%- endfor -%}
+   {% endif %}
+{% endfor %}

--- a/src/test/resources/deferred/vars-in-deferred-node.jinja
+++ b/src/test/resources/deferred/vars-in-deferred-node.jinja
@@ -1,0 +1,9 @@
+{%- set varUsedInForScope = 'outside if statement' -%}
+{%- for item in resolved -%}
+   {%- if deferredValue -%}
+{{ varUsedInForScope }}
+{%- set varUsedInForScope = ' entered if statement' -%}
+{%- endif -%}
+
+{{ varUsedInForScope }}
+{%- endfor -%}

--- a/src/test/resources/tags/macrotag/import-property.jinja
+++ b/src/test/resources/tags/macrotag/import-property.jinja
@@ -1,3 +1,7 @@
 {% import "tags/settag/set-var-exp.jinja" as pegasus %}
 
 {{ pegasus.primary_line_height }}
+{{ pegasus.secondary_line_height }}
+
+{% set expected_to_be_deferred = pegasus.secondary_line_height %}
+{{ expected_to_be_deferred }}

--- a/src/test/resources/tags/settag/set-var-exp.jinja
+++ b/src/test/resources/tags/settag/set-var-exp.jinja
@@ -1,1 +1,2 @@
 {% set primary_line_height = primary_font_size_num*1.5 %}
+{% set secondary_line_height = 1.5 %}


### PR DESCRIPTION
As a follow on to the discussion in the PR here: https://github.com/HubSpot/jinjava/pull/421

This PR proposes a solution for two problems: Handling variables used within a deferred block and handling variables used in deferred blocks that occur at lower scopes.

###  Handling variables used within a deferred block
As discussed in https://github.com/HubSpot/jinjava/pull/421 we want a way to mark variables as deferred _while_ we are processing so that any subsequent uses of the variable are not processed. This is achieved here by scanning the deferred node each time and finding variables used within it. These variables are then put back into the context as DeferredValues with their original value. Any subsequent uses of these variables will result in a DeferredValueException and be handled like any other deferred variable. Before adding DeferredValuesUtils this kind of logic only existed in internal HS code -I believe because it is a small bit hacky. Before now, anyone else making use of the deferred functionality would have had to have their own way to rebuild a Deferred Render Context for their 2nd stage render.

I have also added support for finding yet undefined variables used within deferred blocks and marking them as deferred for example
```
{% if deferred = 'foo' %} 
{% set newVariable = 'deferred was foo' %}
{% else %}
{% set newVariable = 'deferred was not foo' %}
{% endif %}
{{ newVariable }}
```
Previously this would have output newVariable as an empty undefined var. Now it will be put in the context as deferred and so will be re-output as {{ newVariable }}
 

### handling variables used in deferred blocks that occur at lower scopes
I have observed issues in using the previous implementation of deferred variables in a HS setup where things are rendered in lower contexts (eg modules) and any deferred values are lost. These changes copy any deferred values to the parent scope, again with their original value. 

I can think of some cases where this might go wrong. If you had a template, that imported the same module multiple times, the first instance of the module would muddle the global scope with its values. I don't think this more global scope should cause issues as any code making use of deferred values should be preserved and the order of execution should be consistent. I added handling for deferred values to SetTag to handle this case.