### PR TITLE
Only throw fatal errors with context flag

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -565,12 +565,17 @@ public class JinjavaInterpreter {
 
   public void addError(TemplateError templateError) {
     if (context.getThrowInterpreterErrors()) {
-      // Hiding errors when resolving chunks.
-      throw new TemplateSyntaxException(
-        this,
-        templateError.getFieldName(),
-        templateError.getMessage()
-      );
+      if (templateError.getSeverity() == ErrorType.FATAL) {
+        // Throw fatal errors when resolving chunks.
+        throw new TemplateSyntaxException(
+          this,
+          templateError.getFieldName(),
+          templateError.getMessage()
+        );
+      } else {
+        // Hide warning errors when resolving chunks.
+        return;
+      }
     }
     // fix line numbers not matching up with source template
     if (!context.getCurrentPathStack().isEmpty()) {


### PR DESCRIPTION
When the `throwInterpreterErrors` context flag is set, which is used in the ChunkResolver, only `ErrorType.FATAL` errors should be thrown. Warnings can just be ignored.

If warnings are thrown then certain expressions that just generate a warning error will not render properly with the ChunkResolver.