### PR TITLE
Add filter to interpret a string early

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/FilterLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FilterLibrary.java
@@ -110,7 +110,8 @@ public class FilterLibrary extends SimpleLibrary<Filter> {
       ToJsonFilter.class,
       FromJsonFilter.class,
       ToYamlFilter.class,
-      FromYamlFilter.class
+      FromYamlFilter.class,
+      RenderFilter.class
     );
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RenderFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RenderFilter.java
@@ -1,0 +1,29 @@
+package com.hubspot.jinjava.lib.filter;
+
+import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
+import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import java.util.Objects;
+
+@JinjavaDoc(
+  value = "Renders a template string early to be used by other filters and functions",
+  input = @JinjavaParam(value = "s", desc = "String to render", required = true),
+  snippets = {
+    @JinjavaSnippet(
+      code = "{{ \"{% if my_val %}} Hello {% else %} world {% endif %}\"|render }}"
+    ),
+  }
+)
+public class RenderFilter implements Filter {
+
+  @Override
+  public String getName() {
+    return "render";
+  }
+
+  @Override
+  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+    return interpreter.render(Objects.toString(var));
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RenderFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RenderFilter.java
@@ -12,7 +12,7 @@ import java.util.Objects;
   snippets = {
     @JinjavaSnippet(
       code = "{{ \"{% if my_val %} Hello {% else %} world {% endif %}\"|render }}"
-    ),
+    )
   }
 )
 public class RenderFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RenderFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RenderFilter.java
@@ -11,8 +11,8 @@ import java.util.Objects;
   input = @JinjavaParam(value = "s", desc = "String to render", required = true),
   snippets = {
     @JinjavaSnippet(
-      code = "{{ \"{% if my_val %}} Hello {% else %} world {% endif %}\"|render }}"
-    )
+      code = "{{ \"{% if my_val %} Hello {% else %} world {% endif %}\"|render }}"
+    ),
   }
 )
 public class RenderFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RenderFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RenderFilter.java
@@ -12,7 +12,7 @@ import java.util.Objects;
   snippets = {
     @JinjavaSnippet(
       code = "{{ \"{% if my_val %}} Hello {% else %} world {% endif %}\"|render }}"
-    ),
+    )
   }
 )
 public class RenderFilter implements Filter {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RenderFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RenderFilterTest.java
@@ -1,0 +1,23 @@
+package com.hubspot.jinjava.lib.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hubspot.jinjava.BaseInterpretingTest;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RenderFilterTest extends BaseInterpretingTest {
+  private RenderFilter filter;
+
+  @Before
+  public void setup() {
+    filter = new RenderFilter();
+  }
+
+  @Test
+  public void itWritesObjectAsString() {
+    String stringToRender = "{% if null %}}Hello{% else %}world{% endif %}";
+
+    assertThat(filter.filter(stringToRender, interpreter)).isEqualTo("world");
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RenderFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RenderFilterTest.java
@@ -15,8 +15,8 @@ public class RenderFilterTest extends BaseInterpretingTest {
   }
 
   @Test
-  public void itWritesObjectAsString() {
-    String stringToRender = "{% if null %}}Hello{% else %}world{% endif %}";
+  public void itRendersObject() {
+    String stringToRender = "{% if null %}Hello{% else %}world{% endif %}";
 
     assertThat(filter.filter(stringToRender, interpreter)).isEqualTo("world");
   }


### PR DESCRIPTION
This PR adds a new `RenderFilter` which can be used to interpret a template string early.

For instance, the following:
```
{{ "{% if null %}}Hello{% else %}World{% endif %}"|render }}
```
would output `World`. However, you could use the result of the filter in other filters, like so:
```
{{ "{% if null %}}Hello{% else %}World{% endif %}"|render|lower }}
```
which would output `world`.

This is useful in cases where a function or other construct results in an expression that must be interpreted before applying other filters / transformations.

I'm open to naming this something different if people don't like `render`.