### PR TITLE
Revert "Support expressions in selectattr/rejectattr again, more efficiently"

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -235,13 +235,6 @@ public class Context extends ScopeMap<String, Object> {
     }
   }
 
-  public void removeResolvedExpression(String expression) {
-    resolvedExpressions.remove(expression);
-    if (getParent() != null) {
-      getParent().removeResolvedExpression(expression);
-    }
-  }
-
   public Set<String> getResolvedExpressions() {
     return ImmutableSet.copyOf(resolvedExpressions);
   }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
@@ -10,11 +10,11 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.exptest.ExpTest;
 import com.hubspot.jinjava.util.ForLoop;
 import com.hubspot.jinjava.util.ObjectIterator;
+import com.hubspot.jinjava.util.Variable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ThreadLocalRandom;
 
 @JinjavaDoc(
   value = "Filters a sequence of objects by applying a test to an attribute of an object and only selecting the ones with the test succeeding.",
@@ -110,32 +110,20 @@ public class SelectAttrFilter implements AdvancedFilter {
       }
     }
 
-    String tempValue = generateTempVariable();
-    String expression = generateTempVariable(tempValue, attr);
     ForLoop loop = ObjectIterator.getLoop(var);
     while (loop.hasNext()) {
       Object val = loop.next();
-      interpreter.getContext().put(tempValue, val);
 
-      Object attrVal = interpreter.resolveELExpression(
-        expression,
-        interpreter.getLineNumber()
-      );
-
+      Object attrVal = new Variable(
+        interpreter,
+        String.format("%s.%s", "placeholder", attr)
+      )
+      .resolve(val);
       if (acceptObjects == expTest.evaluate(attrVal, interpreter, expArgs)) {
         result.add(val);
       }
     }
-    interpreter.getContext().removeResolvedExpression(expression);
 
     return result;
-  }
-
-  private String generateTempVariable() {
-    return "jj_temp_" + Math.abs(ThreadLocalRandom.current().nextInt());
-  }
-
-  private String generateTempVariable(String tempValue, String expression) {
-    return String.format("%s.%s", tempValue, expression).trim();
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SelectAttrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SelectAttrFilterTest.java
@@ -2,11 +2,9 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.hubspot.jinjava.Jinjava;
 import java.util.HashMap;
-import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -21,27 +19,9 @@ public class SelectAttrFilterTest {
       .put(
         "users",
         Lists.newArrayList(
-          new User(
-            0,
-            false,
-            "foo@bar.com",
-            new Option(0, "option0"),
-            ImmutableList.of(new Option(0, "option0"))
-          ),
-          new User(
-            1,
-            true,
-            "bar@bar.com",
-            new Option(1, "option1"),
-            ImmutableList.of(new Option(1, "option1"))
-          ),
-          new User(
-            2,
-            false,
-            null,
-            new Option(2, "option2"),
-            ImmutableList.of(new Option(2, "option2"))
-          )
+          new User(0, false, "foo@bar.com", new Option(0, "option0")),
+          new User(1, true, "bar@bar.com", new Option(1, "option1")),
+          new User(2, false, null, new Option(2, "option2"))
         )
       );
   }
@@ -109,44 +89,17 @@ public class SelectAttrFilterTest {
       .isEqualTo("[2]");
   }
 
-  @Test
-  public void selectAttrWithNestedFilter() {
-    assertThat(
-        jinjava.render(
-          "{{ users|selectattr(\"optionList|map('id')\", 'containing', 1) }}",
-          new HashMap<String, Object>()
-        )
-      )
-      .isEqualTo("[1]");
-
-    assertThat(
-        jinjava.render(
-          "{{ users|selectattr(\"optionList|map('name')\", 'containing', 'option2') }}",
-          new HashMap<String, Object>()
-        )
-      )
-      .isEqualTo("[2]");
-  }
-
   public static class User {
     private long num;
     private boolean isActive;
     private String email;
     private Option option;
-    private List<Option> optionList;
 
-    public User(
-      long num,
-      boolean isActive,
-      String email,
-      Option option,
-      List<Option> optionList
-    ) {
+    public User(long num, boolean isActive, String email, Option option) {
       this.num = num;
       this.isActive = isActive;
       this.email = email;
       this.option = option;
-      this.optionList = optionList;
     }
 
     public long getNum() {
@@ -163,10 +116,6 @@ public class SelectAttrFilterTest {
 
     public Option getOption() {
       return option;
-    }
-
-    public List<Option> getOptionList() {
-      return optionList;
     }
 
     @Override


### PR DESCRIPTION
Reverts HubSpot/jinjava#450

There are some issues with `-` in variable names we will have to consider more carefully.