### PR TITLE
Better null handling in ChunkResolver

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -105,7 +105,12 @@ public class ChunkResolver {
       .getThrowInterpreterErrors();
     try {
       interpreter.getContext().setThrowInterpreterErrors(true);
-      return String.join("", getChunk(null));
+      String expression = String.join("", getChunk(null));
+      if ("null".equals(expression)) {
+        // Resolved value of null as a string is ''.
+        return "''";
+      }
+      return expression;
     } finally {
       interpreter.getContext().setThrowInterpreterErrors(isThrowInterpreterErrorsStart);
     }
@@ -259,7 +264,7 @@ public class ChunkResolver {
       String resolvedChunk;
       Object val = interpreter.resolveELExpression(chunk, token.getLineNumber());
       if (val == null) {
-        return "''";
+        return "null";
       } else {
         resolvedChunk = getValueAsJinjavaString(val);
       }

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class ChunkResolver {
   private static final String JINJAVA_NULL = "null";
+  private static final String JINJAVA_EMPTY_STRING = "''";
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
   .registerModule(
       new SimpleModule().addSerializer(PyishDate.class, new JsonPyishDateSerializer())
@@ -109,7 +110,7 @@ public class ChunkResolver {
       String expression = String.join("", getChunk(null));
       if (JINJAVA_NULL.equals(expression)) {
         // Resolved value of null as a string is ''.
-        return "''";
+        return JINJAVA_EMPTY_STRING;
       }
       return expression;
     } finally {

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang3.StringUtils;
  * This class is not thread-safe. Do not reuse between threads.
  */
 public class ChunkResolver {
+  private static final String JINJAVA_NULL = "null";
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
   .registerModule(
       new SimpleModule().addSerializer(PyishDate.class, new JsonPyishDateSerializer())
@@ -106,7 +107,7 @@ public class ChunkResolver {
     try {
       interpreter.getContext().setThrowInterpreterErrors(true);
       String expression = String.join("", getChunk(null));
-      if ("null".equals(expression)) {
+      if (JINJAVA_NULL.equals(expression)) {
         // Resolved value of null as a string is ''.
         return "''";
       }
@@ -264,7 +265,7 @@ public class ChunkResolver {
       String resolvedChunk;
       Object val = interpreter.resolveELExpression(chunk, token.getLineNumber());
       if (val == null) {
-        return "null";
+        return JINJAVA_NULL;
       } else {
         resolvedChunk = getValueAsJinjavaString(val);
       }

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -259,7 +259,7 @@ public class ChunkResolver {
       String resolvedChunk;
       Object val = interpreter.resolveELExpression(chunk, token.getLineNumber());
       if (val == null) {
-        return "";
+        return "''";
       } else {
         resolvedChunk = getValueAsJinjavaString(val);
       }

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -45,6 +45,15 @@ public class ChunkResolverTest {
           this.getClass().getDeclaredMethod("voidFunction", int.class)
         )
       );
+    jinjava
+      .getGlobalContext()
+      .registerFunction(
+        new ELFunctionDefinition(
+          "",
+          "is_null",
+          this.getClass().getDeclaredMethod("isNull", Object.class, Object.class)
+        )
+      );
     interpreter = new JinjavaInterpreter(jinjava.newInterpreter());
     context = interpreter.getContext();
     context.put("deferred", DeferredValue.instance());
@@ -317,10 +326,23 @@ public class ChunkResolverTest {
 
   @Test
   public void itOutputsNullAsEmptyString() {
-    assertThat(makeChunkResolver("void_function(nothing)").resolveChunks())
-      .isEqualTo("''");
+    assertThat(makeChunkResolver("void_function(2)").resolveChunks()).isEqualTo("''");
     assertThat(makeChunkResolver("nothing").resolveChunks()).isEqualTo("''");
   }
 
+  @Test
+  public void itInterpretsNullAsNull() {
+    assertThat(makeChunkResolver("is_null(nothing, nothing)").resolveChunks())
+      .isEqualTo("true");
+    assertThat(makeChunkResolver("is_null(void_function(2), nothing)").resolveChunks())
+      .isEqualTo("true");
+    assertThat(makeChunkResolver("is_null('a', nothing)").resolveChunks())
+      .isEqualTo("false");
+  }
+
   public static void voidFunction(int nothing) {}
+
+  public static boolean isNull(Object foo, Object bar) {
+    return foo == null && bar == null;
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -315,5 +315,12 @@ public class ChunkResolverTest {
       .isEmpty();
   }
 
+  @Test
+  public void itOutputsNullAsEmptyString() {
+    assertThat(makeChunkResolver("void_function(nothing)").resolveChunks())
+      .isEqualTo("''");
+    assertThat(makeChunkResolver("nothing").resolveChunks()).isEqualTo("''");
+  }
+
   public static void voidFunction(int nothing) {}
 }

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -332,11 +332,11 @@ public class ChunkResolverTest {
 
   @Test
   public void itInterpretsNullAsNull() {
-    assertThat(makeChunkResolver("is_null(nothing, nothing)").resolveChunks())
+    assertThat(makeChunkResolver("is_null(nothing, null)").resolveChunks())
       .isEqualTo("true");
     assertThat(makeChunkResolver("is_null(void_function(2), nothing)").resolveChunks())
       .isEqualTo("true");
-    assertThat(makeChunkResolver("is_null('a', nothing)").resolveChunks())
+    assertThat(makeChunkResolver("is_null('', nothing)").resolveChunks())
       .isEqualTo("false");
   }
 


### PR DESCRIPTION
Rather than returning an empty string `""`, a null value should be interpreted during the resolving process as null. There may be logic that treats `null` differently from `''`. After the string is resolved, however, a result that is exactly `null` should be returned as the empty Jinjava string (`''`) because `{{ null }}` should be interpreted to result in nothing.

This is tricky logic, and so I'm working to make the ChunkResolver handle edge cases like this exactly how they would normally be handled with expressions. This is part of making Eager Execution's output mirror that of the default execution.