### PR TITLE
Re-output for loop if anything deferred inside

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
@@ -201,11 +202,21 @@ public class ForTag implements Tag {
           }
         }
 
+        int numDeferredNodesBefore = interpreter.getContext().getDeferredNodes().size();
         for (Node node : tagNode.getChildren()) {
           if (interpreter.getContext().isValidationMode()) {
             node.render(interpreter);
           } else {
             buff.append(node.render(interpreter));
+            if (
+              interpreter.getContext().getDeferredNodes().size() > numDeferredNodesBefore
+            ) {
+              throw new DeferredValueException(
+                "for loop",
+                interpreter.getLineNumber(),
+                interpreter.getPosition()
+              );
+            }
           }
         }
       }


### PR DESCRIPTION
If we encounter anything which gets deferred when processing a for loop we want to output the whole loop again. This will allow us to handle more complex logic within for loops.

--------

Currently Jinjava supports contact properties in the iterator of a for loop

`{% for item in contact.list %}
    {{item.value}}
{%endfor%}`

Or something like 
 `{% for item in list %}
    {{contact.firstname ~ item}}
{%endfor%}`
works.


There is an issue with if statements containing a contact property due to how for loops are unrolled.


For example, a for loop

```
{% set languages = ['HTML', 'CSS', 'Javascript'] %}

{% for lang in languages %}
   Lang on this iter {{ lang }}
    {% if lang == contact.lang_preference %}
      Relevant info
    {% else %}
     Fallback info
    {% endif %}
{%endfor%}
```


Will be unrolled to: 

```
Lang on this iter HTML
      {% if lang == contact.lang_preference %}
      Relevant info
    {% else %}
     Fallback info
    {% endif %}

Lang on this iter CSS
    {% if lang == contact.lang_preference %}
      Relevant info
    {% else %}
     Fallback info
    {% endif %}

Lang on this iter Javascript
    {% if lang == contact.lang_preference %}
      Relevant info
    {% else %}
     Fallback info
    {% endif %}
```

The issue here is that lang is no longer defined and not in the context for the second render so all the if statements will evaluate to false. 





