### PR TITLE
remove overrides for append and insert

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyList.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyList.java
@@ -31,18 +31,6 @@ public class SizeLimitingPyList extends PyList implements PyWrapper {
   }
 
   @Override
-  public boolean append(Object e) {
-    checkSize(size() + 1);
-    return super.append(e);
-  }
-
-  @Override
-  public void insert(int i, Object e) {
-    checkSize(size() + 1);
-    super.insert(i, e);
-  }
-
-  @Override
   public boolean add(Object element) {
     checkSize(size() + 1);
     return super.add(element);


### PR DESCRIPTION
`append` and `insert` eventually call `add`, so there's no need to override them to check the size of the array.

This is a followup to https://github.com/HubSpot/jinjava/pull/530