### PR TITLE
Limit eager length

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -61,7 +61,7 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
           interpreter
         );
       } catch (OutputTooBigException e1) {
-        interpreter.addError(TemplateError.fromOutputTooBigException(e));
+        interpreter.addError(TemplateError.fromOutputTooBigException(e1));
         throw new DeferredValueException(
           String.format("Output too big for eager execution: %s", e1.getMessage())
         );

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -26,6 +26,7 @@ import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.tree.parse.Token;
 import com.hubspot.jinjava.util.ChunkResolver;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
+import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -373,7 +374,10 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
    *  resolved than in the original {@link TagToken#getImage()}.
    */
   public String getEagerTagImage(TagToken tagToken, JinjavaInterpreter interpreter) {
-    StringJoiner joiner = new StringJoiner(" ");
+    LengthLimitingStringJoiner joiner = new LengthLimitingStringJoiner(
+      interpreter.getConfig().getMaxOutputSize(),
+      " "
+    );
     joiner
       .add(tagToken.getSymbols().getExpressionStartWithTag())
       .add(tagToken.getTagName());

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -120,9 +120,7 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
    * @return
    */
   public String renderChildren(TagNode tagNode, JinjavaInterpreter interpreter) {
-    LengthLimitingStringBuilder sb = new LengthLimitingStringBuilder(
-      interpreter.getConfig().getMaxStringLength()
-    );
+    StringBuilder sb = new StringBuilder();
     for (Node child : tagNode.getChildren()) {
       sb.append(child.render(interpreter).getValue());
     }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -316,7 +316,10 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
         values.add(value);
       }
     );
-    StringJoiner result = new StringJoiner(" ");
+    LengthLimitingStringJoiner result = new LengthLimitingStringJoiner(
+      interpreter.getConfig().getMaxOutputSize(),
+      " "
+    );
     result
       .add(interpreter.getConfig().getTokenScannerSymbols().getExpressionStartWithTag())
       .add(SetTag.TAG_NAME)

--- a/src/main/java/com/hubspot/jinjava/util/LengthLimitingStringJoiner.java
+++ b/src/main/java/com/hubspot/jinjava/util/LengthLimitingStringJoiner.java
@@ -31,4 +31,9 @@ public class LengthLimitingStringJoiner {
     joiner.add(newElement);
     return this;
   }
+
+  @Override
+  public String toString() {
+    return joiner.toString();
+  }
 }

--- a/src/main/java/com/hubspot/jinjava/util/LengthLimitingStringJoiner.java
+++ b/src/main/java/com/hubspot/jinjava/util/LengthLimitingStringJoiner.java
@@ -1,0 +1,34 @@
+package com.hubspot.jinjava.util;
+
+import com.hubspot.jinjava.interpret.OutputTooBigException;
+import java.util.StringJoiner;
+
+public class LengthLimitingStringJoiner {
+  private final StringJoiner joiner;
+  private final int delimiterLength;
+  private final long maxLength;
+
+  public LengthLimitingStringJoiner(long maxLength, CharSequence delimiter) {
+    joiner = new StringJoiner(delimiter);
+    delimiterLength = delimiter.length();
+    this.maxLength = maxLength;
+  }
+
+  public int length() {
+    return joiner.length();
+  }
+
+  public LengthLimitingStringJoiner add(Object obj) {
+    return add(String.valueOf(obj));
+  }
+
+  public LengthLimitingStringJoiner add(CharSequence newElement) {
+    long newLength =
+      joiner.length() + newElement.length() + (joiner.length() > 0 ? delimiterLength : 0);
+    if (maxLength > 0 && newLength > maxLength) {
+      throw new OutputTooBigException(maxLength, newLength);
+    }
+    joiner.add(newElement);
+    return this;
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 import com.google.common.collect.ImmutableList;
@@ -10,7 +11,12 @@ import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.OutputTooBigException;
+import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
+import com.hubspot.jinjava.lib.tag.Tag;
+import com.hubspot.jinjava.mode.DefaultExecutionMode;
+import com.hubspot.jinjava.mode.EagerExecutionMode;
 import com.hubspot.jinjava.mode.PreserveRawExecutionMode;
 import com.hubspot.jinjava.objects.collections.PyMap;
 import com.hubspot.jinjava.tree.TagNode;
@@ -20,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -29,6 +36,27 @@ import org.mockito.junit.MockitoJUnitRunner;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class EagerTagDecoratorTest extends BaseInterpretingTest {
+  private static final long MAX_OUTPUT_SIZE = 50L;
+  private Tag mockTag;
+  private EagerGenericTag<Tag> eagerTagDecorator;
+
+  @Before
+  public void eagerSetup() {
+    interpreter =
+      new JinjavaInterpreter(
+        jinjava,
+        context,
+        JinjavaConfig
+          .newBuilder()
+          .withMaxOutputSize(MAX_OUTPUT_SIZE)
+          .withExecutionMode(new EagerExecutionMode())
+          .build()
+      );
+    mockTag = mock(Tag.class);
+    eagerTagDecorator = new EagerGenericTag<>(mockTag);
+
+    JinjavaInterpreter.pushCurrent(interpreter);
+  }
 
   @Test
   public void itExecutesInChildContextAndTakesNewValue() {
@@ -183,8 +211,17 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
 
   @Test
   public void itDoesntWrapInRawTagForDefaultConfig() {
+    JinjavaConfig defaultConfig = JinjavaConfig
+      .newBuilder()
+      .withExecutionMode(new DefaultExecutionMode())
+      .build();
     String toWrap = "{{ foo }}";
-    assertThat(EagerTagDecorator.wrapInRawIfNeeded(toWrap, interpreter))
+    assertThat(
+        EagerTagDecorator.wrapInRawIfNeeded(
+          toWrap,
+          new JinjavaInterpreter(jinjava, context, defaultConfig)
+        )
+      )
       .isEqualTo(toWrap);
   }
 
@@ -210,6 +247,52 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
     assertThat(EagerTagDecorator.reconstructEnd(tagNode)).isEqualTo("{% endif %}");
     tagNode = getMockTagNode("endfor");
     assertThat(EagerTagDecorator.reconstructEnd(tagNode)).isEqualTo("{% endfor %}");
+  }
+
+  @Test
+  public void itDoesntLimitShortString() {
+    String template = "{% raw %}abc{% endraw %}";
+
+    TagNode tagNode = (TagNode) (interpreter.parse(template).getChildren().get(0));
+    assertThat(eagerTagDecorator.eagerInterpret(tagNode, interpreter))
+      .isEqualTo(template);
+    assertThat(interpreter.getErrors()).hasSize(0);
+  }
+
+  @Test
+  public void itLimitsEagerInterpretLength() {
+    StringBuilder tooLong = new StringBuilder();
+    for (int i = 0; i < MAX_OUTPUT_SIZE; i++) {
+      tooLong.append(i);
+    }
+    TagNode tagNode = (TagNode) (
+      interpreter
+        .parse(String.format("{%% raw %%}%s{%% endraw %%}", tooLong.toString()))
+        .getChildren()
+        .get(0)
+    );
+    assertThatThrownBy(() -> eagerTagDecorator.eagerInterpret(tagNode, interpreter))
+      .isInstanceOf(OutputTooBigException.class);
+  }
+
+  @Test
+  public void itLimitsInterpretLength() {
+    when(mockTag.interpret(any(), any())).thenThrow(new DeferredValueException(""));
+    StringBuilder tooLong = new StringBuilder();
+    for (int i = 0; i < MAX_OUTPUT_SIZE; i++) {
+      tooLong.append(i);
+    }
+    TagNode tagNode = (TagNode) (
+      interpreter
+        .parse(String.format("{%% raw %%}%s{%% endraw %%}", tooLong.toString()))
+        .getChildren()
+        .get(0)
+    );
+    assertThatThrownBy(() -> eagerTagDecorator.interpret(tagNode, interpreter))
+      .isInstanceOf(DeferredValueException.class);
+    assertThat(interpreter.getErrors()).hasSize(1);
+    assertThat(interpreter.getErrors().get(0).getReason())
+      .isEqualTo(ErrorReason.OUTPUT_TOO_BIG);
   }
 
   private static MacroFunction getMockMacroFunction(String image) {

--- a/src/test/java/com/hubspot/jinjava/util/LengthLimitingStringJoinerTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/LengthLimitingStringJoinerTest.java
@@ -1,0 +1,35 @@
+package com.hubspot.jinjava.util;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.hubspot.jinjava.interpret.OutputTooBigException;
+import org.junit.Test;
+
+public class LengthLimitingStringJoinerTest {
+
+  @Test
+  public void itLimitsStringLength() {
+    LengthLimitingStringJoiner joiner = new LengthLimitingStringJoiner(10, " ");
+    joiner.add("0123456789");
+    assertThatThrownBy(() -> joiner.add("1")).isInstanceOf(OutputTooBigException.class);
+  }
+
+  @Test
+  public void itDoesNotLimitWithZeroLength() {
+    LengthLimitingStringJoiner joiner = new LengthLimitingStringJoiner(0, " ");
+    joiner.add("0123456789");
+  }
+
+  @Test
+  public void itLimitsOnAdd() {
+    LengthLimitingStringJoiner joiner = new LengthLimitingStringJoiner(1, " ");
+    assertThatThrownBy(() -> joiner.add("123")).isInstanceOf(OutputTooBigException.class);
+  }
+
+  @Test
+  public void itIncludesDelimiterInLimit() {
+    LengthLimitingStringJoiner joiner = new LengthLimitingStringJoiner(5, "123456789");
+    joiner.add('a');
+    assertThatThrownBy(() -> joiner.add('b')).isInstanceOf(OutputTooBigException.class);
+  }
+}


### PR DESCRIPTION
Based on the suggestion from @Joeoh here: https://github.com/HubSpot/jinjava/pull/554#discussion_r533217276
Having the `LengthLimitingStringBuilder` is useful to prevent code explosion when doing eager execution which could result in very large output. Using this will catch nodes that are creating too much output and defer them rather than continuing with their eager execution. This PR also introduces a StringJoiner wrapper called `LengthLimitingStringJoiner` which functions like the string builder, but allows for a delimiter to be specified.

This approach allows the overriding subclasses to have the flexibility to use the length limiters on some or all of their output. By default, the entire output is limited, as well as the tag image reconstruction, and the set tag pre-pending. If any are too large, then eager execution will quit and the node will be marked and handles as a deferred node via `handleDeferredNode()`. (This happens when the DeferredValueException is thrown but not caught within the decorator)

In the future, this may be substituted or supplemented with a check on the overall output size of the render from eager execution.