### PR TITLE
Handle void functions in ChunkResolver

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -101,7 +101,7 @@ public class Context extends ScopeMap<String, Object> {
 
   private boolean validationMode = false;
   private boolean deferredExecutionMode = false;
-  private boolean hideInterpreterErrors = false;
+  private boolean throwInterpreterErrors = false;
 
   public Context() {
     this(null, null, null);
@@ -599,11 +599,11 @@ public class Context extends ScopeMap<String, Object> {
     return this;
   }
 
-  public boolean getHideInterpreterErrors() {
-    return hideInterpreterErrors;
+  public boolean getThrowInterpreterErrors() {
+    return throwInterpreterErrors;
   }
 
-  public void setHideInterpreterErrors(boolean hideInterpreterErrors) {
-    this.hideInterpreterErrors = hideInterpreterErrors;
+  public void setThrowInterpreterErrors(boolean throwInterpreterErrors) {
+    this.throwInterpreterErrors = throwInterpreterErrors;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -566,7 +566,11 @@ public class JinjavaInterpreter {
   public void addError(TemplateError templateError) {
     if (context.getHideInterpreterErrors()) {
       // Hiding errors when resolving chunks.
-      return;
+      throw new TemplateSyntaxException(
+        this,
+        templateError.getFieldName(),
+        templateError.getMessage()
+      );
     }
     // fix line numbers not matching up with source template
     if (!context.getCurrentPathStack().isEmpty()) {

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -564,7 +564,7 @@ public class JinjavaInterpreter {
   }
 
   public void addError(TemplateError templateError) {
-    if (context.getHideInterpreterErrors()) {
+    if (context.getThrowInterpreterErrors()) {
       // Hiding errors when resolving chunks.
       throw new TemplateSyntaxException(
         this,

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -121,7 +121,7 @@ public class ChunkResolver {
    */
   public List<String> splitChunks() {
     nextPos = 0;
-    boolean isHideInterpreterErrorsStart = interpreter
+    boolean isThrowInterpreterErrorsStart = interpreter
       .getContext()
       .getThrowInterpreterErrors();
     try {
@@ -132,7 +132,7 @@ public class ChunkResolver {
         .filter(s -> s.length() > 1 || !isMiniChunkSplitter(s.charAt(0)))
         .collect(Collectors.toList());
     } finally {
-      interpreter.getContext().setThrowInterpreterErrors(isHideInterpreterErrorsStart);
+      interpreter.getContext().setThrowInterpreterErrors(isThrowInterpreterErrorsStart);
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -104,12 +104,12 @@ public class ChunkResolver {
     nextPos = 0;
     boolean isHideInterpreterErrorsStart = interpreter
       .getContext()
-      .getHideInterpreterErrors();
+      .getThrowInterpreterErrors();
     try {
-      interpreter.getContext().setHideInterpreterErrors(true);
+      interpreter.getContext().setThrowInterpreterErrors(true);
       return String.join("", getChunk(null));
     } finally {
-      interpreter.getContext().setHideInterpreterErrors(isHideInterpreterErrorsStart);
+      interpreter.getContext().setThrowInterpreterErrors(isHideInterpreterErrorsStart);
     }
   }
 
@@ -125,16 +125,16 @@ public class ChunkResolver {
     nextPos = 0;
     boolean isHideInterpreterErrorsStart = interpreter
       .getContext()
-      .getHideInterpreterErrors();
+      .getThrowInterpreterErrors();
     try {
-      interpreter.getContext().setHideInterpreterErrors(true);
+      interpreter.getContext().setThrowInterpreterErrors(true);
       List<String> miniChunks = getChunk(null);
       return miniChunks
         .stream()
         .filter(s -> s.length() > 1 || !isMiniChunkSplitter(s.charAt(0)))
         .collect(Collectors.toList());
     } finally {
-      interpreter.getContext().setHideInterpreterErrors(isHideInterpreterErrorsStart);
+      interpreter.getContext().setThrowInterpreterErrors(isHideInterpreterErrorsStart);
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -102,14 +102,14 @@ public class ChunkResolver {
    */
   public String resolveChunks() {
     nextPos = 0;
-    boolean isHideInterpreterErrorsStart = interpreter
+    boolean isThrowInterpreterErrorsStart = interpreter
       .getContext()
       .getThrowInterpreterErrors();
     try {
       interpreter.getContext().setThrowInterpreterErrors(true);
       return String.join("", getChunk(null));
     } finally {
-      interpreter.getContext().setThrowInterpreterErrors(isHideInterpreterErrorsStart);
+      interpreter.getContext().setThrowInterpreterErrors(isThrowInterpreterErrorsStart);
     }
   }
 
@@ -352,9 +352,7 @@ public class ChunkResolver {
       }
       // don't defer numbers, values such as true/false, etc.
       return interpreter.resolveELExpression(w, token.getLineNumber()) == null;
-    } catch (DeferredValueException e) {
-      return true;
-    } catch (TemplateSyntaxException e) {
+    } catch (DeferredValueException | TemplateSyntaxException e) {
       return true;
     }
   }

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -60,8 +60,6 @@ public class ChunkResolver {
     ']'
   );
 
-  private static final String VARIABLE_REGEX = "[A-Za-z_][\\w.]*";
-
   private final char[] value;
   private final int length;
   private final Token token;

--- a/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
@@ -60,8 +60,9 @@ public class EagerExpressionStrategyTest extends ExpressionNodeTest {
 
   @Test
   public void itPreservesRawTagsNestedInterpretation() {
+    context.put("bar", "bar");
     assertExpectedOutput(
-      "{{ '{{ 12345 }}' }} {{ '{% print 'bar' %}' }} {{ 'not needed' }}",
+      "{{ '{{ 12345 }}' }} {{ '{% print bar %}' }} {{ 'not needed' }}",
       "12345 bar not needed"
     );
   }


### PR DESCRIPTION
Void functions return null when calling `interpreter.resolveELExpression()` on them. This separates an expression that legitimately returns null from a null return due to an interpreter error by changing the `hideInterpreterErrors` flag to a `throwInterpreterErrors` flag, allowing legitimate null values to be processed separately from interpreter errors.

The ChunkResolver ignores interpreter errors by resolving the offending chunk with an image of itself. However, if a chunk's resolution is actually supposed to be a null object, then the string result should be the empty string `""`.

Additionally, this fix modifies the underlying logic used for the unknown variable fix implemented in https://github.com/HubSpot/jinjava/pull/575, and achieves the same results as the `null` value can be resolved as the empty string now that it's known that an unknown variable is not a syntax error. (Due to the fact that previously null values were treated the same as template errors in the ChunkResolver)