### PR TITLE
Add eager deferred macro logic

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 import java.util.stream.Collectors;
@@ -215,6 +216,27 @@ public class Context extends ScopeMap<String, Object> {
 
   public boolean isGlobalMacro(String identifier) {
     return getGlobalMacro(identifier) != null;
+  }
+
+  public Optional<MacroFunction> getLocalMacro(String fullName) {
+    String[] nameArray = fullName.split("\\.", 2);
+    if (nameArray.length != 2) {
+      return Optional.empty();
+    }
+    String localKey = nameArray[0];
+    String macroName = nameArray[1];
+    Object localValue = get(localKey);
+    if (localValue instanceof DeferredValue) {
+      localValue = ((DeferredValue) localValue).getOriginalValue();
+    }
+    if (!(localValue instanceof Map)) {
+      return Optional.empty();
+    }
+    Object possibleMacroFunction = ((Map<String, Object>) localValue).get(macroName);
+    if (possibleMacroFunction instanceof MacroFunction) {
+      return Optional.of((MacroFunction) possibleMacroFunction);
+    }
+    return Optional.empty();
   }
 
   public boolean isAutoEscape() {

--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -19,7 +19,7 @@ import java.util.Optional;
  *
  */
 public class MacroFunction extends AbstractCallableMethod {
-  protected final List<Node> content;
+  private final List<Node> content;
 
   private final boolean caller;
 

--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -154,10 +154,6 @@ public class MacroFunction extends AbstractCallableMethod {
     return caller;
   }
 
-  public Context getLocalContextScope() {
-    return localContextScope;
-  }
-
   public String reconstructImage() {
     if (content != null && !content.isEmpty()) {
       return content.get(0).getParent().reconstructImage();

--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -19,7 +19,7 @@ import java.util.Optional;
  *
  */
 public class MacroFunction extends AbstractCallableMethod {
-  private final List<Node> content;
+  protected final List<Node> content;
 
   private final boolean caller;
 
@@ -49,6 +49,16 @@ public class MacroFunction extends AbstractCallableMethod {
     this.deferred = false;
   }
 
+  public MacroFunction(MacroFunction source, String name) {
+    super(name, (LinkedHashMap<String, Object>) source.getDefaults());
+    this.content = source.content;
+    this.caller = source.caller;
+    this.localContextScope = source.localContextScope;
+    this.definitionLineNumber = source.definitionLineNumber;
+    this.definitionStartPosition = source.definitionStartPosition;
+    this.deferred = source.deferred;
+  }
+
   @Override
   public Object doEvaluate(
     Map<String, Object> argMap,
@@ -56,6 +66,28 @@ public class MacroFunction extends AbstractCallableMethod {
     List<Object> varArgs
   ) {
     JinjavaInterpreter interpreter = JinjavaInterpreter.getCurrent();
+    Optional<String> importFile = getImportFile(interpreter);
+    try (InterpreterScopeClosable c = interpreter.enterScope()) {
+      String result = getEvaluationResult(argMap, kwargMap, varArgs, interpreter);
+
+      if (
+        !interpreter.getContext().getDeferredNodes().isEmpty() ||
+        !interpreter.getContext().getEagerTokens().isEmpty()
+      ) {
+        throw new DeferredValueException(
+          getName(),
+          interpreter.getLineNumber(),
+          interpreter.getPosition()
+        );
+      }
+
+      return result;
+    } finally {
+      importFile.ifPresent(path -> interpreter.getContext().getCurrentPathStack().pop());
+    }
+  }
+
+  public Optional<String> getImportFile(JinjavaInterpreter interpreter) {
     Optional<String> importFile = Optional.ofNullable(
       (String) localContextScope.get(Context.IMPORT_RESOURCE_PATH_KEY)
     );
@@ -72,50 +104,42 @@ public class MacroFunction extends AbstractCallableMethod {
             interpreter.getPosition()
           )
     );
+    return importFile;
+  }
 
-    try (InterpreterScopeClosable c = interpreter.enterScope()) {
-      interpreter.setLineNumber(definitionLineNumber);
-      interpreter.setPosition(definitionStartPosition);
-
-      for (Map.Entry<String, Object> scopeEntry : localContextScope
-        .getScope()
-        .entrySet()) {
-        if (scopeEntry.getValue() instanceof MacroFunction) {
-          interpreter.getContext().addGlobalMacro((MacroFunction) scopeEntry.getValue());
-        } else {
-          interpreter.getContext().put(scopeEntry.getKey(), scopeEntry.getValue());
-        }
+  public String getEvaluationResult(
+    Map<String, Object> argMap,
+    Map<String, Object> kwargMap,
+    List<Object> varArgs,
+    JinjavaInterpreter interpreter
+  ) {
+    interpreter.setLineNumber(definitionLineNumber);
+    interpreter.setPosition(definitionStartPosition);
+    for (Map.Entry<String, Object> scopeEntry : localContextScope.getScope().entrySet()) {
+      if (scopeEntry.getValue() instanceof MacroFunction) {
+        interpreter.getContext().addGlobalMacro((MacroFunction) scopeEntry.getValue());
+      } else {
+        interpreter.getContext().put(scopeEntry.getKey(), scopeEntry.getValue());
       }
-
-      // named parameters
-      for (Map.Entry<String, Object> argEntry : argMap.entrySet()) {
-        interpreter.getContext().put(argEntry.getKey(), argEntry.getValue());
-      }
-      // parameter map
-      interpreter.getContext().put("kwargs", kwargMap);
-      // varargs list
-      interpreter.getContext().put("varargs", varArgs);
-
-      LengthLimitingStringBuilder result = new LengthLimitingStringBuilder(
-        interpreter.getConfig().getMaxOutputSize()
-      );
-
-      for (Node node : content) {
-        result.append(node.render(interpreter));
-      }
-
-      if (!interpreter.getContext().getDeferredNodes().isEmpty()) {
-        throw new DeferredValueException(
-          getName(),
-          interpreter.getLineNumber(),
-          interpreter.getPosition()
-        );
-      }
-
-      return result.toString();
-    } finally {
-      importFile.ifPresent(path -> interpreter.getContext().getCurrentPathStack().pop());
     }
+
+    // named parameters
+    for (Map.Entry<String, Object> argEntry : argMap.entrySet()) {
+      interpreter.getContext().put(argEntry.getKey(), argEntry.getValue());
+    }
+    // parameter map
+    interpreter.getContext().put("kwargs", kwargMap);
+    // varargs list
+    interpreter.getContext().put("varargs", varArgs);
+
+    LengthLimitingStringBuilder result = new LengthLimitingStringBuilder(
+      interpreter.getConfig().getMaxOutputSize()
+    );
+
+    for (Node node : content) {
+      result.append(node.render(interpreter));
+    }
+    return result.toString();
   }
 
   public void setDeferred(boolean deferred) {
@@ -128,6 +152,10 @@ public class MacroFunction extends AbstractCallableMethod {
 
   public boolean isCaller() {
     return caller;
+  }
+
+  public Context getLocalContextScope() {
+    return localContextScope;
   }
 
   public String reconstructImage() {

--- a/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
@@ -1,0 +1,111 @@
+package com.hubspot.jinjava.lib.fn.eager;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.hubspot.jinjava.el.ext.AbstractCallableMethod;
+import com.hubspot.jinjava.interpret.DeferredValue;
+import com.hubspot.jinjava.interpret.DeferredValueException;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
+import com.hubspot.jinjava.lib.fn.MacroFunction;
+import com.hubspot.jinjava.lib.tag.MacroTag;
+import com.hubspot.jinjava.util.ChunkResolver;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.StringJoiner;
+
+public class EagerMacroFunction extends AbstractCallableMethod {
+  private String fullName;
+  private MacroFunction macroFunction;
+  private JinjavaInterpreter interpreter;
+
+  public EagerMacroFunction(
+    String fullName,
+    MacroFunction macroFunction,
+    JinjavaInterpreter interpreter
+  ) {
+    super(
+      macroFunction.getName(),
+      getLinkedHashmap(macroFunction.getArguments(), macroFunction.getDefaults())
+    );
+    this.fullName = fullName;
+    this.macroFunction = macroFunction;
+    this.interpreter = interpreter;
+  }
+
+  private static LinkedHashMap<String, Object> getLinkedHashmap(
+    List<String> args,
+    Map<String, Object> defaults
+  ) {
+    LinkedHashMap<String, Object> linkedHashMap = new LinkedHashMap<>();
+    for (String arg : args) {
+      linkedHashMap.put(arg, defaults.get(arg));
+    }
+    return linkedHashMap;
+  }
+
+  public Object doEvaluate(
+    Map<String, Object> argMap,
+    Map<String, Object> kwargMap,
+    List<Object> varArgs
+  ) {
+    Optional<String> importFile = macroFunction.getImportFile(interpreter);
+    try (InterpreterScopeClosable c = interpreter.enterScope()) {
+      return macroFunction.getEvaluationResult(argMap, kwargMap, varArgs, interpreter);
+    } finally {
+      importFile.ifPresent(path -> interpreter.getContext().getCurrentPathStack().pop());
+    }
+  }
+
+  public String getStartTag(JinjavaInterpreter interpreter) {
+    StringJoiner argJoiner = new StringJoiner(", ");
+    for (String arg : macroFunction.getArguments()) {
+      try {
+        if (macroFunction.getDefaults().get(arg) != null) {
+          argJoiner.add(
+            String.format(
+              "%s=%s",
+              arg,
+              ChunkResolver.getValueAsJinjavaString(macroFunction.getDefaults().get(arg))
+            )
+          );
+          continue;
+        }
+      } catch (JsonProcessingException ignored) {}
+      argJoiner.add(arg);
+    }
+    return new StringJoiner(" ")
+      .add(interpreter.getConfig().getTokenScannerSymbols().getExpressionStartWithTag())
+      .add(MacroTag.TAG_NAME)
+      .add(String.format("%s(%s)", fullName, argJoiner.toString()))
+      .add(interpreter.getConfig().getTokenScannerSymbols().getExpressionEndWithTag())
+      .toString();
+  }
+
+  public String getEndTag(JinjavaInterpreter interpreter) {
+    return new StringJoiner(" ")
+      .add(interpreter.getConfig().getTokenScannerSymbols().getExpressionStartWithTag())
+      .add(String.format("end%s", MacroTag.TAG_NAME))
+      .add(interpreter.getConfig().getTokenScannerSymbols().getExpressionEndWithTag())
+      .toString();
+  }
+
+  public String reconstructImage() {
+    String result;
+    try {
+      result =
+        (String) evaluate(
+          macroFunction
+            .getArguments()
+            .stream()
+            .map(arg -> DeferredValue.instance())
+            .toArray()
+        );
+    } catch (DeferredValueException ignored) {
+      return macroFunction.reconstructImage();
+    }
+
+    return (getStartTag(interpreter) + result + getEndTag(interpreter));
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
@@ -91,16 +91,31 @@ public class EagerMacroFunction extends AbstractCallableMethod {
       .toString();
   }
 
+  /**
+   * Reconstruct the image of the macro function, @see MacroFunction#reconstructImage()
+   * This image, however, may be partially or fully resolved depending on the
+   * usage of the arguments, which are filled in as deferred values, and any values on
+   * this interpreter's context.
+   * @return An image of the macro function that's body is resolved as much as possible.
+   *  This image allows for the macro function to be recreated during a later
+   *  rendering pass.
+   */
   public String reconstructImage() {
     String result;
-    result =
-      (String) evaluate(
-        macroFunction
-          .getArguments()
-          .stream()
-          .map(arg -> DeferredValue.instance())
-          .toArray()
-      );
+    try {
+      result =
+        (String) evaluate(
+          macroFunction
+            .getArguments()
+            .stream()
+            .map(arg -> DeferredValue.instance())
+            .toArray()
+        );
+    } catch (DeferredValueException e) {
+      // In case something not eager-supported encountered a deferred value
+      return macroFunction.reconstructImage();
+    }
+
     return (getStartTag(interpreter) + result + getEndTag(interpreter));
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
@@ -93,19 +93,14 @@ public class EagerMacroFunction extends AbstractCallableMethod {
 
   public String reconstructImage() {
     String result;
-    try {
-      result =
-        (String) evaluate(
-          macroFunction
-            .getArguments()
-            .stream()
-            .map(arg -> DeferredValue.instance())
-            .toArray()
-        );
-    } catch (DeferredValueException e) {
-      return macroFunction.reconstructImage();
-    }
-
+    result =
+      (String) evaluate(
+        macroFunction
+          .getArguments()
+          .stream()
+          .map(arg -> DeferredValue.instance())
+          .toArray()
+      );
     return (getStartTag(interpreter) + result + getEndTag(interpreter));
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
@@ -102,7 +102,7 @@ public class EagerMacroFunction extends AbstractCallableMethod {
             .map(arg -> DeferredValue.instance())
             .toArray()
         );
-    } catch (DeferredValueException ignored) {
+    } catch (DeferredValueException e) {
       return macroFunction.reconstructImage();
     }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
@@ -6,13 +6,16 @@ import com.google.common.collect.Lists;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
 import com.hubspot.jinjava.tree.TagNode;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
@@ -56,7 +59,11 @@ public class MacroTag implements Tag {
 
   private static final long serialVersionUID = 8397609322126956077L;
 
-  private static final Pattern MACRO_PATTERN = Pattern.compile(
+  public static final Pattern CHILD_MACRO_PATTERN = Pattern.compile(
+    "([a-zA-Z_][\\w_]*)\\.([a-zA-Z_][\\w_]*)[^(]*\\(([^)]*)\\)"
+  );
+
+  public static final Pattern MACRO_PATTERN = Pattern.compile(
     "([a-zA-Z_][\\w_]*)[^(]*\\(([^)]*)\\)"
   );
   private static final Splitter ARGS_SPLITTER = Splitter
@@ -75,22 +82,91 @@ public class MacroTag implements Tag {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
-    Matcher matcher = MACRO_PATTERN.matcher(tagNode.getHelpers());
-    if (!matcher.find()) {
-      throw new TemplateSyntaxException(
-        tagNode.getMaster().getImage(),
-        "Unable to parse macro definition: " + tagNode.getHelpers(),
+    String name;
+    String args;
+    String parentName = "";
+    Matcher childMatcher = CHILD_MACRO_PATTERN.matcher(tagNode.getHelpers());
+    if (childMatcher.find()) {
+      parentName = childMatcher.group(1);
+      name = childMatcher.group(2);
+      args = Strings.nullToEmpty(childMatcher.group(3));
+    } else {
+      Matcher matcher = MACRO_PATTERN.matcher(tagNode.getHelpers());
+      if (!matcher.find()) {
+        throw new TemplateSyntaxException(
+          tagNode.getMaster().getImage(),
+          "Unable to parse macro definition: " + tagNode.getHelpers(),
+          tagNode.getLineNumber(),
+          tagNode.getStartPosition()
+        );
+      }
+
+      name = matcher.group(1);
+      args = Strings.nullToEmpty(matcher.group(2));
+    }
+
+    LinkedHashMap<String, Object> argNamesWithDefaults = new LinkedHashMap<>();
+
+    boolean deferred = populateArgNames(
+      tagNode.getLineNumber(),
+      interpreter,
+      args,
+      argNamesWithDefaults
+    );
+
+    MacroFunction macro = new MacroFunction(
+      tagNode.getChildren(),
+      name,
+      argNamesWithDefaults,
+      false,
+      interpreter.getContext(),
+      interpreter.getLineNumber(),
+      interpreter.getPosition()
+    );
+    macro.setDeferred(deferred);
+
+    if (StringUtils.isNotEmpty(parentName)) {
+      try {
+        if (!(interpreter.getContext().get(parentName) instanceof DeferredValue)) {
+          Map<String, Object> macroOfParent = (Map<String, Object>) interpreter
+            .getContext()
+            .getOrDefault(parentName, new HashMap<>());
+          macroOfParent.put(macro.getName(), macro);
+          if (!interpreter.getContext().containsKey(parentName)) {
+            interpreter.getContext().put(parentName, macroOfParent);
+          }
+        }
+      } catch (ClassCastException e) {
+        throw new TemplateSyntaxException(
+          tagNode.getMaster().getImage(),
+          "Unable to parse macro as a child of: " + parentName,
+          tagNode.getLineNumber(),
+          tagNode.getStartPosition()
+        );
+      }
+    } else {
+      interpreter.getContext().addGlobalMacro(macro);
+    }
+
+    if (deferred) {
+      throw new DeferredValueException(
+        name,
         tagNode.getLineNumber(),
         tagNode.getStartPosition()
       );
     }
 
-    String name = matcher.group(1);
-    String args = Strings.nullToEmpty(matcher.group(2));
+    return "";
+  }
 
-    LinkedHashMap<String, Object> argNamesWithDefaults = new LinkedHashMap<>();
-
+  public static boolean populateArgNames(
+    int lineNumber,
+    JinjavaInterpreter interpreter,
+    String args,
+    LinkedHashMap<String, Object> argNamesWithDefaults
+  ) {
     List<String> argList = Lists.newArrayList(ARGS_SPLITTER.split(args));
     boolean deferred = false;
     for (int i = 0; i < argList.size(); i++) {
@@ -114,7 +190,7 @@ public class MacroTag implements Tag {
         try {
           Object argVal = interpreter.resolveELExpression(
             argValStr.toString(),
-            tagNode.getLineNumber()
+            lineNumber
           );
           argNamesWithDefaults.put(argName, argVal);
         } catch (DeferredValueException e) {
@@ -124,28 +200,6 @@ public class MacroTag implements Tag {
         argNamesWithDefaults.put(arg, null);
       }
     }
-
-    MacroFunction macro = new MacroFunction(
-      tagNode.getChildren(),
-      name,
-      argNamesWithDefaults,
-      false,
-      interpreter.getContext(),
-      interpreter.getLineNumber(),
-      interpreter.getPosition()
-    );
-    macro.setDeferred(deferred);
-
-    interpreter.getContext().addGlobalMacro(macro);
-
-    if (deferred) {
-      throw new DeferredValueException(
-        name,
-        tagNode.getLineNumber(),
-        tagNode.getStartPosition()
-      );
-    }
-
-    return "";
+    return deferred;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -315,12 +315,6 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
     String eagerImage;
     if (token instanceof TagToken) {
       eagerImage = getEagerTagImage((TagToken) token, interpreter);
-    } else if (token instanceof ExpressionToken) {
-      eagerImage = getEagerExpressionImage((ExpressionToken) token, interpreter);
-    } else if (token instanceof TextToken) {
-      eagerImage = getEagerTextImage((TextToken) token, interpreter);
-    } else if (token instanceof NoteToken) {
-      eagerImage = getEagerNoteImage((NoteToken) token, interpreter);
     } else {
       throw new DeferredValueException("Unsupported Token type");
     }
@@ -363,32 +357,6 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
       );
 
     return (newlyDeferredFunctionImages + joiner.toString());
-  }
-
-  public String getEagerExpressionImage(
-    ExpressionToken expressionToken,
-    JinjavaInterpreter interpreter
-  ) {
-    interpreter
-      .getContext()
-      .handleEagerToken(
-        new EagerToken(expressionToken, Collections.singleton(expressionToken.getExpr()))
-      );
-    return expressionToken.getImage();
-  }
-
-  public String getEagerTextImage(TextToken textToken, JinjavaInterpreter interpreter) {
-    interpreter
-      .getContext()
-      .handleEagerToken(
-        new EagerToken(textToken, Collections.singleton(textToken.output()))
-      );
-    return textToken.getImage();
-  }
-
-  public String getEagerNoteImage(NoteToken noteToken, JinjavaInterpreter interpreter) {
-    // Notes should not throw DeferredValueExceptions, but this will handle it anyway
-    return "";
   }
 
   public static String reconstructEnd(TagNode tagNode) {

--- a/src/test/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunctionTest.java
@@ -1,0 +1,75 @@
+package com.hubspot.jinjava.lib.fn.eager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hubspot.jinjava.BaseInterpretingTest;
+import com.hubspot.jinjava.interpret.DeferredValue;
+import com.hubspot.jinjava.lib.fn.MacroFunction;
+import org.junit.Test;
+
+public class EagerMacroFunctionTest extends BaseInterpretingTest {
+
+  @Test
+  public void itReconstructsImage() {
+    String name = "foo";
+    String code = "{% macro foo(bar) %}It's: {{ bar }}{% endmacro %}";
+    MacroFunction macroFunction = makeMacroFunction(name, code);
+    EagerMacroFunction eagerMacroFunction = new EagerMacroFunction(
+      name,
+      macroFunction,
+      interpreter
+    );
+    assertThat(eagerMacroFunction.reconstructImage()).isEqualTo(code);
+  }
+
+  @Test
+  public void itResolvesFromContext() {
+    context.put("foobar", "resolved");
+    String name = "foo";
+    String code = "{% macro foo(bar) %}{{ foobar }} and {{ bar }}{% endmacro %}";
+    MacroFunction macroFunction = makeMacroFunction(name, code);
+    EagerMacroFunction eagerMacroFunction = new EagerMacroFunction(
+      name,
+      macroFunction,
+      interpreter
+    );
+    assertThat(eagerMacroFunction.reconstructImage())
+      .isEqualTo("{% macro foo(bar) %}resolved and {{ bar }}{% endmacro %}");
+  }
+
+  @Test
+  public void itReconstructsForAliasedName() {
+    String name = "foo";
+    String fullName = "local." + name;
+    String codeFormat = "{%% macro %s(bar) %%}It's: {{ bar }}{%% endmacro %%}";
+    MacroFunction macroFunction = makeMacroFunction(
+      name,
+      String.format(codeFormat, name)
+    );
+    EagerMacroFunction eagerMacroFunction = new EagerMacroFunction(
+      fullName,
+      macroFunction,
+      interpreter
+    );
+    assertThat(eagerMacroFunction.reconstructImage())
+      .isEqualTo(String.format(codeFormat, fullName));
+  }
+
+  @Test
+  public void itReconstructsImageWithNamedParams() {
+    String name = "foo";
+    String code = "{% macro foo(bar, baz=0) %}It's: {{ bar }}, {{ baz }}{% endmacro %}";
+    MacroFunction macroFunction = makeMacroFunction(name, code);
+    EagerMacroFunction eagerMacroFunction = new EagerMacroFunction(
+      name,
+      macroFunction,
+      interpreter
+    );
+    assertThat(eagerMacroFunction.reconstructImage()).isEqualTo(code);
+  }
+
+  private MacroFunction makeMacroFunction(String name, String code) {
+    interpreter.render(code);
+    return context.getGlobalMacro(name);
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
@@ -95,7 +95,7 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
       deferredWords,
       interpreter
     );
-    assertThat(result).isEqualTo(image);
+    assertThat(result).isEqualTo("{% macro local.foo(bar) %}something{% endmacro %}");
     assertThat(deferredWords).isEmpty();
   }
 
@@ -217,8 +217,7 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
     when(mockMacroFunction.getName()).thenReturn("foo");
     when(mockMacroFunction.getArguments()).thenReturn(ImmutableList.of("bar"));
     when(mockMacroFunction.getEvaluationResult(anyMap(), anyMap(), anyList(), any()))
-      .thenThrow(new DeferredValueException(""));
-    when(mockMacroFunction.reconstructImage()).thenReturn(image);
+      .thenReturn(image.substring(image.indexOf("%}") + 2, image.lastIndexOf("{%")));
     return mockMacroFunction;
   }
 


### PR DESCRIPTION
Part of https://github.com/HubSpot/jinjava/issues/532
---
This PR unstubs the `getNewlyDeferredFunctionImages()` method in the EagerTagDecorator class by introducing an EagerMacroFunction wrapper class, which wraps the logic of a MacroFunction to be able to reconstruct a partially evaluated image of the macro function to output before a deferred call of the said macro function.

Since macro functions can either be called directly (when they are stored as a global macro function), or with an imported alias, such as `{% import path as simple %} {{ simple.the_macro() }}`, there needs to be a way to create a macro in this way. So I formalised this aliased macro importing by calling it a local macro, rather than a global macro (because it's only local to the alias). The `MacroTag` now allows for a macro function to be stored in such a way: `{% macro parent_alias.macro_name() %}`, which allows for global or local macro functions on the context to be re-output before they're called.

---
For example:
```
{% macro plus_one(val) %}
{{ val + 1 }}
{% endmacro %}
{% import import_path as my_alias %}
{{ plus_one(deferred.age) }}
{% if my_alias.can_vote(deferred.age) %}
You can vote.
{% endif %}
```
Would result in an output similar to the following if doing eager execution (adjusted for readability):
```
{% macro plus_one(val) %}
{{ val + 1 }}
{% endmacro %}
{{ plus_one(deferred.age) }}
{% set my_alias = {} %}
{% macro my_alias.can_vote(val) %}
{{ val >= 18 }}
{% endmacro %}
{% if my_alias.can_vote(deferred.age) %}
You can vote.
{% endif %}
```

cc @boulter @Joeoh 