### PR TITLE
Allow partial Macro Function evaluation in eager execution

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -102,6 +102,7 @@ public class Context extends ScopeMap<String, Object> {
   private boolean validationMode = false;
   private boolean deferredExecutionMode = false;
   private boolean throwInterpreterErrors = false;
+  private boolean partialMacroEvaluation = false;
 
   public Context() {
     this(null, null, null);
@@ -172,6 +173,7 @@ public class Context extends ScopeMap<String, Object> {
       new FunctionLibrary(parent == null, disabled.get(Library.FUNCTION));
     if (parent != null) {
       this.expressionStrategy = parent.expressionStrategy;
+      this.partialMacroEvaluation = parent.partialMacroEvaluation;
     }
   }
 
@@ -604,5 +606,34 @@ public class Context extends ScopeMap<String, Object> {
 
   public void setThrowInterpreterErrors(boolean throwInterpreterErrors) {
     this.throwInterpreterErrors = throwInterpreterErrors;
+  }
+
+  public boolean isPartialMacroEvaluation() {
+    return partialMacroEvaluation;
+  }
+
+  public void setPartialMacroEvaluation(boolean partialMacroEvaluation) {
+    this.partialMacroEvaluation = partialMacroEvaluation;
+  }
+
+  public PartialMacroEvaluationClosable withPartialMacroEvaluation() {
+    PartialMacroEvaluationClosable partialMacroEvaluationClosable = new PartialMacroEvaluationClosable(
+      this.partialMacroEvaluation
+    );
+    this.partialMacroEvaluation = true;
+    return partialMacroEvaluationClosable;
+  }
+
+  public class PartialMacroEvaluationClosable implements AutoCloseable {
+    private final boolean previousPartialMacroEvaluation;
+
+    private PartialMacroEvaluationClosable(boolean previousPartialMacroEvaluation) {
+      this.previousPartialMacroEvaluation = previousPartialMacroEvaluation;
+    }
+
+    @Override
+    public void close() {
+      setPartialMacroEvaluation(previousPartialMacroEvaluation);
+    }
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -39,7 +39,8 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
     EagerStringResult resolvedExpression = EagerTagDecorator.executeInChildContext(
       eagerInterpreter -> chunkResolver.resolveChunks(),
       interpreter,
-      true
+      true,
+      interpreter.getConfig().isNestedInterpretationEnabled()
     );
     StringBuilder prefixToPreserveState = new StringBuilder(
       interpreter.getContext().isDeferredExecutionMode()

--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -71,9 +71,13 @@ public class MacroFunction extends AbstractCallableMethod {
       String result = getEvaluationResult(argMap, kwargMap, varArgs, interpreter);
 
       if (
-        !interpreter.getContext().getDeferredNodes().isEmpty() ||
-        !interpreter.getContext().getEagerTokens().isEmpty()
+        !interpreter.getContext().isPartialMacroEvaluation() &&
+        (
+          !interpreter.getContext().getDeferredNodes().isEmpty() ||
+          !interpreter.getContext().getEagerTokens().isEmpty()
+        )
       ) {
+        // If the macro function could not be fully evaluated, throw a DeferredValueException.
         throw new DeferredValueException(
           getName(),
           interpreter.getLineNumber(),

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
@@ -26,7 +26,8 @@ public class EagerCycleTag extends EagerStateChangingTag<CycleTag> {
     EagerStringResult resolvedExpression = executeInChildContext(
       eagerInterpreter -> chunkResolver.resolveChunks(),
       interpreter,
-      true
+      true,
+      false
     );
     String expression = resolvedExpression.getResult();
     if (WhitespaceUtils.isWrappedWith(expression, "[", "]")) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
@@ -42,6 +42,7 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
           getEagerImage(tagNode.getMaster(), eagerInterpreter) +
           renderChildren(tagNode, eagerInterpreter),
         interpreter,
+        false,
         false
       )
     );

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
@@ -54,7 +54,8 @@ public class EagerPrintTag extends EagerStateChangingTag<PrintTag> {
     EagerStringResult resolvedExpression = executeInChildContext(
       eagerInterpreter -> chunkResolver.resolveChunks(),
       interpreter,
-      true
+      true,
+      false
     );
     LengthLimitingStringJoiner joiner = new LengthLimitingStringJoiner(
       interpreter.getConfig().getMaxOutputSize(),

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTag.java
@@ -43,7 +43,8 @@ public class EagerSetTag extends EagerStateChangingTag<SetTag> {
     EagerStringResult resolvedExpression = executeInChildContext(
       eagerInterpreter -> chunkResolver.resolveChunks(),
       interpreter,
-      true
+      true,
+      false
     );
     LengthLimitingStringJoiner joiner = new LengthLimitingStringJoiner(
       interpreter.getConfig().getMaxOutputSize(),

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
@@ -28,6 +28,7 @@ public class EagerStateChangingTag<T extends Tag> extends EagerTagDecorator<T> {
         executeInChildContext(
           eagerInterpreter -> renderChildren(tagNode, eagerInterpreter),
           interpreter,
+          false,
           false
         )
       );

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
@@ -77,7 +77,8 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
         }
       ),
       interpreter,
-      true
+      true,
+      false
     );
     assertThat(result.getResult()).isEqualTo("function return");
     assertThat(result.getPrefixToPreserveState()).isEqualTo("{% set foo = [1] %}");
@@ -96,6 +97,7 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
         }
       ),
       interpreter,
+      false,
       false
     );
     assertThat(result.getResult()).isEqualTo("function return");

--- a/src/test/resources/eager/defers-caller.expected.jinja
+++ b/src/test/resources/eager/defers-caller.expected.jinja
@@ -1,2 +1,2 @@
-{% macro says_something(person) %}{{ person }} says:
-{% macro caller() %}How do I get a {{ deferred }}?{% endmacro %}{{ caller() }}{% endmacro %}{{ says_something('Jack') }}
+Jack says:
+How do I get a {{ deferred }}?

--- a/src/test/resources/eager/handles-deferred-from-import-as.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-from-import-as.expected.jinja
@@ -1,6 +1,6 @@
 {% set myname = deferred + 7 %}
 {% set bar = myname + 19 %}
-{% macro foo() %}Hello {{ myname }}{% endmacro %}{{ foo() }}
+Hello {{ myname }}
 {% set from_bar = bar %}
-from_foo: {% macro from_foo() %}Hello {{ myname }}{% endmacro %}{{ from_foo() }}
+from_foo: Hello {{ myname }}
 from_bar: {{ from_bar }}

--- a/src/test/resources/eager/handles-deferred-import-vars.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-import-vars.expected.jinja
@@ -1,12 +1,12 @@
 {% set myname = deferred + 3 %}
 {% set bar = myname + 19 %}
-{% macro foo() %}Hello {{ myname }}{% endmacro %}{{ foo() }}
+Hello {{ myname }}
 
-foo: {% macro foo() %}Hello {{ myname }}{% endmacro %}{{ foo() }}
+foo: Hello {{ myname }}
 bar: {{ bar }}
 ---{% set myname = deferred + 7 %}
 {% set bar = myname + 19 %}{% set simple = {} %}{% do simple.update({'bar': bar}) %}
-{% macro foo() %}Hello {{ myname }}{% endmacro %}{{ foo() }}
+Hello {{ myname }}
 
 simple.foo: {% macro simple.foo() %}Hello {{ myname }}{% endmacro %}{{ simple.foo() }}
 simple.bar: {{ simple.bar }}


### PR DESCRIPTION
Allow for macro functions to be partially evaluated when called by an expression node with nested interpretation enabled. This is a performance boost for eager execution, rather than a bug fix.

This is an optimization that allows eager execution to handle more cases, maximizing the amount of code that can be evaluated. In many circumstances, a macro function cannot be partially evaluated because an exact value is necessary to retrieve from the macro function. For example, if used in a `set` tag: `{% set bar = foo() %}`, clearly the macro function needs to be fully evaluated; if there are any nodes or tokens that were deferred, then the macro function should throw a `DeferredValueException` to signify that its evaluation must be deferred.

However, if the macro function is used in an expression node, having eager tokens within it is okay because they can be resolved in a later rendering pass if nested interpretation is enabled.
For example:
```
{% macro foo() %}
{{ deferred }}
{% endmacro %}
{{ foo() }}
```
Without partial evaluation, the output will look identical to the input in this case...
With partial evaluation, however, the output will be:
```
{{ deferred }}
```
This can be evaluated properly during another rendering pass resulting in the same output as if the expression node and macro function both were deferred. And the output will be smaller in size and faster to evaluate.

Additionally, this allows for other usages of MacroFunctions to allow for partial evaluation, if it makes sense for them. (Notably, the Related Blog Posts Widget for HubSpot)