### PR TITLE
[Eager Execution] Add check for PyishSerializable after those changes were merged

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -22,6 +22,7 @@ import com.hubspot.jinjava.lib.tag.RawTag;
 import com.hubspot.jinjava.lib.tag.SetTag;
 import com.hubspot.jinjava.lib.tag.Tag;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
+import com.hubspot.jinjava.objects.serialization.PyishSerializable;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
@@ -178,7 +179,8 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
           try {
             if (
               entry.getValue().getClass().getMethod("toString").getDeclaringClass() !=
-              Object.class
+              Object.class ||
+              entry.getValue() instanceof PyishSerializable
             ) {
               initiallyResolvedAsStrings.put(
                 entry.getKey(),


### PR DESCRIPTION
Following up from https://github.com/HubSpot/jinjava/pull/581 and https://github.com/HubSpot/jinjava/pull/584, we can add in a check to grab the string representation of an object if it implements `PyishSerializable`.