### PR TITLE
Implement ChunkResolver by extending ExtendedParser

### DIFF
--- a/src/main/java/com/hubspot/jinjava/Jinjava.java
+++ b/src/main/java/com/hubspot/jinjava/Jinjava.java
@@ -19,6 +19,7 @@ import com.hubspot.jinjava.doc.JinjavaDoc;
 import com.hubspot.jinjava.doc.JinjavaDocFactory;
 import com.hubspot.jinjava.el.ExtendedSyntaxBuilder;
 import com.hubspot.jinjava.el.TruthyTypeConverter;
+import com.hubspot.jinjava.el.ext.eager.EagerExtendedSyntaxBuilder;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.FatalTemplateErrorsException;
 import com.hubspot.jinjava.interpret.InterpretException;
@@ -84,10 +85,18 @@ public class Jinjava {
     this.globalContext = new Context();
 
     Properties expConfig = new Properties();
+    // TODO add config flag
+    //    if (globalConfig.isEagerExecutionEnabled()) {
     expConfig.setProperty(
       TreeBuilder.class.getName(),
-      ExtendedSyntaxBuilder.class.getName()
+      EagerExtendedSyntaxBuilder.class.getName()
     );
+    //    } else {
+    //      expConfig.setProperty(
+    //        TreeBuilder.class.getName(),
+    //        ExtendedSyntaxBuilder.class.getName()
+    //      );
+    //    }
 
     TypeConverter converter = new TruthyTypeConverter();
     this.expressionFactory = new ExpressionFactoryImpl(expConfig, converter);

--- a/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
@@ -242,6 +242,7 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
             }
 
             if (value instanceof DeferredValue) {
+              // TODO add a flag to toggle which is thrown
               throw new DeferredParsingException(propertyName);
               //              throw new DeferredValueException(
               //                propertyName,

--- a/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
@@ -4,6 +4,7 @@ import static com.hubspot.jinjava.util.Logging.ENGINE_LOG;
 
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.el.ext.AbstractCallableMethod;
+import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.el.ext.ExtendedParser;
 import com.hubspot.jinjava.el.ext.JinjavaBeanELResolver;
 import com.hubspot.jinjava.el.ext.JinjavaListELResolver;
@@ -241,11 +242,12 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
             }
 
             if (value instanceof DeferredValue) {
-              throw new DeferredValueException(
-                propertyName,
-                interpreter.getLineNumber(),
-                interpreter.getPosition()
-              );
+              throw new DeferredParsingException(propertyName);
+              //              throw new DeferredValueException(
+              //                propertyName,
+              //                interpreter.getLineNumber(),
+              //                interpreter.getPosition()
+              //              );
             }
           } catch (PropertyNotFoundException e) {
             if (errOnUnknownProp) {

--- a/src/main/java/com/hubspot/jinjava/el/ext/AdditionOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AdditionOperator.java
@@ -39,5 +39,10 @@ public class AdditionOperator extends AstBinary.SimpleOperator {
     return NumberOperations.add(converter, o1, o2);
   }
 
+  @Override
+  public String toString() {
+    return "+";
+  }
+
   public static final AdditionOperator OP = new AdditionOperator();
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 import javax.el.ELContext;
 
 public class AstDict extends AstLiteral {
-  private final Map<AstNode, AstNode> dict;
+  protected final Map<AstNode, AstNode> dict;
 
   public AstDict(Map<AstNode, AstNode> dict) {
     this.dict = dict;

--- a/src/main/java/com/hubspot/jinjava/el/ext/AstList.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstList.java
@@ -10,7 +10,7 @@ import javax.el.ELContext;
 import org.apache.commons.lang3.StringUtils;
 
 public class AstList extends AstLiteral {
-  private final AstParameters elements;
+  protected final AstParameters elements;
 
   public AstList(AstParameters elements) {
     this.elements = elements;

--- a/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
@@ -58,6 +58,11 @@ public class CollectionMembershipOperator extends SimpleOperator {
     return Boolean.FALSE;
   }
 
+  @Override
+  public String toString() {
+    return TOKEN.getImage();
+  }
+
   public static final CollectionMembershipOperator OP = new CollectionMembershipOperator();
   public static final Scanner.ExtensionToken TOKEN = new Scanner.ExtensionToken("in");
 

--- a/src/main/java/com/hubspot/jinjava/el/ext/DeferredParsingException.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/DeferredParsingException.java
@@ -1,6 +1,8 @@
 package com.hubspot.jinjava.el.ext;
 
-public class DeferredParsingException extends RuntimeException {
+import com.hubspot.jinjava.interpret.DeferredValueException;
+
+public class DeferredParsingException extends DeferredValueException {
   private final String deferredEvalResult;
 
   public DeferredParsingException(String deferredEvalResult) {

--- a/src/main/java/com/hubspot/jinjava/el/ext/DeferredParsingException.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/DeferredParsingException.java
@@ -1,0 +1,14 @@
+package com.hubspot.jinjava.el.ext;
+
+public class DeferredParsingException extends RuntimeException {
+  private final String deferredEvalResult;
+
+  public DeferredParsingException(String deferredEvalResult) {
+    super("AstNode could not be parsed more than: " + deferredEvalResult);
+    this.deferredEvalResult = deferredEvalResult;
+  }
+
+  public String getDeferredEvalResult() {
+    return deferredEvalResult;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -21,6 +21,8 @@ import static de.odysseus.el.tree.impl.Scanner.Symbol.TRUE;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.hubspot.jinjava.el.ext.eager.EagerAstBinaryDecorator;
+import com.hubspot.jinjava.el.ext.eager.EagerAstBracketDecorator;
 import de.odysseus.el.tree.impl.Builder;
 import de.odysseus.el.tree.impl.Builder.Feature;
 import de.odysseus.el.tree.impl.Parser;
@@ -29,14 +31,20 @@ import de.odysseus.el.tree.impl.Scanner.ScanException;
 import de.odysseus.el.tree.impl.Scanner.Symbol;
 import de.odysseus.el.tree.impl.Scanner.Token;
 import de.odysseus.el.tree.impl.ast.AstBinary;
+import de.odysseus.el.tree.impl.ast.AstBinary.Operator;
 import de.odysseus.el.tree.impl.ast.AstBracket;
+import de.odysseus.el.tree.impl.ast.AstChoice;
+import de.odysseus.el.tree.impl.ast.AstComposite;
 import de.odysseus.el.tree.impl.ast.AstDot;
 import de.odysseus.el.tree.impl.ast.AstFunction;
+import de.odysseus.el.tree.impl.ast.AstIdentifier;
+import de.odysseus.el.tree.impl.ast.AstMethod;
 import de.odysseus.el.tree.impl.ast.AstNested;
 import de.odysseus.el.tree.impl.ast.AstNode;
 import de.odysseus.el.tree.impl.ast.AstNull;
 import de.odysseus.el.tree.impl.ast.AstParameters;
 import de.odysseus.el.tree.impl.ast.AstProperty;
+import de.odysseus.el.tree.impl.ast.AstUnary;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -472,4 +480,59 @@ public class ExtendedParser extends Parser {
       return null;
     }
   };
+
+  protected AstBinary createAstBinary(AstNode left, AstNode right, Operator operator) {
+    return new EagerAstBinaryDecorator(left, right, operator);
+  }
+
+  protected AstBracket createAstBracket(
+    AstNode base,
+    AstNode property,
+    boolean lvalue,
+    boolean strict
+  ) {
+    return new EagerAstBracketDecorator(
+      base,
+      property,
+      lvalue,
+      strict,
+      this.context.isEnabled(Feature.IGNORE_RETURN_TYPE)
+    );
+  }
+
+  protected AstChoice createAstChoice(AstNode question, AstNode yes, AstNode no) {
+    return new AstChoice(question, yes, no);
+  }
+
+  protected AstComposite createAstComposite(List<AstNode> nodes) {
+    return new AstComposite(nodes);
+  }
+
+  protected AstDot createAstDot(AstNode base, String property, boolean lvalue) {
+    return new AstDot(
+      base,
+      property,
+      lvalue,
+      this.context.isEnabled(Feature.IGNORE_RETURN_TYPE)
+    );
+  }
+
+  protected AstIdentifier createAstIdentifier(String name, int index) {
+    return new AstIdentifier(
+      name,
+      index,
+      this.context.isEnabled(Feature.IGNORE_RETURN_TYPE)
+    );
+  }
+
+  protected AstMethod createAstMethod(AstProperty property, AstParameters params) {
+    return new AstMethod(property, params);
+  }
+
+  protected AstUnary createAstUnary(
+    AstNode child,
+    de.odysseus.el.tree.impl.ast.AstUnary.Operator operator
+  ) {
+    return new AstUnary(child, operator);
+  }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/NamedParameterOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/NamedParameterOperator.java
@@ -15,6 +15,11 @@ public class NamedParameterOperator {
   ) {
 
     @Override
+    public String toString() {
+      return TOKEN.getImage();
+    }
+
+    @Override
     public AstNode createAstNode(AstNode... children) {
       if (!(children[0] instanceof AstIdentifier)) {
         throw new ELException("Expected IDENTIFIER, found " + children[0].toString());

--- a/src/main/java/com/hubspot/jinjava/el/ext/OrOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/OrOperator.java
@@ -17,5 +17,10 @@ public class OrOperator implements Operator {
     return right.eval(bindings, context);
   }
 
+  @Override
+  public String toString() {
+    return "||";
+  }
+
   public static final OrOperator OP = new OrOperator();
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/PowerOfOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/PowerOfOperator.java
@@ -40,6 +40,11 @@ public class PowerOfOperator extends SimpleOperator {
     );
   }
 
+  @Override
+  public String toString() {
+    return TOKEN.getImage();
+  }
+
   public static final ExtensionHandler HANDLER = new ExtensionHandler(
     ExtensionPoint.MUL
   ) {

--- a/src/main/java/com/hubspot/jinjava/el/ext/StringConcatOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/StringConcatOperator.java
@@ -18,6 +18,11 @@ public class StringConcatOperator extends SimpleOperator {
     return new StringBuilder(o1s).append(o2s).toString();
   }
 
+  @Override
+  public String toString() {
+    return TOKEN.getImage();
+  }
+
   public static final Scanner.ExtensionToken TOKEN = new Scanner.ExtensionToken("~");
   public static final StringConcatOperator OP = new StringConcatOperator();
 

--- a/src/main/java/com/hubspot/jinjava/el/ext/TruncDivOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/TruncDivOperator.java
@@ -40,6 +40,11 @@ public class TruncDivOperator extends SimpleOperator {
     );
   }
 
+  @Override
+  public String toString() {
+    return TOKEN.getImage();
+  }
+
   public static final ExtensionHandler HANDLER = new ExtensionHandler(
     ExtensionPoint.MUL
   ) {

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBinaryDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBinaryDecorator.java
@@ -1,16 +1,17 @@
 package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.util.ChunkResolver;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstBinary;
 import de.odysseus.el.tree.impl.ast.AstNode;
 import javax.el.ELContext;
 
 public class EagerAstBinaryDecorator extends AstBinary implements EvalResultHolder {
-  private Object evalResult;
-  private EvalResultHolder left;
-  private EvalResultHolder right;
-  private Operator operator;
+  protected Object evalResult;
+  protected final EvalResultHolder left;
+  protected final EvalResultHolder right;
+  protected final Operator operator;
 
   public EagerAstBinaryDecorator(AstNode left, AstNode right, Operator operator) {
     this(
@@ -38,24 +39,28 @@ public class EagerAstBinaryDecorator extends AstBinary implements EvalResultHold
     }
     try {
       evalResult = super.eval(bindings, context);
+      return evalResult;
     } catch (DeferredParsingException e) {
       StringBuilder sb = new StringBuilder();
       if (left.getEvalResult() != null) {
-        sb.append(left.getEvalResult());
-        sb.append(operator.toString());
+        sb.append(ChunkResolver.getValueAsJinjavaStringSafe(left.getEvalResult()));
+        sb.append(String.format(" %s ", operator.toString()));
         sb.append(e.getDeferredEvalResult());
       } else {
         sb.append(e.getDeferredEvalResult());
         sb.append(String.format(" %s ", operator.toString()));
         try {
-          sb.append(((AstNode) right).eval(bindings, context));
+          sb.append(
+            ChunkResolver.getValueAsJinjavaStringSafe(
+              ((AstNode) right).eval(bindings, context)
+            )
+          );
         } catch (DeferredParsingException e1) {
           sb.append(e1.getDeferredEvalResult());
         }
       }
       throw new DeferredParsingException(sb.toString());
     }
-    return evalResult;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBinaryDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBinaryDecorator.java
@@ -1,0 +1,65 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import de.odysseus.el.tree.Bindings;
+import de.odysseus.el.tree.impl.ast.AstBinary;
+import de.odysseus.el.tree.impl.ast.AstNode;
+import javax.el.ELContext;
+
+public class EagerAstBinaryDecorator extends AstBinary implements EvalResultHolder {
+  private Object evalResult;
+  private EvalResultHolder left;
+  private EvalResultHolder right;
+  private Operator operator;
+
+  public EagerAstBinaryDecorator(AstNode left, AstNode right, Operator operator) {
+    this(
+      EagerAstNodeDecorator.getAsEvalResultHolder(left),
+      EagerAstNodeDecorator.getAsEvalResultHolder(right),
+      operator
+    );
+  }
+
+  private EagerAstBinaryDecorator(
+    EvalResultHolder left,
+    EvalResultHolder right,
+    Operator operator
+  ) {
+    super((AstNode) left, (AstNode) right, operator);
+    this.left = left;
+    this.right = right;
+    this.operator = operator;
+  }
+
+  @Override
+  public Object eval(Bindings bindings, ELContext context) {
+    if (evalResult != null) {
+      return evalResult;
+    }
+    try {
+      evalResult = super.eval(bindings, context);
+    } catch (DeferredParsingException e) {
+      StringBuilder sb = new StringBuilder();
+      if (left.getEvalResult() != null) {
+        sb.append(left.getEvalResult());
+        sb.append(operator.toString());
+        sb.append(e.getDeferredEvalResult());
+      } else {
+        sb.append(e.getDeferredEvalResult());
+        sb.append(String.format(" %s ", operator.toString()));
+        try {
+          sb.append(((AstNode) right).eval(bindings, context));
+        } catch (DeferredParsingException e1) {
+          sb.append(e1.getDeferredEvalResult());
+        }
+      }
+      throw new DeferredParsingException(sb.toString());
+    }
+    return evalResult;
+  }
+
+  @Override
+  public Object getEvalResult() {
+    return evalResult;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBracketDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBracketDecorator.java
@@ -1,0 +1,73 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import de.odysseus.el.tree.Bindings;
+import de.odysseus.el.tree.impl.ast.AstBracket;
+import de.odysseus.el.tree.impl.ast.AstNode;
+import javax.el.ELContext;
+
+public class EagerAstBracketDecorator extends AstBracket implements EvalResultHolder {
+  private Object evalResult;
+  private final EvalResultHolder base;
+  private final EvalResultHolder property;
+  private final boolean lvalue;
+
+  public EagerAstBracketDecorator(
+    AstNode base,
+    AstNode property,
+    boolean lvalue,
+    boolean strict,
+    boolean ignoreReturnType
+  ) {
+    this(
+      EagerAstNodeDecorator.getAsEvalResultHolder(base),
+      EagerAstNodeDecorator.getAsEvalResultHolder(property),
+      lvalue,
+      strict,
+      ignoreReturnType
+    );
+  }
+
+  private EagerAstBracketDecorator(
+    EvalResultHolder base,
+    EvalResultHolder property,
+    boolean lvalue,
+    boolean strict,
+    boolean ignoreReturnType
+  ) {
+    super((AstNode) base, (AstNode) property, lvalue, strict, ignoreReturnType);
+    this.base = base;
+    this.property = property;
+    this.lvalue = lvalue;
+  }
+
+  @Override
+  public Object eval(Bindings bindings, ELContext context) {
+    if (evalResult != null) {
+      return evalResult;
+    }
+    try {
+      evalResult = super.eval(bindings, context);
+    } catch (DeferredParsingException e) {
+      StringBuilder sb = new StringBuilder();
+      if (base.getEvalResult() != null) {
+        sb.append(base.getEvalResult());
+        sb.append(String.format("[%s]", e.getDeferredEvalResult()));
+      } else {
+        sb.append(e.getDeferredEvalResult());
+        try {
+          sb.append(String.format("[%s]", ((AstNode) property).eval(bindings, context)));
+        } catch (DeferredParsingException e1) {
+          sb.append(String.format("[%s]", e1.getDeferredEvalResult()));
+        }
+      }
+      throw new DeferredParsingException(sb.toString());
+    }
+    return evalResult;
+  }
+
+  @Override
+  public Object getEvalResult() {
+    return evalResult;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoiceDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoiceDecorator.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.util.ChunkResolver;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstChoice;
 import de.odysseus.el.tree.impl.ast.AstNode;
@@ -8,11 +9,10 @@ import javax.el.ELContext;
 import javax.el.ELException;
 
 public class EagerAstChoiceDecorator extends AstChoice implements EvalResultHolder {
-  private Object evalResult;
-
-  private final EvalResultHolder question;
-  private final EvalResultHolder yes;
-  private final EvalResultHolder no;
+  protected Object evalResult;
+  protected final EvalResultHolder question;
+  protected final EvalResultHolder yes;
+  protected final EvalResultHolder no;
 
   public EagerAstChoiceDecorator(AstNode question, AstNode yes, AstNode no) {
     this(
@@ -50,20 +50,28 @@ public class EagerAstChoiceDecorator extends AstChoice implements EvalResultHold
       }
       sb.append(" ? ");
       if (yes.getEvalResult() != null) {
-        sb.append(yes.getEvalResult());
+        sb.append(ChunkResolver.getValueAsJinjavaStringSafe(yes.getEvalResult()));
       } else {
         try {
-          sb.append(((AstNode) yes).eval(bindings, context));
+          sb.append(
+            ChunkResolver.getValueAsJinjavaStringSafe(
+              ((AstNode) yes).eval(bindings, context)
+            )
+          );
         } catch (DeferredParsingException e1) {
           sb.append(e1.getDeferredEvalResult());
         }
       }
       sb.append(" : ");
       if (no.getEvalResult() != null) {
-        sb.append(no.getEvalResult());
+        sb.append(ChunkResolver.getValueAsJinjavaStringSafe(no.getEvalResult()));
       } else {
         try {
-          sb.append(((AstNode) no).eval(bindings, context));
+          sb.append(
+            ChunkResolver.getValueAsJinjavaStringSafe(
+              ((AstNode) no).eval(bindings, context)
+            )
+          );
         } catch (DeferredParsingException e1) {
           sb.append(e1.getDeferredEvalResult());
         }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoiceDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoiceDecorator.java
@@ -1,0 +1,79 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import de.odysseus.el.tree.Bindings;
+import de.odysseus.el.tree.impl.ast.AstChoice;
+import de.odysseus.el.tree.impl.ast.AstNode;
+import javax.el.ELContext;
+import javax.el.ELException;
+
+public class EagerAstChoiceDecorator extends AstChoice implements EvalResultHolder {
+  private Object evalResult;
+
+  private final EvalResultHolder question;
+  private final EvalResultHolder yes;
+  private final EvalResultHolder no;
+
+  public EagerAstChoiceDecorator(AstNode question, AstNode yes, AstNode no) {
+    this(
+      EagerAstNodeDecorator.getAsEvalResultHolder(question),
+      EagerAstNodeDecorator.getAsEvalResultHolder(yes),
+      EagerAstNodeDecorator.getAsEvalResultHolder(no)
+    );
+  }
+
+  private EagerAstChoiceDecorator(
+    EvalResultHolder question,
+    EvalResultHolder yes,
+    EvalResultHolder no
+  ) {
+    super((AstNode) question, (AstNode) yes, (AstNode) no);
+    this.question = question;
+    this.yes = yes;
+    this.no = no;
+  }
+
+  @Override
+  public Object eval(Bindings bindings, ELContext context) throws ELException {
+    if (evalResult != null) {
+      return evalResult;
+    }
+    try {
+      evalResult = super.eval(bindings, context);
+      return evalResult;
+    } catch (DeferredParsingException e) {
+      StringBuilder sb = new StringBuilder();
+      sb.append(e.getDeferredEvalResult());
+      if (question.getEvalResult() != null) {
+        // the question was evaluated so jump to either yes or no
+        throw new DeferredParsingException(sb.toString());
+      }
+      sb.append(" ? ");
+      if (yes.getEvalResult() != null) {
+        sb.append(yes.getEvalResult());
+      } else {
+        try {
+          sb.append(((AstNode) yes).eval(bindings, context));
+        } catch (DeferredParsingException e1) {
+          sb.append(e1.getDeferredEvalResult());
+        }
+      }
+      sb.append(" : ");
+      if (no.getEvalResult() != null) {
+        sb.append(no.getEvalResult());
+      } else {
+        try {
+          sb.append(((AstNode) no).eval(bindings, context));
+        } catch (DeferredParsingException e1) {
+          sb.append(e1.getDeferredEvalResult());
+        }
+      }
+      throw new DeferredParsingException(sb.toString());
+    }
+  }
+
+  @Override
+  public Object getEvalResult() {
+    return evalResult;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstCompositeDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstCompositeDecorator.java
@@ -1,0 +1,3 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+public class EagerAstCompositeDecorator {}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstCompositeDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstCompositeDecorator.java
@@ -1,3 +1,0 @@
-package com.hubspot.jinjava.el.ext.eager;
-
-public class EagerAstCompositeDecorator {}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDictDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDictDecorator.java
@@ -1,0 +1,74 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+import com.hubspot.jinjava.el.ext.AstDict;
+import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.util.ChunkResolver;
+import de.odysseus.el.tree.Bindings;
+import de.odysseus.el.tree.impl.ast.AstNode;
+import java.util.Map;
+import java.util.StringJoiner;
+import javax.el.ELContext;
+
+public class EagerAstDictDecorator extends AstDict implements EvalResultHolder {
+  private Object evalResult;
+
+  public EagerAstDictDecorator(Map<AstNode, AstNode> dict) {
+    super(dict);
+  }
+
+  @Override
+  public Object eval(Bindings bindings, ELContext context) {
+    if (evalResult != null) {
+      return evalResult;
+    }
+    try {
+      evalResult = super.eval(bindings, context);
+      return evalResult;
+    } catch (DeferredParsingException e) {
+      StringJoiner joiner = new StringJoiner(",");
+      dict.forEach(
+        (key, value) -> {
+          StringJoiner kvJoiner = new StringJoiner(":");
+          if (((EvalResultHolder) key).getEvalResult() != null) {
+            kvJoiner.add(
+              ChunkResolver.getValueAsJinjavaStringSafe(
+                ((EvalResultHolder) key).getEvalResult()
+              )
+            );
+          } else {
+            try {
+              kvJoiner.add(
+                ChunkResolver.getValueAsJinjavaStringSafe(key.eval(bindings, context))
+              );
+            } catch (DeferredParsingException e1) {
+              kvJoiner.add(e1.getDeferredEvalResult());
+            }
+          }
+
+          if (((EvalResultHolder) value).getEvalResult() != null) {
+            kvJoiner.add(
+              ChunkResolver.getValueAsJinjavaStringSafe(
+                ((EvalResultHolder) value).getEvalResult()
+              )
+            );
+          } else {
+            try {
+              kvJoiner.add(
+                ChunkResolver.getValueAsJinjavaStringSafe(value.eval(bindings, context))
+              );
+            } catch (DeferredParsingException e1) {
+              kvJoiner.add(e1.getDeferredEvalResult());
+            }
+          }
+          joiner.add(kvJoiner.toString());
+        }
+      );
+      throw new DeferredParsingException(String.format("{%s}", joiner.toString()));
+    }
+  }
+
+  @Override
+  public Object getEvalResult() {
+    return evalResult;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDictDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDictDecorator.java
@@ -26,36 +26,44 @@ public class EagerAstDictDecorator extends AstDict implements EvalResultHolder {
       dict.forEach(
         (key, value) -> {
           StringJoiner kvJoiner = new StringJoiner(":");
-          if (((EvalResultHolder) key).hasEvalResult()) {
-            kvJoiner.add(
-              ChunkResolver.getValueAsJinjavaStringSafe(
-                ((EvalResultHolder) key).getAndClearEvalResult()
-              )
-            );
-          } else {
-            try {
+          if (key instanceof EvalResultHolder) {
+            if (((EvalResultHolder) key).hasEvalResult()) {
               kvJoiner.add(
-                ChunkResolver.getValueAsJinjavaStringSafe(key.eval(bindings, context))
+                ChunkResolver.getValueAsJinjavaStringSafe(
+                  ((EvalResultHolder) key).getAndClearEvalResult()
+                )
               );
-            } catch (DeferredParsingException e1) {
-              kvJoiner.add(e1.getDeferredEvalResult());
+            } else {
+              try {
+                kvJoiner.add(
+                  ChunkResolver.getValueAsJinjavaStringSafe(key.eval(bindings, context))
+                );
+              } catch (DeferredParsingException e1) {
+                kvJoiner.add(e1.getDeferredEvalResult());
+              }
             }
+          } else {
+            kvJoiner.add(key.toString());
           }
 
-          if (((EvalResultHolder) value).hasEvalResult()) {
-            kvJoiner.add(
-              ChunkResolver.getValueAsJinjavaStringSafe(
-                ((EvalResultHolder) value).getAndClearEvalResult()
-              )
-            );
-          } else {
-            try {
+          if (value instanceof EvalResultHolder) {
+            if (((EvalResultHolder) value).hasEvalResult()) {
               kvJoiner.add(
-                ChunkResolver.getValueAsJinjavaStringSafe(value.eval(bindings, context))
+                ChunkResolver.getValueAsJinjavaStringSafe(
+                  ((EvalResultHolder) value).getAndClearEvalResult()
+                )
               );
-            } catch (DeferredParsingException e1) {
-              kvJoiner.add(e1.getDeferredEvalResult());
+            } else {
+              try {
+                kvJoiner.add(
+                  ChunkResolver.getValueAsJinjavaStringSafe(value.eval(bindings, context))
+                );
+              } catch (DeferredParsingException e1) {
+                kvJoiner.add(e1.getDeferredEvalResult());
+              }
             }
+          } else {
+            kvJoiner.add(value.toString());
           }
           joiner.add(kvJoiner.toString());
         }
@@ -64,8 +72,12 @@ public class EagerAstDictDecorator extends AstDict implements EvalResultHolder {
     } finally {
       dict.forEach(
         (key, value) -> {
-          ((EvalResultHolder) key).getAndClearEvalResult();
-          ((EvalResultHolder) value).getAndClearEvalResult();
+          if (key instanceof EvalResultHolder) {
+            ((EvalResultHolder) key).getAndClearEvalResult();
+          }
+          if (value instanceof EvalResultHolder) {
+            ((EvalResultHolder) value).getAndClearEvalResult();
+          }
         }
       );
     }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDotDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDotDecorator.java
@@ -1,3 +1,57 @@
 package com.hubspot.jinjava.el.ext.eager;
 
-public class EagerAstDotDecorator {}
+import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import de.odysseus.el.tree.Bindings;
+import de.odysseus.el.tree.impl.ast.AstDot;
+import de.odysseus.el.tree.impl.ast.AstNode;
+import javax.el.ELContext;
+import javax.el.ELException;
+
+public class EagerAstDotDecorator extends AstDot implements EvalResultHolder {
+  private Object evalResult;
+  private final EvalResultHolder base;
+
+  public EagerAstDotDecorator(
+    AstNode base,
+    String property,
+    boolean lvalue,
+    boolean ignoreReturnType
+  ) {
+    this(
+      EagerAstNodeDecorator.getAsEvalResultHolder(base),
+      property,
+      lvalue,
+      ignoreReturnType
+    );
+  }
+
+  public EagerAstDotDecorator(
+    EvalResultHolder base,
+    String property,
+    boolean lvalue,
+    boolean ignoreReturnType
+  ) {
+    super((AstNode) base, property, lvalue, ignoreReturnType);
+    this.base = base;
+  }
+
+  @Override
+  public Object eval(Bindings bindings, ELContext context) throws ELException {
+    if (evalResult != null) {
+      return evalResult;
+    }
+    try {
+      evalResult = super.eval(bindings, context);
+      return evalResult;
+    } catch (DeferredParsingException e) {
+      throw new DeferredParsingException(
+        String.format("%s.%s", e.getDeferredEvalResult(), this.property)
+      );
+    }
+  }
+
+  @Override
+  public Object getEvalResult() {
+    return evalResult;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDotDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDotDecorator.java
@@ -37,9 +37,6 @@ public class EagerAstDotDecorator extends AstDot implements EvalResultHolder {
 
   @Override
   public Object eval(Bindings bindings, ELContext context) throws ELException {
-    if (evalResult != null) {
-      return evalResult;
-    }
     try {
       evalResult = super.eval(bindings, context);
       return evalResult;
@@ -47,11 +44,20 @@ public class EagerAstDotDecorator extends AstDot implements EvalResultHolder {
       throw new DeferredParsingException(
         String.format("%s.%s", e.getDeferredEvalResult(), this.property)
       );
+    } finally {
+      base.getAndClearEvalResult();
     }
   }
 
   @Override
-  public Object getEvalResult() {
-    return evalResult;
+  public Object getAndClearEvalResult() {
+    Object temp = evalResult;
+    evalResult = null;
+    return temp;
+  }
+
+  @Override
+  public boolean hasEvalResult() {
+    return evalResult != null;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDotDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDotDecorator.java
@@ -10,6 +10,7 @@ import javax.el.ELException;
 public class EagerAstDotDecorator extends AstDot implements EvalResultHolder {
   private Object evalResult;
   private final EvalResultHolder base;
+  private final String property;
 
   public EagerAstDotDecorator(
     AstNode base,
@@ -33,6 +34,7 @@ public class EagerAstDotDecorator extends AstDot implements EvalResultHolder {
   ) {
     super((AstNode) base, property, lvalue, ignoreReturnType);
     this.base = base;
+    this.property = property;
   }
 
   @Override
@@ -59,5 +61,9 @@ public class EagerAstDotDecorator extends AstDot implements EvalResultHolder {
   @Override
   public boolean hasEvalResult() {
     return evalResult != null;
+  }
+
+  public String getProperty() {
+    return property;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDotDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDotDecorator.java
@@ -1,0 +1,3 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+public class EagerAstDotDecorator {}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstFunctionDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstFunctionDecorator.java
@@ -1,3 +1,0 @@
-package com.hubspot.jinjava.el.ext.eager;
-
-public class EagerAstFunctionDecorator {}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstFunctionDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstFunctionDecorator.java
@@ -1,0 +1,3 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+public class EagerAstFunctionDecorator {}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifierDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifierDecorator.java
@@ -1,3 +1,29 @@
 package com.hubspot.jinjava.el.ext.eager;
 
-public class EagerAstIdentifierDecorator {}
+import de.odysseus.el.tree.Bindings;
+import de.odysseus.el.tree.impl.ast.AstIdentifier;
+import javax.el.ELContext;
+
+public class EagerAstIdentifierDecorator
+  extends AstIdentifier
+  implements EvalResultHolder {
+  private Object evalResult;
+
+  public EagerAstIdentifierDecorator(String name, int index, boolean ignoreReturnType) {
+    super(name, index, ignoreReturnType);
+  }
+
+  @Override
+  public Object eval(Bindings bindings, ELContext context) {
+    if (evalResult != null) {
+      return evalResult;
+    }
+    evalResult = super.eval(bindings, context);
+    return evalResult;
+  }
+
+  @Override
+  public Object getEvalResult() {
+    return evalResult;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifierDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifierDecorator.java
@@ -1,0 +1,3 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+public class EagerAstIdentifierDecorator {}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifierDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifierDecorator.java
@@ -15,15 +15,19 @@ public class EagerAstIdentifierDecorator
 
   @Override
   public Object eval(Bindings bindings, ELContext context) {
-    if (evalResult != null) {
-      return evalResult;
-    }
     evalResult = super.eval(bindings, context);
     return evalResult;
   }
 
   @Override
-  public Object getEvalResult() {
-    return evalResult;
+  public Object getAndClearEvalResult() {
+    Object temp = evalResult;
+    evalResult = null;
+    return temp;
+  }
+
+  @Override
+  public boolean hasEvalResult() {
+    return evalResult != null;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstListDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstListDecorator.java
@@ -15,9 +15,6 @@ public class EagerAstListDecorator extends AstList implements EvalResultHolder {
 
   @Override
   public Object eval(Bindings bindings, ELContext context) {
-    if (evalResult != null) {
-      return evalResult;
-    }
     try {
       evalResult = super.eval(bindings, context);
       return evalResult;
@@ -32,11 +29,20 @@ public class EagerAstListDecorator extends AstList implements EvalResultHolder {
       throw new DeferredParsingException(
         String.format("[%s]", e.getDeferredEvalResult())
       );
+    } finally {
+      ((EvalResultHolder) elements).getAndClearEvalResult();
     }
   }
 
   @Override
-  public Object getEvalResult() {
-    return evalResult;
+  public Object getAndClearEvalResult() {
+    Object temp = evalResult;
+    evalResult = null;
+    return temp;
+  }
+
+  @Override
+  public boolean hasEvalResult() {
+    return evalResult != null;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstListDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstListDecorator.java
@@ -1,0 +1,42 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+import com.hubspot.jinjava.el.ext.AstList;
+import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import de.odysseus.el.tree.Bindings;
+import de.odysseus.el.tree.impl.ast.AstParameters;
+import javax.el.ELContext;
+
+public class EagerAstListDecorator extends AstList implements EvalResultHolder {
+  private Object evalResult;
+
+  public EagerAstListDecorator(AstParameters elements) {
+    super(elements);
+  }
+
+  @Override
+  public Object eval(Bindings bindings, ELContext context) {
+    if (evalResult != null) {
+      return evalResult;
+    }
+    try {
+      evalResult = super.eval(bindings, context);
+      return evalResult;
+    } catch (DeferredParsingException e) {
+      try {
+        elements.eval(bindings, context);
+      } catch (DeferredParsingException e1) {
+        throw new DeferredParsingException(
+          String.format("[%s]", e1.getDeferredEvalResult())
+        );
+      }
+      throw new DeferredParsingException(
+        String.format("[%s]", e.getDeferredEvalResult())
+      );
+    }
+  }
+
+  @Override
+  public Object getEvalResult() {
+    return evalResult;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunctionDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunctionDecorator.java
@@ -38,9 +38,6 @@ public class EagerAstMacroFunctionDecorator
 
   @Override
   public Object eval(Bindings bindings, ELContext context) {
-    if (evalResult != null) {
-      return evalResult;
-    }
     try {
       evalResult = super.eval(bindings, context);
       return evalResult;
@@ -59,11 +56,20 @@ public class EagerAstMacroFunctionDecorator
       }
       sb.append(String.format("(%s)", paramString));
       throw new DeferredParsingException(sb.toString());
+    } finally {
+      params.getAndClearEvalResult();
     }
   }
 
   @Override
-  public Object getEvalResult() {
-    return evalResult;
+  public Object getAndClearEvalResult() {
+    Object temp = evalResult;
+    evalResult = null;
+    return temp;
+  }
+
+  @Override
+  public boolean hasEvalResult() {
+    return evalResult != null;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunctionDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunctionDecorator.java
@@ -1,0 +1,69 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+import com.hubspot.jinjava.el.ext.AstMacroFunction;
+import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.interpret.DeferredValueException;
+import com.hubspot.jinjava.util.ChunkResolver;
+import de.odysseus.el.tree.Bindings;
+import de.odysseus.el.tree.impl.ast.AstParameters;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import javax.el.ELContext;
+
+public class EagerAstMacroFunctionDecorator
+  extends AstMacroFunction
+  implements EvalResultHolder {
+  protected Object evalResult;
+  // instanceof AstParameters
+  protected EvalResultHolder params;
+
+  public EagerAstMacroFunctionDecorator(
+    String name,
+    int index,
+    AstParameters params,
+    boolean varargs
+  ) {
+    this(name, index, EagerAstParametersDecorator.getAsEvalResultHolder(params), varargs);
+  }
+
+  private EagerAstMacroFunctionDecorator(
+    String name,
+    int index,
+    EvalResultHolder params,
+    boolean varargs
+  ) {
+    super(name, index, (AstParameters) params, varargs);
+    this.params = params;
+  }
+
+  @Override
+  public Object eval(Bindings bindings, ELContext context) {
+    if (evalResult != null) {
+      return evalResult;
+    }
+    try {
+      evalResult = super.eval(bindings, context);
+      return evalResult;
+    } catch (DeferredValueException e) {
+      StringBuilder sb = new StringBuilder();
+      sb.append(getName());
+      String paramString;
+      try {
+        paramString =
+          Arrays
+            .stream(((AstParameters) params).eval(bindings, context))
+            .map(ChunkResolver::getValueAsJinjavaStringSafe)
+            .collect(Collectors.joining(","));
+      } catch (DeferredParsingException dpe) {
+        paramString = dpe.getDeferredEvalResult();
+      }
+      sb.append(String.format("(%s)", paramString));
+      throw new DeferredParsingException(sb.toString());
+    }
+  }
+
+  @Override
+  public Object getEvalResult() {
+    return evalResult;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethodDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethodDecorator.java
@@ -1,3 +1,78 @@
 package com.hubspot.jinjava.el.ext.eager;
 
-public class EagerAstMethodDecorator {}
+import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.util.ChunkResolver;
+import de.odysseus.el.tree.Bindings;
+import de.odysseus.el.tree.impl.ast.AstMethod;
+import de.odysseus.el.tree.impl.ast.AstParameters;
+import de.odysseus.el.tree.impl.ast.AstProperty;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import javax.el.ELContext;
+
+public class EagerAstMethodDecorator extends AstMethod implements EvalResultHolder {
+  private Object evalResult;
+  // instanceof AstProperty
+  protected final EvalResultHolder property;
+  // instanceof AstParameters
+  protected final EvalResultHolder params;
+
+  public EagerAstMethodDecorator(AstProperty property, AstParameters params) {
+    this(
+      EagerAstNodeDecorator.getAsEvalResultHolder(property),
+      EagerAstParametersDecorator.getAsEvalResultHolder(params)
+    );
+  }
+
+  private EagerAstMethodDecorator(EvalResultHolder property, EvalResultHolder params) {
+    super((AstProperty) property, (AstParameters) params);
+    this.property = property;
+    this.params = params;
+  }
+
+  @Override
+  protected Object eval(
+    Bindings bindings,
+    ELContext context,
+    boolean answerNullIfBaseIsNull
+  ) {
+    if (evalResult != null) {
+      return evalResult;
+    }
+    try {
+      evalResult = super.eval(bindings, context);
+      return evalResult;
+    } catch (DeferredParsingException e) {
+      StringBuilder sb = new StringBuilder();
+      if (property.getEvalResult() != null) {
+        sb.append(ChunkResolver.getValueAsJinjavaStringSafe(property.getEvalResult()));
+      } else {
+        sb.append(e.getDeferredEvalResult());
+        e = null;
+      }
+      String paramString;
+      if (params.getEvalResult() != null) {
+        paramString = ChunkResolver.getValueAsJinjavaStringSafe(params.getEvalResult());
+      } else if (e != null) {
+        paramString = e.getDeferredEvalResult();
+      } else {
+        try {
+          paramString =
+            Arrays
+              .stream(((AstParameters) params).eval(bindings, context))
+              .map(ChunkResolver::getValueAsJinjavaStringSafe)
+              .collect(Collectors.joining(","));
+        } catch (DeferredParsingException e1) {
+          paramString = e1.getDeferredEvalResult();
+        }
+      }
+      sb.append(String.format("(%s)", paramString));
+      throw new DeferredParsingException(sb.toString());
+    }
+  }
+
+  @Override
+  public Object getEvalResult() {
+    return evalResult;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethodDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethodDecorator.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.el.ext.eager;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.util.ChunkResolver;
 import de.odysseus.el.tree.Bindings;
+import de.odysseus.el.tree.impl.ast.AstDot;
 import de.odysseus.el.tree.impl.ast.AstMethod;
 import de.odysseus.el.tree.impl.ast.AstParameters;
 import de.odysseus.el.tree.impl.ast.AstProperty;
@@ -42,7 +43,17 @@ public class EagerAstMethodDecorator extends AstMethod implements EvalResultHold
           ChunkResolver.getValueAsJinjavaStringSafe(property.getAndClearEvalResult())
         );
       } else {
-        sb.append(e.getDeferredEvalResult());
+        if (property instanceof EagerAstDotDecorator) {
+          sb.append(
+            String.format(
+              "%s.%s",
+              e.getDeferredEvalResult(),
+              ((EagerAstDotDecorator) property).getProperty()
+            )
+          );
+        } else {
+          sb.append(e.getDeferredEvalResult());
+        }
         e = null;
       }
       String paramString;

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethodDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethodDecorator.java
@@ -1,0 +1,3 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+public class EagerAstMethodDecorator {}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNestedDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNestedDecorator.java
@@ -1,0 +1,62 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import de.odysseus.el.tree.Bindings;
+import de.odysseus.el.tree.Node;
+import de.odysseus.el.tree.impl.ast.AstNode;
+import de.odysseus.el.tree.impl.ast.AstRightValue;
+import javax.el.ELContext;
+
+/**
+ * AstNested is final so this decorates AstRightValue.
+ */
+public class EagerAstNestedDecorator extends AstRightValue implements EvalResultHolder {
+  private Object evalResult;
+  private final AstNode child;
+
+  public EagerAstNestedDecorator(AstNode child) {
+    this.child = child;
+  }
+
+  @Override
+  public void appendStructure(StringBuilder builder, Bindings bindings) {
+    builder.append("(");
+    child.appendStructure(builder, bindings);
+    builder.append(")");
+  }
+
+  @Override
+  public Object eval(Bindings bindings, ELContext context) {
+    if (evalResult != null) {
+      return evalResult;
+    }
+    try {
+      evalResult = child.eval(bindings, context);
+      return evalResult;
+    } catch (DeferredParsingException e) {
+      throw new DeferredParsingException(
+        String.format("(%s)", e.getDeferredEvalResult())
+      );
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "(...)";
+  }
+
+  @Override
+  public Object getEvalResult() {
+    return evalResult;
+  }
+
+  @Override
+  public int getCardinality() {
+    return 1;
+  }
+
+  @Override
+  public Node getChild(int i) {
+    return i == 0 ? child : null;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNestedDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNestedDecorator.java
@@ -27,9 +27,6 @@ public class EagerAstNestedDecorator extends AstRightValue implements EvalResult
 
   @Override
   public Object eval(Bindings bindings, ELContext context) {
-    if (evalResult != null) {
-      return evalResult;
-    }
     try {
       evalResult = child.eval(bindings, context);
       return evalResult;
@@ -37,6 +34,8 @@ public class EagerAstNestedDecorator extends AstRightValue implements EvalResult
       throw new DeferredParsingException(
         String.format("(%s)", e.getDeferredEvalResult())
       );
+    } finally {
+      ((EvalResultHolder) child).getAndClearEvalResult();
     }
   }
 
@@ -46,8 +45,15 @@ public class EagerAstNestedDecorator extends AstRightValue implements EvalResult
   }
 
   @Override
-  public Object getEvalResult() {
-    return evalResult;
+  public Object getAndClearEvalResult() {
+    Object temp = evalResult;
+    evalResult = null;
+    return temp;
+  }
+
+  @Override
+  public boolean hasEvalResult() {
+    return evalResult != null;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNodeDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNodeDecorator.java
@@ -9,7 +9,7 @@ import javax.el.ValueReference;
 
 public class EagerAstNodeDecorator extends AstNode implements EvalResultHolder {
   private final AstNode astNode;
-  private Object eagerResult;
+  private Object evalResult;
 
   public static EvalResultHolder getAsEvalResultHolder(AstNode astNode) {
     if (astNode instanceof EvalResultHolder) {
@@ -24,7 +24,7 @@ public class EagerAstNodeDecorator extends AstNode implements EvalResultHolder {
 
   @Override
   public Object getEvalResult() {
-    return eagerResult;
+    return evalResult;
   }
 
   @Override
@@ -34,11 +34,11 @@ public class EagerAstNodeDecorator extends AstNode implements EvalResultHolder {
 
   @Override
   public Object eval(Bindings bindings, ELContext elContext) {
-    if (eagerResult != null) {
-      return eagerResult;
+    if (evalResult != null) {
+      return evalResult;
     }
-    eagerResult = astNode.eval(bindings, elContext);
-    return eagerResult;
+    evalResult = astNode.eval(bindings, elContext);
+    return evalResult;
   }
 
   @Override
@@ -94,11 +94,11 @@ public class EagerAstNodeDecorator extends AstNode implements EvalResultHolder {
     Class<?>[] classes,
     Object[] objects
   ) {
-    if (eagerResult != null) {
-      return eagerResult;
+    if (evalResult != null) {
+      return evalResult;
     }
-    eagerResult = astNode.invoke(bindings, elContext, aClass, classes, objects);
-    return eagerResult;
+    evalResult = astNode.invoke(bindings, elContext, aClass, classes, objects);
+    return evalResult;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNodeDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNodeDecorator.java
@@ -1,0 +1,113 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+import de.odysseus.el.tree.Bindings;
+import de.odysseus.el.tree.Node;
+import de.odysseus.el.tree.impl.ast.AstNode;
+import javax.el.ELContext;
+import javax.el.MethodInfo;
+import javax.el.ValueReference;
+
+public class EagerAstNodeDecorator extends AstNode implements EvalResultHolder {
+  private final AstNode astNode;
+  private Object eagerResult;
+
+  public static EvalResultHolder getAsEvalResultHolder(AstNode astNode) {
+    if (astNode instanceof EvalResultHolder) {
+      return (EvalResultHolder) astNode;
+    }
+    return new EagerAstNodeDecorator(astNode);
+  }
+
+  private EagerAstNodeDecorator(AstNode astNode) {
+    this.astNode = astNode;
+  }
+
+  @Override
+  public Object getEvalResult() {
+    return eagerResult;
+  }
+
+  @Override
+  public void appendStructure(StringBuilder stringBuilder, Bindings bindings) {
+    astNode.appendStructure(stringBuilder, bindings);
+  }
+
+  @Override
+  public Object eval(Bindings bindings, ELContext elContext) {
+    if (eagerResult != null) {
+      return eagerResult;
+    }
+    eagerResult = astNode.eval(bindings, elContext);
+    return eagerResult;
+  }
+
+  @Override
+  public boolean isLiteralText() {
+    return astNode.isLiteralText();
+  }
+
+  @Override
+  public boolean isLeftValue() {
+    return astNode.isLeftValue();
+  }
+
+  @Override
+  public boolean isMethodInvocation() {
+    return astNode.isMethodInvocation();
+  }
+
+  @Override
+  public ValueReference getValueReference(Bindings bindings, ELContext elContext) {
+    return astNode.getValueReference(bindings, elContext);
+  }
+
+  @Override
+  public Class<?> getType(Bindings bindings, ELContext elContext) {
+    return astNode.getType(bindings, elContext);
+  }
+
+  @Override
+  public boolean isReadOnly(Bindings bindings, ELContext elContext) {
+    return astNode.isReadOnly(bindings, elContext);
+  }
+
+  @Override
+  public void setValue(Bindings bindings, ELContext elContext, Object o) {
+    astNode.setValue(bindings, elContext, o);
+  }
+
+  @Override
+  public MethodInfo getMethodInfo(
+    Bindings bindings,
+    ELContext elContext,
+    Class<?> aClass,
+    Class<?>[] classes
+  ) {
+    return astNode.getMethodInfo(bindings, elContext, aClass, classes);
+  }
+
+  @Override
+  public Object invoke(
+    Bindings bindings,
+    ELContext elContext,
+    Class<?> aClass,
+    Class<?>[] classes,
+    Object[] objects
+  ) {
+    if (eagerResult != null) {
+      return eagerResult;
+    }
+    eagerResult = astNode.invoke(bindings, elContext, aClass, classes, objects);
+    return eagerResult;
+  }
+
+  @Override
+  public int getCardinality() {
+    return astNode.getCardinality();
+  }
+
+  @Override
+  public Node getChild(int i) {
+    return astNode.getChild(i);
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNodeDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNodeDecorator.java
@@ -23,8 +23,15 @@ public class EagerAstNodeDecorator extends AstNode implements EvalResultHolder {
   }
 
   @Override
-  public Object getEvalResult() {
-    return evalResult;
+  public Object getAndClearEvalResult() {
+    Object temp = evalResult;
+    evalResult = null;
+    return temp;
+  }
+
+  @Override
+  public boolean hasEvalResult() {
+    return evalResult != null;
   }
 
   @Override
@@ -34,9 +41,6 @@ public class EagerAstNodeDecorator extends AstNode implements EvalResultHolder {
 
   @Override
   public Object eval(Bindings bindings, ELContext elContext) {
-    if (evalResult != null) {
-      return evalResult;
-    }
     evalResult = astNode.eval(bindings, elContext);
     return evalResult;
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstParametersDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstParametersDecorator.java
@@ -1,0 +1,90 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.util.ChunkResolver;
+import de.odysseus.el.tree.Bindings;
+import de.odysseus.el.tree.impl.ast.AstNode;
+import de.odysseus.el.tree.impl.ast.AstParameters;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+import javax.el.ELContext;
+
+public class EagerAstParametersDecorator
+  extends AstParameters
+  implements EvalResultHolder {
+  private Object[] evalResult;
+  private final List<AstNode> nodes;
+
+  public EagerAstParametersDecorator(List<AstNode> nodes) {
+    this(
+      nodes
+        .stream()
+        .map(EagerAstNodeDecorator::getAsEvalResultHolder)
+        .map(e -> (AstNode) e)
+        .collect(Collectors.toList()),
+      true
+    );
+  }
+
+  private EagerAstParametersDecorator(
+    List<AstNode> nodes,
+    boolean convertedToEvalResultHolder
+  ) {
+    super(nodes);
+    this.nodes = nodes;
+  }
+
+  public static EvalResultHolder getAsEvalResultHolder(AstParameters astParameters) {
+    if (astParameters instanceof EvalResultHolder) {
+      return (EvalResultHolder) astParameters;
+    }
+    List<AstNode> nodes = new ArrayList<>();
+    for (int i = 0; i < astParameters.getCardinality(); i++) {
+      nodes.add(
+        (AstNode) EagerAstNodeDecorator.getAsEvalResultHolder(astParameters.getChild(i))
+      );
+    }
+    return new EagerAstParametersDecorator(nodes, true);
+  }
+
+  @Override
+  public Object[] eval(Bindings bindings, ELContext context) {
+    if (evalResult != null) {
+      return evalResult;
+    }
+    try {
+      evalResult = super.eval(bindings, context);
+      return evalResult;
+    } catch (DeferredParsingException e) {
+      StringJoiner joiner = new StringJoiner(",");
+      nodes
+        .stream()
+        .map(node -> (EvalResultHolder) node)
+        .forEach(
+          node -> {
+            if (node.getEvalResult() != null) {
+              joiner.add(ChunkResolver.getValueAsJinjavaStringSafe(node.getEvalResult()));
+            } else {
+              try {
+                joiner.add(
+                  ChunkResolver.getValueAsJinjavaStringSafe(
+                    ((AstNode) node).eval(bindings, context)
+                  )
+                );
+              } catch (DeferredParsingException e1) {
+                joiner.add(e1.getDeferredEvalResult());
+              }
+            }
+          }
+        );
+      throw new DeferredParsingException(joiner.toString());
+    }
+  }
+
+  @Override
+  public Object[] getEvalResult() {
+    return evalResult;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstPropertyDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstPropertyDecorator.java
@@ -1,0 +1,69 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+import de.odysseus.el.tree.Bindings;
+import de.odysseus.el.tree.impl.ast.AstNode;
+import de.odysseus.el.tree.impl.ast.AstProperty;
+import javax.el.ELContext;
+import javax.el.ELException;
+
+public class EagerAstPropertyDecorator extends AstProperty implements EvalResultHolder {
+  private Object evalResult;
+  private AstProperty astProperty;
+  protected final AstNode prefix;
+
+  private EagerAstPropertyDecorator(AstProperty astProperty) {
+    this(
+      (AstNode) EagerAstNodeDecorator.getAsEvalResultHolder(astProperty.getChild(0)),
+      astProperty.isLeftValue(),
+      false,
+      false
+    );
+    this.astProperty = astProperty;
+  }
+
+  private EagerAstPropertyDecorator(
+    AstNode prefix,
+    boolean lvalue,
+    boolean strict,
+    boolean ignoreReturnType
+  ) {
+    super(prefix, lvalue, strict, ignoreReturnType);
+    this.prefix = prefix;
+  }
+
+  public static EvalResultHolder getAsEvalResultHolder(AstProperty astProperty) {
+    if (astProperty instanceof EvalResultHolder) {
+      return (EvalResultHolder) astProperty;
+    }
+    return new EagerAstPropertyDecorator(astProperty);
+  }
+
+  @Override
+  public Object eval(Bindings bindings, ELContext context) {
+    if (evalResult != null) {
+      return evalResult;
+    }
+    evalResult = astProperty.eval(bindings, context);
+    return evalResult;
+  }
+
+  @Override
+  public Object getEvalResult() {
+    return evalResult;
+  }
+
+  @Override
+  protected Object getProperty(Bindings bindings, ELContext context) throws ELException {
+    throw new RuntimeException("Not implemented");
+  }
+
+  @Override
+  public void appendStructure(StringBuilder builder, Bindings bindings) {
+    astProperty.appendStructure(builder, bindings);
+  }
+
+  @Override
+  public int getCardinality() {
+    return astProperty.getCardinality();
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstPropertyDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstPropertyDecorator.java
@@ -40,16 +40,24 @@ public class EagerAstPropertyDecorator extends AstProperty implements EvalResult
 
   @Override
   public Object eval(Bindings bindings, ELContext context) {
-    if (evalResult != null) {
+    try {
+      evalResult = astProperty.eval(bindings, context);
       return evalResult;
+    } finally {
+      ((EvalResultHolder) prefix).getAndClearEvalResult();
     }
-    evalResult = astProperty.eval(bindings, context);
-    return evalResult;
   }
 
   @Override
-  public Object getEvalResult() {
-    return evalResult;
+  public Object getAndClearEvalResult() {
+    Object temp = evalResult;
+    evalResult = null;
+    return temp;
+  }
+
+  @Override
+  public boolean hasEvalResult() {
+    return evalResult != null;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstRangeBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstRangeBracket.java
@@ -1,0 +1,97 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+import com.hubspot.jinjava.el.ext.AstRangeBracket;
+import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.util.ChunkResolver;
+import de.odysseus.el.tree.Bindings;
+import de.odysseus.el.tree.impl.ast.AstNode;
+import javax.el.ELContext;
+
+public class EagerAstRangeBracket extends AstRangeBracket implements EvalResultHolder {
+  protected Object evalResult;
+
+  public EagerAstRangeBracket(
+    AstNode base,
+    AstNode rangeStart,
+    AstNode rangeMax,
+    boolean lvalue,
+    boolean strict,
+    boolean ignoreReturnType
+  ) {
+    super(
+      (AstNode) EagerAstNodeDecorator.getAsEvalResultHolder(base),
+      (AstNode) EagerAstNodeDecorator.getAsEvalResultHolder(rangeStart),
+      (AstNode) EagerAstNodeDecorator.getAsEvalResultHolder(rangeMax),
+      lvalue,
+      strict,
+      ignoreReturnType
+    );
+  }
+
+  @Override
+  public Object eval(Bindings bindings, ELContext context) {
+    if (evalResult != null) {
+      return evalResult;
+    }
+    try {
+      evalResult = super.eval(bindings, context);
+      return evalResult;
+    } catch (DeferredParsingException e) {
+      StringBuilder sb = new StringBuilder();
+      if (((EvalResultHolder) prefix).getEvalResult() != null) {
+        sb.append(
+          ChunkResolver.getValueAsJinjavaStringSafe(
+            ((EvalResultHolder) prefix).getEvalResult()
+          )
+        );
+      } else {
+        sb.append(e.getDeferredEvalResult());
+        e = null;
+      }
+      sb.append("[");
+      if (((EvalResultHolder) property).getEvalResult() != null) {
+        sb.append(
+          ChunkResolver.getValueAsJinjavaStringSafe(
+            ((EvalResultHolder) property).getEvalResult()
+          )
+        );
+      } else if (e != null) {
+        sb.append(e.getDeferredEvalResult());
+        e = null;
+      } else {
+        try {
+          sb.append(
+            ChunkResolver.getValueAsJinjavaStringSafe(property.eval(bindings, context))
+          );
+        } catch (DeferredParsingException e1) {
+          sb.append(e1.getDeferredEvalResult());
+        }
+      }
+      sb.append(":");
+      if (((EvalResultHolder) rangeMax).getEvalResult() != null) {
+        sb.append(
+          ChunkResolver.getValueAsJinjavaStringSafe(
+            ((EvalResultHolder) rangeMax).getEvalResult()
+          )
+        );
+      } else if (e != null) {
+        sb.append(e.getDeferredEvalResult());
+      } else {
+        try {
+          sb.append(
+            ChunkResolver.getValueAsJinjavaStringSafe(rangeMax.eval(bindings, context))
+          );
+        } catch (DeferredParsingException e1) {
+          sb.append(e1.getDeferredEvalResult());
+        }
+      }
+      sb.append("]");
+      throw new DeferredParsingException(sb.toString());
+    }
+  }
+
+  @Override
+  public Object getEvalResult() {
+    return evalResult;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstRangeBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstRangeBracket.java
@@ -30,18 +30,15 @@ public class EagerAstRangeBracket extends AstRangeBracket implements EvalResultH
 
   @Override
   public Object eval(Bindings bindings, ELContext context) {
-    if (evalResult != null) {
-      return evalResult;
-    }
     try {
       evalResult = super.eval(bindings, context);
       return evalResult;
     } catch (DeferredParsingException e) {
       StringBuilder sb = new StringBuilder();
-      if (((EvalResultHolder) prefix).getEvalResult() != null) {
+      if (((EvalResultHolder) prefix).hasEvalResult()) {
         sb.append(
           ChunkResolver.getValueAsJinjavaStringSafe(
-            ((EvalResultHolder) prefix).getEvalResult()
+            ((EvalResultHolder) prefix).getAndClearEvalResult()
           )
         );
       } else {
@@ -49,10 +46,10 @@ public class EagerAstRangeBracket extends AstRangeBracket implements EvalResultH
         e = null;
       }
       sb.append("[");
-      if (((EvalResultHolder) property).getEvalResult() != null) {
+      if (((EvalResultHolder) property).hasEvalResult()) {
         sb.append(
           ChunkResolver.getValueAsJinjavaStringSafe(
-            ((EvalResultHolder) property).getEvalResult()
+            ((EvalResultHolder) property).getAndClearEvalResult()
           )
         );
       } else if (e != null) {
@@ -68,10 +65,10 @@ public class EagerAstRangeBracket extends AstRangeBracket implements EvalResultH
         }
       }
       sb.append(":");
-      if (((EvalResultHolder) rangeMax).getEvalResult() != null) {
+      if (((EvalResultHolder) rangeMax).hasEvalResult()) {
         sb.append(
           ChunkResolver.getValueAsJinjavaStringSafe(
-            ((EvalResultHolder) rangeMax).getEvalResult()
+            ((EvalResultHolder) rangeMax).getAndClearEvalResult()
           )
         );
       } else if (e != null) {
@@ -87,11 +84,21 @@ public class EagerAstRangeBracket extends AstRangeBracket implements EvalResultH
       }
       sb.append("]");
       throw new DeferredParsingException(sb.toString());
+    } finally {
+      ((EvalResultHolder) prefix).getAndClearEvalResult();
+      ((EvalResultHolder) property).getAndClearEvalResult();
     }
   }
 
   @Override
-  public Object getEvalResult() {
-    return evalResult;
+  public Object getAndClearEvalResult() {
+    Object temp = evalResult;
+    evalResult = null;
+    return temp;
+  }
+
+  @Override
+  public boolean hasEvalResult() {
+    return evalResult != null;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstTupleDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstTupleDecorator.java
@@ -1,0 +1,42 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+import com.hubspot.jinjava.el.ext.AstTuple;
+import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import de.odysseus.el.tree.Bindings;
+import de.odysseus.el.tree.impl.ast.AstParameters;
+import javax.el.ELContext;
+
+public class EagerAstTupleDecorator extends AstTuple implements EvalResultHolder {
+  private Object evalResult;
+
+  public EagerAstTupleDecorator(AstParameters elements) {
+    super(elements);
+  }
+
+  @Override
+  public Object eval(Bindings bindings, ELContext context) {
+    if (evalResult != null) {
+      return evalResult;
+    }
+    try {
+      evalResult = super.eval(bindings, context);
+      return evalResult;
+    } catch (DeferredParsingException e) {
+      try {
+        elements.eval(bindings, context);
+      } catch (DeferredParsingException e1) {
+        throw new DeferredParsingException(
+          String.format("[%s]", e1.getDeferredEvalResult())
+        );
+      }
+      throw new DeferredParsingException(
+        String.format("[%s]", e.getDeferredEvalResult())
+      );
+    }
+  }
+
+  @Override
+  public Object getEvalResult() {
+    return evalResult;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstTupleDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstTupleDecorator.java
@@ -15,9 +15,6 @@ public class EagerAstTupleDecorator extends AstTuple implements EvalResultHolder
 
   @Override
   public Object eval(Bindings bindings, ELContext context) {
-    if (evalResult != null) {
-      return evalResult;
-    }
     try {
       evalResult = super.eval(bindings, context);
       return evalResult;
@@ -32,11 +29,20 @@ public class EagerAstTupleDecorator extends AstTuple implements EvalResultHolder
       throw new DeferredParsingException(
         String.format("[%s]", e.getDeferredEvalResult())
       );
+    } finally {
+      ((EvalResultHolder) elements).getAndClearEvalResult();
     }
   }
 
   @Override
-  public Object getEvalResult() {
-    return evalResult;
+  public Object getAndClearEvalResult() {
+    Object temp = evalResult;
+    evalResult = null;
+    return temp;
+  }
+
+  @Override
+  public boolean hasEvalResult() {
+    return evalResult != null;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstUnaryDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstUnaryDecorator.java
@@ -24,26 +24,34 @@ public class EagerAstUnaryDecorator extends AstUnary implements EvalResultHolder
 
   @Override
   public Object eval(Bindings bindings, ELContext context) {
-    if (evalResult != null) {
-      return evalResult;
-    }
     try {
       evalResult = super.eval(bindings, context);
+      return evalResult;
     } catch (DeferredParsingException e) {
       StringBuilder sb = new StringBuilder();
       sb.append(operator.toString());
-      if (child.getEvalResult() != null) {
-        sb.append(ChunkResolver.getValueAsJinjavaStringSafe(child.getEvalResult()));
+      if (child.hasEvalResult()) {
+        sb.append(
+          ChunkResolver.getValueAsJinjavaStringSafe(child.getAndClearEvalResult())
+        );
       } else {
         sb.append(e.getDeferredEvalResult());
       }
       throw new DeferredParsingException(sb.toString());
+    } finally {
+      child.getAndClearEvalResult();
     }
-    return evalResult;
   }
 
   @Override
-  public Object getEvalResult() {
-    return evalResult;
+  public Object getAndClearEvalResult() {
+    Object temp = evalResult;
+    evalResult = null;
+    return temp;
+  }
+
+  @Override
+  public boolean hasEvalResult() {
+    return evalResult != null;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstUnaryDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstUnaryDecorator.java
@@ -1,0 +1,3 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+public class EagerAstUnaryDecorator {}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstUnaryDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstUnaryDecorator.java
@@ -1,3 +1,49 @@
 package com.hubspot.jinjava.el.ext.eager;
 
-public class EagerAstUnaryDecorator {}
+import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.util.ChunkResolver;
+import de.odysseus.el.tree.Bindings;
+import de.odysseus.el.tree.impl.ast.AstNode;
+import de.odysseus.el.tree.impl.ast.AstUnary;
+import javax.el.ELContext;
+
+public class EagerAstUnaryDecorator extends AstUnary implements EvalResultHolder {
+  private Object evalResult;
+  protected final EvalResultHolder child;
+  protected final Operator operator;
+
+  public EagerAstUnaryDecorator(AstNode child, Operator operator) {
+    this(EagerAstNodeDecorator.getAsEvalResultHolder(child), operator);
+  }
+
+  private EagerAstUnaryDecorator(EvalResultHolder child, Operator operator) {
+    super((AstNode) child, operator);
+    this.child = child;
+    this.operator = operator;
+  }
+
+  @Override
+  public Object eval(Bindings bindings, ELContext context) {
+    if (evalResult != null) {
+      return evalResult;
+    }
+    try {
+      evalResult = super.eval(bindings, context);
+    } catch (DeferredParsingException e) {
+      StringBuilder sb = new StringBuilder();
+      sb.append(operator.toString());
+      if (child.getEvalResult() != null) {
+        sb.append(ChunkResolver.getValueAsJinjavaStringSafe(child.getEvalResult()));
+      } else {
+        sb.append(e.getDeferredEvalResult());
+      }
+      throw new DeferredParsingException(sb.toString());
+    }
+    return evalResult;
+  }
+
+  @Override
+  public Object getEvalResult() {
+    return evalResult;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerExtendedParser.java
@@ -1,0 +1,150 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+import com.hubspot.jinjava.el.ext.AstDict;
+import com.hubspot.jinjava.el.ext.AstList;
+import com.hubspot.jinjava.el.ext.AstRangeBracket;
+import com.hubspot.jinjava.el.ext.AstTuple;
+import com.hubspot.jinjava.el.ext.ExtendedParser;
+import de.odysseus.el.tree.impl.Builder;
+import de.odysseus.el.tree.impl.Builder.Feature;
+import de.odysseus.el.tree.impl.Scanner.ScanException;
+import de.odysseus.el.tree.impl.ast.AstBinary;
+import de.odysseus.el.tree.impl.ast.AstBinary.Operator;
+import de.odysseus.el.tree.impl.ast.AstBracket;
+import de.odysseus.el.tree.impl.ast.AstChoice;
+import de.odysseus.el.tree.impl.ast.AstDot;
+import de.odysseus.el.tree.impl.ast.AstFunction;
+import de.odysseus.el.tree.impl.ast.AstIdentifier;
+import de.odysseus.el.tree.impl.ast.AstMethod;
+import de.odysseus.el.tree.impl.ast.AstNode;
+import de.odysseus.el.tree.impl.ast.AstParameters;
+import de.odysseus.el.tree.impl.ast.AstProperty;
+import de.odysseus.el.tree.impl.ast.AstRightValue;
+import de.odysseus.el.tree.impl.ast.AstUnary;
+import java.util.List;
+import java.util.Map;
+
+public class EagerExtendedParser extends ExtendedParser {
+
+  public EagerExtendedParser(Builder context, String input) {
+    super(context, input);
+  }
+
+  @Override
+  protected AstBinary createAstBinary(AstNode left, AstNode right, Operator operator) {
+    return new EagerAstBinaryDecorator(left, right, operator);
+  }
+
+  @Override
+  protected AstBracket createAstBracket(
+    AstNode base,
+    AstNode property,
+    boolean lvalue,
+    boolean strict
+  ) {
+    return new EagerAstBracketDecorator(
+      base,
+      property,
+      lvalue,
+      strict,
+      this.context.isEnabled(Feature.IGNORE_RETURN_TYPE)
+    );
+  }
+
+  @Override
+  protected AstFunction createAstFunction(String name, int index, AstParameters params) {
+    return new EagerAstMacroFunctionDecorator(
+      name,
+      index,
+      params,
+      context.isEnabled(Feature.VARARGS)
+    );
+  }
+
+  @Override
+  protected AstChoice createAstChoice(AstNode question, AstNode yes, AstNode no) {
+    return new EagerAstChoiceDecorator(question, yes, no);
+  }
+
+  //  @Override
+  //  protected AstComposite createAstComposite(List<AstNode> nodes) {
+  //    return new AstComposite(nodes);
+  //  }
+
+  @Override
+  protected AstDot createAstDot(AstNode base, String property, boolean lvalue) {
+    return new EagerAstDotDecorator(
+      base,
+      property,
+      lvalue,
+      this.context.isEnabled(Feature.IGNORE_RETURN_TYPE)
+    );
+  }
+
+  @Override
+  protected AstIdentifier createAstIdentifier(String name, int index) {
+    return new EagerAstIdentifierDecorator(
+      name,
+      index,
+      this.context.isEnabled(Feature.IGNORE_RETURN_TYPE)
+    );
+  }
+
+  @Override
+  protected AstMethod createAstMethod(AstProperty property, AstParameters params) {
+    return new EagerAstMethodDecorator(property, params);
+  }
+
+  @Override
+  protected AstUnary createAstUnary(
+    AstNode child,
+    de.odysseus.el.tree.impl.ast.AstUnary.Operator operator
+  ) {
+    return new EagerAstUnaryDecorator(child, operator);
+  }
+
+  @Override
+  protected AstRangeBracket createAstRangeBracket(
+    AstNode base,
+    AstNode rangeStart,
+    AstNode rangeMax,
+    boolean lvalue,
+    boolean strict
+  ) {
+    return new EagerAstRangeBracket(
+      base,
+      rangeStart,
+      rangeMax,
+      lvalue,
+      strict,
+      context.isEnabled(Feature.IGNORE_RETURN_TYPE)
+    );
+  }
+
+  @Override
+  protected AstDict createAstDict(Map<AstNode, AstNode> dict) {
+    return new EagerAstDictDecorator(dict);
+  }
+
+  @Override
+  protected AstRightValue createAstNested(AstNode node) {
+    return new EagerAstNestedDecorator(node);
+  }
+
+  @Override
+  protected AstTuple createAstTuple(AstParameters parameters)
+    throws ScanException, ParseException {
+    return new EagerAstTupleDecorator(parameters);
+  }
+
+  @Override
+  protected AstList createAstList(AstParameters parameters)
+    throws ScanException, ParseException {
+    return new EagerAstListDecorator(parameters);
+  }
+
+  @Override
+  protected AstParameters createAstParameters(List<AstNode> nodes) {
+    return new EagerAstParametersDecorator(nodes);
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerExtendedSyntaxBuilder.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerExtendedSyntaxBuilder.java
@@ -1,0 +1,21 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+import com.hubspot.jinjava.el.ExtendedSyntaxBuilder;
+import com.hubspot.jinjava.el.ext.ExtendedParser;
+import de.odysseus.el.tree.impl.Parser;
+
+public class EagerExtendedSyntaxBuilder extends ExtendedSyntaxBuilder {
+
+  public EagerExtendedSyntaxBuilder() {
+    super();
+  }
+
+  public EagerExtendedSyntaxBuilder(Feature... features) {
+    super(features);
+  }
+
+  @Override
+  protected Parser createParser(String expression) {
+    return new EagerExtendedParser(this, expression);
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
@@ -1,0 +1,5 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+public interface EvalResultHolder {
+  Object getEvalResult();
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
@@ -1,5 +1,10 @@
 package com.hubspot.jinjava.el.ext.eager;
 
+import de.odysseus.el.tree.Bindings;
+import javax.el.ELContext;
+
 public interface EvalResultHolder {
   Object getEvalResult();
+
+  Object eval(Bindings bindings, ELContext elContext);
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
@@ -4,7 +4,9 @@ import de.odysseus.el.tree.Bindings;
 import javax.el.ELContext;
 
 public interface EvalResultHolder {
-  Object getEvalResult();
+  Object getAndClearEvalResult();
+
+  boolean hasEvalResult();
 
   Object eval(Bindings bindings, ELContext elContext);
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -93,6 +93,7 @@ public class Context extends ScopeMap<String, Object> {
   private final Stack<String> renderStack = new Stack<>();
 
   private boolean validationMode = false;
+  private boolean isHideInterpreterErrors = false;
 
   public Context() {
     this(null, null, null);
@@ -525,5 +526,13 @@ public class Context extends ScopeMap<String, Object> {
 
   public SetMultimap<String, String> getDependencies() {
     return this.dependencies;
+  }
+
+  public boolean isHideInterpreterErrors() {
+    return isHideInterpreterErrors;
+  }
+
+  public void setHideInterpreterErrors(boolean hideInterpreterErrors) {
+    isHideInterpreterErrors = hideInterpreterErrors;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Multimap;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.el.ExpressionResolver;
+import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
@@ -401,7 +402,8 @@ public class JinjavaInterpreter {
     Object obj = context.get(varName);
     if (obj != null) {
       if (obj instanceof DeferredValue) {
-        throw new DeferredValueException(variable, lineNumber, startPosition);
+        throw new DeferredParsingException(variable);
+        //        throw new DeferredValueException(variable, lineNumber, startPosition);
       }
       obj = var.resolve(obj);
     }

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -402,6 +402,7 @@ public class JinjavaInterpreter {
     Object obj = context.get(varName);
     if (obj != null) {
       if (obj instanceof DeferredValue) {
+        // TODO add a flag to toggle which is thrown
         throw new DeferredParsingException(variable);
         //        throw new DeferredValueException(variable, lineNumber, startPosition);
       }

--- a/src/main/java/com/hubspot/jinjava/objects/date/JsonPyishDateSerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/JsonPyishDateSerializer.java
@@ -1,0 +1,24 @@
+package com.hubspot.jinjava.objects.date;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.time.format.DateTimeFormatter;
+
+public class JsonPyishDateSerializer extends JsonSerializer<PyishDate> {
+
+  @Override
+  public void serialize(
+    PyishDate pyishDate,
+    JsonGenerator jsonGenerator,
+    SerializerProvider serializerProvider
+  )
+    throws IOException {
+    jsonGenerator.writeString(
+      DateTimeFormatter
+        .ofPattern(PyishDate.PYISH_DATE_FORMAT)
+        .format(pyishDate.toDateTime())
+    );
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.math.NumberUtils;
  */
 public final class PyishDate extends Date implements Serializable, PyWrapper {
   private static final long serialVersionUID = 1L;
+  public static final String PYISH_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
 
   private final ZonedDateTime date;
 
@@ -102,7 +103,7 @@ public final class PyishDate extends Date implements Serializable, PyWrapper {
 
   @Override
   public String toString() {
-    return strftime("yyyy-MM-dd HH:mm:ss");
+    return strftime(PYISH_DATE_FORMAT);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -136,15 +136,8 @@ public class ChunkResolver {
    * Rather than concatenating the chunks, they are split by mini-chunks,
    * with the comma splitter ommitted from the list of results.
    * Therefore an expression of "1, 1 + 1, 1 + range(deferred)" becomes a List of ["1", "2", "1 + range(deferred)"].
-   * Tokens are resolved within "chunks" where a chunk is surrounded by a markers
-   * of {}, [], (). The contents inside of a chunk are split by whitespace
-   * and/or comma, and these "tokens" resolved individually.
    *
-   * The main chunk itself does not get resolved.
-   * e.g.
-   *  `false || (foo), 'bar'` -> `true, 'bar'`
-   *  `[(foo == bar), deferred, bar]` -> `[true,deferred,'hello']`
-   * @return String with chunk layers within it being partially or fully resolved.
+   * @return List of the expression chunk which is split into mini-chunks.
    */
   public List<String> splitChunks() {
     nextPos = 0;

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -272,6 +273,14 @@ public class ChunkResolver {
     } catch (Exception e) {
       deferredWords.addAll(findDeferredWords(chunk));
       return chunk.trim();
+    }
+  }
+
+  public static String getValueAsJinjavaStringSafe(Object val) {
+    try {
+      return getValueAsJinjavaString(val);
+    } catch (JsonProcessingException e) {
+      return Objects.toString(val, "");
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -13,7 +13,6 @@ import com.hubspot.jinjava.objects.date.PyishDate;
 import com.hubspot.jinjava.tree.parse.Token;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -87,7 +86,6 @@ public class ChunkResolver {
   private final JinjavaInterpreter interpreter;
   private final Set<String> deferredWords;
 
-  private boolean useMiniChunks = true;
   private int nextPos = 0;
   private char prevChar = 0;
   private boolean inQuote = false;
@@ -99,18 +97,6 @@ public class ChunkResolver {
     this.token = token;
     this.interpreter = interpreter;
     deferredWords = new HashSet<>();
-  }
-
-  /**
-   * use Comma as token/mini chunk split or not true use it; false don't use it.
-   *
-   * @param onOrOff
-   *          flag to indicate whether or not to split on commas
-   * @return this instance for method chaining
-   */
-  public ChunkResolver useMiniChunks(boolean onOrOff) {
-    useMiniChunks = onOrOff;
-    return this;
   }
 
   /**
@@ -168,14 +154,10 @@ public class ChunkResolver {
     try {
       interpreter.getContext().setHideInterpreterErrors(true);
       List<String> miniChunks = getChunk(null);
-      if (useMiniChunks) {
-        return miniChunks
-          .stream()
-          .filter(s -> s.length() > 1 || !isMiniChunkSplitter(s.charAt(0)))
-          .collect(Collectors.toList());
-      } else {
-        return Collections.singletonList(String.join("", miniChunks));
-      }
+      return miniChunks
+        .stream()
+        .filter(s -> s.length() > 1 || !isMiniChunkSplitter(s.charAt(0)))
+        .collect(Collectors.toList());
     } finally {
       interpreter.getContext().setHideInterpreterErrors(isHideInterpreterErrorsStart);
     }
@@ -241,7 +223,7 @@ public class ChunkResolver {
   }
 
   private boolean isMiniChunkSplitter(char c) {
-    return useMiniChunks && c == ',';
+    return c == ',';
   }
 
   private String resolveToken(String token) {

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -1,0 +1,380 @@
+package com.hubspot.jinjava.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.hubspot.jinjava.interpret.DeferredValueException;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.UnknownTokenException;
+import com.hubspot.jinjava.objects.date.JsonPyishDateSerializer;
+import com.hubspot.jinjava.objects.date.PyishDate;
+import com.hubspot.jinjava.tree.parse.Token;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * This class takes a string and resolves it in chunks. This allows for
+ * strings with deferred values within them to be partially resolved, as much
+ * as they can be with a deferred value.
+ * E.g with foo=3, bar=2:
+ *   "range(0,foo)[-1] + deferred/bar" -> "2 + deferred/2"
+ * This class is not thread-safe. Do not reuse between threads.
+ */
+public class ChunkResolver {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+  .registerModule(
+      new SimpleModule().addSerializer(PyishDate.class, new JsonPyishDateSerializer())
+    );
+
+  private static final Set<String> RESERVED_KEYWORDS = ImmutableSet.of(
+    "and",
+    "block",
+    "cycle",
+    "elif",
+    "else",
+    "endblock",
+    "endfilter",
+    "endfor",
+    "endif",
+    "endmacro",
+    "endraw",
+    "endtrans",
+    "extends",
+    "filter",
+    "for",
+    "if",
+    "in",
+    "include",
+    "is",
+    "macro",
+    "not",
+    "or",
+    "pluralize",
+    "print",
+    "raw",
+    "recursive",
+    "set",
+    "trans",
+    "call",
+    "endcall",
+    "__macros__"
+  );
+
+  // ( -> )
+  // { -> }
+  // [ -> ]
+  private static final Map<Character, Character> CHUNK_LEVEL_MARKER_MAP = ImmutableMap.of(
+    '(',
+    ')',
+    '{',
+    '}',
+    '[',
+    ']'
+  );
+
+  private final char[] value;
+  private final int length;
+  private final Token token;
+  private final JinjavaInterpreter interpreter;
+  private final Set<String> deferredWords;
+
+  private boolean useMiniChunks = true;
+  private int nextPos = 0;
+  private char prevChar = 0;
+  private boolean inQuote = false;
+  private char quoteChar = 0;
+
+  public ChunkResolver(String s, Token token, JinjavaInterpreter interpreter) {
+    value = s.toCharArray();
+    length = value.length;
+    this.token = token;
+    this.interpreter = interpreter;
+    deferredWords = new HashSet<>();
+  }
+
+  /**
+   * use Comma as token/mini chunk split or not true use it; false don't use it.
+   *
+   * @param onOrOff
+   *          flag to indicate whether or not to split on commas
+   * @return this instance for method chaining
+   */
+  public ChunkResolver useMiniChunks(boolean onOrOff) {
+    useMiniChunks = onOrOff;
+    return this;
+  }
+
+  /**
+   * @return Any deferred words that were encountered.
+   */
+  public Set<String> getDeferredWords() {
+    return deferredWords;
+  }
+
+  /**
+   * Chunkify and resolve variables and expressions within the string.
+   * Tokens are resolved within "chunks" where a chunk is surrounded by a markers
+   * of {}, [], (). The contents inside of a chunk are split by whitespace
+   * and/or comma, and these "tokens" resolved individually.
+   *
+   * The main chunk itself does not get resolved.
+   * e.g.
+   *  `false || (foo), 'bar'` -> `true, 'bar'`
+   *  `[(foo == bar), deferred, bar]` -> `[true,deferred,'hello']`
+   * @return String with chunk layers within it being partially or fully resolved.
+   */
+  public String resolveChunks() {
+    nextPos = 0;
+    boolean isHideInterpreterErrorsStart = interpreter
+      .getContext()
+      .isHideInterpreterErrors();
+    try {
+      interpreter.getContext().setHideInterpreterErrors(true);
+      return String.join("", getChunk(null));
+    } finally {
+      interpreter.getContext().setHideInterpreterErrors(isHideInterpreterErrorsStart);
+    }
+  }
+
+  /**
+   * Chunkify and resolve variables and expressions within the string.
+   * Rather than concatenating the chunks, they are split by mini-chunks,
+   * with the comma splitter ommitted from the list of results.
+   * Therefore an expression of "1, 1 + 1, 1 + range(deferred)" becomes a List of ["1", "2", "1 + range(deferred)"].
+   * Tokens are resolved within "chunks" where a chunk is surrounded by a markers
+   * of {}, [], (). The contents inside of a chunk are split by whitespace
+   * and/or comma, and these "tokens" resolved individually.
+   *
+   * The main chunk itself does not get resolved.
+   * e.g.
+   *  `false || (foo), 'bar'` -> `true, 'bar'`
+   *  `[(foo == bar), deferred, bar]` -> `[true,deferred,'hello']`
+   * @return String with chunk layers within it being partially or fully resolved.
+   */
+  public List<String> splitChunks() {
+    nextPos = 0;
+    boolean isHideInterpreterErrorsStart = interpreter
+      .getContext()
+      .isHideInterpreterErrors();
+    try {
+      interpreter.getContext().setHideInterpreterErrors(true);
+      List<String> miniChunks = getChunk(null);
+      if (useMiniChunks) {
+        return miniChunks
+          .stream()
+          .filter(s -> s.length() > 1 || !isMiniChunkSplitter(s.charAt(0)))
+          .collect(Collectors.toList());
+      } else {
+        return Collections.singletonList(String.join("", miniChunks));
+      }
+    } finally {
+      interpreter.getContext().setHideInterpreterErrors(isHideInterpreterErrorsStart);
+    }
+  }
+
+  /**
+   *  e.g. `[0, foo + bar]`:
+   *     `0, foo + bar` is a chunk
+   *     `0` and `foo + bar` are mini chunks
+   *     `0`, `,`, ` `, `foo`, ` `, `+`, ` `, and `bar` are the tokens
+   * @param chunkLevelMarker the marker `(`, `[`, `{` that started this chunk
+   * @return the resolved chunk
+   */
+  private List<String> getChunk(Character chunkLevelMarker) {
+    List<String> chunks = new ArrayList<>();
+    // Mini chunks are split by commas.
+    StringBuilder miniChunkBuilder = new StringBuilder();
+    StringBuilder tokenBuilder = new StringBuilder();
+    while (nextPos < length) {
+      char c = value[nextPos++];
+      if (inQuote) {
+        if (c == quoteChar && prevChar != '\\') {
+          inQuote = false;
+        }
+      } else if ((c == '\'' || c == '"') && prevChar != '\\') {
+        inQuote = true;
+        quoteChar = c;
+      } else if (
+        chunkLevelMarker != null && CHUNK_LEVEL_MARKER_MAP.get(chunkLevelMarker) == c
+      ) {
+        prevChar = c;
+        break;
+      } else if (CHUNK_LEVEL_MARKER_MAP.containsKey(c)) {
+        prevChar = c;
+        tokenBuilder.append(c);
+        tokenBuilder.append(resolveChunk(String.join("", getChunk(c))));
+        tokenBuilder.append(prevChar);
+        continue;
+      } else if (isTokenSplitter(c)) {
+        prevChar = c;
+
+        miniChunkBuilder.append(resolveToken(tokenBuilder.toString()));
+        tokenBuilder = new StringBuilder();
+        if (isMiniChunkSplitter(c)) {
+          chunks.add(resolveChunk(miniChunkBuilder.toString()));
+          chunks.add(String.valueOf(c));
+          miniChunkBuilder = new StringBuilder();
+        } else {
+          miniChunkBuilder.append(c);
+        }
+        continue;
+      }
+      prevChar = c;
+      tokenBuilder.append(c);
+    }
+    miniChunkBuilder.append(resolveToken(tokenBuilder.toString()));
+    chunks.add(resolveChunk(miniChunkBuilder.toString()));
+    return chunks;
+  }
+
+  private boolean isTokenSplitter(char c) {
+    return (!Character.isLetterOrDigit(c) && c != '_' && c != '.');
+  }
+
+  private boolean isMiniChunkSplitter(char c) {
+    return useMiniChunks && c == ',';
+  }
+
+  private String resolveToken(String token) {
+    if (StringUtils.isBlank(token)) {
+      return "";
+    }
+    try {
+      String resolvedToken;
+      if (WhitespaceUtils.isQuoted(token) || RESERVED_KEYWORDS.contains(token)) {
+        resolvedToken = token;
+      } else {
+        Object val = interpreter.retraceVariable(
+          token,
+          this.token.getLineNumber(),
+          this.token.getStartPosition()
+        );
+        if (val == null) {
+          try {
+            val = interpreter.resolveELExpression(token, this.token.getLineNumber());
+          } catch (UnknownTokenException e) {
+            // val is still null
+          }
+        }
+        if (val == null) {
+          resolvedToken = token;
+        } else {
+          resolvedToken = getValueAsJinjavaString(val);
+        }
+      }
+      return resolvedToken.trim();
+    } catch (DeferredValueException | JsonProcessingException e) {
+      deferredWords.addAll(findDeferredWords(token));
+      return token.trim();
+    }
+  }
+
+  // Try resolving the chunk/mini chunk as an ELExpression
+  private String resolveChunk(String chunk) {
+    if (StringUtils.isBlank(chunk)) {
+      return "";
+    } else if (RESERVED_KEYWORDS.contains(chunk)) {
+      return chunk;
+    }
+    try {
+      String resolvedChunk;
+      Object val = interpreter.resolveELExpression(chunk, token.getLineNumber());
+      if (val == null) {
+        resolvedChunk = chunk;
+      } else {
+        resolvedChunk = getValueAsJinjavaString(val);
+      }
+      return resolvedChunk.trim();
+    } catch (Exception e) {
+      deferredWords.addAll(findDeferredWords(chunk));
+      return chunk.trim();
+    }
+  }
+
+  public static String getValueAsJinjavaString(Object val)
+    throws JsonProcessingException {
+    return OBJECT_MAPPER
+      .writeValueAsString(val)
+      .replaceAll("(?<!\\\\)(?:\\\\\\\\)*(\\\\n)", "\n")
+      .replaceAll("(?<!\\\\)(?:\\\\\\\\)*(\")", "'")
+      .replaceAll("(?<!\\\\)(?:\\\\\\\\)*(\\\\\")", "\"");
+  }
+
+  // Find any variables, functions, etc in this chunk to mark as deferred.
+  // similar processing to getChunk method, but without recursion.
+  private Set<String> findDeferredWords(String chunk) {
+    Set<String> words = new HashSet<>();
+    char[] value = chunk.toCharArray();
+    int prevQuotePos = 0;
+    int curPos = 0;
+    char c;
+    char prevChar = 0;
+    boolean inQuote = false;
+    char quoteChar = 0;
+    while (curPos < chunk.length()) {
+      c = value[curPos];
+      if (inQuote) {
+        if (c == quoteChar && prevChar != '\\') {
+          inQuote = false;
+          prevQuotePos = curPos;
+        }
+      } else if ((c == '\'' || c == '"') && prevChar != '\\') {
+        inQuote = true;
+        quoteChar = c;
+        words.addAll(findDeferredWordsInSubstring(chunk, prevQuotePos, curPos));
+      }
+      prevChar = c;
+      curPos++;
+    }
+    words.addAll(findDeferredWordsInSubstring(chunk, prevQuotePos, curPos));
+    return words;
+  }
+
+  // Knowing that there are no quotes between start and end,
+  // split up the words in `chunk` and return whichever ones can't be resolved.
+  private Set<String> findDeferredWordsInSubstring(String chunk, int start, int end) {
+    return Arrays
+      .stream(chunk.substring(start, end).split("[^\\w.]"))
+      .filter(StringUtils::isNotBlank)
+      .filter(w -> shouldBeEvaluated(w, token, interpreter))
+      .collect(Collectors.toSet());
+  }
+
+  public static boolean shouldBeEvaluated(
+    String w,
+    Token token,
+    JinjavaInterpreter interpreter
+  ) {
+    try {
+      if (RESERVED_KEYWORDS.contains(w)) {
+        return false;
+      }
+      try {
+        Object val = interpreter.retraceVariable(
+          w,
+          token.getLineNumber(),
+          token.getStartPosition()
+        );
+        if (val != null) {
+          // It's a variable that must now be deferred
+          return true;
+        }
+      } catch (UnknownTokenException e) {
+        // val is still null
+      }
+      // don't defer numbers, values such as true/false, etc.
+      return interpreter.resolveELExpression(w, token.getLineNumber()) == null;
+    } catch (DeferredValueException e) {
+      return true;
+    }
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -1,0 +1,254 @@
+/**********************************************************************
+ Copyright (c) 2014 HubSpot Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ **********************************************************************/
+package com.hubspot.jinjava.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.interpret.Context;
+import com.hubspot.jinjava.interpret.DeferredValue;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.tree.parse.DefaultTokenScannerSymbols;
+import com.hubspot.jinjava.tree.parse.TagToken;
+import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class ChunkResolverTest {
+  private static final TokenScannerSymbols SYMBOLS = new DefaultTokenScannerSymbols();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private JinjavaInterpreter interpreter;
+  private TagToken tagToken;
+  private Context context;
+
+  @Before
+  public void setUp() {
+    interpreter = new JinjavaInterpreter(new Jinjava().newInterpreter());
+    context = interpreter.getContext();
+    context.put("deferred", DeferredValue.instance());
+    tagToken = new TagToken("{% foo %}", 1, 2, SYMBOLS);
+    JinjavaInterpreter.pushCurrent(interpreter);
+  }
+
+  @After
+  public void cleanup() {
+    JinjavaInterpreter.popCurrent();
+  }
+
+  private ChunkResolver makeChunkResolver(String string) {
+    return new ChunkResolver(string, tagToken, interpreter).useMiniChunks(true);
+  }
+
+  @Test
+  public void itResolvesDeferredBoolean() {
+    context.put("foo", "foo_val");
+    ChunkResolver chunkResolver = makeChunkResolver("(111 == 112) || (foo == deferred)");
+    String partiallyResolved = chunkResolver.resolveChunks();
+    assertThat(partiallyResolved).isEqualTo("false || ('foo_val' == deferred)");
+    assertThat(chunkResolver.getDeferredWords()).containsExactly("deferred");
+
+    context.put("deferred", "foo_val");
+    assertThat(makeChunkResolver(partiallyResolved).resolveChunks()).isEqualTo("true");
+    assertThat(interpreter.resolveELExpression(partiallyResolved, 1)).isEqualTo(true);
+  }
+
+  @Test
+  public void itResolvesDeferredList() {
+    context.put("foo", "foo_val");
+    context.put("bar", "bar_val");
+    ChunkResolver chunkResolver = makeChunkResolver("[foo == bar, deferred, bar]");
+    assertThat(chunkResolver.resolveChunks()).isEqualTo("[false,deferred,'bar_val']");
+    assertThat(chunkResolver.getDeferredWords()).containsExactlyInAnyOrder("deferred");
+    context.put("bar", "foo_val");
+    assertThat(chunkResolver.resolveChunks()).isEqualTo("[true,deferred,'foo_val']");
+  }
+
+  @Test
+  public void itResolvesSimpleBoolean() {
+    context.put("foo", true);
+    ChunkResolver chunkResolver = makeChunkResolver("false || (foo), 'bar'");
+    String partiallyResolved = chunkResolver.resolveChunks();
+    assertThat(partiallyResolved).isEqualTo("true,'bar'");
+    assertThat(chunkResolver.getDeferredWords()).isEmpty();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void itResolvesRange() {
+    ChunkResolver chunkResolver = makeChunkResolver("range(0,2)");
+    String partiallyResolved = chunkResolver.resolveChunks();
+    assertThat(partiallyResolved).isEqualTo("[0,1]");
+    assertThat(chunkResolver.getDeferredWords()).isEmpty();
+    // I don't know why this is a list of longs?
+    assertThat((List<Long>) interpreter.resolveELExpression(partiallyResolved, 1))
+      .contains(0L, 1L);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void itResolvesDeferredRange() throws Exception {
+    List<Integer> expectedList = ImmutableList.of(1, 2, 3);
+    context.put("foo", 1);
+    context.put("bar", 3);
+    ChunkResolver chunkResolver = makeChunkResolver("range(deferred, foo + bar)");
+    String partiallyResolved = chunkResolver.resolveChunks();
+    assertThat(partiallyResolved).isEqualTo("range(deferred,4)");
+    assertThat(chunkResolver.getDeferredWords())
+      .containsExactlyInAnyOrder("deferred", "range");
+
+    context.put("deferred", 1);
+    assertThat(makeChunkResolver(partiallyResolved).resolveChunks())
+      .isEqualTo(OBJECT_MAPPER.writeValueAsString(expectedList));
+    // But this is a list of integers
+    assertThat((List<Integer>) interpreter.resolveELExpression(partiallyResolved, 1))
+      .isEqualTo(expectedList);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void itResolvesDictionary() {
+    Map<String, Object> dict = ImmutableMap.of("foo", "one", "bar", 2L);
+    context.put("the_dictionary", dict);
+
+    ChunkResolver chunkResolver = makeChunkResolver("[the_dictionary, 1]");
+    String partiallyResolved = chunkResolver.resolveChunks();
+    assertThat(chunkResolver.getDeferredWords()).isEmpty();
+    assertThat(interpreter.resolveELExpression(partiallyResolved, 1))
+      .isEqualTo(ImmutableList.of(dict, 1L));
+  }
+
+  @Test
+  public void itResolvesNested() {
+    context.put("foo", 1);
+    context.put("bar", 3);
+    ChunkResolver chunkResolver = makeChunkResolver(
+      "[foo, range(deferred, bar), range(foo, bar)][0:2]"
+    );
+    String partiallyResolved = chunkResolver.resolveChunks();
+    assertThat(partiallyResolved).isEqualTo("[1,range(deferred,3),[1,2]][0:2]");
+    assertThat(chunkResolver.getDeferredWords())
+      .containsExactlyInAnyOrder("deferred", "range");
+
+    context.put("deferred", 2);
+    assertThat(makeChunkResolver(partiallyResolved).resolveChunks()).isEqualTo("[1,[2]]");
+    assertThat(interpreter.resolveELExpression(partiallyResolved, 1))
+      .isEqualTo(ImmutableList.of(1L, ImmutableList.of(2)));
+  }
+
+  @Test
+  public void itSplitsOnNonWords() {
+    context.put("foo", 1);
+    context.put("bar", 4);
+    ChunkResolver chunkResolver = makeChunkResolver("range(0,foo) + -deferred/bar");
+    String partiallyResolved = chunkResolver.resolveChunks();
+    assertThat(partiallyResolved).isEqualTo("[0] + -deferred/4");
+    assertThat(chunkResolver.getDeferredWords()).containsExactly("deferred");
+
+    context.put("deferred", 2);
+    assertThat(makeChunkResolver(partiallyResolved).resolveChunks())
+      .isEqualTo("[0,-0.5]");
+    assertThat(interpreter.resolveELExpression(partiallyResolved, 1))
+      .isEqualTo(ImmutableList.of(0L, -0.5));
+  }
+
+  @Test
+  public void itSplitsAndIndexesOnNonWords() {
+    context.put("foo", 3);
+    context.put("bar", 4);
+    ChunkResolver chunkResolver = makeChunkResolver("range(-2,foo)[-1] + -deferred/bar");
+    String partiallyResolved = chunkResolver.resolveChunks();
+    assertThat(partiallyResolved).isEqualTo("2 + -deferred/4");
+    assertThat(chunkResolver.getDeferredWords()).containsExactly("deferred");
+
+    context.put("deferred", 2);
+    assertThat(makeChunkResolver(partiallyResolved).resolveChunks()).isEqualTo("1.5");
+    assertThat(interpreter.resolveELExpression(partiallyResolved, 1)).isEqualTo(1.5);
+  }
+
+  @Test
+  @Ignore
+  // TODO support order of operations
+  public void itSupportsOrderOfOperations() {
+    ChunkResolver chunkResolver = makeChunkResolver("[0,1]|reverse + deferred");
+    String partiallyResolved = chunkResolver.resolveChunks();
+    assertThat(partiallyResolved).isEqualTo("[1,0] + deferred");
+    assertThat(chunkResolver.getDeferredWords()).containsExactly("deferred");
+
+    context.put("deferred", 2);
+    assertThat(makeChunkResolver(partiallyResolved).resolveChunks()).isEqualTo("[1,0,2]");
+    assertThat(interpreter.resolveELExpression(partiallyResolved, 1))
+      .isEqualTo(ImmutableList.of(1L, 0L, 2L));
+  }
+
+  @Test
+  public void itCatchesDeferredVariables() {
+    ChunkResolver chunkResolver = makeChunkResolver("range(0, deferred)");
+    String partiallyResolved = chunkResolver.resolveChunks();
+    assertThat(partiallyResolved).isEqualTo("range(0,deferred)");
+    // Since the range function is deferred, it is added to deferredWords.
+    assertThat(chunkResolver.getDeferredWords())
+      .containsExactlyInAnyOrder("range", "deferred");
+  }
+
+  @Test
+  public void itSplitsChunks() {
+    ChunkResolver chunkResolver = makeChunkResolver("1, 1 + 1, 1 + 2");
+    List<String> miniChunks = chunkResolver.splitChunks();
+    assertThat(miniChunks).containsExactly("1", "2", "3");
+    assertThat(chunkResolver.getDeferredWords()).isEmpty();
+  }
+
+  @Test
+  public void itProperlySplitsMultiLevelChunks() {
+    ChunkResolver chunkResolver = makeChunkResolver(
+      "[5,7], 1 + 1, 1 + range(0 + 1, deferred)"
+    );
+    List<String> miniChunks = chunkResolver.splitChunks();
+    assertThat(miniChunks).containsExactly("[5,7]", "2", "1 + range(1,deferred)");
+    assertThat(chunkResolver.getDeferredWords())
+      .containsExactlyInAnyOrder("range", "deferred");
+  }
+
+  @Test
+  public void itRespectsNoMiniChunksFlag() {
+    context.put("foo", 9);
+    ChunkResolver chunkResolver = makeChunkResolver("foo, 1 + 1, 1 + 2")
+      .useMiniChunks(false);
+    List<String> miniChunks = chunkResolver.splitChunks();
+    assertThat(miniChunks).containsExactly("9, 1 + 1, 1 + 2");
+    assertThat(chunkResolver.getDeferredWords()).isEmpty();
+  }
+
+  @Test
+  public void itDoesntDeferReservedWords() {
+    context.put("foo", 0);
+    ChunkResolver chunkResolver = makeChunkResolver(
+      "[(foo > 1) or deferred, deferred].append(1)"
+    );
+    String partiallyResolved = chunkResolver.resolveChunks();
+    assertThat(partiallyResolved).isEqualTo("[false or deferred,deferred].append(1)");
+    assertThat(chunkResolver.getDeferredWords()).doesNotContain("false", "or");
+    assertThat(chunkResolver.getDeferredWords()).contains("deferred", ".append");
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -260,7 +260,7 @@ public class ChunkResolverTest {
       "foo == deferred and (foo is not equalto 5)"
     );
     interpreter.getContext().setHideInterpreterErrors(true);
-    interpreter.resolveELExpression("1, deferred, 'hee'", 1);
+    Object bee = interpreter.resolveELExpression("[1, range(foo,deferred), 'hee'][2]", 1);
     Object baz = interpreter.resolveELExpression("deferred || (foo + deferred[2])", 1);
     Object bar = interpreter.resolveELExpression(
       "foo == deferred and (foo is not equalto 5)",

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -1,18 +1,3 @@
-/**********************************************************************
- Copyright (c) 2014 HubSpot Inc.
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
- **********************************************************************/
 package com.hubspot.jinjava.util;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -152,7 +152,7 @@ public class ChunkResolverTest {
     context.put("bar", 4);
     ChunkResolver chunkResolver = makeChunkResolver("range(0,foo) + -deferred/bar");
     String partiallyResolved = chunkResolver.resolveChunks();
-    assertThat(partiallyResolved).isEqualTo("[0] + -deferred/4");
+    assertThat(partiallyResolved).isEqualTo("[0] + -deferred / 4");
     assertThat(chunkResolver.getDeferredWords()).containsExactly("deferred");
 
     context.put("deferred", 2);
@@ -168,7 +168,7 @@ public class ChunkResolverTest {
     context.put("bar", 4);
     ChunkResolver chunkResolver = makeChunkResolver("range(-2,foo)[-1] + -deferred/bar");
     String partiallyResolved = chunkResolver.resolveChunks();
-    assertThat(partiallyResolved).isEqualTo("2 + -deferred/4");
+    assertThat(partiallyResolved).isEqualTo("2 + -deferred / 4");
     assertThat(chunkResolver.getDeferredWords()).containsExactly("deferred");
 
     context.put("deferred", 2);
@@ -227,7 +227,7 @@ public class ChunkResolverTest {
       "[(foo > 1) or deferred, deferred].append(1)"
     );
     String partiallyResolved = chunkResolver.resolveChunks();
-    assertThat(partiallyResolved).isEqualTo("[false or deferred,deferred].append(1)");
+    assertThat(partiallyResolved).isEqualTo("[false || deferred,deferred].append(1)");
     assertThat(chunkResolver.getDeferredWords()).doesNotContain("false", "or");
     assertThat(chunkResolver.getDeferredWords()).contains("deferred", ".append");
   }

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -58,7 +58,7 @@ public class ChunkResolverTest {
   }
 
   private ChunkResolver makeChunkResolver(String string) {
-    return new ChunkResolver(string, tagToken, interpreter).useMiniChunks(true);
+    return new ChunkResolver(string, tagToken, interpreter);
   }
 
   @Test
@@ -229,16 +229,6 @@ public class ChunkResolverTest {
     assertThat(miniChunks).containsExactly("[5,7]", "2", "1 + range(1,deferred)");
     assertThat(chunkResolver.getDeferredWords())
       .containsExactlyInAnyOrder("range", "deferred");
-  }
-
-  @Test
-  public void itRespectsNoMiniChunksFlag() {
-    context.put("foo", 9);
-    ChunkResolver chunkResolver = makeChunkResolver("foo, 1 + 1, 1 + 2")
-      .useMiniChunks(false);
-    List<String> miniChunks = chunkResolver.splitChunks();
-    assertThat(miniChunks).containsExactly("9, 1 + 1, 1 + 2");
-    assertThat(chunkResolver.getDeferredWords()).isEmpty();
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -24,6 +24,7 @@ import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.objects.collections.PyMap;
 import com.hubspot.jinjava.tree.parse.DefaultTokenScannerSymbols;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
@@ -250,5 +251,15 @@ public class ChunkResolverTest {
     assertThat(partiallyResolved).isEqualTo("[false or deferred,deferred].append(1)");
     assertThat(chunkResolver.getDeferredWords()).doesNotContain("false", "or");
     assertThat(chunkResolver.getDeferredWords()).contains("deferred", ".append");
+  }
+
+  @Test
+  public void itEvaluatesDict() {
+    context.put("foo", new PyMap(ImmutableMap.of("bar", 99)));
+    ChunkResolver chunkResolver = makeChunkResolver("foo.bar == deferred.bar");
+    String partiallyResolved = chunkResolver.resolveChunks();
+    assertThat(partiallyResolved).isEqualTo("99 == deferred.bar");
+    assertThat(chunkResolver.getDeferredWords())
+      .containsExactlyInAnyOrder("deferred.bar");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -25,9 +25,13 @@ import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.objects.collections.PyMap;
+import com.hubspot.jinjava.objects.date.PyishDate;
 import com.hubspot.jinjava.tree.parse.DefaultTokenScannerSymbols;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import org.junit.After;
@@ -251,5 +255,16 @@ public class ChunkResolverTest {
     assertThat(partiallyResolved).isEqualTo("99 == deferred.bar");
     assertThat(chunkResolver.getDeferredWords())
       .containsExactlyInAnyOrder("deferred.bar");
+  }
+
+  @Test
+  public void itSerializesDateProperly() {
+    PyishDate date = new PyishDate(
+      ZonedDateTime.ofInstant(Instant.ofEpochMilli(1234567890L), ZoneId.systemDefault())
+    );
+    context.put("date", date);
+    ChunkResolver chunkResolver = makeChunkResolver("date");
+    assertThat(WhitespaceUtils.unquote(chunkResolver.resolveChunks()))
+      .isEqualTo(date.toString());
   }
 }

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -202,25 +202,6 @@ public class ChunkResolverTest {
   }
 
   @Test
-  public void itSplitsChunks() {
-    ChunkResolver chunkResolver = makeChunkResolver("1, 1 + 1, 1 + 2");
-    List<String> miniChunks = chunkResolver.splitChunks();
-    assertThat(miniChunks).containsExactly("1", "2", "3");
-    assertThat(chunkResolver.getDeferredWords()).isEmpty();
-  }
-
-  @Test
-  public void itProperlySplitsMultiLevelChunks() {
-    ChunkResolver chunkResolver = makeChunkResolver(
-      "[5,7], 1 + 1, 1 + range(0 + 1, deferred)"
-    );
-    List<String> miniChunks = chunkResolver.splitChunks();
-    assertThat(miniChunks).containsExactly("[5,7]", "2", "1 + range(1,deferred)");
-    assertThat(chunkResolver.getDeferredWords())
-      .containsExactlyInAnyOrder("range", "deferred");
-  }
-
-  @Test
   public void itDoesntDeferReservedWords() {
     context.put("foo", 0);
     ChunkResolver chunkResolver = makeChunkResolver(

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -252,4 +252,23 @@ public class ChunkResolverTest {
     assertThat(WhitespaceUtils.unquote(chunkResolver.resolveChunks()))
       .isEqualTo(date.toString());
   }
+
+  @Test
+  public void itDoesIsNotEqual() {
+    context.put("foo", 4);
+    ChunkResolver chunkResolver = makeChunkResolver(
+      "foo == deferred and (foo is not equalto 5)"
+    );
+    interpreter.getContext().setHideInterpreterErrors(true);
+    interpreter.resolveELExpression("1, deferred, 'hee'", 1);
+    Object baz = interpreter.resolveELExpression("deferred || (foo + deferred[2])", 1);
+    Object bar = interpreter.resolveELExpression(
+      "foo == deferred and (foo is not equalto 5)",
+      1
+    );
+    String partiallyResolved = chunkResolver.resolveChunks();
+    assertThat(partiallyResolved).isEqualTo("99 == deferred.bar");
+    assertThat(chunkResolver.getDeferredWords())
+      .containsExactlyInAnyOrder("deferred.bar");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -257,17 +257,17 @@ public class ChunkResolverTest {
   public void itDoesIsNotEqual() {
     context.put("foo", 4);
     ChunkResolver chunkResolver = makeChunkResolver(
-      "foo == deferred and (foo is not equalto 5)"
+      "foo == deferred.bar and (foo is not equalto 5)"
     );
     interpreter.getContext().setHideInterpreterErrors(true);
-    Object bee = interpreter.resolveELExpression("[1, range(foo,deferred), 'hee'][2]", 1);
-    Object baz = interpreter.resolveELExpression("deferred || (foo + deferred[2])", 1);
-    Object bar = interpreter.resolveELExpression(
-      "foo == deferred and (foo is not equalto 5)",
-      1
-    );
+    //    Object bee = interpreter.resolveELExpression("[1, range(foo,deferred), 'hee'][2]", 1);
+    //    Object baz = interpreter.resolveELExpression("deferred || (foo + deferred[2])", 1);
+    //    Object bar = interpreter.resolveELExpression(
+    //      "foo == deferred and (foo is not equalto 5)",
+    //      1
+    //    );
     String partiallyResolved = chunkResolver.resolveChunks();
-    assertThat(partiallyResolved).isEqualTo("99 == deferred.bar");
+    assertThat(partiallyResolved).isEqualTo("4 == deferred.bar && true");
     assertThat(chunkResolver.getDeferredWords())
       .containsExactlyInAnyOrder("deferred.bar");
   }


### PR DESCRIPTION
@jboulter Because of your comment about the parser that exists in Jinjava, I decided to look into it as an alternative to the ChunkResolver PR that I opened https://github.com/HubSpot/jinjava/pull/525.
It essentially does the same thing that the ChunkResolver does but in a more low-level (and probably faster) way.

Rather than introducing a new parser that works on top of the `interpreter.resolveELExpression()`, this approach instead extends the Jinjava parser itself by providing decorators for all the different types of AstNodes to allow for deferred values to be handled when they are evaluated.

I created a new Exception type that passes through the Abstract Syntax Tree as it gets evaluated, and when one of the decorated nodes sees this exception, it partially evaluates its children (or whatever they are specifically for each type of AstNode).

This method for partially resolving expressions is more complex than the initial ChunkResolver PR because I had to implement custom overrides for all the different AstNodes.

This is a draft PR because idk if I want to go with this approach. It's a lot more complex than the ChunkResolver, and I haven't fully tested out all the code (I only have it tested against the tests that I wrote for the ChunkResolver PR). A pro to this approach is that I think it is faster than the other PR because the expression gets evaluated a single time, rather than being evaluated several times in sub-expressions.

I don't intend for anyone to read through this code, it's currently just a proof of concept, unless we decide to go with this approach.