### PR TITLE
Fix JinjavaDoc for guice enhanced classes

### DIFF
--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
@@ -271,7 +271,9 @@ public class JinjavaDocFactory {
   private com.hubspot.jinjava.doc.annotations.JinjavaDoc getJinjavaDocAnnotation(
     Class<?> clazz
   ) {
-    if (clazz.getName().contains(GUICE_CLASS_INDICATOR)) {
+    if (
+      clazz.getName().contains(GUICE_CLASS_INDICATOR) && clazz.getSuperclass() != null
+    ) {
       clazz = clazz.getSuperclass();
     }
 

--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
@@ -24,6 +24,8 @@ public class JinjavaDocFactory {
   private static final Class JINJAVA_DOC_CLASS =
     com.hubspot.jinjava.doc.annotations.JinjavaDoc.class;
 
+  private static final String GUICE_CLASS_INDICATOR = "$$EnhancerByGuice$$";
+
   private final Jinjava jinjava;
 
   public JinjavaDocFactory(Jinjava jinjava) {
@@ -43,9 +45,9 @@ public class JinjavaDocFactory {
 
   private void addExpTests(JinjavaDoc doc) {
     for (ExpTest t : jinjava.getGlobalContextCopy().getAllExpTests()) {
-      com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation = t
-        .getClass()
-        .getAnnotation(com.hubspot.jinjava.doc.annotations.JinjavaDoc.class);
+      com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation = getJinjavaDocAnnotation(
+        t.getClass()
+      );
 
       if (docAnnotation == null) {
         LOG.warn(
@@ -84,9 +86,9 @@ public class JinjavaDocFactory {
 
   private void addFilterDocs(JinjavaDoc doc) {
     for (Filter f : jinjava.getGlobalContextCopy().getAllFilters()) {
-      com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation = f
-        .getClass()
-        .getAnnotation(com.hubspot.jinjava.doc.annotations.JinjavaDoc.class);
+      com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation = getJinjavaDocAnnotation(
+        f.getClass()
+      );
 
       if (docAnnotation == null) {
         LOG.warn(
@@ -186,9 +188,9 @@ public class JinjavaDocFactory {
       if (t instanceof EndTag) {
         continue;
       }
-      com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation = t
-        .getClass()
-        .getAnnotation(com.hubspot.jinjava.doc.annotations.JinjavaDoc.class);
+      com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation = getJinjavaDocAnnotation(
+        t.getClass()
+      );
 
       if (docAnnotation == null) {
         LOG.warn(
@@ -264,5 +266,15 @@ public class JinjavaDocFactory {
     }
 
     return meta;
+  }
+
+  private com.hubspot.jinjava.doc.annotations.JinjavaDoc getJinjavaDocAnnotation(
+    Class<?> clazz
+  ) {
+    if (clazz.getName().contains(GUICE_CLASS_INDICATOR)) {
+      clazz = clazz.getSuperclass();
+    }
+
+    return clazz.getAnnotation(com.hubspot.jinjava.doc.annotations.JinjavaDoc.class);
   }
 }


### PR DESCRIPTION
See https://github.com/google/guice/issues/201

An enhanced class loses the annotations of the parent class and as a result we could not generate the Jinjava doc. I haven't found a better workaround other than checking the class name.