### PR TITLE
[Eager Execution] Flip order of calling hashcode and getting as json

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -172,12 +172,12 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
       .filter(e -> !(e.getValue() instanceof DeferredValue) && e.getValue() != null)
       .forEach(
         entry -> {
-          initiallyResolvedHashes.put(entry.getKey(), entry.getValue().hashCode());
           try {
             initiallyResolvedAsStrings.put(
               entry.getKey(),
               ChunkResolver.getValueAsJinjavaString(entry.getValue())
             );
+            initiallyResolvedHashes.put(entry.getKey(), entry.getValue().hashCode());
           } catch (JsonProcessingException jsonProcessingException) {
             // do nothing
           }


### PR DESCRIPTION
For https://github.com/HubSpot/jinjava/issues/532

Flip the order in which `hashCode()` and converting to json string are called. I found a class where calling a getter method for the first time changes the state of the object so the `hashCode()` result is changed. This would break the logic because the hash code is immediately different.

This is an unlikely scenario, but since it's possible (and happened), I am flipping these to make it safer. https://github.com/HubSpot/jinjava/pull/581 should also help provide a stronger/more flexible fix that would also remedy this problem, but this will help for now.