### PR TITLE
Allow commas in kwargs for macro tags

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
@@ -12,6 +12,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
 import com.hubspot.jinjava.tree.TagNode;
+import com.hubspot.jinjava.util.ChunkResolver;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -167,7 +168,7 @@ public class MacroTag implements Tag {
     String args,
     LinkedHashMap<String, Object> argNamesWithDefaults
   ) {
-    List<String> argList = Lists.newArrayList(ARGS_SPLITTER.split(args));
+    List<String> argList = new ChunkResolver(args).splitChunks(); //Lists.newArrayList(ARGS_SPLITTER.split(args));
     boolean deferred = false;
     for (int i = 0; i < argList.size(); i++) {
       String arg = argList.get(i);

--- a/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
@@ -2,7 +2,6 @@ package com.hubspot.jinjava.lib.tag;
 
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
@@ -168,7 +167,7 @@ public class MacroTag implements Tag {
     String args,
     LinkedHashMap<String, Object> argNamesWithDefaults
   ) {
-    List<String> argList = new ChunkResolver(args).splitChunks(); //Lists.newArrayList(ARGS_SPLITTER.split(args));
+    List<String> argList = new ChunkResolver(args).splitChunks();
     boolean deferred = false;
     for (int i = 0; i < argList.size(); i++) {
       String arg = argList.get(i);

--- a/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.lib.tag;
 
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
@@ -167,7 +168,13 @@ public class MacroTag implements Tag {
     String args,
     LinkedHashMap<String, Object> argNamesWithDefaults
   ) {
-    List<String> argList = new ChunkResolver(args).splitChunks();
+    List<String> argList;
+    if (args.contains("=")) {
+      argList = new ChunkResolver(args).splitChunks();
+    } else {
+      // Non-kwargs can use this as it is faster
+      argList = Lists.newArrayList(ARGS_SPLITTER.split(args));
+    }
     boolean deferred = false;
     for (int i = 0; i < argList.size(); i++) {
       String arg = argList.get(i);

--- a/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
@@ -105,6 +105,18 @@ public class MacroTagTest extends BaseInterpretingTest {
   }
 
   @Test
+  public void itAllowsCommasInKwargs() {
+    TagNode t = fixture("allows-commas-in-kwargs");
+    assertThat(t.render(interpreter).getValue()).isEmpty();
+
+    String out = snippet("{{ separate('foo', 'bar') }}")
+      .render(interpreter)
+      .getValue()
+      .trim();
+    assertThat(out).isEqualTo("foo,bar");
+  }
+
+  @Test
   public void testFnWithArgsWithDefVals() {
     TagNode t = fixture("def-vals");
     assertThat(t.render(interpreter).getValue()).isEmpty();

--- a/src/test/resources/tags/macrotag/allows-commas-in-kwargs.jinja
+++ b/src/test/resources/tags/macrotag/allows-commas-in-kwargs.jinja
@@ -1,0 +1,3 @@
+{% macro separate(a, b, separator=',') %}
+{{ a ~ separator ~ b}}
+{% endmacro %}


### PR DESCRIPTION
Fixes the problem exposed in https://github.com/HubSpot/jinjava/issues/496 by using the chunk resolver to split the arguments in the macro tag.

The chunk resolver respects the hierarchy of quotes, parentheses, brackets, etc so it can determine when a comma is in the place to actually signify a new keyword argument, rather than something related to the value.

This requires an option to be added in the chunk resolver to not do the interpreting, and just output the raw strings that are split into a list by a comma.