### PR TITLE
Use ExpressionToken for the eager expression strategy

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -9,7 +9,6 @@ import com.hubspot.jinjava.lib.tag.eager.EagerTagDecorator;
 import com.hubspot.jinjava.lib.tag.eager.EagerToken;
 import com.hubspot.jinjava.tree.output.RenderedOutputNode;
 import com.hubspot.jinjava.tree.parse.ExpressionToken;
-import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.ChunkResolver;
 import com.hubspot.jinjava.util.Logging;
 import com.hubspot.jinjava.util.WhitespaceUtils;
@@ -84,7 +83,7 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
       .getContext()
       .handleEagerToken(
         new EagerToken(
-          new TagToken(
+          new ExpressionToken(
             helpers,
             master.getLineNumber(),
             master.getStartPosition(),


### PR DESCRIPTION
Fix mistake where the eager token was registered as a TagToken here rather than an ExpressionToken. 