### PR TITLE
add size limited pymaps and pylists

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -46,15 +46,17 @@ public class JinjavaConfig {
   private final boolean enableRecursiveMacroCalls;
   private final int maxMacroRecursionDepth;
 
-  private Map<Context.Library, Set<String>> disabled;
+  private final Map<Context.Library, Set<String>> disabled;
   private final boolean failOnUnknownTokens;
   private final boolean nestedInterpretationEnabled;
   private final RandomNumberGeneratorStrategy randomNumberGenerator;
   private final boolean validationMode;
   private final long maxStringLength;
-  private InterpreterFactory interpreterFactory;
+  private final int maxListSize;
+  private final int maxMapSize;
+  private final InterpreterFactory interpreterFactory;
   private TokenScannerSymbols tokenScannerSymbols;
-  private ELResolver elResolver;
+  private final ELResolver elResolver;
   private final boolean iterateOverMapKeys;
   private final boolean preserveForFinalPass;
 
@@ -101,6 +103,8 @@ public class JinjavaConfig {
     randomNumberGenerator = builder.randomNumberGeneratorStrategy;
     validationMode = builder.validationMode;
     maxStringLength = builder.maxStringLength;
+    maxListSize = builder.maxListSize;
+    maxMapSize = builder.maxMapSize;
     interpreterFactory = builder.interpreterFactory;
     tokenScannerSymbols = builder.tokenScannerSymbols;
     elResolver = builder.elResolver;
@@ -126,6 +130,14 @@ public class JinjavaConfig {
 
   public long getMaxOutputSize() {
     return maxOutputSize;
+  }
+
+  public int getMaxListSize() {
+    return maxListSize;
+  }
+
+  public int getMaxMapSize() {
+    return maxMapSize;
   }
 
   public RandomNumberGeneratorStrategy getRandomNumberGeneratorStrategy() {
@@ -216,6 +228,8 @@ public class JinjavaConfig {
     private ELResolver elResolver = JinjavaInterpreterResolver.DEFAULT_RESOLVER_READ_ONLY;
     private boolean iterateOverMapKeys;
     private boolean preserveForFinalPass;
+    private int maxListSize = Integer.MAX_VALUE;
+    private int maxMapSize = Integer.MAX_VALUE;
 
     private Builder() {}
 
@@ -306,6 +320,16 @@ public class JinjavaConfig {
 
     public Builder withMaxStringLength(long maxStringLength) {
       this.maxStringLength = maxStringLength;
+      return this;
+    }
+
+    public Builder withMaxListSize(int maxListSize) {
+      this.maxListSize = maxListSize;
+      return this;
+    }
+
+    public Builder withMaxMapSize(int maxMapSize) {
+      this.maxMapSize = maxMapSize;
       return this;
     }
 

--- a/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
@@ -19,8 +19,8 @@ import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import com.hubspot.jinjava.interpret.errorcategory.BasicTemplateErrorCategory;
 import com.hubspot.jinjava.objects.PyWrapper;
-import com.hubspot.jinjava.objects.collections.PyList;
-import com.hubspot.jinjava.objects.collections.PyMap;
+import com.hubspot.jinjava.objects.collections.SizeLimitingPyList;
+import com.hubspot.jinjava.objects.collections.SizeLimitingPyMap;
 import com.hubspot.jinjava.objects.date.FormattedDate;
 import com.hubspot.jinjava.objects.date.PyishDate;
 import com.hubspot.jinjava.objects.date.StrftimeFormatter;
@@ -295,11 +295,17 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
     }
 
     if (List.class.isAssignableFrom(value.getClass())) {
-      return new PyList((List<Object>) value);
+      return new SizeLimitingPyList(
+        (List<Object>) value,
+        interpreter.getConfig().getMaxListSize()
+      );
     }
     if (Map.class.isAssignableFrom(value.getClass())) {
       // FIXME: ensure keys are actually strings, if not, convert them
-      return new PyMap((Map<String, Object>) value);
+      return new SizeLimitingPyMap(
+        (Map<String, Object>) value,
+        interpreter.getConfig().getMaxMapSize()
+      );
     }
 
     if (Date.class.isAssignableFrom(value.getClass())) {

--- a/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
@@ -1,7 +1,8 @@
 package com.hubspot.jinjava.el.ext;
 
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateStateException;
-import com.hubspot.jinjava.objects.collections.PyMap;
+import com.hubspot.jinjava.objects.collections.SizeLimitingPyMap;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstIdentifier;
 import de.odysseus.el.tree.impl.ast.AstLiteral;
@@ -39,7 +40,11 @@ public class AstDict extends AstLiteral {
       resolved.put(key, entry.getValue().eval(bindings, context));
     }
 
-    return new PyMap(resolved);
+    JinjavaInterpreter interpreter = (JinjavaInterpreter) context
+      .getELResolver()
+      .getValue(context, null, ExtendedParser.INTERPRETER);
+
+    return new SizeLimitingPyMap(resolved, interpreter.getConfig().getMaxMapSize());
   }
 
   @Override
@@ -54,10 +59,7 @@ public class AstDict extends AstLiteral {
     StringBuilder s = new StringBuilder("{");
 
     for (Map.Entry<AstNode, AstNode> entry : dict.entrySet()) {
-      s
-        .append(Objects.toString(entry.getKey()))
-        .append(":")
-        .append(Objects.toString(entry.getValue()));
+      s.append(entry.getKey()).append(":").append(entry.getValue());
     }
 
     return s.append("}").toString();

--- a/src/main/java/com/hubspot/jinjava/el/ext/AstList.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstList.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.el.ext;
 
-import com.hubspot.jinjava.objects.collections.PyList;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.objects.collections.SizeLimitingPyList;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstLiteral;
 import de.odysseus.el.tree.impl.ast.AstParameters;
@@ -24,7 +25,11 @@ public class AstList extends AstLiteral {
       list.add(elements.getChild(i).eval(bindings, context));
     }
 
-    return new PyList(list);
+    JinjavaInterpreter interpreter = (JinjavaInterpreter) context
+      .getELResolver()
+      .getValue(context, null, ExtendedParser.INTERPRETER);
+
+    return new SizeLimitingPyList(list, interpreter.getConfig().getMaxListSize());
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/el/ext/AstRangeBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstRangeBracket.java
@@ -1,7 +1,9 @@
 package com.hubspot.jinjava.el.ext;
 
 import com.google.common.collect.Iterables;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.objects.collections.PyList;
+import com.hubspot.jinjava.objects.collections.SizeLimitingPyList;
 import de.odysseus.el.misc.LocalMessages;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstBracket;
@@ -76,7 +78,14 @@ public class AstRangeBracket extends AstBracket {
     int startNum = ((Number) start).intValue();
     int endNum = ((Number) end).intValue();
 
-    PyList result = new PyList(new ArrayList<>());
+    JinjavaInterpreter interpreter = (JinjavaInterpreter) context
+      .getELResolver()
+      .getValue(context, null, ExtendedParser.INTERPRETER);
+
+    PyList result = new SizeLimitingPyList(
+      new ArrayList<>(),
+      interpreter.getConfig().getMaxListSize()
+    );
     int index = 0;
 
     // Handle negative indices.

--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -308,7 +308,6 @@ public class ExtendedParser extends Parser {
     switch (getToken().getSymbol()) {
       case LBRACK:
         v = new AstList(params(LBRACK, RBRACK));
-
         break;
       case LPAREN:
         v = new AstTuple(params());

--- a/src/main/java/com/hubspot/jinjava/interpret/CollectionTooBigException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/CollectionTooBigException.java
@@ -1,0 +1,28 @@
+package com.hubspot.jinjava.interpret;
+
+public class CollectionTooBigException extends RuntimeException {
+  private final int maxSize;
+  private final int size;
+
+  public CollectionTooBigException(int size, int maxSize) {
+    this.maxSize = maxSize;
+    this.size = size;
+  }
+
+  public int getMaxSize() {
+    return maxSize;
+  }
+
+  public int getSize() {
+    return size;
+  }
+
+  @Override
+  public String getMessage() {
+    return String.format(
+      "Collection of size %d is greater than the maximum size of %d",
+      size,
+      maxSize
+    );
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -56,6 +56,7 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 public class JinjavaInterpreter {
   private final Multimap<String, BlockInfo> blocks = ArrayListMultimap.create();
@@ -270,6 +271,22 @@ public class JinjavaInterpreter {
         }
       } catch (OutputTooBigException e) {
         addError(TemplateError.fromOutputTooBigException(e));
+        return output.getValue();
+      } catch (CollectionTooBigException e) {
+        addError(
+          new TemplateError(
+            ErrorType.FATAL,
+            ErrorReason.COLLECTION_TOO_BIG,
+            ErrorItem.OTHER,
+            ExceptionUtils.getMessage(e),
+            null,
+            -1,
+            -1,
+            e,
+            BasicTemplateErrorCategory.UNKNOWN,
+            ImmutableMap.of()
+          )
+        );
         return output.getValue();
       }
     }

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -17,7 +17,7 @@ public class TemplateError {
 
   public enum ErrorType {
     FATAL,
-    WARNING,
+    WARNING
   }
 
   public enum ErrorReason {
@@ -32,7 +32,7 @@ public class TemplateError {
     OUTPUT_TOO_BIG,
     OVER_LIMIT,
     COLLECTION_TOO_BIG,
-    OTHER,
+    OTHER
   }
 
   public enum ErrorItem {
@@ -43,7 +43,7 @@ public class TemplateError {
     PROPERTY,
     FILTER,
     EXPRESSION_TEST,
-    OTHER,
+    OTHER
   }
 
   private final ErrorType severity;

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -17,7 +17,7 @@ public class TemplateError {
 
   public enum ErrorType {
     FATAL,
-    WARNING
+    WARNING,
   }
 
   public enum ErrorReason {
@@ -31,7 +31,8 @@ public class TemplateError {
     INVALID_INPUT,
     OUTPUT_TOO_BIG,
     OVER_LIMIT,
-    OTHER
+    COLLECTION_TOO_BIG,
+    OTHER,
   }
 
   public enum ErrorItem {
@@ -42,7 +43,7 @@ public class TemplateError {
     PROPERTY,
     FILTER,
     EXPRESSION_TEST,
-    OTHER
+    OTHER,
   }
 
   private final ErrorType severity;

--- a/src/main/java/com/hubspot/jinjava/objects/collections/PyMap.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/PyMap.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class PyMap extends ForwardingMap<String, Object> implements PyWrapper {
-  private Map<String, Object> map;
+  private final Map<String, Object> map;
 
   public PyMap(Map<String, Object> map) {
     this.map = map;

--- a/src/main/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyList.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyList.java
@@ -1,0 +1,90 @@
+package com.hubspot.jinjava.objects.collections;
+
+import com.hubspot.jinjava.interpret.IndexOutOfRangeException;
+import com.hubspot.jinjava.objects.PyWrapper;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class SizeLimitingPyList extends PyList implements PyWrapper {
+  private int maxSize;
+
+  private SizeLimitingPyList(List<Object> list) {
+    super(list);
+  }
+
+  public SizeLimitingPyList(List<Object> list, int maxSize) {
+    super(list);
+    if (maxSize <= 0) {
+      throw new IllegalArgumentException("maxSize must be >= 1");
+    }
+
+    this.maxSize = maxSize;
+    if (list.size() >= maxSize) {
+      throw createOutOfRangeException(list.size());
+    }
+  }
+
+  @Override
+  public boolean append(Object e) {
+    if (size() >= maxSize) {
+      throw createOutOfRangeException(size() + 1);
+    }
+    return super.append(e);
+  }
+
+  @Override
+  public void insert(int i, Object e) {
+    if (size() >= maxSize) {
+      throw createOutOfRangeException(size() + 1);
+    }
+    super.insert(i, e);
+  }
+
+  @Override
+  public boolean add(Object element) {
+    if (size() >= maxSize) {
+      throw createOutOfRangeException(size() + 1);
+    }
+    return super.add(element);
+  }
+
+  @Override
+  public void add(int index, Object element) {
+    if (size() >= maxSize) {
+      throw createOutOfRangeException(size() + 1);
+    }
+    super.add(index, element);
+  }
+
+  @Override
+  public boolean addAll(int index, Collection<?> elements) {
+    if (size() + elements.size() >= maxSize) {
+      throw createOutOfRangeException(size() + elements.size());
+    }
+    return super.addAll(index, elements);
+  }
+
+  @Override
+  public boolean addAll(Collection<?> collection) {
+    if (size() + collection.size() >= maxSize) {
+      throw createOutOfRangeException(size() + collection.size());
+    }
+    return super.addAll(collection);
+  }
+
+  @Override
+  public PyList copy() {
+    return new SizeLimitingPyList(new ArrayList<>(delegate()));
+  }
+
+  IndexOutOfRangeException createOutOfRangeException(int index) {
+    return new IndexOutOfRangeException(
+      String.format(
+        "Index %d is out of range for list of maximum size %d",
+        index,
+        maxSize
+      )
+    );
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyList.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyList.java
@@ -20,14 +20,14 @@ public class SizeLimitingPyList extends PyList implements PyWrapper {
     }
 
     this.maxSize = maxSize;
-    if (list.size() >= maxSize) {
+    if (list.size() > maxSize) {
       throw createOutOfRangeException(list.size());
     }
   }
 
   @Override
   public boolean append(Object e) {
-    if (size() >= maxSize) {
+    if (size() + 1 > maxSize) {
       throw createOutOfRangeException(size() + 1);
     }
     return super.append(e);
@@ -35,7 +35,7 @@ public class SizeLimitingPyList extends PyList implements PyWrapper {
 
   @Override
   public void insert(int i, Object e) {
-    if (size() >= maxSize) {
+    if (size() + 1 > maxSize) {
       throw createOutOfRangeException(size() + 1);
     }
     super.insert(i, e);
@@ -43,7 +43,7 @@ public class SizeLimitingPyList extends PyList implements PyWrapper {
 
   @Override
   public boolean add(Object element) {
-    if (size() >= maxSize) {
+    if (size() + 1 > maxSize) {
       throw createOutOfRangeException(size() + 1);
     }
     return super.add(element);
@@ -51,7 +51,7 @@ public class SizeLimitingPyList extends PyList implements PyWrapper {
 
   @Override
   public void add(int index, Object element) {
-    if (size() >= maxSize) {
+    if (size() + 1 > maxSize) {
       throw createOutOfRangeException(size() + 1);
     }
     super.add(index, element);
@@ -59,7 +59,7 @@ public class SizeLimitingPyList extends PyList implements PyWrapper {
 
   @Override
   public boolean addAll(int index, Collection<?> elements) {
-    if (size() + elements.size() >= maxSize) {
+    if (size() + elements.size() > maxSize) {
       throw createOutOfRangeException(size() + elements.size());
     }
     return super.addAll(index, elements);
@@ -67,7 +67,7 @@ public class SizeLimitingPyList extends PyList implements PyWrapper {
 
   @Override
   public boolean addAll(Collection<?> collection) {
-    if (size() + collection.size() >= maxSize) {
+    if (size() + collection.size() > maxSize) {
       throw createOutOfRangeException(size() + collection.size());
     }
     return super.addAll(collection);

--- a/src/main/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyList.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyList.java
@@ -1,6 +1,6 @@
 package com.hubspot.jinjava.objects.collections;
 
-import com.hubspot.jinjava.interpret.IndexOutOfRangeException;
+import com.hubspot.jinjava.interpret.CollectionTooBigException;
 import com.hubspot.jinjava.objects.PyWrapper;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -21,56 +21,44 @@ public class SizeLimitingPyList extends PyList implements PyWrapper {
 
     this.maxSize = maxSize;
     if (list.size() > maxSize) {
-      throw createOutOfRangeException(list.size());
+      throw new CollectionTooBigException(list.size(), maxSize);
     }
   }
 
   @Override
   public boolean append(Object e) {
-    if (size() + 1 > maxSize) {
-      throw createOutOfRangeException(size() + 1);
-    }
+    checkSize(size() + 1);
     return super.append(e);
   }
 
   @Override
   public void insert(int i, Object e) {
-    if (size() + 1 > maxSize) {
-      throw createOutOfRangeException(size() + 1);
-    }
+    checkSize(size() + 1);
     super.insert(i, e);
   }
 
   @Override
   public boolean add(Object element) {
-    if (size() + 1 > maxSize) {
-      throw createOutOfRangeException(size() + 1);
-    }
+    checkSize(size() + 1);
     return super.add(element);
   }
 
   @Override
   public void add(int index, Object element) {
-    if (size() + 1 > maxSize) {
-      throw createOutOfRangeException(size() + 1);
-    }
+    checkSize(size() + 1);
     super.add(index, element);
   }
 
   @Override
   public boolean addAll(int index, Collection<?> elements) {
-    if (size() + elements.size() > maxSize) {
-      throw createOutOfRangeException(size() + elements.size());
-    }
+    checkSize(size() + elements.size());
     return super.addAll(index, elements);
   }
 
   @Override
-  public boolean addAll(Collection<?> collection) {
-    if (size() + collection.size() > maxSize) {
-      throw createOutOfRangeException(size() + collection.size());
-    }
-    return super.addAll(collection);
+  public boolean addAll(Collection<?> elements) {
+    checkSize(size() + elements.size());
+    return super.addAll(elements);
   }
 
   @Override
@@ -78,13 +66,9 @@ public class SizeLimitingPyList extends PyList implements PyWrapper {
     return new SizeLimitingPyList(new ArrayList<>(delegate()));
   }
 
-  IndexOutOfRangeException createOutOfRangeException(int index) {
-    return new IndexOutOfRangeException(
-      String.format(
-        "Index %d is out of range for list of maximum size %d",
-        index,
-        maxSize
-      )
-    );
+  private void checkSize(int newSize) {
+    if (newSize > maxSize) {
+      throw new CollectionTooBigException(newSize, maxSize);
+    }
   }
 }

--- a/src/main/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyMap.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyMap.java
@@ -26,7 +26,7 @@ public class SizeLimitingPyMap extends PyMap implements PyWrapper {
 
   @Override
   public Object put(String s, Object o) {
-    if (delegate().size() >= maxSize && !delegate().containsKey(s)) {
+    if (delegate().size() + 1 > maxSize && !delegate().containsKey(s)) {
       throw createOutOfRangeException(delegate().size() + 1);
     }
 

--- a/src/main/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyMap.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyMap.java
@@ -1,0 +1,53 @@
+package com.hubspot.jinjava.objects.collections;
+
+import com.hubspot.jinjava.interpret.IndexOutOfRangeException;
+import com.hubspot.jinjava.objects.PyWrapper;
+import java.util.HashSet;
+import java.util.Map;
+
+public class SizeLimitingPyMap extends PyMap implements PyWrapper {
+  private int maxSize;
+
+  private SizeLimitingPyMap(Map<String, Object> map) {
+    super(map);
+  }
+
+  public SizeLimitingPyMap(Map<String, Object> map, int maxSize) {
+    super(map);
+    if (maxSize <= 0) {
+      throw new IllegalArgumentException("maxSize must be >= 1");
+    }
+
+    this.maxSize = maxSize;
+    if (map.size() > maxSize) {
+      throw createOutOfRangeException(map.size());
+    }
+  }
+
+  @Override
+  public Object put(String s, Object o) {
+    if (delegate().size() >= maxSize && !delegate().containsKey(s)) {
+      throw createOutOfRangeException(delegate().size() + 1);
+    }
+
+    return super.put(s, o);
+  }
+
+  @Override
+  public void putAll(Map<? extends String, ?> m) {
+    HashSet<String> keys = new HashSet<>(delegate().keySet());
+    int newKeys = (int) m.keySet().stream().filter(k -> !keys.contains(k)).count();
+
+    if (newKeys + delegate().size() > maxSize) {
+      throw createOutOfRangeException(newKeys + delegate().size());
+    }
+
+    super.putAll(m);
+  }
+
+  IndexOutOfRangeException createOutOfRangeException(int index) {
+    return new IndexOutOfRangeException(
+      String.format("%d is out of range for map of maximum size %d", index, maxSize)
+    );
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperatorTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperatorTest.java
@@ -7,7 +7,6 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import org.junit.Before;
 import org.junit.Test;
 
-@SuppressWarnings("unchecked")
 public class CollectionMembershipOperatorTest {
   private JinjavaInterpreter interpreter;
 

--- a/src/test/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyListTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyListTest.java
@@ -1,0 +1,73 @@
+package com.hubspot.jinjava.objects.collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.hubspot.jinjava.BaseJinjavaTest;
+import com.hubspot.jinjava.interpret.IndexOutOfRangeException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+public class SizeLimitingPyListTest extends BaseJinjavaTest {
+
+  @Test
+  public void itDoesntLimitByDefault() {
+    SizeLimitingPyList objects = new SizeLimitingPyList(
+      createList(10),
+      Integer.MAX_VALUE
+    );
+    assertThat(objects.size()).isEqualTo(10);
+  }
+
+  @Test(expected = IndexOutOfRangeException.class)
+  public void itLimitsOnCreate() {
+    new SizeLimitingPyList(createList(4), 2);
+  }
+
+  @Test
+  public void itLimitsOnAdd() {
+    List<Object> list = createList(3);
+    SizeLimitingPyList objects = new SizeLimitingPyList(new ArrayList<>(), 2);
+    objects.add(list.get(0));
+    objects.add(list.get(1));
+    assertThatThrownBy(() -> objects.add(list.get(2)))
+      .isInstanceOf(IndexOutOfRangeException.class);
+  }
+
+  @Test
+  public void itLimitsOnAppend() {
+    List<Object> list = createList(3);
+    SizeLimitingPyList objects = new SizeLimitingPyList(new ArrayList<>(), 2);
+    objects.append(list.get(0));
+    objects.append(list.get(1));
+    assertThatThrownBy(() -> objects.append(list.get(2)))
+      .isInstanceOf(IndexOutOfRangeException.class);
+  }
+
+  @Test
+  public void itLimitsOnInsert() {
+    List<Object> list = createList(3);
+    SizeLimitingPyList objects = new SizeLimitingPyList(new ArrayList<>(), 2);
+    objects.add(list.get(0));
+    objects.add(list.get(1));
+    assertThatThrownBy(() -> objects.insert(1, list.get(2)))
+      .isInstanceOf(IndexOutOfRangeException.class);
+  }
+
+  @Test
+  public void itLimitsOnAddAll() {
+    List<Object> list = createList(3);
+    SizeLimitingPyList objects = new SizeLimitingPyList(new ArrayList<>(), 2);
+    assertThatThrownBy(() -> objects.addAll(list))
+      .isInstanceOf(IndexOutOfRangeException.class);
+  }
+
+  public static List<Object> createList(int size) {
+    List<Object> result = new ArrayList<>();
+    for (int i = 0; i < size; i++) {
+      result.add(i + 1);
+    }
+    return result;
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyListTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyListTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.hubspot.jinjava.BaseJinjavaTest;
-import com.hubspot.jinjava.interpret.IndexOutOfRangeException;
+import com.hubspot.jinjava.interpret.CollectionTooBigException;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
@@ -20,7 +20,7 @@ public class SizeLimitingPyListTest extends BaseJinjavaTest {
     assertThat(objects.size()).isEqualTo(10);
   }
 
-  @Test(expected = IndexOutOfRangeException.class)
+  @Test(expected = CollectionTooBigException.class)
   public void itLimitsOnCreate() {
     new SizeLimitingPyList(createList(4), 2);
   }
@@ -32,7 +32,7 @@ public class SizeLimitingPyListTest extends BaseJinjavaTest {
     objects.add(list.get(0));
     objects.add(list.get(1));
     assertThatThrownBy(() -> objects.add(list.get(2)))
-      .isInstanceOf(IndexOutOfRangeException.class);
+      .isInstanceOf(CollectionTooBigException.class);
   }
 
   @Test
@@ -42,7 +42,7 @@ public class SizeLimitingPyListTest extends BaseJinjavaTest {
     objects.append(list.get(0));
     objects.append(list.get(1));
     assertThatThrownBy(() -> objects.append(list.get(2)))
-      .isInstanceOf(IndexOutOfRangeException.class);
+      .isInstanceOf(CollectionTooBigException.class);
   }
 
   @Test
@@ -52,7 +52,7 @@ public class SizeLimitingPyListTest extends BaseJinjavaTest {
     objects.add(list.get(0));
     objects.add(list.get(1));
     assertThatThrownBy(() -> objects.insert(1, list.get(2)))
-      .isInstanceOf(IndexOutOfRangeException.class);
+      .isInstanceOf(CollectionTooBigException.class);
   }
 
   @Test
@@ -60,7 +60,7 @@ public class SizeLimitingPyListTest extends BaseJinjavaTest {
     List<Object> list = createList(3);
     SizeLimitingPyList objects = new SizeLimitingPyList(new ArrayList<>(), 2);
     assertThatThrownBy(() -> objects.addAll(list))
-      .isInstanceOf(IndexOutOfRangeException.class);
+      .isInstanceOf(CollectionTooBigException.class);
   }
 
   public static List<Object> createList(int size) {

--- a/src/test/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyListTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyListTest.java
@@ -3,13 +3,14 @@ package com.hubspot.jinjava.objects.collections;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.hubspot.jinjava.BaseJinjavaTest;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.interpret.CollectionTooBigException;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
 
-public class SizeLimitingPyListTest extends BaseJinjavaTest {
+public class SizeLimitingPyListTest extends BaseInterpretingTest {
 
   @Test
   public void itDoesntLimitByDefault() {
@@ -23,6 +24,25 @@ public class SizeLimitingPyListTest extends BaseJinjavaTest {
   @Test(expected = CollectionTooBigException.class)
   public void itLimitsOnCreate() {
     new SizeLimitingPyList(createList(4), 2);
+  }
+
+  @Test
+  public void itWarnsOnAdd() {
+    JinjavaInterpreter interpreter = JinjavaInterpreter.getCurrent();
+    SizeLimitingPyList objects = new SizeLimitingPyList(new ArrayList<>(), 10);
+    int i;
+    for (i = 1; i < 9; i++) {
+      objects.add(i);
+      assertThat(interpreter.getErrors()).isEmpty();
+    }
+    objects.add(i++);
+    assertThat(interpreter.getErrors().size()).isEqualTo(1);
+    assertThat(interpreter.getErrors().get(0).getException())
+      .isInstanceOf(CollectionTooBigException.class);
+    objects.add(i++);
+
+    assertThatThrownBy(() -> objects.add(10))
+      .isInstanceOf(CollectionTooBigException.class);
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyMapTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyMapTest.java
@@ -3,13 +3,15 @@ package com.hubspot.jinjava.objects.collections;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.hubspot.jinjava.BaseJinjavaTest;
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.interpret.CollectionTooBigException;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.junit.Test;
 
-public class SizeLimitingPyMapTest extends BaseJinjavaTest {
+public class SizeLimitingPyMapTest extends BaseInterpretingTest {
 
   @Test
   public void itDoesntLimitByDefault() {
@@ -20,6 +22,24 @@ public class SizeLimitingPyMapTest extends BaseJinjavaTest {
   @Test(expected = CollectionTooBigException.class)
   public void itLimitsOnCreate() {
     new SizeLimitingPyMap(createMap(3), 2);
+  }
+
+  @Test
+  public void itWarnsOnPut() {
+    JinjavaInterpreter interpreter = JinjavaInterpreter.getCurrent();
+    int i = 8;
+    SizeLimitingPyMap objects = new SizeLimitingPyMap(createMap(i), 10);
+    assertThat(interpreter.getErrors()).isEmpty();
+
+    objects.put(Objects.toString(i + 1), ++i);
+    assertThat(interpreter.getErrors().size()).isEqualTo(1);
+    assertThat(interpreter.getErrors().get(0).getException())
+      .isInstanceOf(CollectionTooBigException.class);
+
+    objects.put(Objects.toString(i + 1), ++i);
+
+    assertThatThrownBy(() -> objects.put(Objects.toString(11), 11))
+      .isInstanceOf(CollectionTooBigException.class);
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyMapTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyMapTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.hubspot.jinjava.BaseJinjavaTest;
-import com.hubspot.jinjava.interpret.IndexOutOfRangeException;
+import com.hubspot.jinjava.interpret.CollectionTooBigException;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
@@ -17,7 +17,7 @@ public class SizeLimitingPyMapTest extends BaseJinjavaTest {
     assertThat(objects.size()).isEqualTo(10);
   }
 
-  @Test(expected = IndexOutOfRangeException.class)
+  @Test(expected = CollectionTooBigException.class)
   public void itLimitsOnCreate() {
     new SizeLimitingPyMap(createMap(3), 2);
   }
@@ -32,14 +32,14 @@ public class SizeLimitingPyMapTest extends BaseJinjavaTest {
     objects.put("2", "foo");
     objects.put("2", "foo");
     assertThatThrownBy(() -> objects.put("3", "foo"))
-      .isInstanceOf(IndexOutOfRangeException.class);
+      .isInstanceOf(CollectionTooBigException.class);
   }
 
   @Test
   public void itLimitsOnAddAll() {
     SizeLimitingPyMap objects = new SizeLimitingPyMap(new HashMap<>(), 2);
     assertThatThrownBy(() -> objects.putAll(createMap(3)))
-      .isInstanceOf(IndexOutOfRangeException.class);
+      .isInstanceOf(CollectionTooBigException.class);
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyMapTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyMapTest.java
@@ -1,0 +1,61 @@
+package com.hubspot.jinjava.objects.collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.hubspot.jinjava.BaseJinjavaTest;
+import com.hubspot.jinjava.interpret.IndexOutOfRangeException;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class SizeLimitingPyMapTest extends BaseJinjavaTest {
+
+  @Test
+  public void itDoesntLimitByDefault() {
+    SizeLimitingPyMap objects = new SizeLimitingPyMap(createMap(10), Integer.MAX_VALUE);
+    assertThat(objects.size()).isEqualTo(10);
+  }
+
+  @Test(expected = IndexOutOfRangeException.class)
+  public void itLimitsOnCreate() {
+    new SizeLimitingPyMap(createMap(3), 2);
+  }
+
+  @Test
+  public void itLimitsOnPut() {
+    SizeLimitingPyMap objects = new SizeLimitingPyMap(new HashMap<>(), 2);
+    objects.put("1", "foo");
+    objects.put("2", "foo");
+    objects.put("1", "foo");
+    objects.put("2", "foo");
+    objects.put("2", "foo");
+    objects.put("2", "foo");
+    assertThatThrownBy(() -> objects.put("3", "foo"))
+      .isInstanceOf(IndexOutOfRangeException.class);
+  }
+
+  @Test
+  public void itLimitsOnAddAll() {
+    SizeLimitingPyMap objects = new SizeLimitingPyMap(new HashMap<>(), 2);
+    assertThatThrownBy(() -> objects.putAll(createMap(3)))
+      .isInstanceOf(IndexOutOfRangeException.class);
+  }
+
+  @Test
+  public void itIgnoresLimitsForDuplicateKeys() {
+    SizeLimitingPyMap objects = new SizeLimitingPyMap(new HashMap<>(), 2);
+    objects.putAll(createMap(2));
+    assertThat(objects.size()).isEqualTo(2);
+    objects.putAll(createMap(2));
+    assertThat(objects.size()).isEqualTo(2);
+  }
+
+  private static Map<String, Object> createMap(int size) {
+    Map<String, Object> result = new HashMap<>();
+    for (int i = 0; i < size; i++) {
+      result.put(String.valueOf(i + 1), i + 1);
+    }
+    return result;
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/util/LengthLimitingStringBuilderTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/LengthLimitingStringBuilderTest.java
@@ -8,14 +8,14 @@ import org.junit.Test;
 public class LengthLimitingStringBuilderTest {
 
   @Test
-  public void itLimitsStringLength() throws Exception {
+  public void itLimitsStringLength() {
     LengthLimitingStringBuilder sb = new LengthLimitingStringBuilder(10);
     sb.append("0123456789");
     assertThatThrownBy(() -> sb.append("1")).isInstanceOf(OutputTooBigException.class);
   }
 
   @Test
-  public void itDoesNotLimitWithZeroLength() throws Exception {
+  public void itDoesNotLimitWithZeroLength() {
     LengthLimitingStringBuilder sb = new LengthLimitingStringBuilder(0);
     sb.append("0123456789");
   }


### PR DESCRIPTION
User-provided templates should not be allowed to use unlimited resources. This is a failsafe that adds a limit the maximum size of lists and maps. The default is no (practical) limit.

This is similar to https://github.com/HubSpot/jinjava/pull/137