### PR TITLE
avoid IndexOutOfBoundsExceptions

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.el.ext.NamedParameter;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.DisabledException;
+import com.hubspot.jinjava.interpret.IndexOutOfRangeException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.InvalidInputException;
@@ -141,6 +142,21 @@ public class ExpressionResolver {
         interpreter.addError(
           TemplateError.fromInvalidArgumentException(
             (InvalidArgumentException) e.getCause()
+          )
+        );
+      } else if (
+        e.getCause() != null && e.getCause() instanceof IndexOutOfRangeException
+      ) {
+        interpreter.addError(
+          new TemplateError(
+            ErrorType.WARNING,
+            ErrorReason.EXCEPTION,
+            ErrorItem.FUNCTION,
+            e.getMessage(),
+            null,
+            interpreter.getLineNumber(),
+            interpreter.getPosition(),
+            e
           )
         );
       } else {

--- a/src/main/java/com/hubspot/jinjava/interpret/IndexOutOfRangeException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/IndexOutOfRangeException.java
@@ -1,0 +1,8 @@
+package com.hubspot.jinjava.interpret;
+
+public class IndexOutOfRangeException extends InterpretException {
+
+  public IndexOutOfRangeException(String msg) {
+    super(msg);
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
@@ -29,7 +29,7 @@ public class PyList extends ForwardingList<Object> implements PyWrapper {
   }
 
   public void insert(int i, Object e) {
-    if (i >= list.size()) {
+    if (i < 0 || i >= list.size()) {
       throw createOutOfRangeException(i);
     }
 
@@ -48,7 +48,7 @@ public class PyList extends ForwardingList<Object> implements PyWrapper {
   }
 
   public Object pop(int index) {
-    if (index >= list.size()) {
+    if (index < 0 || index >= list.size()) {
       throw createOutOfRangeException(index);
     }
 

--- a/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
@@ -28,7 +28,7 @@ public class PyList extends ForwardingList<Object> implements PyWrapper {
   }
 
   public void insert(int i, Object e) {
-    add(i, e);
+    add(Math.min(list.size(), i), e);
   }
 
   public boolean extend(PyList e) {
@@ -36,11 +36,11 @@ public class PyList extends ForwardingList<Object> implements PyWrapper {
   }
 
   public Object pop() {
-    return remove(list.size() - 1);
+    return list.size() == 0 ? null : remove(list.size() - 1);
   }
 
   public Object pop(int index) {
-    return remove(index);
+    return index >= list.size() ? null : remove(index);
   }
 
   public long count(Object o) {

--- a/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.objects.collections;
 
 import com.google.common.collect.ForwardingList;
+import com.hubspot.jinjava.interpret.IndexOutOfRangeException;
 import com.hubspot.jinjava.objects.PyWrapper;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -8,7 +9,7 @@ import java.util.List;
 import java.util.Objects;
 
 public class PyList extends ForwardingList<Object> implements PyWrapper {
-  private List<Object> list;
+  private final List<Object> list;
 
   public PyList(List<Object> list) {
     this.list = list;
@@ -28,7 +29,11 @@ public class PyList extends ForwardingList<Object> implements PyWrapper {
   }
 
   public void insert(int i, Object e) {
-    add(Math.min(list.size(), i), e);
+    if (i >= list.size()) {
+      throw createOutOfRangeException(i);
+    }
+
+    add(i, e);
   }
 
   public boolean extend(PyList e) {
@@ -36,11 +41,18 @@ public class PyList extends ForwardingList<Object> implements PyWrapper {
   }
 
   public Object pop() {
-    return list.size() == 0 ? null : remove(list.size() - 1);
+    if (list.size() == 0) {
+      throw createOutOfRangeException(0);
+    }
+    return remove(list.size() - 1);
   }
 
   public Object pop(int index) {
-    return index >= list.size() ? null : remove(index);
+    if (index >= list.size()) {
+      throw createOutOfRangeException(index);
+    }
+
+    return remove(index);
   }
 
   public long count(Object o) {
@@ -66,5 +78,11 @@ public class PyList extends ForwardingList<Object> implements PyWrapper {
       }
     }
     return -1;
+  }
+
+  IndexOutOfRangeException createOutOfRangeException(int index) {
+    return new IndexOutOfRangeException(
+      String.format("Index %d is out of range for list of size %d", index, list.size())
+    );
   }
 }

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
@@ -49,6 +49,17 @@ public class PyListTest {
   }
 
   @Test
+  public void itHandlesInsertOperationOutOfRange() {
+    assertThat(
+        jinjava.render(
+          "{% set test = [1, 2, 3] %}" + "{% do test.insert(99, 4) %}" + "{{ test }}",
+          Collections.emptyMap()
+        )
+      )
+      .isEqualTo("[1, 2, 3, 4]");
+  }
+
+  @Test
   public void itSupportsPopOperation() {
     assertThat(
         jinjava.render(
@@ -68,6 +79,26 @@ public class PyListTest {
         )
       )
       .isEqualTo("2[1, 3]");
+  }
+
+  @Test
+  public void itReturnsNullForPopOfEmptyList() {
+    assertThat(
+        jinjava.render("{% set test = [] %}" + "{{ test.pop() }}", Collections.emptyMap())
+      )
+      .isEqualTo("");
+  }
+
+  @Test
+  public void itReturnsNullForPopOutOfRange() {
+    assertThat(
+        jinjava.render(
+          "{% set test = [1] %}" +
+          "{{ test.pop(1) }},{{ test.pop(0) }},{{ test.pop(0) }}",
+          Collections.emptyMap()
+        )
+      )
+      .isEqualTo(",1,");
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
@@ -3,6 +3,9 @@ package com.hubspot.jinjava.objects.collections;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.interpret.IndexOutOfRangeException;
+import com.hubspot.jinjava.interpret.RenderResult;
+import com.hubspot.jinjava.interpret.TemplateError;
 import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,13 +53,15 @@ public class PyListTest {
 
   @Test
   public void itHandlesInsertOperationOutOfRange() {
-    assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{% do test.insert(99, 4) %}" + "{{ test }}",
-          Collections.emptyMap()
-        )
-      )
-      .isEqualTo("[1, 2, 3, 4]");
+    RenderResult renderResult = jinjava.renderForResult(
+      "{% set test = [1, 2, 3] %}" + "{% do test.insert(99, 4) %}" + "{{ test }}",
+      Collections.emptyMap()
+    );
+
+    assertThat(renderResult.getOutput()).isEqualTo("[1, 2, 3]");
+    assertThat(renderResult.getErrors().get(0)).isInstanceOf(TemplateError.class);
+    assertThat(renderResult.getErrors().get(0).getException().getCause())
+      .isInstanceOf(IndexOutOfRangeException.class);
   }
 
   @Test
@@ -82,23 +87,29 @@ public class PyListTest {
   }
 
   @Test
-  public void itReturnsNullForPopOfEmptyList() {
-    assertThat(
-        jinjava.render("{% set test = [] %}" + "{{ test.pop() }}", Collections.emptyMap())
-      )
-      .isEqualTo("");
+  public void itThrowsIndexOutOfRangeForPopOfEmptyList() {
+    RenderResult renderResult = jinjava.renderForResult(
+      "{% set test = [] %}" + "{{ test.pop() }}",
+      Collections.emptyMap()
+    );
+
+    assertThat(renderResult.getOutput()).isEqualTo("");
+    assertThat(renderResult.getErrors().get(0)).isInstanceOf(TemplateError.class);
+    assertThat(renderResult.getErrors().get(0).getException().getCause())
+      .isInstanceOf(IndexOutOfRangeException.class);
   }
 
   @Test
-  public void itReturnsNullForPopOutOfRange() {
-    assertThat(
-        jinjava.render(
-          "{% set test = [1] %}" +
-          "{{ test.pop(1) }},{{ test.pop(0) }},{{ test.pop(0) }}",
-          Collections.emptyMap()
-        )
-      )
-      .isEqualTo(",1,");
+  public void itThrowsIndexOutOfRangeForPopOutOfRange() {
+    RenderResult renderResult = jinjava.renderForResult(
+      "{% set test = [1] %}" + "{{ test.pop(1) }},{{ test.pop(0) }},{{ test.pop(0) }}",
+      Collections.emptyMap()
+    );
+
+    assertThat(renderResult.getOutput()).isEqualTo(",1,");
+    assertThat(renderResult.getErrors().get(0)).isInstanceOf(TemplateError.class);
+    assertThat(renderResult.getErrors().get(0).getException().getCause())
+      .isInstanceOf(IndexOutOfRangeException.class);
   }
 
   @Test


### PR DESCRIPTION
Jinjava code could throw unchecked `IndexOutOfBoundsExceptions` when using indices that were out of range. This now throws an `IndexOutOfRangeException` which is captured in a `TemplateError` instead.