### PR TITLE
Add node comparison testing util

### DIFF
--- a/src/test/java/com/hubspot/jinjava/ExpectedNodeInterpreter.java
+++ b/src/test/java/com/hubspot/jinjava/ExpectedNodeInterpreter.java
@@ -1,0 +1,59 @@
+package com.hubspot.jinjava;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.io.Resources;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.lib.tag.Tag;
+import com.hubspot.jinjava.tree.Node;
+import com.hubspot.jinjava.tree.TagNode;
+import com.hubspot.jinjava.tree.TreeParser;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class ExpectedNodeInterpreter {
+  private JinjavaInterpreter interpreter;
+  private Tag tag;
+  private String path;
+
+  public ExpectedNodeInterpreter(JinjavaInterpreter interpreter, Tag tag, String path) {
+    this.interpreter = interpreter;
+    this.tag = tag;
+    this.path = path;
+  }
+
+  public String assertExpectedOutput(String name) {
+    TagNode tagNode = (TagNode) fixture(name);
+    String output = tag.interpret(tagNode, interpreter);
+    assertThat(output.trim()).isEqualTo(expected(name).trim());
+    return output;
+  }
+
+  public Node fixture(String name) {
+    try {
+      return new TreeParser(
+        interpreter,
+        Resources.toString(
+          Resources.getResource(String.format("%s/%s.jinja", path, name)),
+          StandardCharsets.UTF_8
+        )
+      )
+        .buildTree()
+        .getChildren()
+        .getFirst();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public String expected(String name) {
+    try {
+      return Resources.toString(
+        Resources.getResource(String.format("%s/%s.expected.jinja", path, name)),
+        StandardCharsets.UTF_8
+      );
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
This adds a testing utility that is similar to the `ExpectedTemplateInterpreter`, except it's used for testing a single node rather than a template.

I'm putting it in a separate PR because it will be used in some parallel PR's to test specific tags.