### PR TITLE
Stub as the default strategy rather than returning null

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -11,6 +11,6 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
     ExpressionToken master,
     JinjavaInterpreter interpreter
   ) {
-    return null; // TODO replace with actual functionality
+    return new DefaultExpressionStrategy().interpretOutput(master, interpreter); // TODO replace with actual functionality
   }
 }


### PR DESCRIPTION
Stubs this out in a safer way than returning null. Some test cases that I want to include get null pointer exceptions because of this, when the default strategy can be used as a stub for the time being.