### PR TITLE
Add single argument constructor back for ExpressionNode

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -17,6 +17,7 @@ package com.hubspot.jinjava.tree;
 
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.lib.expression.DefaultExpressionStrategy;
 import com.hubspot.jinjava.lib.expression.ExpressionStrategy;
 import com.hubspot.jinjava.tree.output.OutputNode;
 import com.hubspot.jinjava.tree.output.RenderedOutputNode;
@@ -27,6 +28,12 @@ public class ExpressionNode extends Node {
 
   private final ExpressionStrategy expressionStrategy;
   private final ExpressionToken master;
+
+  public ExpressionNode(ExpressionToken token) {
+    super(token, token.getLineNumber(), token.getStartPosition());
+    this.expressionStrategy = new DefaultExpressionStrategy();
+    master = token;
+  }
 
   public ExpressionNode(ExpressionStrategy expressionStrategy, ExpressionToken token) {
     super(token, token.getLineNumber(), token.getStartPosition());


### PR DESCRIPTION
Adds the single argument constructor back in for posterity after I changed the constructor here https://github.com/HubSpot/jinjava/pull/544/files#diff-cead90d8d087f05311d57036f3d2b661eb035226d2b45c03bb4200b20d2ab09fR31