### PR TITLE
Test for null arguments with regex replace filter operations

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilter.java
@@ -57,6 +57,14 @@ public class RegexReplaceFilter implements Filter {
       );
     }
 
+    if (args[0] == null || args[1] == null) {
+      throw new TemplateSyntaxException(
+        interpreter,
+        getName(),
+        "requires both a valid regex and new params (not null)"
+      );
+    }
+
     if (var == null) {
       return null;
     }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilterTest.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.interpret.InterpretException;
@@ -20,9 +21,18 @@ public class RegexReplaceFilterTest {
     filter = new RegexReplaceFilter();
   }
 
-  @Test(expected = InterpretException.class)
+  @Test
   public void expects2Args() {
-    filter.filter("foo", interpreter);
+    assertThatThrownBy(() -> filter.filter("foo", interpreter))
+      .hasMessageContaining("requires 2 arguments");
+  }
+
+  @Test
+  public void expectsNotNullArgs() {
+    assertThatThrownBy(
+        () -> filter.filter("foo", interpreter, new String[] { null, null })
+      )
+      .hasMessageContaining("both a valid regex");
   }
 
   public void noopOnNullExpr() {


### PR DESCRIPTION
Regex filter replacement requests had been allowed without first testing that the regex and new arguments were valid.