### PR TITLE
check if list index is numeric before parsing to int

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/JinjavaListELResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/JinjavaListELResolver.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.el.ext;
 import java.util.List;
 import javax.el.ELContext;
 import javax.el.ListELResolver;
+import org.apache.commons.lang3.StringUtils;
 
 public class JinjavaListELResolver extends ListELResolver {
 
@@ -64,10 +65,13 @@ public class JinjavaListELResolver extends ListELResolver {
    *             if property cannot be coerced to an integer.
    */
   private static int toIndex(Object property) {
-    int index = 0;
+    int index;
     if (property instanceof Number) {
       index = ((Number) property).intValue();
     } else if (property instanceof String) {
+      if (!StringUtils.isNumeric((String) property)) {
+        throw new IllegalArgumentException("Cannot parse list index: " + property);
+      }
       try {
         // ListELResolver uses valueOf, but findbugs complains.
         index = Integer.parseInt((String) property);

--- a/src/main/java/com/hubspot/jinjava/el/ext/JinjavaListELResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/JinjavaListELResolver.java
@@ -3,7 +3,6 @@ package com.hubspot.jinjava.el.ext;
 import java.util.List;
 import javax.el.ELContext;
 import javax.el.ListELResolver;
-import org.apache.commons.lang3.StringUtils;
 
 public class JinjavaListELResolver extends ListELResolver {
 
@@ -69,7 +68,7 @@ public class JinjavaListELResolver extends ListELResolver {
     if (property instanceof Number) {
       index = ((Number) property).intValue();
     } else if (property instanceof String) {
-      if (!StringUtils.isNumeric((String) property)) {
+      if (!isNumeric((String) property)) {
         throw new IllegalArgumentException("Cannot parse list index: " + property);
       }
       try {
@@ -95,5 +94,18 @@ public class JinjavaListELResolver extends ListELResolver {
     try {
       super.setValue(context, base, property, value);
     } catch (IllegalArgumentException ignored) {}
+  }
+
+  public static boolean isNumeric(final CharSequence cs) {
+    if (cs == null || cs.length() == 0) {
+      return false;
+    }
+    final int sz = cs.length();
+    for (int i = 0; i < sz; i++) {
+      if (!Character.isDigit(cs.charAt(i)) && cs.charAt(i) != '-') {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverPerformanceTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverPerformanceTest.java
@@ -40,9 +40,7 @@ public class ExpressionResolverPerformanceTest {
     }
 
     public void stopTimer() {
-      System.out.println(
-        String.format("%d msec", System.currentTimeMillis() - startTime)
-      );
+      System.out.printf("%d msec%n", System.currentTimeMillis() - startTime);
     }
 
     public void testMapResolver(int iterations) {


### PR DESCRIPTION
`Integer.parseInt` is rather expensive. For lists, `CompositeElResolver` first checks if the attribute is numeric which makes calling methods on lists like `append()` slow. We can speed that up by ensuring that the attribute is numeric before we try to parse it into an int.

For 100,000 iterations, `append()` took 11.4 seconds with the change and 14.6 seconds without for a speedup of 22%. 100,000 iterations of numeric attribute accesses showed no significant slowdown.