### PR TITLE
Use kwargs in truncatehtml filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,16 +210,6 @@
                   <include>de.odysseus.juel:juel-impl</include>
                 </includes>
               </artifactSet>
-              <relocations>
-                <relocation>
-                  <pattern>javax.el</pattern>
-                  <shadedPattern>jinjava.javax.el</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>de.odysseus.el</pattern>
-                  <shadedPattern>jinjava.de.odysseus.el</shadedPattern>
-                </relocation>
-              </relocations>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,16 @@
                   <include>de.odysseus.juel:juel-impl</include>
                 </includes>
               </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>javax.el</pattern>
+                  <shadedPattern>jinjava.javax.el</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>de.odysseus.el</pattern>
+                  <shadedPattern>jinjava.de.odysseus.el</shadedPattern>
+                </relocation>
+              </relocations>
             </configuration>
           </execution>
         </executions>

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
@@ -79,7 +79,7 @@ public class TruncateHtmlFilter implements Filter {
         if (obj == null) {
           ends = Objects.toString(args[1]);
         } else {
-          killwords = BooleanUtils.toBoolean(args[2]);
+          killwords = BooleanUtils.toBoolean(args[1]);
         }
       }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
@@ -37,13 +37,13 @@ import org.jsoup.select.NodeVisitor;
       type = "boolean",
       defaultValue = "false",
       desc = "If set to true, text will be truncated in the middle of words"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
       code = "{{ \"<p>I want to truncate this text without breaking my HTML<p>\"|truncatehtml(28, '..', false) }}",
       output = "<p>I want to truncate this text without breaking my HTML</p>"
-    )
+    ),
   }
 )
 public class TruncateHtmlFilter implements Filter {
@@ -73,12 +73,18 @@ public class TruncateHtmlFilter implements Filter {
         }
       }
 
-      if (args.length > 1) {
-        ends = Objects.toString(args[1]);
+      boolean killwords = false;
+      if (args.length == 2) {
+        Boolean obj = BooleanUtils.toBooleanObject(args[1]);
+        if (obj == null) {
+          ends = Objects.toString(args[1]);
+        } else {
+          killwords = BooleanUtils.toBoolean(args[2]);
+        }
       }
 
-      boolean killwords = false;
-      if (args.length > 2) {
+      if (args.length == 3) {
+        ends = Objects.toString(args[1]);
         killwords = BooleanUtils.toBoolean(args[2]);
       }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
@@ -50,6 +50,9 @@ import org.jsoup.select.NodeVisitor;
 public class TruncateHtmlFilter implements AdvancedFilter {
   private static final int DEFAULT_TRUNCATE_LENGTH = 255;
   private static final String DEFAULT_END = "...";
+  private static final String LENGTH_KEY = "length";
+  private static final String END_KEY = "end";
+  private static final String BREAKWORD_KEY = "breakword";
 
   @Override
   public String getName() {
@@ -64,16 +67,16 @@ public class TruncateHtmlFilter implements AdvancedFilter {
     Map<String, Object> kwargs
   ) {
     String length = null;
-    if (kwargs.containsKey(("length"))) {
-      length = Objects.toString(kwargs.get("length"));
+    if (kwargs.containsKey((LENGTH_KEY)) {
+      length = Objects.toString(kwargs.get(LENGTH_KEY));
     }
     String end = null;
-    if (kwargs.containsKey("end")) {
-      end = Objects.toString(kwargs.get("end"));
+    if (kwargs.containsKey(END_KEY)) {
+      end = Objects.toString(kwargs.get(END_KEY));
     }
     String breakword = null;
-    if (kwargs.containsKey("breakword")) {
-      breakword = Objects.toString(kwargs.get("breakword"));
+    if (kwargs.containsKey(BREAKWORD_KEY)) {
+      breakword = Objects.toString(kwargs.get(BREAKWORD_KEY));
     }
 
     String[] newArgs = new String[3];

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
@@ -37,13 +37,13 @@ import org.jsoup.select.NodeVisitor;
       type = "boolean",
       defaultValue = "false",
       desc = "If set to true, text will be truncated in the middle of words"
-    ),
+    )
   },
   snippets = {
     @JinjavaSnippet(
       code = "{{ \"<p>I want to truncate this text without breaking my HTML<p>\"|truncatehtml(28, '..', false) }}",
       output = "<p>I want to truncate this text without breaking my HTML</p>"
-    ),
+    )
   }
 )
 public class TruncateHtmlFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
@@ -115,12 +115,12 @@ public class TruncateHtmlFilter implements AdvancedFilter {
         }
       }
 
-      if (args.length > 1) {
+      if (args.length > 1 && args[1] != null) {
         ends = Objects.toString(args[1]);
       }
 
       boolean killwords = false;
-      if (args.length > 2) {
+      if (args.length > 2 && args[2] != null) {
         killwords = BooleanUtils.toBoolean(args[2]);
       }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
@@ -38,13 +38,13 @@ import org.jsoup.select.NodeVisitor;
       type = "boolean",
       defaultValue = "false",
       desc = "If set to true, text will be truncated in the middle of words"
-    ),
+    )
   },
   snippets = {
     @JinjavaSnippet(
       code = "{{ \"<p>I want to truncate this text without breaking my HTML<p>\"|truncatehtml(28, '..', false) }}",
       output = "<p>I want to truncate this text without breaking my HTML</p>"
-    ),
+    )
   }
 )
 public class TruncateHtmlFilter implements AdvancedFilter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
@@ -67,7 +67,7 @@ public class TruncateHtmlFilter implements AdvancedFilter {
     Map<String, Object> kwargs
   ) {
     String length = null;
-    if (kwargs.containsKey((LENGTH_KEY)) {
+    if (kwargs.containsKey(LENGTH_KEY)) {
       length = Objects.toString(kwargs.get(LENGTH_KEY));
     }
     String end = null;

--- a/src/test/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilterTest.java
@@ -59,6 +59,32 @@ public class TruncateHtmlFilterTest {
       );
   }
 
+  @Test
+  public void itDeducesArgumentTypes() {
+    String result = (String) filter.filter(
+      fixture("filter/truncatehtml/long-content-with-tags.html"),
+      interpreter,
+      "35",
+      "false"
+    );
+    assertThat(result)
+      .isEqualTo(
+        "<h1>HTML Ipsum Presents</h1> \n<p><strong>Pellentesque...</strong></p>"
+      );
+
+    result =
+      (String) filter.filter(
+        fixture("filter/truncatehtml/long-content-with-tags.html"),
+        interpreter,
+        "35",
+        "TEST"
+      );
+    assertThat(result)
+      .isEqualTo(
+        "<h1>HTML Ipsum Presents</h1> \n<p><strong>Pellentesque haTEST</strong></p>"
+      );
+  }
+
   private static String fixture(String name) {
     try {
       return Resources.toString(Resources.getResource(name), StandardCharsets.UTF_8);

--- a/src/test/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilterTest.java
@@ -81,7 +81,7 @@ public class TruncateHtmlFilterTest {
       );
     assertThat(result)
       .isEqualTo(
-        "<h1>HTML Ipsum Presents</h1> \n<p><strong>Pellentesque haTEST</strong></p>"
+        "<h1>HTML Ipsum Presents</h1> \n<p><strong>PellentesqueTEST</strong></p>"
       );
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilterTest.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.io.IOException;
@@ -60,12 +61,12 @@ public class TruncateHtmlFilterTest {
   }
 
   @Test
-  public void itDeducesArgumentTypes() {
+  public void itTakesKwargs() {
     String result = (String) filter.filter(
       fixture("filter/truncatehtml/long-content-with-tags.html"),
       interpreter,
-      "35",
-      "false"
+      new Object[] { "35" },
+      ImmutableMap.of("breakwords", false)
     );
     assertThat(result)
       .isEqualTo(
@@ -76,8 +77,8 @@ public class TruncateHtmlFilterTest {
       (String) filter.filter(
         fixture("filter/truncatehtml/long-content-with-tags.html"),
         interpreter,
-        "35",
-        "TEST"
+        new Object[] { "35" },
+        ImmutableMap.of("end", "TEST")
       );
     assertThat(result)
       .isEqualTo(


### PR DESCRIPTION
The [`truncatehtml`](https://developers.hubspot.com/docs/cms/hubl/filters#truncatehtml) filter has two optional arguments, `end` and `breakwords`. The `end` argument is a string which specifies the trailing characters after truncation, while `breakwords` determines if the last word of text is discarded.

Currently, these two optional arguments are recognized purely by their position in the array. This means that the following code:
```
{% set html_text = "<p>I want to truncate this text without breaking my HTML<p>" %} 
{{ html_text|truncatehtml(28, false) }}
```
Renders this:
```
<p>I want to truncate thisfalse</p>
```

My expectation would be that the `false` passed to the filter should be recognized as `breakwords` -- since the two arguments are different types -- but instead it is used as `end`.

This PR changes this behavior so that if there is only one optional argument present, the filter will deduce which one it is based on the type. First we try and parse it as a boolean, and if it is not a recognized boolean value, we consider it to be `end`. If it is a recognized boolean value, we consider it to be `breakwords`.

If we don't like this new behavior, we should instead update the docs so that the current behavior is more clear.