### PR TITLE
Change config name to preserveForFinalPass

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -56,7 +56,7 @@ public class JinjavaConfig {
   private TokenScannerSymbols tokenScannerSymbols;
   private ELResolver elResolver;
   private final boolean iterateOverMapKeys;
-  private final boolean preserveForSecondPass;
+  private final boolean preserveForFinalPass;
 
   public static Builder newBuilder() {
     return new Builder();
@@ -141,7 +141,7 @@ public class JinjavaConfig {
     TokenScannerSymbols tokenScannerSymbols,
     ELResolver elResolver,
     boolean iterateOverMapKeys,
-    boolean preserveForSecondPass
+    boolean preserveForFinalPass
   ) {
     this.charset = charset;
     this.locale = locale;
@@ -162,7 +162,7 @@ public class JinjavaConfig {
     this.tokenScannerSymbols = tokenScannerSymbols;
     this.elResolver = elResolver;
     this.iterateOverMapKeys = iterateOverMapKeys;
-    this.preserveForSecondPass = preserveForSecondPass;
+    this.preserveForFinalPass = preserveForFinalPass;
   }
 
   public Charset getCharset() {
@@ -245,8 +245,8 @@ public class JinjavaConfig {
     return iterateOverMapKeys;
   }
 
-  public boolean isPreserveForSecondPass() {
-    return preserveForSecondPass;
+  public boolean isPreserveForFinalPass() {
+    return preserveForFinalPass;
   }
 
   public static class Builder {
@@ -272,7 +272,7 @@ public class JinjavaConfig {
     private TokenScannerSymbols tokenScannerSymbols = new DefaultTokenScannerSymbols();
     private ELResolver elResolver = JinjavaInterpreterResolver.DEFAULT_RESOLVER_READ_ONLY;
     private boolean iterateOverMapKeys;
-    private boolean preserveForSecondPass;
+    private boolean preserveForFinalPass;
 
     private Builder() {}
 
@@ -381,8 +381,8 @@ public class JinjavaConfig {
       return this;
     }
 
-    public Builder withPreserveForSecondPass(boolean preserveForSecondPass) {
-      this.preserveForSecondPass = preserveForSecondPass;
+    public Builder withPreserveForFinalPass(boolean preserveForFinalPass) {
+      this.preserveForFinalPass = preserveForFinalPass;
       return this;
     }
 
@@ -407,7 +407,7 @@ public class JinjavaConfig {
         tokenScannerSymbols,
         elResolver,
         iterateOverMapKeys,
-        preserveForSecondPass
+        preserveForFinalPass
       );
     }
   }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/RawTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/RawTag.java
@@ -30,7 +30,7 @@ public class RawTag implements Tag {
 
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
-    if (interpreter.getConfig().isPreserveForSecondPass()) {
+    if (interpreter.getConfig().isPreserveForFinalPass()) {
       return renderNodeRaw(tagNode);
     }
 

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -225,7 +225,7 @@ public class JinjavaInterpreterTest {
   public void itCanPreserveRawTags() {
     JinjavaConfig preserveConfig = JinjavaConfig
       .newBuilder()
-      .withPreserveForSecondPass(true)
+      .withPreserveForFinalPass(true)
       .build();
     String input = "1{% raw %}2{% endraw %}3";
     String normalOutput = "123";

--- a/src/test/java/com/hubspot/jinjava/lib/tag/RawTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/RawTagTest.java
@@ -101,7 +101,7 @@ public class RawTagTest {
     JinjavaInterpreter preserveInterpreter = new JinjavaInterpreter(
       jinjava,
       jinjava.getGlobalContextCopy(),
-      JinjavaConfig.newBuilder().withPreserveForSecondPass(true).build()
+      JinjavaConfig.newBuilder().withPreserveForFinalPass(true).build()
     );
     String result = tag.interpret(tagNode, preserveInterpreter);
     try {
@@ -123,7 +123,7 @@ public class RawTagTest {
     JinjavaInterpreter preserveInterpreter = new JinjavaInterpreter(
       jinjava,
       jinjava.getGlobalContextCopy(),
-      JinjavaConfig.newBuilder().withPreserveForSecondPass(true).build()
+      JinjavaConfig.newBuilder().withPreserveForFinalPass(true).build()
     );
     preserveInterpreter.getContext().put("deferred", DeferredValue.instance());
     interpreter.getContext().put("deferred", DeferredValue.instance());


### PR DESCRIPTION
Following up on [my comment](https://github.com/HubSpot/jinjava/pull/518#issuecomment-716593242) after the suggestion of renaming due to the purpose of the config being for preserving raw, etc. tags until the final pass, rather than just until the second pass (if there happen to be _n_ passes).