### PR TITLE
Better ensure interpreter popping by moving method

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -53,10 +53,9 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
         .newInstance(interpreter);
       child.getContext().put(Context.IMPORT_RESOURCE_PATH_KEY, templateFile);
       JinjavaInterpreter.pushCurrent(child);
-      setupImportAlias(currentImportAlias, child, interpreter);
-
       String output;
       try {
+        setupImportAlias(currentImportAlias, child, interpreter);
         output = child.render(node);
       } finally {
         JinjavaInterpreter.popCurrent();


### PR DESCRIPTION
It is safer to put this within the `try` block to ensure the `finally` block gets executed and the newly pushed interpreter gets popped.