### PR TITLE
Use kwargs in truncatehtml filter (with SafeString)

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
@@ -7,6 +7,7 @@ import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.fn.Functions;
+import java.util.Map;
 import java.util.Objects;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -46,13 +47,57 @@ import org.jsoup.select.NodeVisitor;
     )
   }
 )
-public class TruncateHtmlFilter implements Filter {
+public class TruncateHtmlFilter implements AdvancedFilter {
   private static final int DEFAULT_TRUNCATE_LENGTH = 255;
   private static final String DEFAULT_END = "...";
+  private static final String LENGTH_KEY = "length";
+  private static final String END_KEY = "end";
+  private static final String BREAKWORD_KEY = "breakword";
 
   @Override
   public String getName() {
     return "truncatehtml";
+  }
+
+  @Override
+  public Object filter(
+    Object var,
+    JinjavaInterpreter interpreter,
+    Object[] args,
+    Map<String, Object> kwargs
+  ) {
+    String length = null;
+    if (kwargs.containsKey(LENGTH_KEY)) {
+      length = Objects.toString(kwargs.get(LENGTH_KEY));
+    }
+    String end = null;
+    if (kwargs.containsKey(END_KEY)) {
+      end = Objects.toString(kwargs.get(END_KEY));
+    }
+    String breakword = null;
+    if (kwargs.containsKey(BREAKWORD_KEY)) {
+      breakword = Objects.toString(kwargs.get(BREAKWORD_KEY));
+    }
+
+    String[] newArgs = new String[3];
+    for (int i = 0; i < args.length; i++) {
+      if (i >= newArgs.length) {
+        break;
+      }
+      newArgs[i] = Objects.toString(args[i]);
+    }
+
+    if (length != null) {
+      newArgs[0] = length;
+    }
+    if (end != null) {
+      newArgs[1] = end;
+    }
+    if (breakword != null) {
+      newArgs[2] = breakword;
+    }
+
+    return filter(var, interpreter, newArgs);
   }
 
   @Override
@@ -73,12 +118,12 @@ public class TruncateHtmlFilter implements Filter {
         }
       }
 
-      if (args.length > 1) {
+      if (args.length > 1 && args[1] != null) {
         ends = Objects.toString(args[1]);
       }
 
       boolean killwords = false;
-      if (args.length > 2) {
+      if (args.length > 2 && args[2] != null) {
         killwords = BooleanUtils.toBoolean(args[2]);
       }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
@@ -7,6 +7,7 @@ import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.fn.Functions;
+import com.hubspot.jinjava.objects.SafeString;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.commons.lang3.BooleanUtils;
@@ -95,6 +96,10 @@ public class TruncateHtmlFilter implements AdvancedFilter {
     }
     if (breakword != null) {
       newArgs[2] = breakword;
+    }
+
+    if (var instanceof SafeString) {
+      return filter((SafeString) var, interpreter, newArgs);
     }
 
     return filter(var, interpreter, newArgs);

--- a/src/test/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilterTest.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.io.IOException;
@@ -56,6 +57,32 @@ public class TruncateHtmlFilterTest {
     assertThat(result)
       .isEqualTo(
         "<h1>HTML Ipsum Presents</h1> \n<p><strong>Pellentesque ha...</strong></p>"
+      );
+  }
+
+  @Test
+  public void itTakesKwargs() {
+    String result = (String) filter.filter(
+      fixture("filter/truncatehtml/long-content-with-tags.html"),
+      interpreter,
+      new Object[] { "35" },
+      ImmutableMap.of("breakwords", false)
+    );
+    assertThat(result)
+      .isEqualTo(
+        "<h1>HTML Ipsum Presents</h1> \n<p><strong>Pellentesque...</strong></p>"
+      );
+
+    result =
+      (String) filter.filter(
+        fixture("filter/truncatehtml/long-content-with-tags.html"),
+        interpreter,
+        new Object[] { "35" },
+        ImmutableMap.of("end", "TEST")
+      );
+    assertThat(result)
+      .isEqualTo(
+        "<h1>HTML Ipsum Presents</h1> \n<p><strong>PellentesqueTEST</strong></p>"
       );
   }
 


### PR DESCRIPTION
An improved version of #490 that accounts for the use of `SafeString`. This will make sure the string is unboxed before going through the filter by using the default `filter` method from the superclass: https://github.com/HubSpot/jinjava/blob/c2d7df73cc9b91c90ee0ea4c89f85dcb3abbe532/src/main/java/com/hubspot/jinjava/lib/filter/Filter.java#L77