### PR TITLE
Filter upgrades to support kw params

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/AbstractFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AbstractFilter.java
@@ -239,6 +239,10 @@ public abstract class AbstractFilter implements Filter, AdvancedFilter {
       .orElse(null);
   }
 
+  public Object getDefaultValue(String argName) {
+    return defaultValues.get(argName);
+  }
+
   public Map<String, JinjavaParam> initNamedArguments() {
     JinjavaDoc jinjavaDoc = this.getClass().getAnnotation(JinjavaDoc.class);
     if (jinjavaDoc != null) {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/AbstractFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AbstractFilter.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.lang3.BooleanUtils;

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilter.java
@@ -6,6 +6,7 @@ import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.fn.Functions;
 import com.hubspot.jinjava.objects.date.StrftimeFormatter;
+import java.util.Map;
 
 @JinjavaDoc(
   value = "Formats a date object",
@@ -17,19 +18,19 @@ import com.hubspot.jinjava.objects.date.StrftimeFormatter;
   ),
   params = {
     @JinjavaParam(
-      value = "format",
+      value = DateTimeFormatFilter.FORMAT_PARAM,
       defaultValue = StrftimeFormatter.DEFAULT_DATE_FORMAT,
       desc = "The format of the date determined by the directives added to this parameter"
     ),
     @JinjavaParam(
-      value = "timezone",
-      defaultValue = "utc",
+      value = DateTimeFormatFilter.TIMEZONE_PARAM,
+      defaultValue = "UTC",
       desc = "Time zone of output date"
     ),
     @JinjavaParam(
-      value = "locale",
+      value = DateTimeFormatFilter.LOCALE_PARAM,
       type = "string",
-      defaultValue = "us",
+      defaultValue = "en-US",
       desc = "The language code to use when formatting the datetime"
     )
   },
@@ -40,7 +41,10 @@ import com.hubspot.jinjava.objects.date.StrftimeFormatter;
     )
   }
 )
-public class DateTimeFormatFilter implements Filter {
+public class DateTimeFormatFilter extends AbstractFilter implements Filter {
+  public static final String FORMAT_PARAM = "format";
+  public static final String TIMEZONE_PARAM = "timezone";
+  public static final String LOCALE_PARAM = "locale";
 
   @Override
   public String getName() {
@@ -48,11 +52,18 @@ public class DateTimeFormatFilter implements Filter {
   }
 
   @Override
-  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
-    if (args.length > 0) {
-      return Functions.dateTimeFormat(var, args);
-    } else {
+  public Object filter(
+    Object var,
+    JinjavaInterpreter interpreter,
+    Map<String, Object> parsedArgs
+  ) {
+    String format = (String) parsedArgs.get(FORMAT_PARAM);
+    String timezone = (String) parsedArgs.get(TIMEZONE_PARAM);
+    String locale = (String) parsedArgs.get(LOCALE_PARAM);
+    if (format == null && timezone == null && locale == null) {
       return Functions.dateTimeFormat(var);
+    } else {
+      return Functions.dateTimeFormat(var, format, timezone, locale);
     }
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/JoinFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/JoinFilter.java
@@ -12,6 +12,7 @@ import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import com.hubspot.jinjava.util.ForLoop;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import com.hubspot.jinjava.util.ObjectIterator;
+import java.util.Map;
 import java.util.Objects;
 
 @JinjavaDoc(
@@ -19,12 +20,12 @@ import java.util.Objects;
   input = @JinjavaParam(value = "value", desc = "The values to join", required = true),
   params = {
     @JinjavaParam(
-      value = "d",
+      value = JoinFilter.SEPARATOR_PARAM,
       desc = "The separator string used to join the items",
       defaultValue = "(empty String)"
     ),
     @JinjavaParam(
-      value = "attr",
+      value = JoinFilter.ATTRIBUTE_PARAM,
       desc = "Optional dict object attribute to use in joining"
     )
   },
@@ -37,7 +38,9 @@ import java.util.Objects;
     )
   }
 )
-public class JoinFilter implements Filter {
+public class JoinFilter extends AbstractFilter implements Filter {
+  public static final String SEPARATOR_PARAM = "d";
+  public static final String ATTRIBUTE_PARAM = "attribute";
 
   @Override
   public String getName() {
@@ -45,20 +48,18 @@ public class JoinFilter implements Filter {
   }
 
   @Override
-  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+  public Object filter(
+    Object var,
+    JinjavaInterpreter interpreter,
+    Map<String, Object> parsedArgs
+  ) {
     LengthLimitingStringBuilder stringBuilder = new LengthLimitingStringBuilder(
       interpreter.getConfig().getMaxStringLength()
     );
 
-    String separator = "";
-    if (args.length > 0) {
-      separator = args[0];
-    }
+    String separator = (String) parsedArgs.get(SEPARATOR_PARAM);
 
-    String attr = null;
-    if (args.length > 1) {
-      attr = args[1];
-    }
+    String attr = (String) parsedArgs.get(ATTRIBUTE_PARAM);
 
     ForLoop loop = ObjectIterator.getLoop(var);
     boolean first = true;

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilter.java
@@ -10,7 +10,7 @@ import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.interpret.TemplateSyntaxException;
+import java.util.Map;
 
 @JinjavaDoc(
   value = "Return a copy of the value with all occurrences of a matched regular expression (Java RE2 syntax) " +
@@ -23,12 +23,12 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
   ),
   params = {
     @JinjavaParam(
-      value = "regex",
+      value = RegexReplaceFilter.REGEX_KEY,
       desc = "The regular expression that you want to match and replace",
       required = true
     ),
     @JinjavaParam(
-      value = "new",
+      value = RegexReplaceFilter.REPLACE_WITH,
       desc = "The new string that you replace the matched substring",
       required = true
     )
@@ -40,7 +40,9 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
     )
   }
 )
-public class RegexReplaceFilter implements Filter {
+public class RegexReplaceFilter extends AbstractFilter {
+  public static final String REGEX_KEY = "regex";
+  public static final String REPLACE_WITH = "new";
 
   @Override
   public String getName() {
@@ -48,31 +50,19 @@ public class RegexReplaceFilter implements Filter {
   }
 
   @Override
-  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
-    if (args.length < 2) {
-      throw new TemplateSyntaxException(
-        interpreter,
-        getName(),
-        "requires 2 arguments (regex string, replacement string)"
-      );
-    }
-
-    if (args[0] == null || args[1] == null) {
-      throw new TemplateSyntaxException(
-        interpreter,
-        getName(),
-        "requires both a valid regex and new params (not null)"
-      );
-    }
-
+  public Object filter(
+    Object var,
+    JinjavaInterpreter interpreter,
+    Map<String, Object> parsedArgs
+  ) {
     if (var == null) {
       return null;
     }
 
     if (var instanceof String) {
       String s = (String) var;
-      String toReplace = args[0];
-      String replaceWith = args[1];
+      String toReplace = (String) parsedArgs.get(REGEX_KEY);
+      String replaceWith = (String) parsedArgs.get(REPLACE_WITH);
 
       try {
         Pattern p = Pattern.compile(toReplace);

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ReplaceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ReplaceFilter.java
@@ -4,9 +4,8 @@ import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.interpret.TemplateSyntaxException;
+import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
 
 @JinjavaDoc(
   value = "Return a copy of the value with all occurrences of a substring replaced with a new one. " +
@@ -19,18 +18,18 @@ import org.apache.commons.lang3.math.NumberUtils;
   ),
   params = {
     @JinjavaParam(
-      value = "old",
+      value = ReplaceFilter.OLD_KEY,
       desc = "The old substring that you want to match and replace",
       required = true
     ),
     @JinjavaParam(
-      value = "new",
+      value = ReplaceFilter.REPLACE_WITH_KEY,
       desc = "The new string that you replace the matched substring",
       required = true
     ),
     @JinjavaParam(
-      value = "count",
-      type = "number",
+      value = ReplaceFilter.COUNT_KEY,
+      type = "int",
       desc = "Replace only the first N occurrences"
     )
   },
@@ -45,7 +44,10 @@ import org.apache.commons.lang3.math.NumberUtils;
     )
   }
 )
-public class ReplaceFilter implements Filter {
+public class ReplaceFilter extends AbstractFilter {
+  public static final String OLD_KEY = "old";
+  public static final String REPLACE_WITH_KEY = "new";
+  public static final String COUNT_KEY = "count";
 
   @Override
   public String getName() {
@@ -53,26 +55,19 @@ public class ReplaceFilter implements Filter {
   }
 
   @Override
-  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+  public Object filter(
+    Object var,
+    JinjavaInterpreter interpreter,
+    Map<String, Object> parsedArgs
+  ) {
     if (var == null) {
       return null;
     }
-    if (args.length < 2) {
-      throw new TemplateSyntaxException(
-        interpreter,
-        getName(),
-        "requires 2 arguments (substring to replace, replacement string) or 3 arguments (substring to replace, replacement string, number of occurrences to replace)"
-      );
-    }
 
     String s = (String) var;
-    String toReplace = args[0];
-    String replaceWith = args[1];
-    Integer count = null;
-
-    if (args.length > 2) {
-      count = NumberUtils.createInteger(args[2]);
-    }
+    String toReplace = (String) parsedArgs.get(OLD_KEY);
+    String replaceWith = (String) parsedArgs.get(REPLACE_WITH_KEY);
+    Integer count = (Integer) (parsedArgs.get(COUNT_KEY));
 
     if (count == null) {
       return StringUtils.replace(s, toReplace, replaceWith);

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SortFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SortFilter.java
@@ -15,8 +15,9 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 
 @JinjavaDoc(
   value = "Sort an iterable.",
@@ -28,18 +29,21 @@ import org.apache.commons.lang3.BooleanUtils;
   ),
   params = {
     @JinjavaParam(
-      value = "reverse",
+      value = SortFilter.REVERSE_PARAM,
       type = "boolean",
       defaultValue = "False",
       desc = "Boolean to reverse the sort order"
     ),
     @JinjavaParam(
-      value = "case_sensitive",
+      value = SortFilter.CASE_SENSITIVE_PARAM,
       type = "boolean",
       defaultValue = "False",
       desc = "Determines whether or not the sorting is case sensitive"
     ),
-    @JinjavaParam(value = "attribute", desc = "Specifies an attribute to sort by")
+    @JinjavaParam(
+      value = SortFilter.ATTRIBUTE_PARAM,
+      desc = "Specifies an attribute to sort by"
+    )
   },
   snippets = {
     @JinjavaSnippet(
@@ -54,9 +58,12 @@ import org.apache.commons.lang3.BooleanUtils;
     )
   }
 )
-public class SortFilter implements Filter {
+public class SortFilter extends AbstractFilter implements Filter {
   private static final Splitter DOT_SPLITTER = Splitter.on('.').omitEmptyStrings();
   private static final Joiner DOT_JOINER = Joiner.on('.');
+  public static final String REVERSE_PARAM = "reverse";
+  public static final String CASE_SENSITIVE_PARAM = "case_sensitive";
+  public static final String ATTRIBUTE_PARAM = "attribute";
 
   @Override
   public String getName() {
@@ -64,20 +71,25 @@ public class SortFilter implements Filter {
   }
 
   @Override
-  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+  public Object filter(
+    Object var,
+    JinjavaInterpreter interpreter,
+    Map<String, Object> parsedArgs
+  ) {
     if (var == null) {
       return null;
     }
 
-    boolean reverse = args.length > 0 && BooleanUtils.toBoolean(args[0]);
-    boolean caseSensitive = args.length > 1 && BooleanUtils.toBoolean(args[1]);
+    boolean reverse = (boolean) parsedArgs.get(REVERSE_PARAM);
+    boolean caseSensitive = (boolean) parsedArgs.get(CASE_SENSITIVE_PARAM);
+    String attribute = (String) parsedArgs.get(ATTRIBUTE_PARAM);
 
-    if (args.length > 2 && args[2] == null) {
+    if (parsedArgs.containsKey(ATTRIBUTE_PARAM) && attribute == null) {
       throw new InvalidArgumentException(interpreter, this, InvalidReason.NULL, 2);
     }
 
-    List<String> attr = args.length > 2
-      ? DOT_SPLITTER.splitToList(args[2])
+    List<String> attr = StringUtils.isNotEmpty(attribute)
+      ? DOT_SPLITTER.splitToList(attribute)
       : Collections.emptyList();
     return Lists
       .newArrayList(ObjectIterator.getLoop(var))

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SplitFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SplitFilter.java
@@ -7,8 +7,8 @@ import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import java.util.Map;
 import java.util.Objects;
-import org.apache.commons.lang3.math.NumberUtils;
 
 /**
  * split(separator=' ', limit=0)
@@ -24,13 +24,13 @@ import org.apache.commons.lang3.math.NumberUtils;
   input = @JinjavaParam(value = "string", desc = "The string to split", required = true),
   params = {
     @JinjavaParam(
-      value = "separator",
+      value = SplitFilter.SEPARATOR_PARAM,
       defaultValue = " ",
       desc = "Specifies the separator to split the variable by"
     ),
     @JinjavaParam(
-      value = "limit",
-      type = "number",
+      value = SplitFilter.LIMIT_PARAM,
+      type = "int",
       defaultValue = "0",
       desc = "Limits resulting list by putting remainder of string into last list item"
     )
@@ -47,7 +47,9 @@ import org.apache.commons.lang3.math.NumberUtils;
     )
   }
 )
-public class SplitFilter implements Filter {
+public class SplitFilter extends AbstractFilter implements Filter {
+  public static final String SEPARATOR_PARAM = "separator";
+  public static final String LIMIT_PARAM = "limit";
 
   @Override
   public String getName() {
@@ -55,20 +57,22 @@ public class SplitFilter implements Filter {
   }
 
   @Override
-  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+  public Object filter(
+    Object var,
+    JinjavaInterpreter interpreter,
+    Map<String, Object> parsedArgs
+  ) {
+    String separator = (String) parsedArgs.get(SEPARATOR_PARAM);
     Splitter splitter;
-
-    if (args.length > 0) {
-      splitter = Splitter.on(args[0]);
+    if (separator != null) {
+      splitter = Splitter.on(separator);
     } else {
       splitter = Splitter.on(CharMatcher.whitespace());
     }
 
-    if (args.length > 1) {
-      int limit = NumberUtils.toInt(args[1], 0);
-      if (limit > 0) {
-        splitter = splitter.limit(limit);
-      }
+    int limit = (Integer) parsedArgs.get(LIMIT_PARAM);
+    if (limit > 0) {
+      splitter = splitter.limit(limit);
     }
 
     return Lists.newArrayList(

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SumFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SumFilter.java
@@ -20,13 +20,13 @@ import java.util.Objects;
   ),
   params = {
     @JinjavaParam(
-      value = "start",
+      value = SumFilter.START_PARAM,
       type = "number",
       defaultValue = "0",
       desc = "Sets a value to return, if there is nothing in the variable to sum"
     ),
     @JinjavaParam(
-      value = "attribute",
+      value = SumFilter.ATTRIBUTE_PARAM,
       desc = "Specify an optional attribute of dict to sum"
     )
   },
@@ -40,7 +40,9 @@ import java.util.Objects;
     )
   }
 )
-public class SumFilter implements AdvancedFilter {
+public class SumFilter extends AbstractFilter implements AdvancedFilter {
+  public static final String START_PARAM = "start";
+  public static final String ATTRIBUTE_PARAM = "attribute";
 
   @Override
   public String getName() {
@@ -51,21 +53,16 @@ public class SumFilter implements AdvancedFilter {
   public Object filter(
     Object var,
     JinjavaInterpreter interpreter,
-    Object[] args,
-    Map<String, Object> kwargs
+    Map<String, Object> parsedArgs
   ) {
     ForLoop loop = ObjectIterator.getLoop(var);
 
-    BigDecimal sum = BigDecimal.ZERO;
-    String attr = kwargs.containsKey("attribute")
-      ? kwargs.get("attribute").toString()
-      : null;
+    Number start = (Number) parsedArgs.get(START_PARAM);
+    String attr = (String) parsedArgs.get(ATTRIBUTE_PARAM);
 
-    if (args.length > 0) {
-      try {
-        sum = sum.add(new BigDecimal(args[0].toString()));
-      } catch (NumberFormatException ignored) {}
-    }
+    BigDecimal sum = start instanceof BigDecimal
+      ? (BigDecimal) start
+      : new BigDecimal(Objects.toString(start.toString(), "0"));
 
     while (loop.hasNext()) {
       Object val = loop.next();

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TruncateFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TruncateFilter.java
@@ -20,6 +20,7 @@ import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.fn.Functions;
+import java.util.Map;
 
 @JinjavaDoc(
   value = "Return a truncated copy of the string. The length is specified with the first parameter which defaults to 255. " +
@@ -33,19 +34,19 @@ import com.hubspot.jinjava.lib.fn.Functions;
   ),
   params = {
     @JinjavaParam(
-      value = "length",
-      type = "number",
+      value = TruncateFilter.LENGTH_PARAM,
+      type = "int",
       defaultValue = "255",
       desc = "Specifies the length at which to truncate the text (includes HTML characters)"
     ),
     @JinjavaParam(
-      value = "killwords",
+      value = TruncateFilter.KILLWORDS_PARAM,
       type = "boolean",
       defaultValue = "False",
       desc = "If true, the string will cut text at length"
     ),
     @JinjavaParam(
-      value = "end",
+      value = TruncateFilter.END_PARAM,
       defaultValue = "...",
       desc = "The characters that will be added to indicate where the text was truncated"
     )
@@ -61,11 +62,21 @@ import com.hubspot.jinjava.lib.fn.Functions;
     )
   }
 )
-public class TruncateFilter implements Filter {
+public class TruncateFilter extends AbstractFilter implements Filter {
+  public static final String LENGTH_PARAM = "length";
+  public static final String KILLWORDS_PARAM = "killwords";
+  public static final String END_PARAM = "end";
 
   @Override
-  public Object filter(Object object, JinjavaInterpreter interpreter, String... arg) {
-    return Functions.truncate(object, arg);
+  public Object filter(
+    Object object,
+    JinjavaInterpreter interpreter,
+    Map<String, Object> parsedArgs
+  ) {
+    int length = (int) parsedArgs.get(LENGTH_PARAM);
+    boolean killwords = (boolean) parsedArgs.get(KILLWORDS_PARAM);
+    String end = (String) parsedArgs.get(END_PARAM);
+    return Functions.truncate(object, length, killwords, end);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
@@ -1,16 +1,11 @@
 package com.hubspot.jinjava.lib.filter;
 
-import static com.hubspot.jinjava.util.Logging.ENGINE_LOG;
-
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.fn.Functions;
-import com.hubspot.jinjava.objects.SafeString;
 import java.util.Map;
-import java.util.Objects;
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -24,18 +19,18 @@ import org.jsoup.select.NodeVisitor;
   input = @JinjavaParam(value = "html", desc = "HTML to truncate", required = true),
   params = {
     @JinjavaParam(
-      value = "length",
-      type = "number",
+      value = TruncateHtmlFilter.LENGTH_KEY,
+      type = "int",
       defaultValue = "255",
       desc = "Length at which to truncate text (HTML characters not included)"
     ),
     @JinjavaParam(
-      value = "end",
+      value = TruncateHtmlFilter.END_KEY,
       defaultValue = "...",
       desc = "The characters that will be added to indicate where the text was truncated"
     ),
     @JinjavaParam(
-      value = "breakword",
+      value = TruncateHtmlFilter.BREAKWORD_KEY,
       type = "boolean",
       defaultValue = "false",
       desc = "If set to true, text will be truncated in the middle of words"
@@ -48,12 +43,10 @@ import org.jsoup.select.NodeVisitor;
     )
   }
 )
-public class TruncateHtmlFilter implements AdvancedFilter {
-  private static final int DEFAULT_TRUNCATE_LENGTH = 255;
-  private static final String DEFAULT_END = "...";
-  private static final String LENGTH_KEY = "length";
-  private static final String END_KEY = "end";
-  private static final String BREAKWORD_KEY = "breakword";
+public class TruncateHtmlFilter extends AbstractFilter implements AdvancedFilter {
+  public static final String LENGTH_KEY = "length";
+  public static final String END_KEY = "end";
+  public static final String BREAKWORD_KEY = "breakword";
 
   @Override
   public String getName() {
@@ -64,87 +57,21 @@ public class TruncateHtmlFilter implements AdvancedFilter {
   public Object filter(
     Object var,
     JinjavaInterpreter interpreter,
-    Object[] args,
-    Map<String, Object> kwargs
+    Map<String, Object> parsedArgs
   ) {
-    String length = null;
-    if (kwargs.containsKey(LENGTH_KEY)) {
-      length = Objects.toString(kwargs.get(LENGTH_KEY));
-    }
-    String end = null;
-    if (kwargs.containsKey(END_KEY)) {
-      end = Objects.toString(kwargs.get(END_KEY));
-    }
-    String breakword = null;
-    if (kwargs.containsKey(BREAKWORD_KEY)) {
-      breakword = Objects.toString(kwargs.get(BREAKWORD_KEY));
-    }
+    int length = ((int) parsedArgs.get(LENGTH_KEY));
+    String end = (String) parsedArgs.get(END_KEY);
+    boolean breakword = (boolean) parsedArgs.get(BREAKWORD_KEY);
+    Document dom = Jsoup.parseBodyFragment((String) var);
 
-    String[] newArgs = new String[3];
-    for (int i = 0; i < args.length; i++) {
-      if (i >= newArgs.length) {
-        break;
-      }
-      newArgs[i] = Objects.toString(args[i]);
-    }
-
-    if (length != null) {
-      newArgs[0] = length;
-    }
-    if (end != null) {
-      newArgs[1] = end;
-    }
-    if (breakword != null) {
-      newArgs[2] = breakword;
-    }
-
-    if (var instanceof SafeString) {
-      return filter((SafeString) var, interpreter, newArgs);
-    }
-
-    return filter(var, interpreter, newArgs);
-  }
-
-  @Override
-  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
-    if (var instanceof String) {
-      int length = DEFAULT_TRUNCATE_LENGTH;
-      String ends = DEFAULT_END;
-
-      if (args.length > 0) {
-        try {
-          length = Integer.parseInt(Objects.toString(args[0]));
-        } catch (Exception e) {
-          ENGINE_LOG.warn(
-            "truncatehtml(): error setting length for {}, using default {}",
-            args[0],
-            DEFAULT_TRUNCATE_LENGTH
-          );
-        }
-      }
-
-      if (args.length > 1 && args[1] != null) {
-        ends = Objects.toString(args[1]);
-      }
-
-      boolean killwords = false;
-      if (args.length > 2 && args[2] != null) {
-        killwords = BooleanUtils.toBoolean(args[2]);
-      }
-
-      Document dom = Jsoup.parseBodyFragment((String) var);
-      ContentTruncatingNodeVisitor visitor = new ContentTruncatingNodeVisitor(
-        length,
-        ends,
-        killwords
-      );
-      dom.select("body").traverse(visitor);
-      dom.select(".__deleteme").remove();
-
-      return dom.select("body").html();
-    }
-
-    return var;
+    ContentTruncatingNodeVisitor visitor = new ContentTruncatingNodeVisitor(
+      length,
+      end,
+      breakword
+    );
+    dom.select("body").traverse(visitor);
+    dom.select(".__deleteme").remove();
+    return dom.select("body").html();
   }
 
   private static class ContentTruncatingNodeVisitor implements NodeVisitor {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
@@ -74,6 +74,22 @@ public class TruncateHtmlFilter extends AbstractFilter implements AdvancedFilter
     return dom.select("body").html();
   }
 
+  @Override
+  protected Object parseArg(
+    JinjavaInterpreter interpreter,
+    JinjavaParam jinjavaParamMetadata,
+    Object value
+  ) {
+    if (jinjavaParamMetadata.value().equals(LENGTH_KEY) && interpreter != null) {
+      try {
+        return super.parseArg(interpreter, jinjavaParamMetadata, value);
+      } catch (Exception e) {
+        return getDefaultValue(LENGTH_KEY);
+      }
+    }
+    return super.parseArg(interpreter, jinjavaParamMetadata, value);
+  }
+
   private static class ContentTruncatingNodeVisitor implements NodeVisitor {
     private int maxTextLen;
     private int textLen;

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UrlizeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UrlizeFilter.java
@@ -4,12 +4,11 @@ import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
 
 @JinjavaDoc(
   value = "Converts URLs in plain text into clickable links.",
@@ -21,17 +20,21 @@ import org.apache.commons.lang3.math.NumberUtils;
   ),
   params = {
     @JinjavaParam(
-      value = "trim_url_limit",
-      type = "number",
-      desc = "Sets a character limit"
+      value = UrlizeFilter.TRIM_URL_LIMIT_KEY,
+      type = "int",
+      desc = "Sets a character limit",
+      defaultValue = "2147483647"
     ),
     @JinjavaParam(
-      value = "nofollow",
+      value = UrlizeFilter.NO_FOLLOW_KEY,
       type = "boolean",
       defaultValue = "False",
       desc = "Adds nofollow to generated link tag"
     ),
-    @JinjavaParam(value = "target", desc = "Adds target attr to generated link tag")
+    @JinjavaParam(
+      value = UrlizeFilter.TARGET_KEY,
+      desc = "Adds target attr to generated link tag"
+    )
   },
   snippets = {
     @JinjavaSnippet(
@@ -44,7 +47,10 @@ import org.apache.commons.lang3.math.NumberUtils;
     )
   }
 )
-public class UrlizeFilter implements Filter {
+public class UrlizeFilter extends AbstractFilter implements Filter {
+  public static final String TRIM_URL_LIMIT_KEY = "trim_url_limit";
+  public static final String NO_FOLLOW_KEY = "nofollow";
+  public static final String TARGET_KEY = "target";
 
   @Override
   public String getName() {
@@ -52,26 +58,21 @@ public class UrlizeFilter implements Filter {
   }
 
   @Override
-  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+  public Object filter(
+    Object var,
+    JinjavaInterpreter interpreter,
+    Map<String, Object> parsedArgs
+  ) {
     Matcher m = URL_RE.matcher(Objects.toString(var, ""));
     StringBuffer result = new StringBuffer();
 
-    int trimUrlLimit = Integer.MAX_VALUE;
-    if (args.length > 0) {
-      trimUrlLimit = NumberUtils.toInt(args[0], Integer.MAX_VALUE);
-    }
+    int trimUrlLimit = ((int) parsedArgs.get(TRIM_URL_LIMIT_KEY));
 
     String fmt = "<a href=\"%s\"";
 
-    boolean nofollow = false;
-    if (args.length > 1) {
-      nofollow = BooleanUtils.toBoolean(args[1]);
-    }
+    boolean nofollow = (boolean) parsedArgs.get(NO_FOLLOW_KEY);
 
-    String target = "";
-    if (args.length > 2) {
-      target = args[2];
-    }
+    String target = (String) parsedArgs.get(TARGET_KEY);
 
     if (nofollow) {
       fmt += " rel=\"nofollow\"";

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -105,6 +105,11 @@ public class Functions {
         value = "timezone",
         defaultValue = "utc",
         desc = "Time zone of output date"
+      ),
+      @JinjavaParam(
+        value = "locale",
+        defaultValue = "us",
+        desc = "The language code to use when formatting the datetime"
       )
     }
   )

--- a/src/test/java/com/hubspot/jinjava/lib/filter/AbstractFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/AbstractFilterTest.java
@@ -10,7 +10,6 @@ import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.math.BigDecimal;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
 
@@ -81,7 +80,7 @@ public class AbstractFilterTest extends BaseInterpretingTest {
       .put("long", "2")
       .put("double", "3")
       .put("float", "4")
-      .put("number", "5")
+      .put("number", "55555555555555555555.555555555555555555")
       .put("object", new Object())
       .put("dict", new Object())
       .build();
@@ -95,7 +94,7 @@ public class AbstractFilterTest extends BaseInterpretingTest {
       .put("long", 2L)
       .put("double", 3.0)
       .put("float", 4.0f)
-      .put("number", new BigDecimal(5))
+      .put("number", new BigDecimal("55555555555555555555.555555555555555555"))
       .put("object", kwArgs.get("object"))
       .put("dict", kwArgs.get("dict"))
       .build();
@@ -144,6 +143,19 @@ public class AbstractFilterTest extends BaseInterpretingTest {
           )
       )
       .hasMessageContaining("Argument named 'unknown' is invalid");
+  }
+
+  @JinjavaDoc(
+    params = {
+      @JinjavaParam(value = "int", type = "int", desc = "int", defaultValue = "?")
+    }
+  )
+  public static class InvalidDefaultValueFilter extends ArgCapturingFilter {}
+
+  @Test
+  public void itErrorsInitOnInvalidDefaultValue() {
+    assertThatThrownBy(() -> new InvalidDefaultValueFilter())
+      .hasMessageContaining("Input '?' is not parsable type of 'int' for filter");
   }
 
   public static class ArgCapturingFilter extends AbstractFilter {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilterTest.java
@@ -20,7 +20,7 @@ public class RegexReplaceFilterTest extends BaseInterpretingTest {
   @Test
   public void expects2Args() {
     assertThatThrownBy(() -> filter.filter("foo", interpreter))
-      .hasMessageContaining("requires 2 arguments");
+      .hasMessageContaining("Argument named 'regex' is required but missing");
   }
 
   @Test
@@ -28,7 +28,7 @@ public class RegexReplaceFilterTest extends BaseInterpretingTest {
     assertThatThrownBy(
         () -> filter.filter("foo", interpreter, new String[] { null, null })
       )
-      .hasMessageContaining("both a valid regex");
+      .hasMessageContaining("Argument named 'regex' is required but missing");
   }
 
   public void noopOnNullExpr() {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/ReplaceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/ReplaceFilterTest.java
@@ -3,7 +3,7 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hubspot.jinjava.BaseInterpretingTest;
-import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.objects.SafeString;
 import org.junit.Before;
 import org.junit.Test;
@@ -16,7 +16,7 @@ public class ReplaceFilterTest extends BaseInterpretingTest {
     filter = new ReplaceFilter();
   }
 
-  @Test(expected = InterpretException.class)
+  @Test(expected = InvalidInputException.class)
   public void expectsAtLeast2Args() {
     filter.filter("foo", interpreter);
   }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilterTest.java
@@ -63,7 +63,7 @@ public class TruncateHtmlFilterTest extends BaseInterpretingTest {
       fixture("filter/truncatehtml/long-content-with-tags.html"),
       interpreter,
       new Object[] { "35" },
-      ImmutableMap.of("breakwords", false)
+      ImmutableMap.of(TruncateHtmlFilter.BREAKWORD_KEY, false)
     );
     assertThat(result)
       .isEqualTo(
@@ -75,7 +75,7 @@ public class TruncateHtmlFilterTest extends BaseInterpretingTest {
         fixture("filter/truncatehtml/long-content-with-tags.html"),
         interpreter,
         new Object[] { "35" },
-        ImmutableMap.of("end", "TEST")
+        ImmutableMap.of(TruncateHtmlFilter.END_KEY, "TEST")
       );
     assertThat(result)
       .isEqualTo(

--- a/src/test/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilterTest.java
@@ -83,6 +83,21 @@ public class TruncateHtmlFilterTest extends BaseInterpretingTest {
       );
   }
 
+  @Test
+  public void itDefaultsLengthWhenCannotBeParsed() {
+    String result = (String) filter.filter(
+      fixture("filter/truncatehtml/long-content-with-tags.html"),
+      interpreter,
+      new Object[] { "?" },
+      ImmutableMap.of(TruncateHtmlFilter.BREAKWORD_KEY, false)
+    );
+    assertThat(result)
+      .isEqualTo(
+        "<h1>HTML Ipsum Presents</h1> \n" +
+        "<p><strong>Pellentesque habitant morbi tristique</strong> senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. <em>Aenean ultricies...</em></p>"
+      );
+  }
+
   private static String fixture(String name) {
     try {
       return Resources.toString(Resources.getResource(name), StandardCharsets.UTF_8);


### PR DESCRIPTION
This change includes the following:

- Upgrades to filters with >1 params that have 100% code coverage
- There are some fixes to Jinjavadoc as they didn't match unit tests

@boulter This is following up on the `AbstractFilter` #523 , these are draft changes so let me know what you think of these changes and whether you'd prefer split PRs too

Jinjavadoc alignment with tests includes:

- DateTimeFormatFilter
- JoinFilter
- various `number` => `int` changes where filter actually required an integer - the conversion is done in AbstractFilter