### PR TITLE
Accept ip address without network prefix in ipaddr('address') filter

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/IpAddrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IpAddrFilter.java
@@ -202,7 +202,7 @@ public class IpAddrFilter implements Filter {
       parts.add("0");
     }
 
-    if (parts.size() != 2) {
+    if (parts.size() > 2) {
       return null;
     }
 
@@ -213,6 +213,10 @@ public class IpAddrFilter implements Filter {
 
     if (parameter.equalsIgnoreCase(ADDRESS_STRING)) {
       return ipAddress;
+    }
+
+    if (parts.size() != 2) {
+      return null;
     }
 
     String prefixString = parts.get(1);

--- a/src/test/java/com/hubspot/jinjava/lib/filter/IpAddrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/IpAddrFilterTest.java
@@ -134,6 +134,8 @@ public class IpAddrFilterTest {
   public void itReturnsIpv4AddressAddress() {
     assertThat(ipAddrFilter.filter("192.168.0.1/20", interpreter, "address"))
       .isEqualTo("192.168.0.1");
+    assertThat(ipAddrFilter.filter("192.168.0.2", interpreter, "address"))
+      .isEqualTo("192.168.0.2");
   }
 
   @Test
@@ -146,6 +148,14 @@ public class IpAddrFilterTest {
         )
       )
       .isEqualTo("1200:0000:AB00:1234:0000:2552:7777:1313");
+    assertThat(
+        ipAddrFilter.filter(
+          "1200:0000:AB00:1234:0000:2552:7777:1314",
+          interpreter,
+          "address"
+        )
+      )
+      .isEqualTo("1200:0000:AB00:1234:0000:2552:7777:1314");
   }
 
   @Test
@@ -275,7 +285,12 @@ public class IpAddrFilterTest {
       null,
       13
     );
-    List<Object> expectedAddresses = Arrays.asList("192.168.32.0", "fe80::100");
+    List<Object> expectedAddresses = Arrays.asList(
+      "192.24.2.1",
+      "::1",
+      "192.168.32.0",
+      "fe80::100"
+    );
     assertThat(ipAddrFilter.filter(inputAddresses, interpreter, "address"))
       .isEqualTo(expectedAddresses);
   }


### PR DESCRIPTION
In jinja2 with netaddr, the ipaddr('address') filter accepts a plain ip address, like "192.168.0.1". Jinjava currently rejects this because it has no network prefix. This patch fixes the jinjava behaviour for these cases.