### PR TITLE
Support expressions in selectattr/rejectattr again, more efficiently

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -234,6 +234,13 @@ public class Context extends ScopeMap<String, Object> {
     }
   }
 
+  public void removeResolvedExpression(String expression) {
+    resolvedExpressions.remove(expression);
+    if (getParent() != null) {
+      getParent().removeResolvedExpression(expression);
+    }
+  }
+
   public Set<String> getResolvedExpressions() {
     return ImmutableSet.copyOf(resolvedExpressions);
   }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
@@ -126,6 +126,7 @@ public class SelectAttrFilter implements AdvancedFilter {
         result.add(val);
       }
     }
+    interpreter.getContext().removeResolvedExpression(expression);
 
     return result;
   }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SelectAttrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SelectAttrFilterTest.java
@@ -2,9 +2,11 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.hubspot.jinjava.Jinjava;
 import java.util.HashMap;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -19,9 +21,27 @@ public class SelectAttrFilterTest {
       .put(
         "users",
         Lists.newArrayList(
-          new User(0, false, "foo@bar.com", new Option(0, "option0")),
-          new User(1, true, "bar@bar.com", new Option(1, "option1")),
-          new User(2, false, null, new Option(2, "option2"))
+          new User(
+            0,
+            false,
+            "foo@bar.com",
+            new Option(0, "option0"),
+            ImmutableList.of(new Option(0, "option0"))
+          ),
+          new User(
+            1,
+            true,
+            "bar@bar.com",
+            new Option(1, "option1"),
+            ImmutableList.of(new Option(1, "option1"))
+          ),
+          new User(
+            2,
+            false,
+            null,
+            new Option(2, "option2"),
+            ImmutableList.of(new Option(2, "option2"))
+          )
         )
       );
   }
@@ -89,17 +109,44 @@ public class SelectAttrFilterTest {
       .isEqualTo("[2]");
   }
 
+  @Test
+  public void selectAttrWithNestedFilter() {
+    assertThat(
+        jinjava.render(
+          "{{ users|selectattr(\"optionList|map('id')\", 'containing', 1) }}",
+          new HashMap<String, Object>()
+        )
+      )
+      .isEqualTo("[1]");
+
+    assertThat(
+        jinjava.render(
+          "{{ users|selectattr(\"optionList|map('name')\", 'containing', 'option2') }}",
+          new HashMap<String, Object>()
+        )
+      )
+      .isEqualTo("[2]");
+  }
+
   public static class User {
     private long num;
     private boolean isActive;
     private String email;
     private Option option;
+    private List<Option> optionList;
 
-    public User(long num, boolean isActive, String email, Option option) {
+    public User(
+      long num,
+      boolean isActive,
+      String email,
+      Option option,
+      List<Option> optionList
+    ) {
       this.num = num;
       this.isActive = isActive;
       this.email = email;
       this.option = option;
+      this.optionList = optionList;
     }
 
     public long getNum() {
@@ -116,6 +163,10 @@ public class SelectAttrFilterTest {
 
     public Option getOption() {
       return option;
+    }
+
+    public List<Option> getOptionList() {
+      return optionList;
     }
 
     @Override


### PR DESCRIPTION
Redoes the changes made (and reverted) in #238 to support full expressions as the first argument to the `selectattr` filter. The previous approach caused performance issues because of the generation of a unique expression for each value processed in the sequence. These expressions all get saved in the context ([code](https://github.com/HubSpot/jinjava/blob/fb946da2b49fc899ef37f7a1da4e9e232b98b57c/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java#L67)), making iterating through resolved expressions and even just checking membership in the set ([code](https://github.com/HubSpot/jinjava/blob/25dd4240010061bad602b5991fa2bc6ba209a36f/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java#L85)) unwieldy. 

This PR uses the same expression string for processing each value and removes it from the context after we've finished iterating through the loop. Doing so not only avoids the bloated context issue, but also allows us to take advantage of caching in the `TreeStore` when parsing the expression string into a `TreeValueExpression`.

Locally testing this implementation on very large lists (of 10,000 elements) showed that performance is the same, if not slightly faster, than the current master branch implementation that only supports chained attributes, and an order of magnitude faster than the #238 implementation with unique expressions.