### PR TITLE
Catch output exception in tag node interpretation

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -269,6 +269,9 @@ public class JinjavaInterpreter {
         } catch (DeferredValueException e) {
           context.handleDeferredNode(node);
           out = new RenderedOutputNode(node.getMaster().getImage());
+        } catch (OutputTooBigException e) {
+          addError(TemplateError.fromOutputTooBigException(e));
+          return output.getValue();
         }
         context.popRenderStack();
         try {
@@ -296,8 +299,8 @@ public class JinjavaInterpreter {
         for (Node node : parentRoot.getChildren()) {
           lineNumber = node.getLineNumber() - 1; // The line number is off by one when rendering the extend parent
           position = node.getStartPosition();
-          OutputNode out = node.render(this);
           try {
+            OutputNode out = node.render(this);
             output.addNode(out);
           } catch (OutputTooBigException e) {
             addError(TemplateError.fromOutputTooBigException(e));

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -23,6 +23,8 @@ import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
+import com.hubspot.jinjava.interpret.OutputTooBigException;
+import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.objects.DummyObject;
 import com.hubspot.jinjava.objects.collections.PyList;
@@ -207,7 +209,12 @@ public class ForTag implements Tag {
           if (interpreter.getContext().isValidationMode()) {
             node.render(interpreter);
           } else {
-            buff.append(node.render(interpreter));
+            try {
+              buff.append(node.render(interpreter));
+            } catch (OutputTooBigException e) {
+              interpreter.addError(TemplateError.fromOutputTooBigException(e));
+              return buff.toString();
+            }
             if (
               interpreter.getContext().getDeferredNodes().size() > numDeferredNodesBefore
             ) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IfTag.java
@@ -18,6 +18,8 @@ package com.hubspot.jinjava.lib.tag;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.OutputTooBigException;
+import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.TagNode;
@@ -99,7 +101,12 @@ public class IfTag implements Tag {
         }
 
         if (execute) {
-          sb.append(node.render(interpreter));
+          try {
+            sb.append(node.render(interpreter));
+          } catch (OutputTooBigException e) {
+            interpreter.addError(TemplateError.fromOutputTooBigException(e));
+            return sb.toString();
+          }
         } else if (interpreter.getContext().isValidationMode()) {
           node.render(interpreter);
         }

--- a/src/main/java/com/hubspot/jinjava/tree/TagNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TagNode.java
@@ -20,6 +20,7 @@ import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.OutputTooBigException;
 import com.hubspot.jinjava.lib.tag.Tag;
 import com.hubspot.jinjava.tree.output.OutputNode;
 import com.hubspot.jinjava.tree.output.RenderedOutputNode;
@@ -53,7 +54,12 @@ public class TagNode extends Node {
     } catch (DeferredValueException e) {
       interpreter.getContext().handleDeferredNode(this);
       return new RenderedOutputNode(reconstructImage());
-    } catch (InterpretException | InvalidInputException | InvalidArgumentException e) {
+    } catch (
+      InterpretException
+      | InvalidInputException
+      | InvalidArgumentException
+      | OutputTooBigException e
+    ) {
       throw e;
     } catch (Exception e) {
       throw new InterpretException(

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -202,6 +202,27 @@ public class JinjavaInterpreterTest {
   }
 
   @Test
+  public void itLimitsOutputSizeOnTagNode() {
+    JinjavaConfig outputSizeLimitedConfig = JinjavaConfig
+      .newBuilder()
+      .withMaxOutputSize(10)
+      .build();
+    String output = "{% for i in range(20) %} {{ i }} {% endfor %}";
+
+    RenderResult renderResult = new Jinjava().renderForResult(output, new HashMap<>());
+    assertThat(renderResult.getOutput())
+      .isEqualTo(
+        " 0  1  2  3  4  5  6  7  8  9  10  11  12  13  14  15  16  17  18  19 "
+      );
+    assertThat(renderResult.hasErrors()).isFalse();
+
+    renderResult =
+      new Jinjava(outputSizeLimitedConfig).renderForResult(output, new HashMap<>());
+    assertThat(renderResult.getErrors().get(0).getMessage())
+      .contains("OutputTooBigException");
+  }
+
+  @Test
   public void itLimitsOutputSizeWhenSumOfNodeSizesExceedsMax() {
     JinjavaConfig outputSizeLimitedConfig = JinjavaConfig
       .newBuilder()

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -220,6 +220,8 @@ public class JinjavaInterpreterTest {
       new Jinjava(outputSizeLimitedConfig).renderForResult(output, new HashMap<>());
     assertThat(renderResult.getErrors().get(0).getMessage())
       .contains("OutputTooBigException");
+
+    assertThat(renderResult.getOutput()).isEqualTo(" 0  1  2  ");
   }
 
   @Test


### PR DESCRIPTION
`OutputTooBigException` was never handled when rendering node tags, so this exception would bubble up with a generic `Error rendering tag` message rather than the more specific like `OutputTooBigException: 11 byte output rendered, over limit of 10 bytes`.

Furthermore there are improvements that I made to specific tags such as `for` and `if` so we can extract partial output at least.