### PR TITLE
Check for nulls in range function

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -196,7 +196,7 @@ public class Functions {
         value = "var",
         type = "datetimeFormat",
         desc = "format of the datetime string"
-      )
+      ),
     }
   )
   public static PyishDate stringToTime(String datetimeString, String datetimeFormat) {
@@ -331,16 +331,18 @@ public class Functions {
         break;
       case 1:
         start = NumberUtils.toInt(arg1.toString());
-        if (NumberUtils.isNumber(args[0].toString())) {
+        if (args[0] != null && NumberUtils.isNumber(args[0].toString())) {
           end = NumberUtils.toInt(args[0].toString(), start + RANGE_LIMIT);
         }
         break;
       default:
         start = NumberUtils.toInt(arg1.toString());
-        if (NumberUtils.isNumber(args[0].toString())) {
+        if (args[0] != null && NumberUtils.isNumber(args[0].toString())) {
           end = NumberUtils.toInt(args[0].toString(), start + RANGE_LIMIT);
         }
-        step = NumberUtils.toInt(args[1].toString(), 1);
+        if (args[1] != null) {
+          step = NumberUtils.toInt(args[1].toString(), 1);
+        }
     }
 
     if (step == 0) {

--- a/src/test/java/com/hubspot/jinjava/lib/fn/RangeFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/RangeFunctionTest.java
@@ -38,6 +38,8 @@ public class RangeFunctionTest {
   public void itHandlesBadValues() {
     assertThat(Functions.range("f")).isEmpty();
     assertThat(Functions.range(2, "f")).isEmpty();
+    assertThat(Functions.range(2, new Object[] { null })).isEmpty();
+    assertThat(Functions.range(2, 4, null)).isEqualTo(Arrays.asList(2, 3));
   }
 
   @Test


### PR DESCRIPTION
The range function was not checking for null values passed in the args array and was throwing NPEs when an unresolved variable was passed as and end or step parameter.