### PR TITLE
Fix for "Equalto operator doesn't work in "or" statement (== does)"

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -400,45 +400,36 @@ public class ExtendedParser extends Parser {
           ) {
             consumeToken(); // 'is'
             consumeToken(); // 'not'
-            String exptestName = consumeToken().getImage();
-            List<AstNode> exptestParams = Lists.newArrayList(v, interpreter());
-
-            // optional exptest arg
-            AstNode arg = value();
-            if (arg != null) {
-              exptestParams.add(arg);
-            }
-
-            AstProperty exptestProperty = createAstDot(
-              identifier(EXPTEST_PREFIX + exptestName),
-              "evaluateNegated",
-              true
-            );
-            v = createAstMethod(exptestProperty, new AstParameters(exptestParams));
+            v = buildAstMethodForIdentifier(v, "evaluateNegated");
           } else if (
-            "is".equals(getToken().getImage()) && lookahead(0).getSymbol() == IDENTIFIER
+            "is".equals(getToken().getImage()) &&
+            lookahead(0).getSymbol() == IDENTIFIER
           ) {
             consumeToken(); // 'is'
-            String exptestName = consumeToken().getImage();
-            List<AstNode> exptestParams = Lists.newArrayList(v, interpreter());
-
-            // optional exptest arg
-            AstNode arg = value();
-            if (arg != null) {
-              exptestParams.add(arg);
-            }
-
-            AstProperty exptestProperty = createAstDot(
-              identifier(EXPTEST_PREFIX + exptestName),
-              "evaluate",
-              true
-            );
-            v = createAstMethod(exptestProperty, new AstParameters(exptestParams));
+            v = buildAstMethodForIdentifier(v, "evaluate");
           }
 
           return v;
       }
     }
+  }
+
+  private AstNode buildAstMethodForIdentifier(AstNode astNode, String property) throws ScanException, ParseException {
+    String exptestName = consumeToken().getImage();
+    List<AstNode> exptestParams = Lists.newArrayList(astNode, interpreter());
+
+    // optional exptest arg
+    AstNode arg = value();
+    if (arg != null) {
+      exptestParams.add(arg);
+    }
+
+    AstProperty exptestProperty = createAstDot(
+            identifier(EXPTEST_PREFIX + exptestName),
+            property,
+            true
+    );
+    return createAstMethod(exptestProperty, new AstParameters(exptestParams));
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -402,8 +402,7 @@ public class ExtendedParser extends Parser {
             consumeToken(); // 'not'
             v = buildAstMethodForIdentifier(v, "evaluateNegated");
           } else if (
-            "is".equals(getToken().getImage()) &&
-            lookahead(0).getSymbol() == IDENTIFIER
+            "is".equals(getToken().getImage()) && lookahead(0).getSymbol() == IDENTIFIER
           ) {
             consumeToken(); // 'is'
             v = buildAstMethodForIdentifier(v, "evaluate");
@@ -414,7 +413,8 @@ public class ExtendedParser extends Parser {
     }
   }
 
-  private AstNode buildAstMethodForIdentifier(AstNode astNode, String property) throws ScanException, ParseException {
+  private AstNode buildAstMethodForIdentifier(AstNode astNode, String property)
+    throws ScanException, ParseException {
     String exptestName = consumeToken().getImage();
     List<AstNode> exptestParams = Lists.newArrayList(astNode, interpreter());
 
@@ -425,9 +425,9 @@ public class ExtendedParser extends Parser {
     }
 
     AstProperty exptestProperty = createAstDot(
-            identifier(EXPTEST_PREFIX + exptestName),
-            property,
-            true
+      identifier(EXPTEST_PREFIX + exptestName),
+      property,
+      true
     );
     return createAstMethod(exptestProperty, new AstParameters(exptestParams));
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -404,7 +404,7 @@ public class ExtendedParser extends Parser {
             List<AstNode> exptestParams = Lists.newArrayList(v, interpreter());
 
             // optional exptest arg
-            AstNode arg = expr(false);
+            AstNode arg = value();
             if (arg != null) {
               exptestParams.add(arg);
             }

--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -423,7 +423,7 @@ public class ExtendedParser extends Parser {
             List<AstNode> exptestParams = Lists.newArrayList(v, interpreter());
 
             // optional exptest arg
-            AstNode arg = expr(false);
+            AstNode arg = value();
             if (arg != null) {
               exptestParams.add(arg);
             }

--- a/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
@@ -135,6 +135,11 @@ public class ExtendedSyntaxBuilderTest {
   }
 
   @Test
+  public void conditionalExprWithOrConditionalAndCustomExpression() {
+    assertThat(val("'a' is equalto 'b' or 'a' is equalto 'a'")).isEqualTo(true);
+  }
+
+  @Test
   public void newlineEscChar() {
     context.put("comment", "foo\nbar");
     assertThat(val("comment|replace('\\n', '<br/>')")).isEqualTo("foo<br/>bar");

--- a/src/test/java/com/hubspot/jinjava/el/ext/ExtendedParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/ExtendedParserTest.java
@@ -1,0 +1,123 @@
+package com.hubspot.jinjava.el.ext;
+
+import de.odysseus.el.tree.impl.Builder;
+import de.odysseus.el.tree.impl.ast.AstBinary;
+import de.odysseus.el.tree.impl.ast.AstIdentifier;
+import de.odysseus.el.tree.impl.ast.AstMethod;
+import de.odysseus.el.tree.impl.ast.AstNode;
+import de.odysseus.el.tree.impl.ast.AstParameters;
+import de.odysseus.el.tree.impl.ast.AstString;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+public class ExtendedParserTest {
+
+    @Test
+    public void itParseSingleBinaryEqualCondition() {
+        AstNode astNode = buildExpressionNodes("#{'a' == 'b'}");
+
+        assertThat(astNode).isInstanceOf(AstBinary.class);
+        assertLeftAndRightByOperator((AstBinary) astNode, "a", "b", AstBinary.EQ);
+    }
+
+    @Test
+    public void itParseBinaryOrEqualCondition() {
+        AstNode astNode = buildExpressionNodes("#{'a' == 'b' or 'c' == 'c'}");
+
+        assertThat(astNode).isInstanceOf(AstBinary.class);
+
+        AstBinary astBinary = (AstBinary) astNode;
+        AstNode left = astBinary.getChild(0);
+        AstNode right = astBinary.getChild(1);
+
+        assertThat(astBinary.getOperator()).isEqualTo(OrOperator.OP);
+        assertThat(left).isInstanceOf(AstBinary.class);
+        assertThat(right).isInstanceOf(AstBinary.class);
+
+        assertLeftAndRightByOperator((AstBinary) left, "a", "b", AstBinary.EQ);
+        assertLeftAndRightByOperator((AstBinary) right, "c", "c", AstBinary.EQ);
+    }
+
+    @Test
+    public void itParseSingleBinaryWithExpressionCondition() {
+        AstNode astNode = buildExpressionNodes("#{'a' is equalto 'b'}");
+
+        assertThat(astNode).isInstanceOf(AstMethod.class);
+        assertForExpression(astNode, "a", "b", "exptest:equalto");
+    }
+
+    @Test
+    public void itParseBinaryOrWithEqualSymbolAndExpressionCondition() {
+        AstNode astNode = buildExpressionNodes("#{'a' == 'b' or 'c' is equalto 'c'}");
+
+        assertThat(astNode).isInstanceOf(AstBinary.class);
+
+        AstBinary astBinary = (AstBinary) astNode;
+        AstNode left = astBinary.getChild(0);
+        AstNode right = astBinary.getChild(1);
+
+        assertThat(astBinary.getOperator()).isEqualTo(OrOperator.OP);
+        assertThat(left).isInstanceOf(AstBinary.class);
+        assertThat(right).isInstanceOf(AstMethod.class);
+
+        assertLeftAndRightByOperator((AstBinary) left, "a", "b", AstBinary.EQ);
+        assertForExpression(right, "c", "c", "exptest:equalto");
+    }
+
+    private void assertForExpression(AstNode astNode, String leftExpected, String rightExpected, String expression) {
+        AstIdentifier astIdentifier = (AstIdentifier) astNode.getChild(0).getChild(0);
+        assertThat(astIdentifier.getName()).isEqualTo(expression);
+
+        AstParameters astParameters = (AstParameters) astNode.getChild(1);
+        assertThat(astParameters.getChild(0)).isInstanceOf(AstString.class);
+        assertThat(astParameters.getChild(1)).isInstanceOf(AstIdentifier.class);
+        assertThat(astParameters.getChild(2)).isInstanceOf(AstString.class);
+
+        assertThat(astParameters.getChild(0).eval(null, null)).isEqualTo(leftExpected);
+        assertThat(((AstIdentifier) astParameters.getChild(1)).getName()).isEqualTo("____int3rpr3t3r____");
+        assertThat(astParameters.getChild(2).eval(null, null)).isEqualTo(rightExpected);
+    }
+
+    private void assertLeftAndRightByOperator(AstBinary astBinary, String leftExpected, String rightExpected,
+                                              AstBinary.Operator operator) {
+        AstNode left = astBinary.getChild(0);
+        AstNode right = astBinary.getChild(1);
+
+        assertThat(astBinary.getOperator()).isEqualTo(operator);
+        assertThat(left).isInstanceOf(AstString.class);
+        assertThat(right).isInstanceOf(AstString.class);
+        assertThat(left.eval(null, null)).isEqualTo(leftExpected);
+        assertThat(right.eval(null, null)).isEqualTo(rightExpected);
+    }
+
+    private AstNode buildExpressionNodes(String input) {
+        ExtendedCustomParser extendedParser = new ExtendedCustomParser(new Builder(), input);
+        extendedParser.consumeTokenExpose();
+        extendedParser.consumeTokenExpose();
+
+        try {
+            return extendedParser.expr(true);
+        } catch (Exception exception) {
+            fail(exception.getMessage(), exception);
+            return null;
+        }
+    }
+
+    private static class ExtendedCustomParser extends ExtendedParser {
+        private ExtendedCustomParser(Builder context, String input) {
+            super(context, input);
+        }
+
+        private void consumeTokenExpose() {
+            try {
+                super.consumeToken();
+            } catch (Exception exception) {
+                Assertions.fail(exception.getMessage(), exception);
+            }
+
+        }
+    }
+}

--- a/src/test/java/com/hubspot/jinjava/el/ext/ExtendedParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/ExtendedParserTest.java
@@ -25,7 +25,7 @@ public class ExtendedParserTest {
 
     @Test
     public void itParseBinaryOrEqualCondition() {
-        AstNode astNode = buildExpressionNodes("#{'a' == 'b' or 'c' == 'c'}");
+        AstNode astNode = buildExpressionNodes("#{'a' == 'b' or 'c' == 'd'}");
 
         assertThat(astNode).isInstanceOf(AstBinary.class);
 
@@ -38,7 +38,7 @@ public class ExtendedParserTest {
         assertThat(right).isInstanceOf(AstBinary.class);
 
         assertLeftAndRightByOperator((AstBinary) left, "a", "b", AstBinary.EQ);
-        assertLeftAndRightByOperator((AstBinary) right, "c", "c", AstBinary.EQ);
+        assertLeftAndRightByOperator((AstBinary) right, "c", "d", AstBinary.EQ);
     }
 
     @Test
@@ -51,7 +51,7 @@ public class ExtendedParserTest {
 
     @Test
     public void itParseBinaryOrWithEqualSymbolAndExpressionCondition() {
-        AstNode astNode = buildExpressionNodes("#{'a' == 'b' or 'c' is equalto 'c'}");
+        AstNode astNode = buildExpressionNodes("#{'a' == 'b' or 'c' is equalto 'd'}");
 
         assertThat(astNode).isInstanceOf(AstBinary.class);
 
@@ -64,7 +64,25 @@ public class ExtendedParserTest {
         assertThat(right).isInstanceOf(AstMethod.class);
 
         assertLeftAndRightByOperator((AstBinary) left, "a", "b", AstBinary.EQ);
-        assertForExpression(right, "c", "c", "exptest:equalto");
+        assertForExpression(right, "c", "d", "exptest:equalto");
+    }
+
+    @Test
+    public void itParseBinaryOrWithExpressionsCondition() {
+        AstNode astNode = buildExpressionNodes("#{'a' is equalto 'b' or 'c' is equalto 'd'}");
+
+        assertThat(astNode).isInstanceOf(AstBinary.class);
+
+        AstBinary astBinary = (AstBinary) astNode;
+        AstNode left = astBinary.getChild(0);
+        AstNode right = astBinary.getChild(1);
+
+        assertThat(astBinary.getOperator()).isEqualTo(OrOperator.OP);
+        assertThat(left).isInstanceOf(AstMethod.class);
+        assertThat(right).isInstanceOf(AstMethod.class);
+
+        assertForExpression(left, "a", "b", "exptest:equalto");
+        assertForExpression(right, "c", "d", "exptest:equalto");
     }
 
     private void assertForExpression(AstNode astNode, String leftExpected, String rightExpected, String expression) {

--- a/src/test/java/com/hubspot/jinjava/el/ext/ExtendedParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/ExtendedParserTest.java
@@ -1,5 +1,8 @@
 package com.hubspot.jinjava.el.ext;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
 import de.odysseus.el.tree.impl.Builder;
 import de.odysseus.el.tree.impl.ast.AstBinary;
 import de.odysseus.el.tree.impl.ast.AstIdentifier;
@@ -10,150 +13,159 @@ import de.odysseus.el.tree.impl.ast.AstString;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-
 public class ExtendedParserTest {
 
-    @Test
-    public void itParseSingleBinaryEqualCondition() {
-        AstNode astNode = buildExpressionNodes("#{'a' == 'b'}");
+  @Test
+  public void itParseSingleBinaryEqualCondition() {
+    AstNode astNode = buildExpressionNodes("#{'a' == 'b'}");
 
-        assertThat(astNode).isInstanceOf(AstBinary.class);
-        assertLeftAndRightByOperator((AstBinary) astNode, "a", "b", AstBinary.EQ);
+    assertThat(astNode).isInstanceOf(AstBinary.class);
+    assertLeftAndRightByOperator((AstBinary) astNode, "a", "b", AstBinary.EQ);
+  }
+
+  @Test
+  public void itParseBinaryOrEqualCondition() {
+    AstNode astNode = buildExpressionNodes("#{'a' == 'b' or 'c' == 'd'}");
+
+    assertThat(astNode).isInstanceOf(AstBinary.class);
+
+    AstBinary astBinary = (AstBinary) astNode;
+    AstNode left = astBinary.getChild(0);
+    AstNode right = astBinary.getChild(1);
+
+    assertThat(astBinary.getOperator()).isEqualTo(OrOperator.OP);
+    assertThat(left).isInstanceOf(AstBinary.class);
+    assertThat(right).isInstanceOf(AstBinary.class);
+
+    assertLeftAndRightByOperator((AstBinary) left, "a", "b", AstBinary.EQ);
+    assertLeftAndRightByOperator((AstBinary) right, "c", "d", AstBinary.EQ);
+  }
+
+  @Test
+  public void itParseSingleBinaryWithExpressionCondition() {
+    AstNode astNode = buildExpressionNodes("#{'a' is equalto 'b'}");
+
+    assertThat(astNode).isInstanceOf(AstMethod.class);
+    assertForExpression(astNode, "a", "b", "exptest:equalto");
+  }
+
+  @Test
+  public void itParseBinaryOrWithEqualSymbolAndExpressionCondition() {
+    AstNode astNode = buildExpressionNodes("#{'a' == 'b' or 'c' is equalto 'd'}");
+
+    assertThat(astNode).isInstanceOf(AstBinary.class);
+
+    AstBinary astBinary = (AstBinary) astNode;
+    AstNode left = astBinary.getChild(0);
+    AstNode right = astBinary.getChild(1);
+
+    assertThat(astBinary.getOperator()).isEqualTo(OrOperator.OP);
+    assertThat(left).isInstanceOf(AstBinary.class);
+    assertThat(right).isInstanceOf(AstMethod.class);
+
+    assertLeftAndRightByOperator((AstBinary) left, "a", "b", AstBinary.EQ);
+    assertForExpression(right, "c", "d", "exptest:equalto");
+  }
+
+  @Test
+  public void itParseBinaryOrWithExpressionsCondition() {
+    AstNode astNode = buildExpressionNodes("#{'a' is equalto 'b' or 'c' is equalto 'd'}");
+
+    assertThat(astNode).isInstanceOf(AstBinary.class);
+
+    AstBinary astBinary = (AstBinary) astNode;
+    AstNode left = astBinary.getChild(0);
+    AstNode right = astBinary.getChild(1);
+
+    assertThat(astBinary.getOperator()).isEqualTo(OrOperator.OP);
+    assertThat(left).isInstanceOf(AstMethod.class);
+    assertThat(right).isInstanceOf(AstMethod.class);
+
+    assertForExpression(left, "a", "b", "exptest:equalto");
+    assertForExpression(right, "c", "d", "exptest:equalto");
+  }
+
+  @Test
+  public void itParseBinaryOrWithNegativeExpressionsCondition() {
+    AstNode astNode = buildExpressionNodes(
+      "#{'a' is not equalto 'b' or 'c' is not equalto 'd'}"
+    );
+
+    assertThat(astNode).isInstanceOf(AstBinary.class);
+
+    AstBinary astBinary = (AstBinary) astNode;
+    AstNode left = astBinary.getChild(0);
+    AstNode right = astBinary.getChild(1);
+
+    assertThat(astBinary.getOperator()).isEqualTo(OrOperator.OP);
+    assertThat(left).isInstanceOf(AstMethod.class);
+    assertThat(right).isInstanceOf(AstMethod.class);
+
+    assertForExpression(left, "a", "b", "exptest:equalto");
+    assertForExpression(right, "c", "d", "exptest:equalto");
+  }
+
+  private void assertForExpression(
+    AstNode astNode,
+    String leftExpected,
+    String rightExpected,
+    String expression
+  ) {
+    AstIdentifier astIdentifier = (AstIdentifier) astNode.getChild(0).getChild(0);
+    assertThat(astIdentifier.getName()).isEqualTo(expression);
+
+    AstParameters astParameters = (AstParameters) astNode.getChild(1);
+    assertThat(astParameters.getChild(0)).isInstanceOf(AstString.class);
+    assertThat(astParameters.getChild(1)).isInstanceOf(AstIdentifier.class);
+    assertThat(astParameters.getChild(2)).isInstanceOf(AstString.class);
+
+    assertThat(astParameters.getChild(0).eval(null, null)).isEqualTo(leftExpected);
+    assertThat(((AstIdentifier) astParameters.getChild(1)).getName())
+      .isEqualTo("____int3rpr3t3r____");
+    assertThat(astParameters.getChild(2).eval(null, null)).isEqualTo(rightExpected);
+  }
+
+  private void assertLeftAndRightByOperator(
+    AstBinary astBinary,
+    String leftExpected,
+    String rightExpected,
+    AstBinary.Operator operator
+  ) {
+    AstNode left = astBinary.getChild(0);
+    AstNode right = astBinary.getChild(1);
+
+    assertThat(astBinary.getOperator()).isEqualTo(operator);
+    assertThat(left).isInstanceOf(AstString.class);
+    assertThat(right).isInstanceOf(AstString.class);
+    assertThat(left.eval(null, null)).isEqualTo(leftExpected);
+    assertThat(right.eval(null, null)).isEqualTo(rightExpected);
+  }
+
+  private AstNode buildExpressionNodes(String input) {
+    ExtendedCustomParser extendedParser = new ExtendedCustomParser(new Builder(), input);
+    extendedParser.consumeTokenExpose();
+    extendedParser.consumeTokenExpose();
+
+    try {
+      return extendedParser.expr(true);
+    } catch (Exception exception) {
+      fail(exception.getMessage(), exception);
+      return null;
+    }
+  }
+
+  private static class ExtendedCustomParser extends ExtendedParser {
+
+    private ExtendedCustomParser(Builder context, String input) {
+      super(context, input);
     }
 
-    @Test
-    public void itParseBinaryOrEqualCondition() {
-        AstNode astNode = buildExpressionNodes("#{'a' == 'b' or 'c' == 'd'}");
-
-        assertThat(astNode).isInstanceOf(AstBinary.class);
-
-        AstBinary astBinary = (AstBinary) astNode;
-        AstNode left = astBinary.getChild(0);
-        AstNode right = astBinary.getChild(1);
-
-        assertThat(astBinary.getOperator()).isEqualTo(OrOperator.OP);
-        assertThat(left).isInstanceOf(AstBinary.class);
-        assertThat(right).isInstanceOf(AstBinary.class);
-
-        assertLeftAndRightByOperator((AstBinary) left, "a", "b", AstBinary.EQ);
-        assertLeftAndRightByOperator((AstBinary) right, "c", "d", AstBinary.EQ);
+    private void consumeTokenExpose() {
+      try {
+        super.consumeToken();
+      } catch (Exception exception) {
+        Assertions.fail(exception.getMessage(), exception);
+      }
     }
-
-    @Test
-    public void itParseSingleBinaryWithExpressionCondition() {
-        AstNode astNode = buildExpressionNodes("#{'a' is equalto 'b'}");
-
-        assertThat(astNode).isInstanceOf(AstMethod.class);
-        assertForExpression(astNode, "a", "b", "exptest:equalto");
-    }
-
-    @Test
-    public void itParseBinaryOrWithEqualSymbolAndExpressionCondition() {
-        AstNode astNode = buildExpressionNodes("#{'a' == 'b' or 'c' is equalto 'd'}");
-
-        assertThat(astNode).isInstanceOf(AstBinary.class);
-
-        AstBinary astBinary = (AstBinary) astNode;
-        AstNode left = astBinary.getChild(0);
-        AstNode right = astBinary.getChild(1);
-
-        assertThat(astBinary.getOperator()).isEqualTo(OrOperator.OP);
-        assertThat(left).isInstanceOf(AstBinary.class);
-        assertThat(right).isInstanceOf(AstMethod.class);
-
-        assertLeftAndRightByOperator((AstBinary) left, "a", "b", AstBinary.EQ);
-        assertForExpression(right, "c", "d", "exptest:equalto");
-    }
-
-    @Test
-    public void itParseBinaryOrWithExpressionsCondition() {
-        AstNode astNode = buildExpressionNodes("#{'a' is equalto 'b' or 'c' is equalto 'd'}");
-
-        assertThat(astNode).isInstanceOf(AstBinary.class);
-
-        AstBinary astBinary = (AstBinary) astNode;
-        AstNode left = astBinary.getChild(0);
-        AstNode right = astBinary.getChild(1);
-
-        assertThat(astBinary.getOperator()).isEqualTo(OrOperator.OP);
-        assertThat(left).isInstanceOf(AstMethod.class);
-        assertThat(right).isInstanceOf(AstMethod.class);
-
-        assertForExpression(left, "a", "b", "exptest:equalto");
-        assertForExpression(right, "c", "d", "exptest:equalto");
-    }
-
-    @Test
-    public void itParseBinaryOrWithNegativeExpressionsCondition() {
-        AstNode astNode = buildExpressionNodes("#{'a' is not equalto 'b' or 'c' is not equalto 'd'}");
-
-        assertThat(astNode).isInstanceOf(AstBinary.class);
-
-        AstBinary astBinary = (AstBinary) astNode;
-        AstNode left = astBinary.getChild(0);
-        AstNode right = astBinary.getChild(1);
-
-        assertThat(astBinary.getOperator()).isEqualTo(OrOperator.OP);
-        assertThat(left).isInstanceOf(AstMethod.class);
-        assertThat(right).isInstanceOf(AstMethod.class);
-
-        assertForExpression(left, "a", "b", "exptest:equalto");
-        assertForExpression(right, "c", "d", "exptest:equalto");
-    }
-
-    private void assertForExpression(AstNode astNode, String leftExpected, String rightExpected, String expression) {
-        AstIdentifier astIdentifier = (AstIdentifier) astNode.getChild(0).getChild(0);
-        assertThat(astIdentifier.getName()).isEqualTo(expression);
-
-        AstParameters astParameters = (AstParameters) astNode.getChild(1);
-        assertThat(astParameters.getChild(0)).isInstanceOf(AstString.class);
-        assertThat(astParameters.getChild(1)).isInstanceOf(AstIdentifier.class);
-        assertThat(astParameters.getChild(2)).isInstanceOf(AstString.class);
-
-        assertThat(astParameters.getChild(0).eval(null, null)).isEqualTo(leftExpected);
-        assertThat(((AstIdentifier) astParameters.getChild(1)).getName()).isEqualTo("____int3rpr3t3r____");
-        assertThat(astParameters.getChild(2).eval(null, null)).isEqualTo(rightExpected);
-    }
-
-    private void assertLeftAndRightByOperator(AstBinary astBinary, String leftExpected, String rightExpected,
-                                              AstBinary.Operator operator) {
-        AstNode left = astBinary.getChild(0);
-        AstNode right = astBinary.getChild(1);
-
-        assertThat(astBinary.getOperator()).isEqualTo(operator);
-        assertThat(left).isInstanceOf(AstString.class);
-        assertThat(right).isInstanceOf(AstString.class);
-        assertThat(left.eval(null, null)).isEqualTo(leftExpected);
-        assertThat(right.eval(null, null)).isEqualTo(rightExpected);
-    }
-
-    private AstNode buildExpressionNodes(String input) {
-        ExtendedCustomParser extendedParser = new ExtendedCustomParser(new Builder(), input);
-        extendedParser.consumeTokenExpose();
-        extendedParser.consumeTokenExpose();
-
-        try {
-            return extendedParser.expr(true);
-        } catch (Exception exception) {
-            fail(exception.getMessage(), exception);
-            return null;
-        }
-    }
-
-    private static class ExtendedCustomParser extends ExtendedParser {
-        private ExtendedCustomParser(Builder context, String input) {
-            super(context, input);
-        }
-
-        private void consumeTokenExpose() {
-            try {
-                super.consumeToken();
-            } catch (Exception exception) {
-                Assertions.fail(exception.getMessage(), exception);
-            }
-
-        }
-    }
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/el/ext/ExtendedParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/ExtendedParserTest.java
@@ -85,6 +85,24 @@ public class ExtendedParserTest {
         assertForExpression(right, "c", "d", "exptest:equalto");
     }
 
+    @Test
+    public void itParseBinaryOrWithNegativeExpressionsCondition() {
+        AstNode astNode = buildExpressionNodes("#{'a' is not equalto 'b' or 'c' is not equalto 'd'}");
+
+        assertThat(astNode).isInstanceOf(AstBinary.class);
+
+        AstBinary astBinary = (AstBinary) astNode;
+        AstNode left = astBinary.getChild(0);
+        AstNode right = astBinary.getChild(1);
+
+        assertThat(astBinary.getOperator()).isEqualTo(OrOperator.OP);
+        assertThat(left).isInstanceOf(AstMethod.class);
+        assertThat(right).isInstanceOf(AstMethod.class);
+
+        assertForExpression(left, "a", "b", "exptest:equalto");
+        assertForExpression(right, "c", "d", "exptest:equalto");
+    }
+
     private void assertForExpression(AstNode astNode, String leftExpected, String rightExpected, String expression) {
         AstIdentifier astIdentifier = (AstIdentifier) astNode.getChild(0).getChild(0);
         assertThat(astIdentifier.getName()).isEqualTo(expression);

--- a/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
@@ -122,7 +122,7 @@ public class DeferredTest {
   @Test
   public void itResolveEqualToInOrCondition() {
     String output = interpreter.render(
-            "{% if 'a' is equalto 'b' or 'a' is equalto 'a' %}{{deferred}}{% endif %}"
+      "{% if 'a' is equalto 'b' or 'a' is equalto 'a' %}{{deferred}}{% endif %}"
     );
     assertThat(output).isEqualTo("{{deferred}}");
   }

--- a/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
@@ -120,6 +120,14 @@ public class DeferredTest {
   }
 
   @Test
+  public void itResolveEqualToInOrCondition() {
+    String output = interpreter.render(
+            "{% if 'a' is equalto 'b' or 'a' is equalto 'a' %}{{deferred}}{% endif %}"
+    );
+    assertThat(output).isEqualTo("{{deferred}}");
+  }
+
+  @Test
   public void itResolvesForTagWherePossible() {
     String output = interpreter.render(
       "{% for i in [1, 2] %}{{i}}{{deferred}}{% endfor %}"

--- a/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
@@ -128,6 +128,16 @@ public class DeferredTest {
   }
 
   @Test
+  public void itPreserveDeferredVariableResolvingEqualToInOrCondition() {
+    String inputOutputExpected =
+      "{% if 'a' is equalto 'b' or 'a' is equalto deferred %}preserved{% endif %}";
+    String output = interpreter.render(inputOutputExpected);
+
+    assertThat(output).isEqualTo(inputOutputExpected);
+    assertThat(interpreter.getErrors()).isEmpty();
+  }
+
+  @Test
   public void itResolvesForTagWherePossible() {
     String output = interpreter.render(
       "{% for i in [1, 2] %}{{i}}{{deferred}}{% endfor %}"


### PR DESCRIPTION
This is a fix to be able to support multiple equals when using multiple conditions.

This issue was related here #414 

This commit is the main resolution for this fix https://github.com/HubSpot/jinjava/commit/8cb5142832a310f22cab8c1c2a9650a4cf4f8334#diff-dfa299c9356b094d756062285eaf6efdL426-R426

Also, after applied I could notice that for `is no`" expression had the same issue, so I applied too.

Feedback is welcome.