### PR TITLE
Add abstract base test classes

### DIFF
--- a/src/test/java/com/hubspot/jinjava/BaseInterpretingTest.java
+++ b/src/test/java/com/hubspot/jinjava/BaseInterpretingTest.java
@@ -1,20 +1,25 @@
-package com.hubspot.jinjava.lib.tag;
+package com.hubspot.jinjava;
 
-import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import org.junit.After;
 import org.junit.Before;
 
-public abstract class BaseTagTest {
-  public Jinjava jinjava;
+public abstract class BaseInterpretingTest extends BaseJinjavaTest {
   public JinjavaInterpreter interpreter;
-
   public Context context;
 
   @Before
+  @Override
   public void baseSetup() {
-    jinjava = new Jinjava();
+    super.baseSetup();
     interpreter = new JinjavaInterpreter(jinjava.newInterpreter());
     context = interpreter.getContext();
+    JinjavaInterpreter.pushCurrent(interpreter);
+  }
+
+  @After
+  public void baseTeardown() {
+    JinjavaInterpreter.popCurrent();
   }
 }

--- a/src/test/java/com/hubspot/jinjava/BaseJinjavaTest.java
+++ b/src/test/java/com/hubspot/jinjava/BaseJinjavaTest.java
@@ -1,0 +1,12 @@
+package com.hubspot.jinjava;
+
+import org.junit.Before;
+
+public abstract class BaseJinjavaTest {
+  public Jinjava jinjava;
+
+  @Before
+  public void baseSetup() {
+    jinjava = new Jinjava();
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/BooleanExpTestsTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/BooleanExpTestsTest.java
@@ -2,18 +2,11 @@ package com.hubspot.jinjava.lib.exptest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
-import org.junit.Before;
 import org.junit.Test;
 
-public class BooleanExpTestsTest {
-  private Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
+public class BooleanExpTestsTest extends BaseJinjavaTest {
 
   @Test
   public void testIsBoolean() {

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/ComparisonExpTestsTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/ComparisonExpTestsTest.java
@@ -3,21 +3,14 @@ package com.hubspot.jinjava.lib.exptest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.objects.date.PyishDate;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Before;
 import org.junit.Test;
 
-public class ComparisonExpTestsTest {
-  private Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
+public class ComparisonExpTestsTest extends BaseJinjavaTest {
 
   @Test
   public void itComparesNumbers() {

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsContainingAllExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsContainingAllExpTestTest.java
@@ -2,21 +2,13 @@ package com.hubspot.jinjava.lib.exptest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
-import org.junit.Before;
 import org.junit.Test;
 
-public class IsContainingAllExpTestTest {
+public class IsContainingAllExpTestTest extends BaseJinjavaTest {
   private static final String CONTAINING_TEMPLATE =
     "{%% if %s is containingall %s %%}pass{%% else %%}fail{%% endif %%}";
-
-  private Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
 
   @Test
   public void itPassesOnContainedValues() {

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsContainingExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsContainingExpTestTest.java
@@ -2,21 +2,13 @@ package com.hubspot.jinjava.lib.exptest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
-import org.junit.Before;
 import org.junit.Test;
 
-public class IsContainingExpTestTest {
+public class IsContainingExpTestTest extends BaseJinjavaTest {
   private static final String CONTAINING_TEMPLATE =
     "{%% if %s is containing %s %%}pass{%% else %%}fail{%% endif %%}";
-
-  private Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
 
   @Test
   public void itPassesOnContainedValue() {

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTestTest.java
@@ -2,20 +2,12 @@ package com.hubspot.jinjava.lib.exptest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
-import org.junit.Before;
 import org.junit.Test;
 
-public class IsEqualToExpTestTest {
+public class IsEqualToExpTestTest extends BaseJinjavaTest {
   private static final String EQUAL_TEMPLATE = "{{ %s is equalto %s }}";
-
-  private Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
 
   @Test
   public void itEquatesNumbers() {

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsFloatExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsFloatExpTestTest.java
@@ -2,18 +2,11 @@ package com.hubspot.jinjava.lib.exptest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
-import org.junit.Before;
 import org.junit.Test;
 
-public class IsFloatExpTestTest {
-  private Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
+public class IsFloatExpTestTest extends BaseJinjavaTest {
 
   @Test
   public void testValidFloats() {

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsInExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsInExpTestTest.java
@@ -3,18 +3,11 @@ package com.hubspot.jinjava.lib.exptest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
-import org.junit.Before;
 import org.junit.Test;
 
-public class IsInExpTestTest {
-  private Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
+public class IsInExpTestTest extends BaseJinjavaTest {
 
   @Test
   public void testIsInList() {

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsIntegerExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsIntegerExpTestTest.java
@@ -2,18 +2,11 @@ package com.hubspot.jinjava.lib.exptest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
-import org.junit.Before;
 import org.junit.Test;
 
-public class IsIntegerExpTestTest {
-  private Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
+public class IsIntegerExpTestTest extends BaseJinjavaTest {
 
   @Test
   public void testValidIntegers() {

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsIterableExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsIterableExpTestTest.java
@@ -2,18 +2,11 @@ package com.hubspot.jinjava.lib.exptest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
-import org.junit.Before;
 import org.junit.Test;
 
-public class IsIterableExpTestTest {
-  private Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
+public class IsIterableExpTestTest extends BaseJinjavaTest {
 
   @Test
   public void testIsIterable() {

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsStringContainingExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsStringContainingExpTestTest.java
@@ -3,20 +3,12 @@ package com.hubspot.jinjava.lib.exptest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.objects.SafeString;
-import org.junit.Before;
 import org.junit.Test;
 
-public class IsStringContainingExpTestTest {
+public class IsStringContainingExpTestTest extends BaseJinjavaTest {
   private static final String CONTAINING_TEMPLATE = "{{ var is string_containing arg }}";
-
-  private Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
 
   @Test
   public void itReturnsTrueForContainedString() {

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsStringStartingWithExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsStringStartingWithExpTestTest.java
@@ -3,20 +3,12 @@ package com.hubspot.jinjava.lib.exptest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.objects.SafeString;
-import org.junit.Before;
 import org.junit.Test;
 
-public class IsStringStartingWithExpTestTest {
+public class IsStringStartingWithExpTestTest extends BaseJinjavaTest {
   private static final String STARTING_TEMPLATE = "{{ var is string_startingwith arg }}";
-
-  private Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
 
   @Test
   public void itReturnsTrueForContainedString() {

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsUpperExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsUpperExpTestTest.java
@@ -3,21 +3,13 @@ package com.hubspot.jinjava.lib.exptest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.objects.SafeString;
-import org.junit.Before;
 import org.junit.Test;
 
-public class IsUpperExpTestTest {
+public class IsUpperExpTestTest extends BaseJinjavaTest {
   private static final String STARTING_TEMPLATE = "{{ var is upper }}";
   private static final String SAFE_TEMPLATE = "{{ (var|safe) is upper }}";
-
-  private Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
 
   @Test
   public void itReturnsTrueForUpperString() {

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsWithinExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsWithinExpTestTest.java
@@ -2,21 +2,13 @@ package com.hubspot.jinjava.lib.exptest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
-import org.junit.Before;
 import org.junit.Test;
 
-public class IsWithinExpTestTest {
+public class IsWithinExpTestTest extends BaseJinjavaTest {
   private static final String IN_TEMPLATE =
     "{%% if %s is within %s %%}pass{%% else %%}fail{%% endif %%}";
-
-  private Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
 
   @Test
   public void itPassesOnValueInSequence() {

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/NegatedExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/NegatedExpTestTest.java
@@ -2,23 +2,15 @@ package com.hubspot.jinjava.lib.exptest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
-import org.junit.Before;
 import org.junit.Test;
 
-public class NegatedExpTestTest {
+public class NegatedExpTestTest extends BaseJinjavaTest {
   private static final String TEMPLATE =
     "{%% if %s is %s %s %%}pass{%% else %%}fail{%% endif %%}";
   private static final String CONTAINING_TEMPLATE =
     "{%% if %s is not containing %s %%}pass{%% else %%}fail{%% endif %%}";
-
-  private Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
 
   @Test
   public void itNegatesDefined() {

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/isDivisibleByExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/isDivisibleByExpTestTest.java
@@ -2,24 +2,16 @@ package com.hubspot.jinjava.lib.exptest;
 
 import static org.junit.Assert.assertEquals;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import java.util.HashMap;
-import org.junit.Before;
 import org.junit.Test;
 
-public class isDivisibleByExpTestTest {
+public class isDivisibleByExpTestTest extends BaseJinjavaTest {
   private static final String DIVISIBLE_BY_TEMPLATE = "{{ %s is divisibleby %s }}";
-
-  private Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
 
   @Test
   public void itRequiresDividend() {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/AdvancedFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/AdvancedFilterTest.java
@@ -2,20 +2,17 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
 
-public class AdvancedFilterTest {
-  Jinjava jinjava;
+public class AdvancedFilterTest extends BaseJinjavaTest {
 
   @Test
   public void testOnlyArgs() {
-    jinjava = new Jinjava();
-
     Object[] expectedArgs = new Object[] { 3L, 1L };
     Map<String, Object> expectedKwargs = new HashMap<>();
 
@@ -29,8 +26,6 @@ public class AdvancedFilterTest {
 
   @Test
   public void testOnlyKwargs() {
-    jinjava = new Jinjava();
-
     Object[] expectedArgs = new Object[] {};
     Map<String, Object> expectedKwargs = new HashMap<String, Object>() {
 
@@ -56,8 +51,6 @@ public class AdvancedFilterTest {
 
   @Test
   public void itTestsNullKwargs() {
-    jinjava = new Jinjava();
-
     Object[] expectedArgs = new Object[] {};
     Map<String, Object> expectedKwargs = new HashMap<String, Object>() {
 
@@ -76,8 +69,6 @@ public class AdvancedFilterTest {
 
   @Test
   public void testMixedArgsAndKwargs() {
-    jinjava = new Jinjava();
-
     Object[] expectedArgs = new Object[] { 1L, 2L };
     Map<String, Object> expectedKwargs = new HashMap<String, Object>() {
 
@@ -96,8 +87,6 @@ public class AdvancedFilterTest {
 
   @Test
   public void testUnorderedArgsAndKwargs() {
-    jinjava = new Jinjava();
-
     Object[] expectedArgs = new Object[] { "1", 2L };
     Map<String, Object> expectedKwargs = new HashMap<String, Object>() {
 
@@ -118,8 +107,6 @@ public class AdvancedFilterTest {
 
   @Test
   public void testRepeatedKwargs() {
-    jinjava = new Jinjava();
-
     Object[] expectedArgs = new Object[] { true };
     Map<String, Object> expectedKwargs = new HashMap<String, Object>() {
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/AttrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/AttrFilterTest.java
@@ -2,21 +2,14 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Before;
 import org.junit.Test;
 
-public class AttrFilterTest {
-  Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
+public class AttrFilterTest extends BaseJinjavaTest {
 
   @Test
   public void testAttr() {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/BatchFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/BatchFilterTest.java
@@ -5,22 +5,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
-import org.junit.Before;
 import org.junit.Test;
 
-public class BatchFilterTest {
-  Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
+public class BatchFilterTest extends BaseJinjavaTest {
 
   @Test
   public void batchFilterNoBackfill() {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/BetweenTimesFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/BetweenTimesFilterTest.java
@@ -3,7 +3,7 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.objects.date.PyishDate;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -12,12 +12,10 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
-public class BetweenTimesFilterTest {
-  Jinjava jinjava;
+public class BetweenTimesFilterTest extends BaseJinjavaTest {
 
   @Before
   public void setup() {
-    jinjava = new Jinjava();
     jinjava.getGlobalContext().registerClasses(EscapeJsFilter.class);
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/BoolFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/BoolFilterTest.java
@@ -15,18 +15,15 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import org.junit.Before;
 import org.junit.Test;
 
-public class BoolFilterTest {
+public class BoolFilterTest extends BaseInterpretingTest {
   BoolFilter filter;
-  JinjavaInterpreter interpreter;
 
   @Before
   public void setup() {
-    interpreter = new Jinjava().newInterpreter();
     filter = new BoolFilter();
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/CamelCaseRegisteringFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/CamelCaseRegisteringFilterTest.java
@@ -2,19 +2,16 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
 
-public class CamelCaseRegisteringFilterTest {
-  Jinjava jinjava;
+public class CamelCaseRegisteringFilterTest extends BaseJinjavaTest {
 
   @Test
   public void itAllowsCamelCasedFilterNames() {
-    jinjava = new Jinjava();
     jinjava.getGlobalContext().registerFilter(new ReturnHelloFilter());
 
     assertThat(jinjava.render("{{ 'test'|returnHello }}", new HashMap<>()))

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
@@ -2,20 +2,17 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.lib.fn.Functions;
 import com.hubspot.jinjava.objects.date.InvalidDateFormatException;
 import com.hubspot.jinjava.objects.date.StrftimeFormatter;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Locale;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class DateTimeFormatFilterTest {
-  JinjavaInterpreter interpreter;
+public class DateTimeFormatFilterTest extends BaseInterpretingTest {
   DateTimeFormatFilter filter;
 
   ZonedDateTime d;
@@ -23,15 +20,8 @@ public class DateTimeFormatFilterTest {
   @Before
   public void setup() {
     Locale.setDefault(Locale.ENGLISH);
-    interpreter = new Jinjava().newInterpreter();
     filter = new DateTimeFormatFilter();
     d = ZonedDateTime.parse("2013-11-06T14:22:00.000+00:00[UTC]");
-    JinjavaInterpreter.pushCurrent(interpreter);
-  }
-
-  @After
-  public void clearCurrentInterpreter() {
-    JinjavaInterpreter.popCurrent();
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DefaultFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DefaultFilterTest.java
@@ -2,7 +2,7 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
@@ -11,12 +11,10 @@ import org.junit.Test;
  * Created by manishdevgan on 25/06/19.
  */
 
-public class DefaultFilterTest {
-  Jinjava jinjava;
+public class DefaultFilterTest extends BaseJinjavaTest {
 
   @Before
   public void setup() {
-    jinjava = new Jinjava();
     jinjava.getGlobalContext().registerClasses(DefaultFilter.class);
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DifferenceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DifferenceFilterTest.java
@@ -2,17 +2,15 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
 
-public class DifferenceFilterTest {
-  Jinjava jinjava;
+public class DifferenceFilterTest extends BaseJinjavaTest {
 
   @Before
   public void setup() {
-    jinjava = new Jinjava();
     jinjava.getGlobalContext().registerClasses(EscapeJsFilter.class);
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/EscapeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/EscapeFilterTest.java
@@ -1,20 +1,17 @@
 package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
 
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.objects.SafeString;
 import org.junit.Before;
 import org.junit.Test;
 
-public class EscapeFilterTest {
-  JinjavaInterpreter interpreter;
+public class EscapeFilterTest extends BaseInterpretingTest {
   EscapeFilter f;
 
   @Before
   public void setup() {
-    interpreter = mock(JinjavaInterpreter.class);
     f = new EscapeFilter();
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilterTest.java
@@ -1,20 +1,17 @@
 package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
 
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.objects.SafeString;
 import org.junit.Before;
 import org.junit.Test;
 
-public class EscapeJinjavaFilterTest {
-  JinjavaInterpreter interpreter;
+public class EscapeJinjavaFilterTest extends BaseInterpretingTest {
   EscapeJinjavaFilter f;
 
   @Before
   public void setup() {
-    interpreter = mock(JinjavaInterpreter.class);
     f = new EscapeJinjavaFilter();
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJsFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJsFilterTest.java
@@ -3,18 +3,16 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
-public class EscapeJsFilterTest {
-  Jinjava jinjava;
+public class EscapeJsFilterTest extends BaseJinjavaTest {
 
   @Before
   public void setup() {
-    jinjava = new Jinjava();
     jinjava.getGlobalContext().registerClasses(EscapeJsFilter.class);
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJsonFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJsonFilterTest.java
@@ -3,18 +3,16 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
-public class EscapeJsonFilterTest {
-  Jinjava jinjava;
+public class EscapeJsonFilterTest extends BaseJinjavaTest {
 
   @Before
   public void setup() {
-    jinjava = new Jinjava();
     jinjava.getGlobalContext().registerClasses(EscapeJsonFilter.class);
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/FileSizeFormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FileSizeFormatFilterTest.java
@@ -2,19 +2,17 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
 import java.util.Locale;
 import org.junit.Before;
 import org.junit.Test;
 
-public class FileSizeFormatFilterTest {
-  Jinjava jinjava;
+public class FileSizeFormatFilterTest extends BaseJinjavaTest {
 
   @Before
   public void setup() {
     Locale.setDefault(Locale.ENGLISH);
-    jinjava = new Jinjava();
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/filter/FloatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FloatFilterTest.java
@@ -17,16 +17,16 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
 import java.util.Locale;
 import org.junit.Before;
 import org.junit.Test;
 
-public class FloatFilterTest {
+public class FloatFilterTest extends BaseInterpretingTest {
   private static final Locale FRENCH_LOCALE = new Locale("fr", "FR");
   private static final JinjavaConfig FRENCH_LOCALE_CONFIG = new JinjavaConfig(
     StandardCharsets.UTF_8,
@@ -36,11 +36,9 @@ public class FloatFilterTest {
   );
 
   FloatFilter filter;
-  JinjavaInterpreter interpreter;
 
   @Before
   public void setup() {
-    interpreter = new Jinjava().newInterpreter();
     filter = new FloatFilter();
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/FormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FormatFilterTest.java
@@ -3,19 +3,12 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.interpret.FatalTemplateErrorsException;
 import java.util.HashMap;
-import org.junit.Before;
 import org.junit.Test;
 
-public class FormatFilterTest {
-  Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
+public class FormatFilterTest extends BaseJinjavaTest {
 
   @Test
   public void testFormatFilter() {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/FromJsonFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FromJsonFilterTest.java
@@ -3,22 +3,17 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.interpret.InvalidInputException;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
-public class FromJsonFilterTest {
-  private JinjavaInterpreter interpreter;
-  private Jinjava jinjava;
+public class FromJsonFilterTest extends BaseInterpretingTest {
   private FromJsonFilter filter;
 
   @Before
   public void setup() {
-    jinjava = new Jinjava();
-    interpreter = jinjava.newInterpreter();
     filter = new FromJsonFilter();
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/GroupByFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/GroupByFilterTest.java
@@ -5,20 +5,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.nio.charset.StandardCharsets;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.junit.Before;
 import org.junit.Test;
 
-public class GroupByFilterTest {
-  Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
+public class GroupByFilterTest extends BaseJinjavaTest {
 
   @Test
   public void testGroupByAttr() throws Exception {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/IntFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/IntFilterTest.java
@@ -2,16 +2,16 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
 import java.util.Locale;
 import org.junit.Before;
 import org.junit.Test;
 
-public class IntFilterTest {
+public class IntFilterTest extends BaseInterpretingTest {
   private static final Locale FRENCH_LOCALE = new Locale("fr", "FR");
   private static final JinjavaConfig FRENCH_LOCALE_CONFIG = new JinjavaConfig(
     StandardCharsets.UTF_8,
@@ -21,11 +21,9 @@ public class IntFilterTest {
   );
 
   IntFilter filter;
-  JinjavaInterpreter interpreter;
 
   @Before
   public void setup() {
-    interpreter = new Jinjava().newInterpreter();
     filter = new IntFilter();
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/IntersectFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/IntersectFilterTest.java
@@ -2,17 +2,15 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
 
-public class IntersectFilterTest {
-  Jinjava jinjava;
+public class IntersectFilterTest extends BaseJinjavaTest {
 
   @Before
   public void setup() {
-    jinjava = new Jinjava();
     jinjava.getGlobalContext().registerClasses(EscapeJsFilter.class);
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/IpAddrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/IpAddrFilterTest.java
@@ -3,8 +3,7 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.objects.SafeString;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -15,18 +14,16 @@ import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Test;
 
-public class IpAddrFilterTest {
+public class IpAddrFilterTest extends BaseInterpretingTest {
   private IpAddrFilter ipAddrFilter;
   private Ipv4Filter ipv4Filter;
   private Ipv6Filter ipv6Filter;
-  private JinjavaInterpreter interpreter;
 
   @Before
   public void setup() {
     ipAddrFilter = new IpAddrFilter();
     ipv4Filter = new Ipv4Filter();
     ipv6Filter = new Ipv6Filter();
-    interpreter = new Jinjava().newInterpreter();
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/filter/JoinFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/JoinFilterTest.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Lists;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.RenderResult;
@@ -10,12 +11,10 @@ import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
 
-public class JoinFilterTest {
-  Jinjava jinjava;
+public class JoinFilterTest extends BaseJinjavaTest {
 
   @Before
   public void setup() {
-    jinjava = new Jinjava();
     jinjava
       .getGlobalContext()
       .put("users", Lists.newArrayList(new User("foo"), new User("bar")));

--- a/src/test/java/com/hubspot/jinjava/lib/filter/LogFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/LogFilterTest.java
@@ -2,21 +2,18 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.InvalidInputException;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.math.BigDecimal;
 import org.junit.Before;
 import org.junit.Test;
 
-public class LogFilterTest {
-  JinjavaInterpreter interpreter;
+public class LogFilterTest extends BaseInterpretingTest {
   LogFilter filter;
 
   @Before
   public void setup() {
-    interpreter = new Jinjava().newInterpreter();
     filter = new LogFilter();
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/MapFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/MapFilterTest.java
@@ -5,18 +5,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.lib.filter.JoinFilterTest.User;
-import org.junit.Before;
 import org.junit.Test;
 
-public class MapFilterTest {
-  Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
+public class MapFilterTest extends BaseJinjavaTest {
 
   @Test
   public void mapAttr() {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/MinusTimeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/MinusTimeFilterTest.java
@@ -3,7 +3,7 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.objects.date.PyishDate;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -12,12 +12,10 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
-public class MinusTimeFilterTest {
-  Jinjava jinjava;
+public class MinusTimeFilterTest extends BaseJinjavaTest {
 
   @Before
   public void setup() {
-    jinjava = new Jinjava();
     jinjava.getGlobalContext().registerClasses(EscapeJsFilter.class);
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/PlusTimeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/PlusTimeFilterTest.java
@@ -3,7 +3,7 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.objects.date.PyishDate;
 import java.time.Instant;
@@ -13,12 +13,10 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
-public class PlusTimeFilterTest {
-  Jinjava jinjava;
+public class PlusTimeFilterTest extends BaseJinjavaTest {
 
   @Before
   public void setup() {
-    jinjava = new Jinjava();
     jinjava.getGlobalContext().registerClasses(EscapeJsFilter.class);
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilterTest.java
@@ -3,21 +3,17 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.interpret.InvalidArgumentException;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.objects.SafeString;
 import org.junit.Before;
 import org.junit.Test;
 
-public class RegexReplaceFilterTest {
-  JinjavaInterpreter interpreter;
+public class RegexReplaceFilterTest extends BaseInterpretingTest {
   RegexReplaceFilter filter;
 
   @Before
   public void setup() {
-    interpreter = new Jinjava().newInterpreter();
     filter = new RegexReplaceFilter();
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RejectAttrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RejectAttrFilterTest.java
@@ -3,17 +3,15 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Lists;
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
 
-public class RejectAttrFilterTest {
-  Jinjava jinjava;
+public class RejectAttrFilterTest extends BaseJinjavaTest {
 
   @Before
   public void setup() {
-    jinjava = new Jinjava();
     jinjava
       .getGlobalContext()
       .put(

--- a/src/test/java/com/hubspot/jinjava/lib/filter/ReplaceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/ReplaceFilterTest.java
@@ -2,20 +2,17 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.interpret.InterpretException;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.objects.SafeString;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ReplaceFilterTest {
-  JinjavaInterpreter interpreter;
+public class ReplaceFilterTest extends BaseInterpretingTest {
   ReplaceFilter filter;
 
   @Before
   public void setup() {
-    interpreter = new Jinjava().newInterpreter();
     filter = new ReplaceFilter();
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RootFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RootFilterTest.java
@@ -2,21 +2,18 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.InvalidInputException;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.math.BigDecimal;
 import org.junit.Before;
 import org.junit.Test;
 
-public class RootFilterTest {
-  JinjavaInterpreter interpreter;
+public class RootFilterTest extends BaseInterpretingTest {
   RootFilter filter;
 
   @Before
   public void setup() {
-    interpreter = new Jinjava().newInterpreter();
     filter = new RootFilter();
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RoundFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RoundFilterTest.java
@@ -2,18 +2,11 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
-import org.junit.Before;
 import org.junit.Test;
 
-public class RoundFilterTest {
-  Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
+public class RoundFilterTest extends BaseJinjavaTest {
 
   @Test
   public void roundDefault() {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SafeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SafeFilterTest.java
@@ -3,14 +3,13 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
-import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class SafeFilterTest {
+public class SafeFilterTest extends BaseInterpretingTest {
   private static final String HTML = "<a>Link</a>";
   private static final List<Integer> TEST_NUMBERS = ImmutableList.of(43, 1, 24);
   private static final List<String> TEST_STRINGS = ImmutableList.of(
@@ -46,11 +45,8 @@ public class SafeFilterTest {
     "root"
   );
 
-  private JinjavaInterpreter interpreter;
-
   @Before
   public void setup() {
-    interpreter = new Jinjava().newInterpreter();
     interpreter.getContext().setAutoEscape(true);
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SelectAttrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SelectAttrFilterTest.java
@@ -3,17 +3,15 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Lists;
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
 
-public class SelectAttrFilterTest {
-  Jinjava jinjava;
+public class SelectAttrFilterTest extends BaseJinjavaTest {
 
   @Before
   public void setup() {
-    jinjava = new Jinjava();
     jinjava
       .getGlobalContext()
       .put(

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SelectFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SelectFilterTest.java
@@ -3,17 +3,15 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Lists;
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
 
-public class SelectFilterTest {
-  Jinjava jinjava;
+public class SelectFilterTest extends BaseJinjavaTest {
 
   @Before
   public void setup() {
-    jinjava = new Jinjava();
     jinjava.getGlobalContext().put("numbers", Lists.newArrayList(1L, 2L, 3L, 4L, 5L));
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SliceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SliceFilterTest.java
@@ -5,21 +5,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.interpret.RenderResult;
 import java.nio.charset.StandardCharsets;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.junit.Before;
 import org.junit.Test;
 
-public class SliceFilterTest {
-  Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
+public class SliceFilterTest extends BaseJinjavaTest {
 
   @Test
   public void itSlicesLists() throws Exception {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SortFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SortFilterTest.java
@@ -2,22 +2,15 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Before;
 import org.junit.Test;
 
-public class SortFilterTest {
-  Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
+public class SortFilterTest extends BaseJinjavaTest {
 
   @Test
   public void sortAsc() {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SplitFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SplitFilterTest.java
@@ -2,20 +2,13 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("unchecked")
-public class SplitFilterTest {
-  @Mock
-  JinjavaInterpreter interpreter;
-
+public class SplitFilterTest extends BaseInterpretingTest {
   SplitFilter filter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/filter/StringToTimeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/StringToTimeFilterTest.java
@@ -3,17 +3,15 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
-public class StringToTimeFilterTest {
-  Jinjava jinjava;
+public class StringToTimeFilterTest extends BaseJinjavaTest {
 
   @Before
   public void setup() {
-    jinjava = new Jinjava();
     jinjava.getGlobalContext().registerClasses(EscapeJsFilter.class);
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SumFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SumFilterTest.java
@@ -3,20 +3,13 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Lists;
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Before;
 import org.junit.Test;
 
 @SuppressWarnings("unchecked")
-public class SumFilterTest {
-  Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
+public class SumFilterTest extends BaseJinjavaTest {
 
   @Test
   public void sumWithAttr() {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SymmetricDifferenceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SymmetricDifferenceFilterTest.java
@@ -2,17 +2,15 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
 
-public class SymmetricDifferenceFilterTest {
-  Jinjava jinjava;
+public class SymmetricDifferenceFilterTest extends BaseJinjavaTest {
 
   @Before
   public void setup() {
-    jinjava = new Jinjava();
     jinjava.getGlobalContext().registerClasses(EscapeJsFilter.class);
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/ToJsonFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/ToJsonFilterTest.java
@@ -2,20 +2,17 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ToJsonFilterTest {
-  private JinjavaInterpreter interpreter;
+public class ToJsonFilterTest extends BaseInterpretingTest {
   private ToJsonFilter filter;
 
   @Before
   public void setup() {
-    interpreter = new Jinjava().newInterpreter();
     filter = new ToJsonFilter();
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/TrimFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/TrimFilterTest.java
@@ -2,19 +2,16 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.objects.SafeString;
 import org.junit.Before;
 import org.junit.Test;
 
-public class TrimFilterTest {
-  JinjavaInterpreter interpreter;
+public class TrimFilterTest extends BaseInterpretingTest {
   TrimFilter filter;
 
   @Before
   public void setup() {
-    interpreter = new Jinjava().newInterpreter();
     filter = new TrimFilter();
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilterTest.java
@@ -1,24 +1,21 @@
 package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.junit.Before;
 import org.junit.Test;
 
-public class TruncateHtmlFilterTest {
+public class TruncateHtmlFilterTest extends BaseInterpretingTest {
   TruncateHtmlFilter filter;
-  JinjavaInterpreter interpreter;
 
   @Before
   public void setup() {
     filter = new TruncateHtmlFilter();
-    interpreter = mock(JinjavaInterpreter.class);
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/filter/UnionFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/UnionFilterTest.java
@@ -2,17 +2,15 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
 
-public class UnionFilterTest {
-  Jinjava jinjava;
+public class UnionFilterTest extends BaseJinjavaTest {
 
   @Before
   public void setup() {
-    jinjava = new Jinjava();
     jinjava.getGlobalContext().registerClasses(EscapeJsFilter.class);
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/UniqueFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/UniqueFilterTest.java
@@ -2,20 +2,13 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Before;
 import org.junit.Test;
 
-public class UniqueFilterTest {
-  Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
+public class UniqueFilterTest extends BaseJinjavaTest {
 
   @Test
   public void itDoesntFilterWhenNoDuplicateItemsInSeq() {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilterTest.java
@@ -2,16 +2,13 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import java.time.ZonedDateTime;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class UnixTimestampFilterTest {
-  JinjavaInterpreter interpreter;
-
+public class UnixTimestampFilterTest extends BaseInterpretingTest {
   private final ZonedDateTime d = ZonedDateTime.parse(
     "2013-11-06T14:22:00.000+00:00[UTC]"
   );
@@ -19,7 +16,6 @@ public class UnixTimestampFilterTest {
 
   @Before
   public void setup() {
-    interpreter = new Jinjava().newInterpreter();
     interpreter.getContext().put("d", d);
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/UpperFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/UpperFilterTest.java
@@ -1,19 +1,16 @@
 package com.hubspot.jinjava.lib.filter;
 
-import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.objects.SafeString;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 
-public class UpperFilterTest {
+public class UpperFilterTest extends BaseInterpretingTest {
   private UpperFilter filter;
-  private JinjavaInterpreter interpreter;
 
   @Before
   public void setup() {
-    interpreter = new Jinjava().newInterpreter();
     filter = new UpperFilter();
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/UrlEncodeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/UrlEncodeFilterTest.java
@@ -2,20 +2,17 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
-public class UrlEncodeFilterTest {
-  JinjavaInterpreter interpreter;
+public class UrlEncodeFilterTest extends BaseInterpretingTest {
   UrlEncodeFilter filter;
 
   @Before
   public void setup() {
-    interpreter = new Jinjava().newInterpreter();
     filter = new UrlEncodeFilter();
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/UrlizeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/UrlizeFilterTest.java
@@ -3,7 +3,7 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.io.Resources;
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import org.jsoup.Jsoup;
@@ -11,12 +11,10 @@ import org.jsoup.nodes.Document;
 import org.junit.Before;
 import org.junit.Test;
 
-public class UrlizeFilterTest {
-  Jinjava jinjava;
+public class UrlizeFilterTest extends BaseJinjavaTest {
 
   @Before
   public void setup() throws Exception {
-    jinjava = new Jinjava();
     jinjava
       .getGlobalContext()
       .put(

--- a/src/test/java/com/hubspot/jinjava/lib/filter/XmlAttrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/XmlAttrFilterTest.java
@@ -2,21 +2,14 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
 import java.util.Map;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.junit.Before;
 import org.junit.Test;
 
-public class XmlAttrFilterTest {
-  Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
+public class XmlAttrFilterTest extends BaseJinjavaTest {
 
   @Test
   public void testXmlAttr() {

--- a/src/test/java/com/hubspot/jinjava/lib/fn/TypeFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/TypeFunctionTest.java
@@ -2,22 +2,13 @@ package com.hubspot.jinjava.lib.fn;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.objects.SafeString;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
-import org.junit.Before;
 import org.junit.Test;
 
 public class TypeFunctionTest {
-  private JinjavaInterpreter interpreter;
-
-  @Before
-  public void setup() {
-    interpreter = new Jinjava().newInterpreter();
-  }
 
   @Test
   public void testString() {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/AutoEscapeTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/AutoEscapeTagTest.java
@@ -3,13 +3,14 @@ package com.hubspot.jinjava.lib.tag;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.io.Resources;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
 
-public class AutoEscapeTagTest extends BaseTagTest {
+public class AutoEscapeTagTest extends BaseJinjavaTest {
 
   @Test
   public void itEscapesVarsInScope() throws IOException {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/AutoEscapeTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/AutoEscapeTagTest.java
@@ -3,21 +3,13 @@ package com.hubspot.jinjava.lib.tag;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.io.Resources;
-import com.hubspot.jinjava.Jinjava;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Before;
 import org.junit.Test;
 
-public class AutoEscapeTagTest {
-  private Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
+public class AutoEscapeTagTest extends BaseTagTest {
 
   @Test
   public void itEscapesVarsInScope() throws IOException {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/BaseTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/BaseTagTest.java
@@ -1,0 +1,20 @@
+package com.hubspot.jinjava.lib.tag;
+
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.interpret.Context;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import org.junit.Before;
+
+public abstract class BaseTagTest {
+  public Jinjava jinjava;
+  public JinjavaInterpreter interpreter;
+
+  public Context context;
+
+  @Before
+  public void baseSetup() {
+    jinjava = new Jinjava();
+    interpreter = new JinjavaInterpreter(jinjava.newInterpreter());
+    context = interpreter.getContext();
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/lib/tag/CallTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/CallTagTest.java
@@ -3,26 +3,14 @@ package com.hubspot.jinjava.lib.tag;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.io.Resources;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
-public class CallTagTest extends BaseTagTest {
-
-  @Before
-  public void setup() {
-    JinjavaInterpreter.pushCurrent(interpreter);
-  }
-
-  @After
-  public void cleanup() {
-    JinjavaInterpreter.popCurrent();
-  }
+public class CallTagTest extends BaseInterpretingTest {
 
   @Test
   public void testSimpleFn() {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/CallTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/CallTagTest.java
@@ -3,7 +3,6 @@ package com.hubspot.jinjava.lib.tag;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.io.Resources;
-import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -13,12 +12,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class CallTagTest {
-  JinjavaInterpreter interpreter;
+public class CallTagTest extends BaseTagTest {
 
   @Before
   public void setup() {
-    interpreter = new Jinjava().newInterpreter();
     JinjavaInterpreter.pushCurrent(interpreter);
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/DoTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/DoTagTest.java
@@ -3,11 +3,12 @@ package com.hubspot.jinjava.lib.tag;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Maps;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import org.junit.Test;
 
-public class DoTagTest extends BaseTagTest {
+public class DoTagTest extends BaseJinjavaTest {
 
   @Test
   public void itResolvesExpressions() {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/DoTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/DoTagTest.java
@@ -3,25 +3,11 @@ package com.hubspot.jinjava.lib.tag;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Maps;
-import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.Context;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
-import org.junit.Before;
 import org.junit.Test;
 
-public class DoTagTest {
-  private Context context;
-  private JinjavaInterpreter interpreter;
-  private Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-    interpreter = jinjava.newInterpreter();
-    context = interpreter.getContext();
-  }
+public class DoTagTest extends BaseTagTest {
 
   @Test
   public void itResolvesExpressions() {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ExtendsTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ExtendsTagTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.fail;
 
 import com.google.common.collect.SetMultimap;
 import com.google.common.io.Resources;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.interpret.FatalTemplateErrorsException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.RenderResult;
@@ -23,7 +24,7 @@ import org.jsoup.nodes.Document;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ExtendsTagTest extends BaseTagTest {
+public class ExtendsTagTest extends BaseJinjavaTest {
   private ExtendsTagTestResourceLocator locator;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ExtendsTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ExtendsTagTest.java
@@ -6,8 +6,6 @@ import static org.assertj.core.api.Assertions.fail;
 
 import com.google.common.collect.SetMultimap;
 import com.google.common.io.Resources;
-import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.FatalTemplateErrorsException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.RenderResult;
@@ -25,16 +23,13 @@ import org.jsoup.nodes.Document;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ExtendsTagTest {
+public class ExtendsTagTest extends BaseTagTest {
   private ExtendsTagTestResourceLocator locator;
-  private Jinjava jinjava;
 
   @Before
   public void setup() {
     locator = new ExtendsTagTestResourceLocator();
 
-    JinjavaConfig conf = new JinjavaConfig();
-    jinjava = new Jinjava(conf);
     jinjava.setResourceLocator(locator);
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Resources;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.objects.date.PyishDate;
 import com.hubspot.jinjava.tree.Node;
@@ -25,7 +26,7 @@ import org.jsoup.select.Elements;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ForTagTest extends BaseTagTest {
+public class ForTagTest extends BaseInterpretingTest {
   public Tag tag;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
@@ -9,10 +9,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Resources;
-import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.InterpretException;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.objects.date.PyishDate;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.TagNode;
@@ -28,19 +25,11 @@ import org.jsoup.select.Elements;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ForTagTest {
-  ForTag tag;
-
-  private Context context;
-  JinjavaInterpreter interpreter;
-  Jinjava jinjava;
+public class ForTagTest extends BaseTagTest {
+  public Tag tag;
 
   @Before
   public void setup() {
-    jinjava = new Jinjava();
-    interpreter = jinjava.newInterpreter();
-    context = interpreter.getContext();
-
     tag = new ForTag();
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/FromTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/FromTagTest.java
@@ -5,8 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.io.Resources;
-import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.errorcategory.BasicTemplateErrorCategory;
@@ -22,13 +20,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class FromTagTest {
-  private Context context;
-  private JinjavaInterpreter interpreter;
+public class FromTagTest extends BaseTagTest {
 
   @Before
   public void setup() {
-    Jinjava jinjava = new Jinjava();
     jinjava.setResourceLocator(
       new ResourceLocator() {
         private RelativePathResolver relativePathResolver = new RelativePathResolver();
@@ -53,10 +48,8 @@ public class FromTagTest {
       }
     );
 
-    interpreter = jinjava.newInterpreter();
     JinjavaInterpreter.pushCurrent(interpreter);
 
-    context = interpreter.getContext();
     context.put("padding", 42);
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/FromTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/FromTagTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.io.Resources;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.errorcategory.BasicTemplateErrorCategory;
@@ -16,11 +17,10 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class FromTagTest extends BaseTagTest {
+public class FromTagTest extends BaseInterpretingTest {
 
   @Before
   public void setup() {
@@ -47,15 +47,7 @@ public class FromTagTest extends BaseTagTest {
         }
       }
     );
-
-    JinjavaInterpreter.pushCurrent(interpreter);
-
     context.put("padding", 42);
-  }
-
-  @After
-  public void cleanup() {
-    JinjavaInterpreter.popCurrent();
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/tag/IfTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/IfTagTest.java
@@ -4,8 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
-import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.TreeParser;
@@ -14,25 +12,13 @@ import java.nio.charset.StandardCharsets;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.runners.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.class)
-public class IfTagTest {
-  JinjavaInterpreter interpreter;
-
-  @InjectMocks
-  IfTag tag;
-
-  Jinjava jinjava;
-  private Context context;
+public class IfTagTest extends BaseTagTest {
+  public Tag tag;
 
   @Before
   public void setup() {
-    jinjava = new Jinjava();
-    interpreter = jinjava.newInterpreter();
-    context = interpreter.getContext();
+    tag = new IfTag();
     JinjavaInterpreter.pushCurrent(interpreter);
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/IfTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/IfTagTest.java
@@ -4,27 +4,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.TreeParser;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class IfTagTest extends BaseTagTest {
+public class IfTagTest extends BaseInterpretingTest {
   public Tag tag;
 
   @Before
   public void setup() {
     tag = new IfTag();
-    JinjavaInterpreter.pushCurrent(interpreter);
-  }
-
-  @After
-  public void tearDown() {
-    JinjavaInterpreter.popCurrent();
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
 import com.google.common.io.Resources;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -22,11 +23,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ImportTagTest extends BaseTagTest {
+public class ImportTagTest extends BaseInterpretingTest {
 
   @Before
   public void setup() {
@@ -38,14 +38,7 @@ public class ImportTagTest extends BaseTagTest {
         )
     );
 
-    JinjavaInterpreter.pushCurrent(interpreter);
-
     context.put("padding", 42);
-  }
-
-  @After
-  public void cleanup() {
-    JinjavaInterpreter.popCurrent();
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.entry;
 
 import com.google.common.io.Resources;
 import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.RenderResult;
@@ -27,33 +26,18 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ImportTagTest {
-  private Context context;
-  private JinjavaInterpreter interpreter;
+public class ImportTagTest extends BaseTagTest {
 
   @Before
   public void setup() {
-    Jinjava jinjava = new Jinjava();
     jinjava.setResourceLocator(
-      new ResourceLocator() {
-
-        @Override
-        public String getString(
-          String fullName,
-          Charset encoding,
-          JinjavaInterpreter interpreter
+      (fullName, encoding, interpreter) ->
+        Resources.toString(
+          Resources.getResource(String.format("tags/macrotag/%s", fullName)),
+          StandardCharsets.UTF_8
         )
-          throws IOException {
-          return Resources.toString(
-            Resources.getResource(String.format("tags/macrotag/%s", fullName)),
-            StandardCharsets.UTF_8
-          );
-        }
-      }
     );
 
-    context = new Context();
-    interpreter = new JinjavaInterpreter(jinjava, context, jinjava.getGlobalConfig());
     JinjavaInterpreter.pushCurrent(interpreter);
 
     context.put("padding", 42);

--- a/src/test/java/com/hubspot/jinjava/lib/tag/IncludeTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/IncludeTagTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.base.Splitter;
 import com.google.common.collect.SetMultimap;
 import com.google.common.io.Resources;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.RenderResult;
@@ -19,7 +20,7 @@ import java.util.HashMap;
 import java.util.Optional;
 import org.junit.Test;
 
-public class IncludeTagTest extends BaseTagTest {
+public class IncludeTagTest extends BaseJinjavaTest {
 
   @Test
   public void itAvoidsSimpleIncludeCycles() throws IOException {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/IncludeTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/IncludeTagTest.java
@@ -17,16 +17,9 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Optional;
-import org.junit.Before;
 import org.junit.Test;
 
-public class IncludeTagTest {
-  Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
+public class IncludeTagTest extends BaseTagTest {
 
   @Test
   public void itAvoidsSimpleIncludeCycles() throws IOException {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.entry;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.DeferredValue;
@@ -21,21 +22,9 @@ import java.util.Map;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
-public class MacroTagTest extends BaseTagTest {
-
-  @Before
-  public void setup() {
-    JinjavaInterpreter.pushCurrent(interpreter);
-  }
-
-  @After
-  public void cleanup() {
-    JinjavaInterpreter.popCurrent();
-  }
+public class MacroTagTest extends BaseInterpretingTest {
 
   @Test
   public void testSimpleFn() {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
@@ -8,7 +8,6 @@ import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
-import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
@@ -26,16 +25,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class MacroTagTest {
-  Context context;
-  JinjavaInterpreter interpreter;
+public class MacroTagTest extends BaseTagTest {
 
   @Before
   public void setup() {
-    interpreter = new Jinjava().newInterpreter();
     JinjavaInterpreter.pushCurrent(interpreter);
-
-    context = interpreter.getContext();
   }
 
   @After

--- a/src/test/java/com/hubspot/jinjava/lib/tag/RawTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/RawTagTest.java
@@ -3,7 +3,6 @@ package com.hubspot.jinjava.lib.tag;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.io.Resources;
-import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -18,15 +17,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 
-public class RawTagTest {
-  Jinjava jinjava;
-  JinjavaInterpreter interpreter;
-  RawTag tag;
+public class RawTagTest extends BaseTagTest {
+  Tag tag;
 
   @Before
   public void setup() {
-    jinjava = new Jinjava();
-    interpreter = jinjava.newInterpreter();
     tag = new RawTag();
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/RawTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/RawTagTest.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.lib.tag;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.io.Resources;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -17,7 +18,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 
-public class RawTagTest extends BaseTagTest {
+public class RawTagTest extends BaseInterpretingTest {
   Tag tag;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/tag/SetTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/SetTagTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.entry;
 
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
@@ -21,7 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 @SuppressWarnings("unchecked")
-public class SetTagTest extends BaseTagTest {
+public class SetTagTest extends BaseInterpretingTest {
   public Tag tag;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/tag/SetTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/SetTagTest.java
@@ -6,11 +6,8 @@ import static org.assertj.core.api.Assertions.entry;
 
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
-import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.TagNode;
@@ -22,23 +19,14 @@ import java.util.List;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.runners.MockitoJUnitRunner;
 
 @SuppressWarnings("unchecked")
-@RunWith(MockitoJUnitRunner.class)
-public class SetTagTest {
-  @InjectMocks
-  SetTag tag;
-
-  Context context;
-  JinjavaInterpreter interpreter;
+public class SetTagTest extends BaseTagTest {
+  public Tag tag;
 
   @Before
   public void setup() {
-    interpreter = new Jinjava().newInterpreter();
-    context = interpreter.getContext();
+    tag = new SetTag();
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/tag/UnlessTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/UnlessTagTest.java
@@ -3,9 +3,6 @@ package com.hubspot.jinjava.lib.tag;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.io.Resources;
-import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.Context;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.TreeParser;
 import java.io.IOException;
@@ -13,17 +10,11 @@ import java.nio.charset.StandardCharsets;
 import org.junit.Before;
 import org.junit.Test;
 
-public class UnlessTagTest {
-  JinjavaInterpreter interpreter;
-  UnlessTag tag;
-
-  Context context;
+public class UnlessTagTest extends BaseTagTest {
+  public Tag tag;
 
   @Before
-  public void setup() {
-    interpreter = new Jinjava().newInterpreter();
-    context = interpreter.getContext();
-
+  public void setupTag() {
     tag = new UnlessTag();
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/UnlessTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/UnlessTagTest.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.lib.tag;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.io.Resources;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.TreeParser;
 import java.io.IOException;
@@ -10,7 +11,7 @@ import java.nio.charset.StandardCharsets;
 import org.junit.Before;
 import org.junit.Test;
 
-public class UnlessTagTest extends BaseTagTest {
+public class UnlessTagTest extends BaseInterpretingTest {
   public Tag tag;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ValidationModeTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ValidationModeTest.java
@@ -337,5 +337,6 @@ public class ValidationModeTest {
     assertThat(validatingInterpreter.getErrors().get(0).getMessage()).contains("hey(");
     assertThat(result).isEqualTo("10");
     assertThat(validationFilter.getExecutionCount()).isEqualTo(2);
+    JinjavaInterpreter.popCurrent();
   }
 }

--- a/src/test/java/com/hubspot/jinjava/loader/ClasspathResourceLocatorTest.java
+++ b/src/test/java/com/hubspot/jinjava/loader/ClasspathResourceLocatorTest.java
@@ -2,19 +2,11 @@ package com.hubspot.jinjava.loader;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import java.nio.charset.StandardCharsets;
-import org.junit.Before;
 import org.junit.Test;
 
-public class ClasspathResourceLocatorTest {
-  JinjavaInterpreter interpreter;
-
-  @Before
-  public void setup() {
-    interpreter = new Jinjava().newInterpreter();
-  }
+public class ClasspathResourceLocatorTest extends BaseInterpretingTest {
 
   @Test
   public void testLoadFromClasspath() throws Exception {

--- a/src/test/java/com/hubspot/jinjava/loader/FileLocatorTest.java
+++ b/src/test/java/com/hubspot/jinjava/loader/FileLocatorTest.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.loader;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.io.Files;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.io.File;
@@ -11,9 +12,7 @@ import java.nio.charset.StandardCharsets;
 import org.junit.Before;
 import org.junit.Test;
 
-public class FileLocatorTest {
-  JinjavaInterpreter interpreter;
-
+public class FileLocatorTest extends BaseInterpretingTest {
   FileLocator locatorWorkingDir;
   FileLocator locatorTmpDir;
 
@@ -22,8 +21,6 @@ public class FileLocatorTest {
 
   @Before
   public void setUp() throws Exception {
-    interpreter = new Jinjava().newInterpreter();
-
     locatorWorkingDir = new FileLocator();
 
     File tmpDir = java

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
@@ -2,21 +2,14 @@ package com.hubspot.jinjava.objects.collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.interpret.IndexOutOfRangeException;
 import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.interpret.TemplateError;
 import java.util.Collections;
-import org.junit.Before;
 import org.junit.Test;
 
-public class PyListTest {
-  private Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
+public class PyListTest extends BaseJinjavaTest {
 
   @Test
   public void itSupportsAppendOperation() {

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
@@ -3,23 +3,15 @@ package com.hubspot.jinjava.objects.collections;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.interpret.IndexOutOfRangeException;
 import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.interpret.TemplateError;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Map;
-import org.junit.Before;
 import org.junit.Test;
 
-public class PyMapTest {
-  private Jinjava jinjava;
-
-  @Before
-  public void setup() {
-    jinjava = new Jinjava();
-  }
+public class PyMapTest extends BaseJinjavaTest {
 
   @Test
   public void itSupportsAppendOperation() {

--- a/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
@@ -4,24 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.io.Resources;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.UnknownTokenException;
 import java.nio.charset.StandardCharsets;
-import org.junit.Before;
 import org.junit.Test;
 
-public class ExpressionNodeTest {
-  private Context context;
-  private JinjavaInterpreter interpreter;
-
-  @Before
-  public void setup() {
-    interpreter = new Jinjava().newInterpreter();
-    context = interpreter.getContext();
-  }
+public class ExpressionNodeTest extends BaseInterpretingTest {
 
   @Test
   public void itRendersResultAsTemplateWhenContainingVarBlocks() throws Exception {

--- a/src/test/java/com/hubspot/jinjava/tree/FailOnUnknownTokensTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/FailOnUnknownTokensTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
-import com.hubspot.jinjava.interpret.FatalTemplateErrorsException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.UnknownTokenException;
 import java.util.HashMap;

--- a/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
@@ -3,21 +3,14 @@ package com.hubspot.jinjava.tree;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.io.Resources;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import java.nio.charset.StandardCharsets;
-import org.junit.Before;
 import org.junit.Test;
 
-public class TreeParserTest {
-  JinjavaInterpreter interpreter;
-
-  @Before
-  public void setup() {
-    interpreter = new Jinjava().newInterpreter();
-  }
+public class TreeParserTest extends BaseInterpretingTest {
 
   @Test
   public void parseHtmlWithCommentLines() {


### PR DESCRIPTION
I found that there's a lot of code duplication in most of the tests, whether it be setting up a `Jinjava` object or `JinjavaInterpreter` instance variable in the `@Before setup()` method.

This PR adds 2 abstract classes: `BaseJinjavaTest` and `BaseInterpretingTest`, the latter of which extends the former.
These base test classes help remove a lot of duplicate logic from the setup of the test classes.