### PR TITLE
Global context

### DIFF
--- a/src/main/java/com/hubspot/jinjava/Jinjava.java
+++ b/src/main/java/com/hubspot/jinjava/Jinjava.java
@@ -123,6 +123,10 @@ public class Jinjava {
     return globalContext;
   }
 
+  public Context getGlobalContextCopy() {
+    return copyGlobalContext();
+  }
+
   public ResourceLocator getResourceLocator() {
     return resourceLocator;
   }
@@ -192,7 +196,11 @@ public class Jinjava {
     Map<String, ?> bindings,
     JinjavaConfig renderConfig
   ) {
-    Context context = new Context(globalContext, bindings, renderConfig.getDisabled());
+    Context context = new Context(
+      copyGlobalContext(),
+      bindings,
+      renderConfig.getDisabled()
+    );
 
     JinjavaInterpreter parentInterpreter = JinjavaInterpreter.getCurrent();
     if (parentInterpreter != null) {
@@ -256,6 +264,16 @@ public class Jinjava {
   public JinjavaInterpreter newInterpreter() {
     return globalConfig
       .getInterpreterFactory()
-      .newInstance(this, this.getGlobalContext(), this.getGlobalConfig());
+      .newInstance(this, copyGlobalContext(), this.getGlobalConfig());
+  }
+
+  private Context copyGlobalContext() {
+    Context context = new Context(null, globalContext);
+    // copy registered.
+    globalContext.getAllExpTests().forEach(context::registerExpTest);
+    globalContext.getAllFilters().forEach(context::registerFilter);
+    globalContext.getAllFunctions().forEach(context::registerFunction);
+    globalContext.getAllTags().forEach(context::registerTag);
+    return context;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/Jinjava.java
+++ b/src/main/java/com/hubspot/jinjava/Jinjava.java
@@ -38,6 +38,7 @@ import com.hubspot.jinjava.loader.ResourceLocator;
 import de.odysseus.el.ExpressionFactoryImpl;
 import de.odysseus.el.misc.TypeConverter;
 import de.odysseus.el.tree.TreeBuilder;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -204,10 +205,12 @@ public class Jinjava {
     JinjavaInterpreter parentInterpreter = JinjavaInterpreter.getCurrent();
     if (parentInterpreter != null) {
       renderConfig = parentInterpreter.getConfig();
+      Map<String, Object> bindingsWithParentContext = new HashMap<>(bindings);
+      bindingsWithParentContext.putAll(parentInterpreter.getContext());
       context =
         new Context(
           copyGlobalContext(),
-          parentInterpreter.getContext(),
+          bindingsWithParentContext,
           renderConfig.getDisabled()
         );
     } else {

--- a/src/main/java/com/hubspot/jinjava/Jinjava.java
+++ b/src/main/java/com/hubspot/jinjava/Jinjava.java
@@ -200,15 +200,18 @@ public class Jinjava {
     Map<String, ?> bindings,
     JinjavaConfig renderConfig
   ) {
-    Context context = new Context(
-      copyGlobalContext(),
-      bindings,
-      renderConfig.getDisabled()
-    );
-
+    Context context;
     JinjavaInterpreter parentInterpreter = JinjavaInterpreter.getCurrent();
     if (parentInterpreter != null) {
       renderConfig = parentInterpreter.getConfig();
+      context =
+        new Context(
+          copyGlobalContext(),
+          parentInterpreter.getContext(),
+          renderConfig.getDisabled()
+        );
+    } else {
+      context = new Context(copyGlobalContext(), bindings, renderConfig.getDisabled());
     }
 
     JinjavaInterpreter interpreter = globalConfig

--- a/src/main/java/com/hubspot/jinjava/Jinjava.java
+++ b/src/main/java/com/hubspot/jinjava/Jinjava.java
@@ -128,7 +128,7 @@ public class Jinjava {
     return globalContext;
   }
 
-  public Context getGlobalContextReadOnly() {
+  public Context getGlobalContextCopy() {
     return copyGlobalContext();
   }
 

--- a/src/main/java/com/hubspot/jinjava/Jinjava.java
+++ b/src/main/java/com/hubspot/jinjava/Jinjava.java
@@ -29,6 +29,10 @@ import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
+import com.hubspot.jinjava.lib.exptest.ExpTest;
+import com.hubspot.jinjava.lib.filter.Filter;
+import com.hubspot.jinjava.lib.fn.ELFunctionDefinition;
+import com.hubspot.jinjava.lib.tag.Tag;
 import com.hubspot.jinjava.loader.ClasspathResourceLocator;
 import com.hubspot.jinjava.loader.ResourceLocator;
 import de.odysseus.el.ExpressionFactoryImpl;
@@ -123,7 +127,7 @@ public class Jinjava {
     return globalContext;
   }
 
-  public Context getGlobalContextCopy() {
+  public Context getGlobalContextReadOnly() {
     return copyGlobalContext();
   }
 
@@ -265,6 +269,22 @@ public class Jinjava {
     return globalConfig
       .getInterpreterFactory()
       .newInstance(this, copyGlobalContext(), this.getGlobalConfig());
+  }
+
+  public void registerTag(Tag t) {
+    globalContext.registerTag(t);
+  }
+
+  public void registerFunction(ELFunctionDefinition f) {
+    globalContext.registerFunction(f);
+  }
+
+  public void registerFilter(Filter f) {
+    globalContext.registerFilter(f);
+  }
+
+  public void registerExpTest(ExpTest t) {
+    globalContext.registerExpTest(t);
   }
 
   private Context copyGlobalContext() {

--- a/src/main/java/com/hubspot/jinjava/Jinjava.java
+++ b/src/main/java/com/hubspot/jinjava/Jinjava.java
@@ -206,7 +206,9 @@ public class Jinjava {
     if (parentInterpreter != null) {
       renderConfig = parentInterpreter.getConfig();
       Map<String, Object> bindingsWithParentContext = new HashMap<>(bindings);
-      bindingsWithParentContext.putAll(parentInterpreter.getContext());
+      if (parentInterpreter.getContext() != null) {
+        bindingsWithParentContext.putAll(parentInterpreter.getContext());
+      }
       context =
         new Context(
           copyGlobalContext(),

--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
@@ -42,7 +42,7 @@ public class JinjavaDocFactory {
   }
 
   private void addExpTests(JinjavaDoc doc) {
-    for (ExpTest t : jinjava.getGlobalContextReadOnly().getAllExpTests()) {
+    for (ExpTest t : jinjava.getGlobalContextCopy().getAllExpTests()) {
       com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation = t
         .getClass()
         .getAnnotation(com.hubspot.jinjava.doc.annotations.JinjavaDoc.class);
@@ -83,7 +83,7 @@ public class JinjavaDocFactory {
   }
 
   private void addFilterDocs(JinjavaDoc doc) {
-    for (Filter f : jinjava.getGlobalContextReadOnly().getAllFilters()) {
+    for (Filter f : jinjava.getGlobalContextCopy().getAllFilters()) {
       com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation = f
         .getClass()
         .getAnnotation(com.hubspot.jinjava.doc.annotations.JinjavaDoc.class);
@@ -124,7 +124,7 @@ public class JinjavaDocFactory {
   }
 
   private void addFnDocs(JinjavaDoc doc) {
-    for (ELFunctionDefinition fn : jinjava.getGlobalContextReadOnly().getAllFunctions()) {
+    for (ELFunctionDefinition fn : jinjava.getGlobalContextCopy().getAllFunctions()) {
       if (StringUtils.isBlank(fn.getNamespace())) {
         Method realMethod = fn.getMethod();
         if (
@@ -182,7 +182,7 @@ public class JinjavaDocFactory {
   }
 
   private void addTagDocs(JinjavaDoc doc) {
-    for (Tag t : jinjava.getGlobalContextReadOnly().getAllTags()) {
+    for (Tag t : jinjava.getGlobalContextCopy().getAllTags()) {
       if (t instanceof EndTag) {
         continue;
       }

--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
@@ -42,7 +42,7 @@ public class JinjavaDocFactory {
   }
 
   private void addExpTests(JinjavaDoc doc) {
-    for (ExpTest t : jinjava.getGlobalContextCopy().getAllExpTests()) {
+    for (ExpTest t : jinjava.getGlobalContextReadOnly().getAllExpTests()) {
       com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation = t
         .getClass()
         .getAnnotation(com.hubspot.jinjava.doc.annotations.JinjavaDoc.class);
@@ -83,7 +83,7 @@ public class JinjavaDocFactory {
   }
 
   private void addFilterDocs(JinjavaDoc doc) {
-    for (Filter f : jinjava.getGlobalContextCopy().getAllFilters()) {
+    for (Filter f : jinjava.getGlobalContextReadOnly().getAllFilters()) {
       com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation = f
         .getClass()
         .getAnnotation(com.hubspot.jinjava.doc.annotations.JinjavaDoc.class);
@@ -124,7 +124,7 @@ public class JinjavaDocFactory {
   }
 
   private void addFnDocs(JinjavaDoc doc) {
-    for (ELFunctionDefinition fn : jinjava.getGlobalContextCopy().getAllFunctions()) {
+    for (ELFunctionDefinition fn : jinjava.getGlobalContextReadOnly().getAllFunctions()) {
       if (StringUtils.isBlank(fn.getNamespace())) {
         Method realMethod = fn.getMethod();
         if (
@@ -182,7 +182,7 @@ public class JinjavaDocFactory {
   }
 
   private void addTagDocs(JinjavaDoc doc) {
-    for (Tag t : jinjava.getGlobalContextCopy().getAllTags()) {
+    for (Tag t : jinjava.getGlobalContextReadOnly().getAllTags()) {
       if (t instanceof EndTag) {
         continue;
       }

--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
@@ -42,7 +42,7 @@ public class JinjavaDocFactory {
   }
 
   private void addExpTests(JinjavaDoc doc) {
-    for (ExpTest t : jinjava.getGlobalContext().getAllExpTests()) {
+    for (ExpTest t : jinjava.getGlobalContextCopy().getAllExpTests()) {
       com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation = t
         .getClass()
         .getAnnotation(com.hubspot.jinjava.doc.annotations.JinjavaDoc.class);
@@ -83,7 +83,7 @@ public class JinjavaDocFactory {
   }
 
   private void addFilterDocs(JinjavaDoc doc) {
-    for (Filter f : jinjava.getGlobalContext().getAllFilters()) {
+    for (Filter f : jinjava.getGlobalContextCopy().getAllFilters()) {
       com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation = f
         .getClass()
         .getAnnotation(com.hubspot.jinjava.doc.annotations.JinjavaDoc.class);
@@ -124,7 +124,7 @@ public class JinjavaDocFactory {
   }
 
   private void addFnDocs(JinjavaDoc doc) {
-    for (ELFunctionDefinition fn : jinjava.getGlobalContext().getAllFunctions()) {
+    for (ELFunctionDefinition fn : jinjava.getGlobalContextCopy().getAllFunctions()) {
       if (StringUtils.isBlank(fn.getNamespace())) {
         Method realMethod = fn.getMethod();
         if (
@@ -182,7 +182,7 @@ public class JinjavaDocFactory {
   }
 
   private void addTagDocs(JinjavaDoc doc) {
-    for (Tag t : jinjava.getGlobalContext().getAllTags()) {
+    for (Tag t : jinjava.getGlobalContextCopy().getAllTags()) {
       if (t instanceof EndTag) {
         continue;
       }


### PR DESCRIPTION
JinJava can be a singleton and shared by multiple threads.  The JinJava rendering context is scoped, but the root of the context -- the global context -- is shared. However, the context should not be shared, especially they can be modified during the rendering. To alleviate the issue,

1) we add a read only accessor, jinjava.getGlobalContextReadOnly(),
2) proxy the registering functions, so that a caller does not have to access the globalContext directly.
3) make a copy of the global context as the root of scoped context for each rendering.

Drawback is once the JinJava's `renderForResult` is started, updating the global content (registering new filter, etc) has no effect. It might actually be desired.