### PR TITLE
[Eager Execution] Don't track context classes with default toString method

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -169,7 +169,21 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
           !e.getKey().equals(GLOBAL_MACROS_SCOPE_KEY) &&
           !e.getKey().equals(IMPORT_RESOURCE_PATH_KEY)
       )
-      .filter(e -> !(e.getValue() instanceof DeferredValue) && e.getValue() != null)
+      .filter(
+        entry -> !(entry.getValue() instanceof DeferredValue) && entry.getValue() != null
+      )
+      .filter(
+        entry -> {
+          try {
+            return (
+              entry.getValue().getClass().getMethod("toString").getDeclaringClass() !=
+              Object.class
+            );
+          } catch (NoSuchMethodException e) {
+            return false; // Will never happen.
+          }
+        }
+      )
       .forEach(
         entry -> {
           try {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -172,27 +172,20 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
       .filter(
         entry -> !(entry.getValue() instanceof DeferredValue) && entry.getValue() != null
       )
-      .filter(
-        entry -> {
-          try {
-            return (
-              entry.getValue().getClass().getMethod("toString").getDeclaringClass() !=
-              Object.class
-            );
-          } catch (NoSuchMethodException e) {
-            return false; // Will never happen.
-          }
-        }
-      )
       .forEach(
         entry -> {
           try {
-            initiallyResolvedAsStrings.put(
-              entry.getKey(),
-              ChunkResolver.getValueAsJinjavaString(entry.getValue())
-            );
+            if (
+              entry.getValue().getClass().getMethod("toString").getDeclaringClass() !=
+              Object.class
+            ) {
+              initiallyResolvedAsStrings.put(
+                entry.getKey(),
+                ChunkResolver.getValueAsJinjavaString(entry.getValue())
+              );
+            }
             initiallyResolvedHashes.put(entry.getKey(), entry.getValue().hashCode());
-          } catch (JsonProcessingException jsonProcessingException) {
+          } catch (JsonProcessingException | NoSuchMethodException ignored) {
             // do nothing
           }
         }


### PR DESCRIPTION
For https://github.com/HubSpot/jinjava/issues/532
---

Classes that don't override the default `Object.toString()` were never envisioned to be output as a string so we don't need to be tracking them for changes to potentially output them as a string during eager execution. This will be supplemented with https://github.com/HubSpot/jinjava/pull/581, which will allow for more optimizations to the python string representation of objects.

If one of these objects does see a change in its hash code, since we aren't trying to output it as a string, then we must throw a `DeferredValueException`, which will result in the calling node becoming a deferred node, rather than utilizing the functionality of the `eagerTokens`. If that happens, then the final render will need to be redone, rather than using the result from eager execution.