### PR TITLE
Fix args for aliased functions

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/AbstractFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AbstractFilter.java
@@ -15,6 +15,7 @@
  **********************************************************************/
 package com.hubspot.jinjava.lib.filter;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
@@ -208,6 +209,12 @@ public abstract class AbstractFilter implements Filter {
 
   public Map<String, JinjavaParam> initNamedArguments() {
     JinjavaDoc jinjavaDoc = this.getClass().getAnnotation(JinjavaDoc.class);
+
+    if (jinjavaDoc != null && !Strings.isNullOrEmpty(jinjavaDoc.aliasOf())) {
+      // aliased functions extend the base function. We need to get the annotations on the base
+      jinjavaDoc = this.getClass().getSuperclass().getAnnotation(JinjavaDoc.class);
+    }
+
     if (jinjavaDoc != null) {
       ImmutableMap.Builder<String, JinjavaParam> namedArgsBuilder = ImmutableMap.builder();
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DAliasedDefaultFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DAliasedDefaultFilterTest.java
@@ -1,0 +1,18 @@
+package com.hubspot.jinjava.lib.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hubspot.jinjava.BaseJinjavaTest;
+import java.util.HashMap;
+import org.junit.Test;
+
+public class DAliasedDefaultFilterTest extends BaseJinjavaTest {
+
+  @Test
+  public void itSetsDefaultStringValues() {
+    assertThat(
+        jinjava.render("{% set d=d |d(\"some random value\") %}{{ d }}", new HashMap<>())
+      )
+      .isEqualTo("some random value");
+  }
+}


### PR DESCRIPTION
A slight oversight in https://github.com/HubSpot/jinjava/pull/523. Some functions use `aliasOf` so that a filter can have multiple names (short and long). These will have empty `jinjavaDoc` annotations so no longer worked after that PR.