### PR TITLE
disallow adding a map to itself

### DIFF
--- a/src/test/java/com/hubspot/jinjava/util/ScopeMapTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ScopeMapTest.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 
 import com.google.common.collect.ImmutableMap;
@@ -54,5 +55,22 @@ public class ScopeMapTest {
         entry("a3", "vc3"),
         entry("a4", "vc4")
       );
+  }
+
+  @SuppressWarnings("CollectionAddedToSelf")
+  @Test
+  public void itDisallowsPuttingItself() {
+    ScopeMap<Object, Object> map = new ScopeMap<>();
+    assertThatThrownBy(() -> map.put("foo", map))
+      .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void itDisallowsPuttingAllWithItselfAsValue() {
+    ScopeMap<Object, Object> map1 = new ScopeMap<>();
+    ScopeMap<Object, Object> map2 = new ScopeMap<>();
+    map2.put("map1", map1);
+    assertThatThrownBy(() -> map1.putAll(map2))
+      .isInstanceOf(IllegalArgumentException.class);
   }
 }


### PR DESCRIPTION
Since serializing a map with references to itself is disasterous, let's try to prevent that when adding things to the map.