### PR TITLE
Prepare context from ExecutionMode

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -83,6 +83,8 @@ public class JinjavaInterpreter {
     this.config = renderConfig;
     this.application = application;
 
+    this.config.getExecutionMode().prepareContext(this.context);
+
     switch (config.getRandomNumberGeneratorStrategy()) {
       case THREAD_LOCAL:
         random = ThreadLocalRandom.current();

--- a/src/main/java/com/hubspot/jinjava/mode/EagerExecutionMode.java
+++ b/src/main/java/com/hubspot/jinjava/mode/EagerExecutionMode.java
@@ -1,6 +1,9 @@
 package com.hubspot.jinjava.mode;
 
 import com.hubspot.jinjava.interpret.Context;
+import com.hubspot.jinjava.lib.tag.eager.EagerTagDecorator;
+import com.hubspot.jinjava.lib.tag.eager.EagerTagFactory;
+import java.util.Optional;
 
 public class EagerExecutionMode implements ExecutionMode {
 
@@ -11,6 +14,13 @@ public class EagerExecutionMode implements ExecutionMode {
 
   @Override
   public void prepareContext(Context context) {
-    // TODO register eager tags & expression node
+    context
+      .getAllTags()
+      .stream()
+      .filter(tag -> !(tag instanceof EagerTagDecorator))
+      .map(tag -> EagerTagFactory.getEagerTagDecorator(tag.getClass()))
+      .filter(Optional::isPresent)
+      .forEach(maybeEagerTag -> context.registerTag(maybeEagerTag.get()));
+    // TODO prepare expression node
   }
 }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -79,13 +79,6 @@ public class EagerTest {
       new ExpectedTemplateInterpreter(jinjava, interpreter, "eager");
     localContext = interpreter.getContext();
 
-    localContext
-      .getAllTags()
-      .stream()
-      .map(tag -> EagerTagFactory.getEagerTagDecorator(tag.getClass()))
-      .filter(Optional::isPresent)
-      .forEach(maybeEagerTag -> localContext.registerTag(maybeEagerTag.get()));
-
     localContext.put("deferred", DeferredValue.instance());
     localContext.put("resolved", "resolvedValue");
     localContext.put("dict", ImmutableSet.of("a", "b", "c"));
@@ -723,15 +716,6 @@ public class EagerTest {
       config
     );
     JinjavaInterpreter noNestedInterpreter = new JinjavaInterpreter(parentInterpreter);
-    noNestedInterpreter
-      .getContext()
-      .getAllTags()
-      .stream()
-      .map(tag -> EagerTagFactory.getEagerTagDecorator(tag.getClass()))
-      .filter(Optional::isPresent)
-      .forEach(
-        maybeEagerTag -> noNestedInterpreter.getContext().registerTag(maybeEagerTag.get())
-      );
 
     JinjavaInterpreter.pushCurrent(noNestedInterpreter);
     try {


### PR DESCRIPTION
Part of https://github.com/HubSpot/jinjava/issues/532
---
Moved from https://github.com/jasmith-hs/jinjava/pull/3 (temporarily set the base as `eager-tag-decorator` to increase changes readability as this PR depends on https://github.com/HubSpot/jinjava/pull/542)

When an interpreter is created, use the ExecutionMode's implementation of the `prepareContext()` method to prepare the context in a way specific to that type of execution.
For Eager Execution, this includes registering eager tag decorators and registering a different strategy for interpreting expression nodes (coming in next PR).