### PR TITLE
Replicate handling of non-existent variables in ChunkResolver

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -59,6 +59,8 @@ public class ChunkResolver {
     ']'
   );
 
+  private static final String VARIABLE_REGEX = "[A-Za-z_][\\w.]*";
+
   private final char[] value;
   private final int length;
   private final Token token;
@@ -252,6 +254,10 @@ public class ChunkResolver {
       String resolvedChunk;
       Object val = interpreter.resolveELExpression(chunk, token.getLineNumber());
       if (val == null) {
+        if (chunk.matches(VARIABLE_REGEX)) {
+          // Non-existent variable
+          return "";
+        }
         resolvedChunk = chunk;
       } else {
         resolvedChunk = getValueAsJinjavaString(val);

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -160,16 +160,16 @@ public class ChunkResolver {
       } else if (
         chunkLevelMarker != null && CHUNK_LEVEL_MARKER_MAP.get(chunkLevelMarker) == c
       ) {
-        prevChar = c;
+        setPrevChar(c);
         break;
       } else if (CHUNK_LEVEL_MARKER_MAP.containsKey(c)) {
-        prevChar = c;
+        setPrevChar(c);
         tokenBuilder.append(c);
         tokenBuilder.append(resolveChunk(String.join("", getChunk(c))));
         tokenBuilder.append(prevChar);
         continue;
       } else if (isTokenSplitter(c)) {
-        prevChar = c;
+        setPrevChar(c);
 
         miniChunkBuilder.append(resolveToken(tokenBuilder.toString()));
         tokenBuilder = new StringBuilder();
@@ -182,12 +182,21 @@ public class ChunkResolver {
         }
         continue;
       }
-      prevChar = c;
+      setPrevChar(c);
       tokenBuilder.append(c);
     }
     miniChunkBuilder.append(resolveToken(tokenBuilder.toString()));
     chunks.add(resolveChunk(miniChunkBuilder.toString()));
     return chunks;
+  }
+
+  private void setPrevChar(char c) {
+    if (c == '\\' && prevChar == '\\') {
+      // Backslashes cancel each other out for escaping when there's an even number.
+      prevChar = '\0';
+    } else {
+      prevChar = c;
+    }
   }
 
   private boolean isTokenSplitter(char c) {

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -274,4 +274,11 @@ public class ChunkResolverTest {
     assertThat(WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunks()))
       .isEqualTo("\n & \n & \\n & \\n");
   }
+
+  @Test
+  public void itOutputsUnknownVariablesAsEmpty() {
+    ChunkResolver chunkResolver = makeChunkResolver("contact.some_odd_property");
+    assertThat(WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunks()))
+      .isEqualTo("");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -281,4 +281,12 @@ public class ChunkResolverTest {
     assertThat(WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunks()))
       .isEqualTo("");
   }
+
+  @Test
+  public void itHandlesCancellingSlashes() {
+    context.put("foo", "bar");
+    ChunkResolver chunkResolver = makeChunkResolver("foo ~ 'foo\\\\' ~ foo ~ 'foo'");
+    assertThat(WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunks()))
+      .isEqualTo("barfoo\\barfoo");
+  }
 }


### PR DESCRIPTION
This PR addresses 2 bugs in the ChunkResolver:
- An even number of slashes followed by a quote character would be interpreted as an escaped quote when it shouldn't be escaped
- In Jinjava, when an unknown variable is used in an expression node, the result is an empty string:
  `Something {{ nonexistent }}!` -> `Something !` So match this functionality with the ChunkResolver, as it previously would just output the variable name

ChunkResolver is currently just used within Eager Execution so the scope of this bug is essentially nothing.