### PR TITLE
Make execution mode a singleton

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -231,7 +231,7 @@ public class JinjavaConfig {
     private boolean iterateOverMapKeys;
     private int maxListSize = Integer.MAX_VALUE;
     private int maxMapSize = Integer.MAX_VALUE;
-    private ExecutionMode executionMode = new DefaultExecutionMode();
+    private ExecutionMode executionMode = DefaultExecutionMode.instance();
 
     private Builder() {}
 

--- a/src/main/java/com/hubspot/jinjava/mode/DefaultExecutionMode.java
+++ b/src/main/java/com/hubspot/jinjava/mode/DefaultExecutionMode.java
@@ -1,3 +1,11 @@
 package com.hubspot.jinjava.mode;
 
-public class DefaultExecutionMode implements ExecutionMode {}
+public class DefaultExecutionMode implements ExecutionMode {
+  private static final ExecutionMode INSTANCE = new DefaultExecutionMode();
+
+  private DefaultExecutionMode() {}
+
+  public static ExecutionMode instance() {
+    return INSTANCE;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/mode/EagerExecutionMode.java
+++ b/src/main/java/com/hubspot/jinjava/mode/EagerExecutionMode.java
@@ -7,6 +7,13 @@ import com.hubspot.jinjava.lib.tag.eager.EagerTagFactory;
 import java.util.Optional;
 
 public class EagerExecutionMode implements ExecutionMode {
+  private static final ExecutionMode INSTANCE = new EagerExecutionMode();
+
+  private EagerExecutionMode() {}
+
+  public static ExecutionMode instance() {
+    return INSTANCE;
+  }
 
   @Override
   public boolean isPreserveRawTags() {

--- a/src/main/java/com/hubspot/jinjava/mode/PreserveRawExecutionMode.java
+++ b/src/main/java/com/hubspot/jinjava/mode/PreserveRawExecutionMode.java
@@ -1,6 +1,13 @@
 package com.hubspot.jinjava.mode;
 
 public class PreserveRawExecutionMode implements ExecutionMode {
+  private static final ExecutionMode INSTANCE = new PreserveRawExecutionMode();
+
+  private PreserveRawExecutionMode() {}
+
+  public static ExecutionMode instance() {
+    return INSTANCE;
+  }
 
   @Override
   public boolean isPreserveRawTags() {

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -64,7 +64,7 @@ public class EagerTest {
     JinjavaConfig config = JinjavaConfig
       .newBuilder()
       .withRandomNumberGeneratorStrategy(RandomNumberGeneratorStrategy.DEFERRED)
-      .withExecutionMode(new EagerExecutionMode())
+      .withExecutionMode(EagerExecutionMode.instance())
       .withNestedInterpretationEnabled(true)
       .build();
     JinjavaInterpreter parentInterpreter = new JinjavaInterpreter(
@@ -739,7 +739,7 @@ public class EagerTest {
     JinjavaConfig config = JinjavaConfig
       .newBuilder()
       .withRandomNumberGeneratorStrategy(RandomNumberGeneratorStrategy.DEFERRED)
-      .withExecutionMode(new EagerExecutionMode())
+      .withExecutionMode(EagerExecutionMode.instance())
       .withNestedInterpretationEnabled(false)
       .build();
     JinjavaInterpreter parentInterpreter = new JinjavaInterpreter(

--- a/src/test/java/com/hubspot/jinjava/ExpectedTemplateInterpreter.java
+++ b/src/test/java/com/hubspot/jinjava/ExpectedTemplateInterpreter.java
@@ -37,7 +37,10 @@ public class ExpectedTemplateInterpreter {
     JinjavaInterpreter preserveInterpreter = new JinjavaInterpreter(
       jinjava,
       jinjava.getGlobalContextCopy(),
-      JinjavaConfig.newBuilder().withExecutionMode(new DefaultExecutionMode()).build()
+      JinjavaConfig
+        .newBuilder()
+        .withExecutionMode(DefaultExecutionMode.instance())
+        .build()
     );
     try {
       JinjavaInterpreter.pushCurrent(preserveInterpreter);

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -249,7 +249,7 @@ public class JinjavaInterpreterTest {
   public void itCanPreserveRawTags() {
     JinjavaConfig preserveConfig = JinjavaConfig
       .newBuilder()
-      .withExecutionMode(new PreserveRawExecutionMode())
+      .withExecutionMode(PreserveRawExecutionMode.instance())
       .build();
     String input = "1{% raw %}2{% endraw %}3";
     String normalOutput = "123";

--- a/src/test/java/com/hubspot/jinjava/lib/tag/RawTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/RawTagTest.java
@@ -98,7 +98,10 @@ public class RawTagTest extends BaseInterpretingTest {
     JinjavaInterpreter preserveInterpreter = new JinjavaInterpreter(
       jinjava,
       jinjava.getGlobalContextCopy(),
-      JinjavaConfig.newBuilder().withExecutionMode(new PreserveRawExecutionMode()).build()
+      JinjavaConfig
+        .newBuilder()
+        .withExecutionMode(PreserveRawExecutionMode.instance())
+        .build()
     );
     String result = tag.interpret(tagNode, preserveInterpreter);
     try {
@@ -120,7 +123,10 @@ public class RawTagTest extends BaseInterpretingTest {
     JinjavaInterpreter preserveInterpreter = new JinjavaInterpreter(
       jinjava,
       jinjava.getGlobalContextCopy(),
-      JinjavaConfig.newBuilder().withExecutionMode(new PreserveRawExecutionMode()).build()
+      JinjavaConfig
+        .newBuilder()
+        .withExecutionMode(PreserveRawExecutionMode.instance())
+        .build()
     );
     preserveInterpreter.getContext().put("deferred", DeferredValue.instance());
     interpreter.getContext().put("deferred", DeferredValue.instance());

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
@@ -51,7 +51,7 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
         JinjavaConfig
           .newBuilder()
           .withMaxOutputSize(MAX_OUTPUT_SIZE)
-          .withExecutionMode(new EagerExecutionMode())
+          .withExecutionMode(EagerExecutionMode.instance())
           .build()
       );
     mockTag = mock(Tag.class);
@@ -207,7 +207,7 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
     String toWrap = "{{ foo }}";
     JinjavaConfig preserveRawConfig = JinjavaConfig
       .newBuilder()
-      .withExecutionMode(new PreserveRawExecutionMode())
+      .withExecutionMode(PreserveRawExecutionMode.instance())
       .build();
     assertThat(
         EagerTagDecorator.wrapInRawIfNeeded(
@@ -223,7 +223,7 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
     String toWrap = "foo";
     JinjavaConfig preserveRawConfig = JinjavaConfig
       .newBuilder()
-      .withExecutionMode(new PreserveRawExecutionMode())
+      .withExecutionMode(PreserveRawExecutionMode.instance())
       .build();
     assertThat(
         EagerTagDecorator.wrapInRawIfNeeded(
@@ -238,7 +238,7 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
   public void itDoesntWrapInRawTagForDefaultConfig() {
     JinjavaConfig defaultConfig = JinjavaConfig
       .newBuilder()
-      .withExecutionMode(new DefaultExecutionMode())
+      .withExecutionMode(DefaultExecutionMode.instance())
       .build();
     String toWrap = "{{ foo }}";
     assertThat(


### PR DESCRIPTION
Added an `instance()` method so that the execution mode is set statically.
The execution modes don't have any state so this seems better than having to instantiate them.