### PR TITLE
support negative indexes in lists

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
@@ -29,8 +29,12 @@ public class PyList extends ForwardingList<Object> implements PyWrapper {
   }
 
   public void insert(int i, Object e) {
-    if (i < 0 || i >= list.size()) {
+    if (i >= list.size()) {
       throw createOutOfRangeException(i);
+    }
+
+    if (i < 0) {
+      i = Math.max(0, list.size() + i);
     }
 
     add(i, e);
@@ -48,8 +52,12 @@ public class PyList extends ForwardingList<Object> implements PyWrapper {
   }
 
   public Object pop(int index) {
-    if (index < 0 || index >= list.size()) {
+    if (Math.abs(index) >= list.size()) {
       throw createOutOfRangeException(index);
+    }
+
+    if (index < 0) {
+      index = list.size() + index;
     }
 
     return remove(index);

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
@@ -52,6 +52,28 @@ public class PyListTest {
   }
 
   @Test
+  public void itSupportsInsertOperationWithNegativeIndex() {
+    assertThat(
+        jinjava.render(
+          "{% set test = [1, 2, 3] %}" + "{% do test.insert(-1, 4) %}" + "{{ test }}",
+          Collections.emptyMap()
+        )
+      )
+      .isEqualTo("[1, 2, 4, 3]");
+  }
+
+  @Test
+  public void itSupportsInsertOperationWithLargeNegativeIndex() {
+    assertThat(
+        jinjava.render(
+          "{% set test = [1, 2, 3] %}" + "{% do test.insert(-99, 4) %}" + "{{ test }}",
+          Collections.emptyMap()
+        )
+      )
+      .isEqualTo("[4, 1, 2, 3]");
+  }
+
+  @Test
   public void itHandlesInsertOperationOutOfRange() {
     RenderResult renderResult = jinjava.renderForResult(
       "{% set test = [1, 2, 3] %}" + "{% do test.insert(99, 4) %}" + "{{ test }}",
@@ -84,6 +106,17 @@ public class PyListTest {
         )
       )
       .isEqualTo("2[1, 3]");
+  }
+
+  @Test
+  public void itSupportsPopAtNegativeIndexOperation() {
+    assertThat(
+        jinjava.render(
+          "{% set test = [1, 2, 3] %}" + "{{ test.pop(-1) }}" + "{{ test }}",
+          Collections.emptyMap()
+        )
+      )
+      .isEqualTo("3[1, 2]");
   }
 
   @Test


### PR DESCRIPTION
Adds support for negative indexes on `list.pop` and `list.insert` like python has. 

Followup to https://github.com/HubSpot/jinjava/pull/462