### PR TITLE
Build using Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: java
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 
 # https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766
 dist: trusty


### PR DESCRIPTION
We have a test failing in master due to the build running on Java 8 and there being slight changes to datetime format between 8 and 11.