### PR TITLE
handle java exceptions with format filter

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/FormatFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FormatFilter.java
@@ -78,7 +78,7 @@ public class FormatFilter implements AdvancedFilter {
           "' is missing a width"
         );
       }
-      // TODO: possibly handle other subclasses of IllegalFormatException if they come up
+      // could possibly handle other subclasses of IllegalFormatException here if they come up
       throw new InvalidArgumentException(interpreter, NAME, e.getMessage());
     }
   }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FormatFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FormatFilter.java
@@ -3,8 +3,13 @@ package com.hubspot.jinjava.lib.filter;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import java.util.IllegalFormatConversionException;
+import java.util.IllegalFormatException;
 import java.util.Map;
+import java.util.MissingFormatArgumentException;
+import java.util.MissingFormatWidthException;
 import java.util.Objects;
 
 @JinjavaDoc(
@@ -29,10 +34,11 @@ import java.util.Objects;
   }
 )
 public class FormatFilter implements AdvancedFilter {
+  public static final String NAME = "format";
 
   @Override
   public String getName() {
-    return "format";
+    return NAME;
   }
 
   @Override
@@ -42,7 +48,38 @@ public class FormatFilter implements AdvancedFilter {
     Object[] args,
     Map<String, Object> kwargs
   ) {
-    String fmt = Objects.toString(var, "");
-    return String.format(fmt, args);
+    try {
+      return String.format(Objects.toString(var, ""), args);
+    } catch (IllegalFormatException e) {
+      if (e instanceof MissingFormatArgumentException) {
+        throw new InvalidArgumentException(
+          interpreter,
+          NAME,
+          "Missing format argument for '" +
+          ((MissingFormatArgumentException) e).getFormatSpecifier() +
+          "'"
+        );
+      } else if (e instanceof IllegalFormatConversionException) {
+        throw new InvalidArgumentException(
+          interpreter,
+          NAME,
+          "'" +
+          args[0] +
+          "' is not a compatible type for conversion to format specifier '" +
+          ((IllegalFormatConversionException) e).getConversion() +
+          "'"
+        );
+      } else if (e instanceof MissingFormatWidthException) {
+        throw new InvalidArgumentException(
+          interpreter,
+          NAME,
+          "'" +
+          ((MissingFormatWidthException) e).getFormatSpecifier() +
+          "' is missing a width"
+        );
+      }
+      // TODO: possibly handle other subclasses of IllegalFormatException if they come up
+      throw new InvalidArgumentException(interpreter, NAME, e.getMessage());
+    }
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/FormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FormatFilterTest.java
@@ -1,8 +1,10 @@
 package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.interpret.FatalTemplateErrorsException;
 import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,5 +29,30 @@ public class FormatFilterTest {
   public void testFormatNumber() {
     assertThat(jinjava.render("{{ '%,d'|format(10000) }}", new HashMap<>()))
       .isEqualTo("10,000");
+  }
+
+  @Test
+  public void itThrowsExceptionOnMissingFormatArgument() {
+    assertThatThrownBy(
+        () -> jinjava.render("{{ '%s %s'|format(10000) }}", new HashMap<>())
+      )
+      .isInstanceOf(FatalTemplateErrorsException.class)
+      .hasMessageContaining("Missing format argument");
+  }
+
+  @Test
+  public void itThrowsExceptionOnBadConversion() {
+    assertThatThrownBy(() -> jinjava.render("{{ '%d'|format('hi') }}", new HashMap<>()))
+      .isInstanceOf(FatalTemplateErrorsException.class)
+      .hasMessageContaining("is not a compatible type");
+  }
+
+  @Test
+  public void itThrowsExceptionOnFormat() {
+    assertThatThrownBy(
+        () -> jinjava.render("{{ '%0.0f'|format(1000) }}", new HashMap<>())
+      )
+      .isInstanceOf(FatalTemplateErrorsException.class)
+      .hasMessageContaining("'%0.0f' is missing a width");
   }
 }


### PR DESCRIPTION
The format filter was throwing raw java exceptions back like this:

`Error in rendering at line 149, col -1: class java.util.MissingFormatArgumentException : java.util.MissingFormatArgumentException: Format specifier '%s'`

 This catches those exceptions and wraps them in Jinjava exception classes.