### PR TITLE
Ensure that after pushing the interpreter, it gets popped

### DIFF
--- a/src/test/java/com/hubspot/jinjava/util/ObjectIteratorTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ObjectIteratorTest.java
@@ -111,9 +111,13 @@ public class ObjectIteratorTest {
     items.put("world", 2);
     items.put("jinjava", "ko");
     items.put("asfun", new ObjectIteratorTest());
-    loop = ObjectIterator.getLoop(items);
+    try {
+      loop = ObjectIterator.getLoop(items);
 
-    assertEquals(4, loop.getLength());
-    assertTrue(items.containsKey(loop.next()));
+      assertEquals(4, loop.getLength());
+      assertTrue(items.containsKey(loop.next()));
+    } finally {
+      JinjavaInterpreter.popCurrent();
+    }
   }
 }


### PR DESCRIPTION
Since the interpreter is pushed to the current stack in this test, it should subsequently get popped from the stack.
This fixes the build when using `mvn`.