### PR TITLE
Map Json string to Object instead of HashMap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ notifications:
 before_install:
   - pip install --user codecov
 after_success:
-  - mvn validate -e
+  - travis_wait mvn validate -e
   - codecov
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FromJsonFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FromJsonFilter.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.filter;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
@@ -28,12 +29,11 @@ public class FromJsonFilter implements Filter {
       return null;
     }
 
+    if (!(var instanceof String)) {
+      throw new InvalidInputException(interpreter, this, InvalidReason.STRING);
+    }
     try {
-      if (var instanceof String) {
-        return OBJECT_MAPPER.readValue((String) var, HashMap.class);
-      } else {
-        throw new InvalidInputException(interpreter, this, InvalidReason.STRING);
-      }
+      return OBJECT_MAPPER.readValue((String) var, JsonNode.class);
     } catch (IOException e) {
       throw new InvalidInputException(interpreter, this, InvalidReason.JSON_READ);
     }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FromJsonFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FromJsonFilter.java
@@ -1,6 +1,5 @@
 package com.hubspot.jinjava.lib.filter;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
@@ -9,7 +8,6 @@ import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.io.IOException;
-import java.util.HashMap;
 
 @JinjavaDoc(
   value = "Converts JSON string to Object",
@@ -33,7 +31,7 @@ public class FromJsonFilter implements Filter {
       throw new InvalidInputException(interpreter, this, InvalidReason.STRING);
     }
     try {
-      return OBJECT_MAPPER.readValue((String) var, JsonNode.class);
+      return OBJECT_MAPPER.readValue((String) var, Object.class);
     } catch (IOException e) {
       throw new InvalidInputException(interpreter, this, InvalidReason.JSON_READ);
     }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/FromJsonFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FromJsonFilterTest.java
@@ -1,19 +1,30 @@
 package com.hubspot.jinjava.lib.filter;
 
+import static java.util.Arrays.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.objects.SafeString;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
 public class FromJsonFilterTest {
+  private static final String TRIVIAL_JSON_ARRAY = "[\"one\",\"two\",\"three\"]";
   private static final String NESTED_JSON =
     "{\"first\":[1,2,3],\"nested\":{\"second\":\"string\",\"third\":4}}";
+  private static final String DEEPLY_NESTED_ARRAY = "{\"a\":{\"b\":{\"c\": [1,2,3]}}}";
+  private static final String EMPTY_JSON_OBJECT = "{}";
+  private static final String EMPTY_JSON_ARRAY = "[]";
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
   private JinjavaInterpreter interpreter;
   private FromJsonFilter filter;
 
@@ -21,15 +32,6 @@ public class FromJsonFilterTest {
   public void setup() {
     interpreter = new Jinjava().newInterpreter();
     filter = new FromJsonFilter();
-  }
-
-  @Test
-  public void itReadsStringAsObject() {
-    HashMap<String, Object> node = (HashMap<String, Object>) filter.filter(
-      NESTED_JSON,
-      interpreter
-    );
-    checkedNestJson(node);
   }
 
   @Test(expected = InvalidInputException.class)
@@ -47,20 +49,72 @@ public class FromJsonFilterTest {
   }
 
   @Test
-  public void itReadsSafeStringAsObject() {
-    SafeString nestedJson = new SafeString(NESTED_JSON);
-    HashMap<String, Object> node = (HashMap<String, Object>) filter.filter(
-      nestedJson,
-      interpreter
-    );
-    checkedNestJson(node);
+  public void itReadsEmptyJsonObjectString() {
+    JsonNode node = (JsonNode) filter.filter(EMPTY_JSON_OBJECT, interpreter);
+    assertThat(node.elements().hasNext()).isEqualTo(false);
   }
 
-  private void checkedNestJson(HashMap<String, Object> node) {
-    assertThat(node.get("first")).isEqualTo(Arrays.asList(1, 2, 3));
+  @Test
+  public void itReadsStringAsObject() {
+    JsonNode node = (JsonNode) filter.filter(NESTED_JSON, interpreter);
 
-    HashMap<String, Object> nested = (HashMap<String, Object>) node.get("nested");
-    assertThat(nested.get("second")).isEqualTo("string");
-    assertThat(nested.get("third")).isEqualTo(4);
+    checkNestedJson(node);
+  }
+
+  @Test
+  public void itReadsSafeStringAsObject() {
+    SafeString nestedJson = new SafeString(NESTED_JSON);
+    JsonNode node = (JsonNode) filter.filter(nestedJson, interpreter);
+
+    checkNestedJson(node);
+  }
+
+  @Test
+  public void itReadsEmptyJsonArrayString() {
+    JsonNode node = (JsonNode) filter.filter(EMPTY_JSON_ARRAY, interpreter);
+    assertThat(node.elements().hasNext()).isEqualTo(false);
+  }
+
+  @Test
+  public void itReadsStringAsList() {
+    JsonNode node = (JsonNode) filter.filter(TRIVIAL_JSON_ARRAY, interpreter);
+
+    List<String> nodeAsList = OBJECT_MAPPER.convertValue(node, List.class);
+    assertThat(nodeAsList.toArray())
+      .containsExactly(Arrays.asList("one", "two", "three").toArray());
+  }
+
+  @Test
+  public void itReadsSafeStringArrayAsObject() {
+    SafeString arrayJson = new SafeString(TRIVIAL_JSON_ARRAY);
+    JsonNode node = (JsonNode) filter.filter(arrayJson, interpreter);
+
+    List<String> nodeAsList = OBJECT_MAPPER.convertValue(node, List.class);
+    assertThat(nodeAsList.toArray())
+      .containsExactly(Arrays.asList("one", "two", "three").toArray());
+  }
+
+  @Test
+  public void itReadsDeeplyNestedArrayString() {
+    JsonNode node = (JsonNode) filter.filter(DEEPLY_NESTED_ARRAY, interpreter);
+    JsonNode target = node.get("a").get("b").get("c");
+
+    List<String> targetAsList = OBJECT_MAPPER.convertValue(target, List.class);
+    assertThat(targetAsList.toArray()).containsExactly(Arrays.asList(1, 2, 3).toArray());
+  }
+
+  private void checkNestedJson(JsonNode node) {
+    assertThat(node.get("first").isArray());
+
+    List<Integer> firstFieldValue = OBJECT_MAPPER.convertValue(
+      node.get("first"),
+      List.class
+    );
+    assertThat(firstFieldValue.toArray())
+      .containsExactly(Arrays.asList(1, 2, 3).toArray());
+
+    JsonNode nested = node.get("nested");
+    assertThat(nested.get("second").asText()).isEqualTo("string");
+    assertThat(nested.get("third").asInt()).isEqualTo(4);
   }
 }


### PR DESCRIPTION
Resolves https://github.com/HubSpot/jinjava/issues/457
Related to https://hubspotdev.slack.com/archives/C2YH119N2/p1592854855031000

This pr changes `jinjava.lib.filter.FromJsonFilter` to return a `Object` instead of a `HashMap` in order to also support deserializing JSON array strings [(see issue)]( https://github.com/HubSpot/jinjava/issues/457).

Now, we are able to use array JSON strings:
```
// template
{% test = "[one, two, three]" | fromjson %}
{{  test[0] }}

// output
one

/* Before this would raise an InvalidInputException */
```