### PR TITLE
Ignore non deferred values

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
@@ -53,8 +53,6 @@ public class DeferredValueUtils {
               ((DeferredValue) contextItem).getOriginalValue()
             );
           }
-        } else {
-          deferredContext.put(contextKey, contextItem);
         }
       }
     );

--- a/src/test/java/com/hubspot/jinjava/util/DeferredValueUtilsTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/DeferredValueUtilsTest.java
@@ -161,9 +161,10 @@ public class DeferredValueUtilsTest {
     assertThat(result).contains(entry("simple_map", simpleMap));
     assertThat(result).contains(entry("nested_map", nestedMap));
 
-    assertThat(result).contains(entry("simple_var_undeferred", "SimpleVarUnDeferred"));
-    assertThat(result).contains(entry("java_bean_undeferred", javaBean));
-    assertThat(result).contains(entry("nested_map_undeferred", nestedMap));
+    assertThat(result)
+      .doesNotContain(entry("simple_var_undeferred", "SimpleVarUnDeferred"));
+    assertThat(result).doesNotContain(entry("java_bean_undeferred", javaBean));
+    assertThat(result).doesNotContain(entry("nested_map_undeferred", nestedMap));
   }
 
   @Test


### PR DESCRIPTION
Incorrectly returned non-deferred values when getDeferredContextWithOriginalValues.

Caused context to be bloated