### PR TITLE
Add EagerTagDecorator functionality minus deferred macro logic

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStringResult.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStringResult.java
@@ -1,0 +1,34 @@
+package com.hubspot.jinjava.lib.tag.eager;
+
+/**
+ * This represents the result of executing an expression, where if something got
+ * deferred, then the <code>prefixToPreserveState</code> can be added to the output
+ * that would preserve the state for a second pass.
+ */
+public class EagerStringResult {
+  private final String result;
+  private final String prefixToPreserveState;
+
+  public EagerStringResult(String result) {
+    this.result = result;
+    this.prefixToPreserveState = "";
+  }
+
+  public EagerStringResult(String result, String prefixToPreserveState) {
+    this.result = result;
+    this.prefixToPreserveState = prefixToPreserveState;
+  }
+
+  public String getResult() {
+    return result;
+  }
+
+  public String getPrefixToPreserveState() {
+    return prefixToPreserveState;
+  }
+
+  @Override
+  public String toString() {
+    return prefixToPreserveState + result;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -1,10 +1,34 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import static com.hubspot.jinjava.interpret.Context.GLOBAL_MACROS_SCOPE_KEY;
+import static com.hubspot.jinjava.interpret.Context.IMPORT_RESOURCE_PATH_KEY;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.hubspot.jinjava.interpret.Context.Library;
+import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
+import com.hubspot.jinjava.interpret.DisabledException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.tag.AutoEscapeTag;
+import com.hubspot.jinjava.lib.tag.RawTag;
+import com.hubspot.jinjava.lib.tag.SetTag;
 import com.hubspot.jinjava.lib.tag.Tag;
+import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.TagNode;
+import com.hubspot.jinjava.tree.parse.TagToken;
+import com.hubspot.jinjava.tree.parse.Token;
+import com.hubspot.jinjava.util.ChunkResolver;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 
 public abstract class EagerTagDecorator<T extends Tag> implements Tag {
   private T tag;
@@ -21,7 +45,7 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     try {
       return tag.interpret(tagNode, interpreter);
-    } catch (DeferredValueException e) {
+    } catch (DeferredValueException | TemplateSyntaxException e) {
       return wrapInAutoEscapeIfNeeded(eagerInterpret(tagNode, interpreter), interpreter);
     }
   }
@@ -41,8 +65,319 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
     return tag.isRenderedInValidationMode();
   }
 
+  /**
+   * Return the string value of interpreting this tag node knowing that
+   * a deferred value has been encountered.
+   * The tag node can not simply get evaluated normally in this circumstance.
+   * @param tagNode TagNode to interpret.
+   * @param interpreter The JinjavaInterpreter.
+   * @return The string result of performing an eager interpretation of the TagNode
+   */
   public String eagerInterpret(TagNode tagNode, JinjavaInterpreter interpreter) {
-    return ""; // TODO replace with actual functionality
+    StringBuilder result = new StringBuilder(
+      executeInChildContext(
+          eagerInterpreter ->
+            getEagerImage(tagNode.getMaster(), eagerInterpreter) +
+            renderChildren(tagNode, eagerInterpreter),
+          interpreter,
+          false
+        )
+        .toString()
+    );
+
+    if (StringUtils.isNotBlank(tagNode.getEndName())) {
+      result.append(reconstructEnd(tagNode));
+    }
+
+    return result.toString();
+  }
+
+  /**
+   * Render all children of this TagNode.
+   * @param tagNode TagNode to render the children of.
+   * @param interpreter The JinjavaInterpreter.
+   * @return
+   */
+  public String renderChildren(TagNode tagNode, JinjavaInterpreter interpreter) {
+    StringBuilder sb = new StringBuilder();
+    for (Node child : tagNode.getChildren()) {
+      sb.append(child.render(interpreter).getValue());
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Execute the specified functions within a protected context.
+   * Additionally, if the execution causes existing values on the context to become
+   *   deferred, then their previous values will wrapped in a <code>set</code>
+   *   tag that gets prepended to the returned result.
+   * The <code>function</code> is run in protectedMode=true, where the context needs to
+   *   be protected from having values updated or set,
+   *   such as when evaluating both the positive and negative nodes in an if statement.
+   * @param function Function to run within a "protected" child context
+   * @param interpreter JinjavaInterpreter to create a child from.
+   * @param takeNewValue If a value is updated (not replaced) either take the new value or
+   *                     take the previous value and put it into the
+   *                     <code>EagerStringResult.prefixToPreserveState</code>.
+   * @return An <code>EagerStringResult</code> where:
+   *  <code>result</code> is the string result of <code>function</code>.
+   *  <code>prefixToPreserveState</code> is either blank or a <code>set</code> tag
+   *    that preserves the state within the output for a second rendering pass.
+   */
+  public static EagerStringResult executeInChildContext(
+    Function<JinjavaInterpreter, String> function,
+    JinjavaInterpreter interpreter,
+    boolean takeNewValue
+  ) {
+    StringBuilder result = new StringBuilder();
+    Map<String, Integer> initiallyResolvedHashes = new HashMap<>();
+    Map<String, String> initiallyResolvedAsStrings = new HashMap<>();
+    interpreter
+      .getContext()
+      .entrySet()
+      .stream()
+      .filter(
+        e ->
+          !e.getKey().equals(GLOBAL_MACROS_SCOPE_KEY) &&
+          !e.getKey().equals(IMPORT_RESOURCE_PATH_KEY)
+      )
+      .filter(e -> !(e.getValue() instanceof DeferredValue))
+      .forEach(
+        entry -> {
+          initiallyResolvedHashes.put(entry.getKey(), entry.getValue().hashCode());
+          try {
+            initiallyResolvedAsStrings.put(
+              entry.getKey(),
+              ChunkResolver.getValueAsJinjavaString(entry.getValue())
+            );
+          } catch (JsonProcessingException jsonProcessingException) {
+            // do nothing
+          }
+        }
+      );
+
+    try (InterpreterScopeClosable c = interpreter.enterScope()) {
+      interpreter.getContext().setProtectedMode(true);
+      result.append(function.apply(interpreter));
+    }
+    Map<String, String> deferredValuesToSet = interpreter
+      .getContext()
+      .entrySet()
+      .stream()
+      .filter(e -> initiallyResolvedHashes.containsKey(e.getKey()))
+      .filter(
+        e -> !initiallyResolvedHashes.get(e.getKey()).equals(e.getValue().hashCode())
+      )
+      .collect(
+        Collectors.toMap(
+          Entry::getKey,
+          e -> {
+            try {
+              if (e instanceof DeferredValue) {
+                return ChunkResolver.getValueAsJinjavaString(
+                  ((DeferredValue) e.getValue()).getOriginalValue()
+                );
+              }
+              if (takeNewValue) {
+                return ChunkResolver.getValueAsJinjavaString(e.getValue());
+              }
+
+              // This is necessary if a state-changing function, such as .update()
+              // or .append() is run against a variable in the context.
+              // It will revert the effects when takeNewValue is false.
+              if (initiallyResolvedAsStrings.containsKey(e.getKey())) {
+                return initiallyResolvedAsStrings.get(e.getKey());
+              }
+            } catch (JsonProcessingException ignored) {
+              // pass through
+            }
+            // Previous value could not be mapped to a string
+            throw new DeferredValueException(e.getKey());
+          }
+        )
+      );
+    if (deferredValuesToSet.size() > 0) {
+      return new EagerStringResult(
+        result.toString(),
+        buildSetTagForDeferredInChildContext(
+          deferredValuesToSet,
+          interpreter,
+          !takeNewValue
+        )
+      );
+    }
+    return new EagerStringResult(result.toString());
+  }
+
+  /**
+   * Build macro tag images for any macro functions that are included in deferredWords
+   * and remove those macro functions from the deferredWords set.
+   * These macro functions are either global or local macro functions, with local
+   * meaning they've been imported under an alias such as "simple.multiply()".
+   * @param deferredWords Set of words that were encountered and their evaluation has
+   *                      to be deferred for a later render.
+   * @param interpreter The Jinjava interpreter.
+   * @return A jinjava-syntax string that is the images of any macro functions that must
+   *  be evaluated at a later time.
+   */
+  public static String getNewlyDeferredFunctionImages(
+    Set<String> deferredWords,
+    JinjavaInterpreter interpreter
+  ) {
+    return ""; // TODO un-stub
+  }
+
+  /**
+   * Build the image for a set tag which preserves the values of objects on the context
+   * for a later rendering pass. The set tag will set the keys to the values within
+   * the {@code deferredValuesToSet} Map.
+   * @param deferredValuesToSet Map that specifies what the context objects should be set
+   *                            to in the returned image.
+   * @param interpreter The Jinjava interpreter.
+   * @param registerEagerToken Whether or not to register the returned {@link SetTag}
+   *                           image as an {@link EagerToken}.
+   * @return A jinjava-syntax string that is the image of a set tag that will
+   *  be executed at a later time.
+   */
+  public static String buildSetTagForDeferredInChildContext(
+    Map<String, String> deferredValuesToSet,
+    JinjavaInterpreter interpreter,
+    boolean registerEagerToken
+  ) {
+    if (
+      interpreter.getConfig().getDisabled().containsKey(Library.TAG) &&
+      interpreter.getConfig().getDisabled().get(Library.TAG).contains(SetTag.TAG_NAME)
+    ) {
+      throw new DisabledException("set tag disabled");
+    }
+
+    StringJoiner vars = new StringJoiner(",");
+    StringJoiner values = new StringJoiner(",");
+    deferredValuesToSet.forEach(
+      (key, value) -> {
+        // This ensures they are properly aligned to each other.
+        vars.add(key);
+        values.add(value);
+      }
+    );
+    StringJoiner result = new StringJoiner(" ");
+    result
+      .add(interpreter.getConfig().getTokenScannerSymbols().getExpressionStartWithTag())
+      .add(SetTag.TAG_NAME)
+      .add(vars.toString())
+      .add("=")
+      .add(values.toString())
+      .add(interpreter.getConfig().getTokenScannerSymbols().getExpressionEndWithTag());
+    String image = result.toString();
+    // Don't defer if we're sticking with the new value
+    if (registerEagerToken) {
+      interpreter
+        .getContext()
+        .handleEagerToken(
+          new EagerToken(
+            new TagToken(
+              image,
+              // TODO this line number won't be accurate, currently doesn't matter.
+              interpreter.getLineNumber(),
+              interpreter.getPosition(),
+              interpreter.getConfig().getTokenScannerSymbols()
+            ),
+            Collections.emptySet(),
+            deferredValuesToSet.keySet()
+          )
+        );
+    }
+    return image;
+  }
+
+  /**
+   * Casts token to TagToken if possible to get the eager image of the token.
+   * @see #getEagerTagImage(TagToken, JinjavaInterpreter)
+   * @param token Token to cast.
+   * @param interpreter The Jinjava interpreter.
+   * @return The image of the token which has been evaluated as much as possible.
+   */
+  public final String getEagerImage(Token token, JinjavaInterpreter interpreter) {
+    String eagerImage;
+    if (token instanceof TagToken) {
+      eagerImage = getEagerTagImage((TagToken) token, interpreter);
+    } else {
+      throw new DeferredValueException("Unsupported Token type");
+    }
+    return eagerImage;
+  }
+
+  /**
+   * Uses the {@link ChunkResolver} to partially evaluate any expression within
+   * the tagToken's helpers. If there are any macro functions that must be deferred,
+   * then their images are pre-pended to the result, which is the partial image
+   * of the {@link TagToken}.
+   * @param tagToken TagToken to get the eager image of.
+   * @param interpreter The Jinjava interpreter.
+   * @return A new image of the tagToken, which may have expressions that are further
+   *  resolved than in the original {@link TagToken#getImage()}.
+   */
+  public String getEagerTagImage(TagToken tagToken, JinjavaInterpreter interpreter) {
+    StringJoiner joiner = new StringJoiner(" ");
+    joiner
+      .add(tagToken.getSymbols().getExpressionStartWithTag())
+      .add(tagToken.getTagName());
+
+    ChunkResolver chunkResolver = new ChunkResolver(
+      tagToken.getHelpers().trim(),
+      tagToken,
+      interpreter
+    );
+    String resolvedChunks = chunkResolver.resolveChunks();
+    if (StringUtils.isNotBlank(resolvedChunks)) {
+      joiner.add(resolvedChunks);
+    }
+    joiner.add(tagToken.getSymbols().getExpressionEndWithTag());
+    String newlyDeferredFunctionImages = getNewlyDeferredFunctionImages(
+      chunkResolver.getDeferredWords(),
+      interpreter
+    );
+
+    interpreter
+      .getContext()
+      .handleEagerToken(
+        new EagerToken(
+          new TagToken(
+            joiner.toString(),
+            tagToken.getLineNumber(),
+            tagToken.getStartPosition(),
+            tagToken.getSymbols()
+          ),
+          chunkResolver.getDeferredWords()
+        )
+      );
+
+    return (newlyDeferredFunctionImages + joiner.toString());
+  }
+
+  public static String reconstructEnd(TagNode tagNode) {
+    return String.format(
+      "%s %s %s",
+      tagNode.getSymbols().getExpressionStartWithTag(),
+      tagNode.getEndName(),
+      tagNode.getSymbols().getExpressionEndWithTag()
+    );
+  }
+
+  public static String wrapInRawIfNeeded(String output, JinjavaInterpreter interpreter) {
+    if (interpreter.getConfig().getExecutionMode().isPreserveRawTags()) {
+      if (
+        output.contains(
+          interpreter.getConfig().getTokenScannerSymbols().getExpressionStart()
+        ) ||
+        output.contains(
+          interpreter.getConfig().getTokenScannerSymbols().getExpressionStartWithTag()
+        )
+      ) {
+        output = wrapInTag(output, RawTag.TAG_NAME, interpreter);
+      }
+    }
+    return output;
   }
 
   public static String wrapInAutoEscapeIfNeeded(

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -9,7 +9,6 @@ import com.google.common.io.Resources;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.lib.tag.eager.EagerTagFactory;
 import com.hubspot.jinjava.loader.LocationResolver;
 import com.hubspot.jinjava.loader.RelativePathResolver;
 import com.hubspot.jinjava.loader.ResourceLocator;
@@ -30,7 +29,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-@Ignore // TODO remove
 public class EagerTest {
   private JinjavaInterpreter interpreter;
   private final Jinjava jinjava = new Jinjava();
@@ -113,14 +111,14 @@ public class EagerTest {
 
   @Test
   public void itDefersSimpleExpressions() {
-    String output = interpreter.render("a {{deferred}} b");
+    String output = interpreter.render("a {{ deferred }} b");
     assertThat(output).isEqualTo("a {{ deferred }} b");
     assertThat(interpreter.getErrors()).isEmpty();
   }
 
   @Test
   public void itDefersWholeNestedExpressions() {
-    String output = interpreter.render("a {{deferred.nested}} b");
+    String output = interpreter.render("a {{ deferred.nested }} b");
     assertThat(output).isEqualTo("a {{ deferred.nested }} b");
     assertThat(interpreter.getErrors()).isEmpty();
   }
@@ -133,6 +131,7 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itPreservesIfTag() {
     String output = interpreter.render(
       "{% if deferred %}{{resolved}}{% else %}b{% endif %}"
@@ -142,6 +141,7 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itEagerlyResolvesNestedIfTag() {
     String output = interpreter.render(
       "{% if deferred %}{% if resolved %}{{resolved}}{% endif %}{% else %}b{% endif %}"
@@ -187,6 +187,7 @@ public class EagerTest {
 
   @Test
   @SuppressWarnings("unchecked")
+  @Ignore
   public void itDoesNotResolveForTagDeferredBlockInside() {
     String output = interpreter.render(
       "{% for item in dict %}{% if item == deferred %} equal {% else %} not equal {% endif %}{% endfor %}"
@@ -249,6 +250,7 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itPreservesForTag() {
     String output = interpreter.render(
       "{% for item in deferred %}{{ item.name }}last{% endfor %}"
@@ -280,6 +282,7 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itDefersMacro() {
     localContext.put("padding", 0);
     localContext.put("added_padding", 10);
@@ -302,6 +305,7 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itDefersAllVariablesUsedInDeferredNode() {
     String template = expectedTemplateInterpreter.getDeferredFixtureTemplate(
       "vars-in-deferred-node.jinja"
@@ -335,6 +339,7 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itDefersVariablesComparedAgainstDeferredVals() {
     String template = "";
     template += "{% set testVar = 'testvalue' %}";
@@ -397,6 +402,7 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itMarksVariablesSetInDeferredBlockAsDeferred() {
     String template = expectedTemplateInterpreter.getDeferredFixtureTemplate(
       "set-in-deferred.jinja"
@@ -438,12 +444,14 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itEagerlyDefersSet() {
     localContext.put("bar", true);
     expectedTemplateInterpreter.assertExpectedOutput("eagerly-defers-set");
   }
 
   @Test
+  @Ignore
   public void itEvaluatesNonEagerSet() {
     expectedTemplateInterpreter.assertExpectedOutput("evaluates-non-eager-set");
     assertThat(
@@ -465,11 +473,13 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itDefersOnImmutableMode() {
     expectedTemplateInterpreter.assertExpectedOutput("defers-on-immutable-mode");
   }
 
   @Test
+  @Ignore
   public void itDoesntAffectParentFromEagerIf() {
     expectedTemplateInterpreter.assertExpectedOutput(
       "doesnt-affect-parent-from-eager-if"
@@ -477,11 +487,13 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itDefersEagerChildScopedVars() {
     expectedTemplateInterpreter.assertExpectedOutput("defers-eager-child-scoped-vars");
   }
 
   @Test
+  @Ignore
   public void itSetsMultipleVarsDeferredInChild() {
     expectedTemplateInterpreter.assertExpectedOutput(
       "sets-multiple-vars-deferred-in-child"
@@ -497,6 +509,7 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itDoesntDoubleAppendInDeferredTag() {
     expectedTemplateInterpreter.assertExpectedOutput(
       "doesnt-double-append-in-deferred-tag"
@@ -504,11 +517,13 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itPrependsSetIfStateChanges() {
     expectedTemplateInterpreter.assertExpectedOutput("prepends-set-if-state-changes");
   }
 
   @Test
+  @Ignore
   public void itHandlesLoopVarAgainstDeferredInLoop() {
     expectedTemplateInterpreter.assertExpectedOutput(
       "handles-loop-var-against-deferred-in-loop"
@@ -527,6 +542,7 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itDefersMacroForDoAndPrint() {
     localContext.put("my_list", new PyList(new ArrayList<>()));
     localContext.put("first", 10);
@@ -555,18 +571,21 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itDefersMacroInFor() {
     localContext.put("my_list", new PyList(new ArrayList<>()));
     expectedTemplateInterpreter.assertExpectedOutput("defers-macro-in-for");
   }
 
   @Test
+  @Ignore
   public void itDefersMacroInIf() {
     localContext.put("my_list", new PyList(new ArrayList<>()));
     expectedTemplateInterpreter.assertExpectedOutput("defers-macro-in-if");
   }
 
   @Test
+  @Ignore
   public void itPutsDeferredImportedMacroInOutput() {
     expectedTemplateInterpreter.assertExpectedOutput(
       "puts-deferred-imported-macro-in-output"
@@ -574,6 +593,7 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itPutsDeferredImportedMacroInOutputSecondPass() {
     localContext.put("deferred", 1);
     expectedTemplateInterpreter.assertExpectedOutput(
@@ -585,6 +605,7 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itPutsDeferredFromedMacroInOutput() {
     expectedTemplateInterpreter.assertExpectedOutput(
       "puts-deferred-fromed-macro-in-output"
@@ -592,6 +613,7 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itEagerlyDefersMacro() {
     localContext.put("foo", "I am foo");
     localContext.put("bar", "I am bar");
@@ -608,11 +630,13 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itLoadsImportedMacroSyntax() {
     expectedTemplateInterpreter.assertExpectedOutput("loads-imported-macro-syntax");
   }
 
   @Test
+  @Ignore
   public void itDefersCaller() {
     expectedTemplateInterpreter.assertExpectedOutput("defers-caller");
   }
@@ -625,6 +649,7 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itDefersMacroInExpression() {
     expectedTemplateInterpreter.assertExpectedOutput("defers-macro-in-expression");
   }
@@ -642,16 +667,19 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itHandlesDeferredInIfchanged() {
     expectedTemplateInterpreter.assertExpectedOutput("handles-deferred-in-ifchanged");
   }
 
   @Test
+  @Ignore
   public void itDefersIfchanged() {
     expectedTemplateInterpreter.assertExpectedOutput("defers-ifchanged");
   }
 
   @Test
+  @Ignore
   public void itHandlesCycleInDeferredFor() {
     expectedTemplateInterpreter.assertExpectedOutput("handles-cycle-in-deferred-for");
   }
@@ -668,11 +696,13 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itHandlesDeferredInCycle() {
     expectedTemplateInterpreter.assertExpectedOutput("handles-deferred-in-cycle");
   }
 
   @Test
+  @Ignore
   public void itHandlesDeferredCycleAs() {
     expectedTemplateInterpreter.assertExpectedOutput("handles-deferred-cycle-as");
   }
@@ -697,12 +727,14 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itHandlesAutoEscape() {
     localContext.put("myvar", "foo < bar");
     expectedTemplateInterpreter.assertExpectedOutput("handles-auto-escape");
   }
 
   @Test
+  @Ignore
   public void itWrapsCertainOutputInRaw() {
     JinjavaConfig config = JinjavaConfig
       .newBuilder()
@@ -727,11 +759,13 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itHandlesDeferredImportVars() {
     expectedTemplateInterpreter.assertExpectedOutput("handles-deferred-import-vars");
   }
 
   @Test
+  @Ignore
   public void itHandlesDeferredImportVarsSecondPass() {
     localContext.put("deferred", 1);
     expectedTemplateInterpreter.assertExpectedOutput(
@@ -740,6 +774,7 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itHandlesDeferredFromImportAs() {
     expectedTemplateInterpreter.assertExpectedOutput("handles-deferred-from-import-as");
   }
@@ -753,6 +788,7 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore
   public void itPreservesValueSetInIf() {
     expectedTemplateInterpreter.assertExpectedOutput("preserves-value-set-in-if");
   }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
@@ -1,0 +1,185 @@
+package com.hubspot.jinjava.lib.tag.eager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.hubspot.jinjava.BaseInterpretingTest;
+import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.interpret.DeferredValue;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.mode.PreserveRawExecutionMode;
+import com.hubspot.jinjava.tree.TagNode;
+import com.hubspot.jinjava.tree.parse.DefaultTokenScannerSymbols;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Test for the static methods in the EagerTagDecorator.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class EagerTagDecoratorTest extends BaseInterpretingTest {
+
+  @Test
+  public void itExecutesInChildContextAndTakesNewValue() {
+    context.put("foo", new ArrayList<Integer>());
+    EagerStringResult result = EagerTagDecorator.executeInChildContext(
+      (
+        interpreter1 -> {
+          ((List<Integer>) interpreter1.getContext().get("foo")).add(1);
+          return "function return";
+        }
+      ),
+      interpreter,
+      true
+    );
+    assertThat(result.getResult()).isEqualTo("function return");
+    assertThat(result.getPrefixToPreserveState()).isEqualTo("{% set foo = [1] %}");
+    assertThat(context.get("foo")).isEqualTo(ImmutableList.of(1));
+    assertThat(context.getEagerTokens()).isEmpty();
+  }
+
+  @Test
+  public void itExecutesInChildContextAndDefersNewValue() {
+    context.put("foo", new ArrayList<Integer>());
+    EagerStringResult result = EagerTagDecorator.executeInChildContext(
+      (
+        interpreter1 -> {
+          ((List<Integer>) interpreter1.getContext().get("foo")).add(1);
+          return "function return";
+        }
+      ),
+      interpreter,
+      false
+    );
+    assertThat(result.getResult()).isEqualTo("function return");
+    assertThat(result.getPrefixToPreserveState()).isEqualTo("{% set foo = [] %}");
+    assertThat(context.get("foo")).isInstanceOf(DeferredValue.class);
+    assertThat(context.getEagerTokens()).isNotEmpty();
+  }
+
+  @Test
+  public void itBuildsSetTagForDeferredAndRegisters() {
+    Map<String, String> deferredValuesToSet = ImmutableMap.of("foo", "'bar'");
+    String result = EagerTagDecorator.buildSetTagForDeferredInChildContext(
+      deferredValuesToSet,
+      interpreter,
+      true
+    );
+    assertThat(result).isEqualTo("{% set foo = 'bar' %}");
+    assertThat(context.getEagerTokens()).hasSize(1);
+    EagerToken eagerToken = context
+      .getEagerTokens()
+      .stream()
+      .findAny()
+      .orElseThrow(RuntimeException::new);
+    assertThat(eagerToken.getSetDeferredWords()).containsExactly("foo");
+    assertThat(eagerToken.getUsedDeferredWords()).isEmpty();
+  }
+
+  @Test
+  public void itBuildsSetTagForDeferredAndDoesntRegister() {
+    Map<String, String> deferredValuesToSet = ImmutableMap.of("foo", "'bar'");
+    String result = EagerTagDecorator.buildSetTagForDeferredInChildContext(
+      deferredValuesToSet,
+      interpreter,
+      false
+    );
+    assertThat(result).isEqualTo("{% set foo = 'bar' %}");
+    assertThat(context.getEagerTokens()).isEmpty();
+  }
+
+  @Test
+  public void itBuildsSetTagForMultipleDeferred() {
+    Map<String, String> deferredValuesToSet = ImmutableMap.of("foo", "'bar'", "baz", "2");
+    String result = EagerTagDecorator.buildSetTagForDeferredInChildContext(
+      deferredValuesToSet,
+      interpreter,
+      true
+    );
+    assertThat(result).isEqualTo("{% set foo,baz = 'bar',2 %}");
+    assertThat(context.getEagerTokens()).hasSize(1);
+    EagerToken eagerToken = context
+      .getEagerTokens()
+      .stream()
+      .findAny()
+      .orElseThrow(RuntimeException::new);
+    assertThat(eagerToken.getSetDeferredWords()).containsExactlyInAnyOrder("foo", "baz");
+    assertThat(eagerToken.getUsedDeferredWords()).isEmpty();
+  }
+
+  @Test
+  public void itWrapsInRawTag() {
+    String toWrap = "{{ foo }}";
+    JinjavaConfig preserveRawConfig = JinjavaConfig
+      .newBuilder()
+      .withExecutionMode(new PreserveRawExecutionMode())
+      .build();
+    assertThat(
+        EagerTagDecorator.wrapInRawIfNeeded(
+          toWrap,
+          new JinjavaInterpreter(jinjava, context, preserveRawConfig)
+        )
+      )
+      .isEqualTo(String.format("{%% raw %%}%s{%% endraw %%}", toWrap));
+  }
+
+  @Test
+  public void itDoesntWrapInRawTagUnnecessarily() {
+    String toWrap = "foo";
+    JinjavaConfig preserveRawConfig = JinjavaConfig
+      .newBuilder()
+      .withExecutionMode(new PreserveRawExecutionMode())
+      .build();
+    assertThat(
+        EagerTagDecorator.wrapInRawIfNeeded(
+          toWrap,
+          new JinjavaInterpreter(jinjava, context, preserveRawConfig)
+        )
+      )
+      .isEqualTo(toWrap);
+  }
+
+  @Test
+  public void itDoesntWrapInRawTagForDefaultConfig() {
+    String toWrap = "{{ foo }}";
+    assertThat(EagerTagDecorator.wrapInRawIfNeeded(toWrap, interpreter))
+      .isEqualTo(toWrap);
+  }
+
+  @Test
+  public void itWrapsInAutoEscapeTag() {
+    String toWrap = "<div>{{deferred}}</div>";
+    interpreter.getContext().setAutoEscape(true);
+    assertThat(EagerTagDecorator.wrapInAutoEscapeIfNeeded(toWrap, interpreter))
+      .isEqualTo(String.format("{%% autoescape %%}%s{%% endautoescape %%}", toWrap));
+  }
+
+  @Test
+  public void itDoesntWrapInAutoEscapeWhenFalse() {
+    String toWrap = "<div>{{deferred}}</div>";
+    interpreter.getContext().setAutoEscape(false);
+    assertThat(EagerTagDecorator.wrapInAutoEscapeIfNeeded(toWrap, interpreter))
+      .isEqualTo(toWrap);
+  }
+
+  @Test
+  public void itReconstructsTheEndOfATagNode() {
+    TagNode tagNode = getMockTagNode("endif");
+    assertThat(EagerTagDecorator.reconstructEnd(tagNode)).isEqualTo("{% endif %}");
+    tagNode = getMockTagNode("endfor");
+    assertThat(EagerTagDecorator.reconstructEnd(tagNode)).isEqualTo("{% endfor %}");
+  }
+
+  private static TagNode getMockTagNode(String endName) {
+    TagNode mockTagNode = mock(TagNode.class);
+    when(mockTagNode.getSymbols()).thenReturn(new DefaultTokenScannerSymbols());
+    when(mockTagNode.getEndName()).thenReturn(endName);
+    return mockTagNode;
+  }
+}

--- a/src/test/resources/eager/handles-cycle-in-deferred-for.jinja
+++ b/src/test/resources/eager/handles-cycle-in-deferred-for.jinja
@@ -1,4 +1,4 @@
-{% set foo = [1,2,3] %}
+{% set foo = ['1','2','3'] %}
 {%- for item in deferred %}
 {% cycle foo %}
 {% cycle foo[0],foo[1],foo[2] %}

--- a/src/test/resources/tags/macrotag/macro-and-set.jinja
+++ b/src/test/resources/tags/macrotag/macro-and-set.jinja
@@ -1,0 +1,5 @@
+{% macro foo() -%}
+Hello {{ myname }}
+{%- endmacro %}
+{% set bar = myname + 19 %}
+{{ foo() }}


### PR DESCRIPTION
Part of https://github.com/HubSpot/jinjava/issues/532
---

This PR fills in the logic for the generic eager tag functionality within the `EagerTagDecorator.eagerInterpret()`. Much of this logic will be used by every type of Tag, but some must be overridden for certain types of tags. The main logic that's added for the EagerTagDecorator is:
- Interpret the token
- Build a set tag to preserve values
- Get macro function images (stubbed)
- Register as an eager token
- Render the children

In general, the `eagerInterpret()` function gets called when the default tag logic throws a DeferredValueException. The above steps are performed for most tag types to handle the deferred value. Notably, the set tag that gets built and pre-pended to the output. This is useful for being able to preserve the state of the context without actually retaining the context. This could be helpful if the context is very large during the initial eager execution path. The context need not be stored until the final rendering pass with the use of these set tags. The necessary context will be therefore be rebuilt as the eager output is interpreted the second time around.

cc @boulter @Joeoh 