### PR TITLE
Rename protectedMode to deferredExecutionMode

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -99,7 +99,7 @@ public class Context extends ScopeMap<String, Object> {
   private final Stack<String> renderStack = new Stack<>();
 
   private boolean validationMode = false;
-  private boolean protectedMode = false;
+  private boolean deferredExecutionMode = false;
   private boolean hideInterpreterErrors = false;
 
   public Context() {
@@ -589,12 +589,12 @@ public class Context extends ScopeMap<String, Object> {
     return this.dependencies;
   }
 
-  public boolean isProtectedMode() {
-    return protectedMode;
+  public boolean isDeferredExecutionMode() {
+    return deferredExecutionMode;
   }
 
-  public Context setProtectedMode(boolean protectedMode) {
-    this.protectedMode = protectedMode;
+  public Context setDeferredExecutionMode(boolean deferredExecutionMode) {
+    this.deferredExecutionMode = deferredExecutionMode;
     return this;
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -43,7 +43,7 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
       true
     );
     StringBuilder prefixToPreserveState = new StringBuilder(
-      interpreter.getContext().isProtectedMode()
+      interpreter.getContext().isDeferredExecutionMode()
         ? resolvedExpression.getPrefixToPreserveState()
         : ""
     );

--- a/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
@@ -52,7 +52,7 @@ public class EagerMacroFunction extends AbstractCallableMethod {
   ) {
     Optional<String> importFile = macroFunction.getImportFile(interpreter);
     try (InterpreterScopeClosable c = interpreter.enterScope()) {
-      interpreter.getContext().setProtectedMode(true);
+      interpreter.getContext().setDeferredExecutionMode(true);
       return macroFunction.getEvaluationResult(argMap, kwargMap, varArgs, interpreter);
     } finally {
       importFile.ifPresent(path -> interpreter.getContext().getCurrentPathStack().pop());

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -134,7 +134,7 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
    * Additionally, if the execution causes existing values on the context to become
    *   deferred, then their previous values will wrapped in a <code>set</code>
    *   tag that gets prepended to the returned result.
-   * The <code>function</code> is run in protectedMode=true, where the context needs to
+   * The <code>function</code> is run in deferredExecutionMode=true, where the context needs to
    *   be protected from having values updated or set,
    *   such as when evaluating both the positive and negative nodes in an if statement.
    * @param function Function to run within a "protected" child context
@@ -180,7 +180,7 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
       );
 
     try (InterpreterScopeClosable c = interpreter.enterScope()) {
-      interpreter.getContext().setProtectedMode(true);
+      interpreter.getContext().setDeferredExecutionMode(true);
       result.append(function.apply(interpreter));
     }
     Map<String, String> deferredValuesToSet = interpreter
@@ -310,8 +310,8 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
     Set<String> deferredWords,
     JinjavaInterpreter interpreter
   ) {
-    if (interpreter.getContext().isProtectedMode()) {
-      return ""; // This will be handled outside of the protected mode.
+    if (interpreter.getContext().isDeferredExecutionMode()) {
+      return ""; // This will be handled outside of the deferred execution mode.
     }
     Map<String, String> deferredMap = new HashMap<>();
     deferredWords

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
@@ -148,11 +148,11 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
   }
 
   @Test
-  public void itDoesntReconstructVariablesInProtectedMode() {
+  public void itDoesntReconstructVariablesInDeferredExecutionMode() {
     Set<String> deferredWords = new HashSet<>();
     deferredWords.add("foo.append");
     context.put("foo", new PyList(new ArrayList<>()));
-    context.setProtectedMode(true);
+    context.setDeferredExecutionMode(true);
     String result = EagerTagDecorator.reconstructFromContextBeforeDeferring(
       deferredWords,
       interpreter


### PR DESCRIPTION
Since the term "protected mode" is nondescript and confusing, I'm renaming it to "deferred execution mode". This is because this mode happens when the final execution of that block of code is being deferred, such as when the correct branch of an if tag is not yet known: the branches have their code executed in "deferred execution mode".

https://github.com/HubSpot/jinjava/pull/557#discussion_r534261660