### PR TITLE
[Eager Execution] Make EagerTagFactory touse the tag instances from the context

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
@@ -17,6 +17,10 @@ public class EagerCycleTag extends EagerStateChangingTag<CycleTag> {
     super(new CycleTag());
   }
 
+  public EagerCycleTag(CycleTag cycleTag) {
+    super(cycleTag);
+  }
+
   @SuppressWarnings("unchecked")
   @Override
   public String getEagerTagImage(TagToken tagToken, JinjavaInterpreter interpreter) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTag.java
@@ -21,6 +21,10 @@ public class EagerFromTag extends EagerStateChangingTag<FromTag> {
     super(new FromTag());
   }
 
+  public EagerFromTag(FromTag fromTag) {
+    super(fromTag);
+  }
+
   @Override
   public String getEagerTagImage(TagToken tagToken, JinjavaInterpreter interpreter) {
     List<String> helper = FromTag.getHelpers(tagToken);

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -28,6 +28,10 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
     super(new ImportTag());
   }
 
+  public EagerImportTag(ImportTag importTag) {
+    super(importTag);
+  }
+
   @Override
   public String getEagerTagImage(TagToken tagToken, JinjavaInterpreter interpreter) {
     List<String> helper = ImportTag.getHelpers(tagToken);

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactory.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactory.java
@@ -47,8 +47,9 @@ public class EagerTagFactory {
 
   @SuppressWarnings("unchecked")
   public static <T extends Tag> Optional<EagerTagDecorator<T>> getEagerTagDecorator(
-    Class<T> clazz
+    T tag
   ) {
+    Class<? extends Tag> clazz = tag.getClass();
     try {
       if (TAG_CLASSES_TO_SKIP.contains(clazz)) {
         return Optional.empty();
@@ -56,13 +57,12 @@ public class EagerTagFactory {
       if (EAGER_TAG_OVERRIDES.containsKey(clazz)) {
         EagerTagDecorator<?> decorator = EAGER_TAG_OVERRIDES
           .get(clazz)
-          .getDeclaredConstructor()
-          .newInstance();
+          .getDeclaredConstructor(clazz)
+          .newInstance(tag);
         if (decorator.getTag().getClass() == clazz) {
           return Optional.of((EagerTagDecorator<T>) decorator);
         }
       }
-      T tag = clazz.getDeclaredConstructor().newInstance();
       return Optional.of(new EagerGenericTag<>(tag));
     } catch (NoSuchMethodException e) {
       return Optional.empty();

--- a/src/main/java/com/hubspot/jinjava/mode/EagerExecutionMode.java
+++ b/src/main/java/com/hubspot/jinjava/mode/EagerExecutionMode.java
@@ -26,7 +26,7 @@ public class EagerExecutionMode implements ExecutionMode {
       .getAllTags()
       .stream()
       .filter(tag -> !(tag instanceof EagerTagDecorator))
-      .map(tag -> EagerTagFactory.getEagerTagDecorator(tag.getClass()))
+      .map(EagerTagFactory::getEagerTagDecorator)
       .filter(Optional::isPresent)
       .forEach(maybeEagerTag -> context.registerTag(maybeEagerTag.get()));
     context.setExpressionStrategy(new EagerExpressionStrategy());

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTagTest.java
@@ -33,8 +33,7 @@ public class EagerFromTagTest extends FromTagTest {
           String fullName,
           Charset encoding,
           JinjavaInterpreter interpreter
-        )
-          throws IOException {
+        ) throws IOException {
           return Resources.toString(
             Resources.getResource(String.format("tags/macrotag/%s", fullName)),
             StandardCharsets.UTF_8
@@ -58,7 +57,7 @@ public class EagerFromTagTest extends FromTagTest {
           .build()
       );
     Tag tag = EagerTagFactory
-      .getEagerTagDecorator(FromTag.class)
+      .getEagerTagDecorator(new FromTag())
       .orElseThrow(RuntimeException::new);
     context.registerTag(tag);
     context.put("deferred", DeferredValue.instance());

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTagTest.java
@@ -33,7 +33,8 @@ public class EagerFromTagTest extends FromTagTest {
           String fullName,
           Charset encoding,
           JinjavaInterpreter interpreter
-        ) throws IOException {
+        )
+          throws IOException {
           return Resources.toString(
             Resources.getResource(String.format("tags/macrotag/%s", fullName)),
             StandardCharsets.UTF_8

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -7,7 +7,6 @@ import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.lib.tag.FromTag;
 import com.hubspot.jinjava.lib.tag.ImportTag;
 import com.hubspot.jinjava.lib.tag.ImportTagTest;
 import com.hubspot.jinjava.lib.tag.Tag;
@@ -114,21 +113,21 @@ public class EagerImportTagTest extends ImportTagTest {
     );
     assertThat(interpreter.getContext().get(CONTEXT_VAR)).isInstanceOf(Map.class);
     assertThat(
-      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2Alias)
-    )
+        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2Alias)
+      )
       .isInstanceOf(Map.class);
     assertThat(
-      (
-        (Map<String, Object>) (
-          (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
-        ).get(child2Alias)
-      ).get("foo")
-    )
+        (
+          (Map<String, Object>) (
+            (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
+          ).get(child2Alias)
+        ).get("foo")
+      )
       .isEqualTo("foo val");
 
     assertThat(
-      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar")
-    )
+        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar")
+      )
       .isEqualTo("bar val");
   }
 
@@ -157,25 +156,25 @@ public class EagerImportTagTest extends ImportTagTest {
     );
     assertThat(interpreter.getContext().get(CONTEXT_VAR)).isInstanceOf(PyMap.class);
     assertThat(
-      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2Alias)
-    )
+        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2Alias)
+      )
       .isInstanceOf(DeferredValue.class);
     assertThat(
-      (
         (
-          (Map<String, Object>) (
-            (DeferredValue) (
-              (Map<String, Object>) (interpreter.getContext().get(CONTEXT_VAR))
-            ).get(child2Alias)
-          ).getOriginalValue()
-        ).get("foo")
+          (
+            (Map<String, Object>) (
+              (DeferredValue) (
+                (Map<String, Object>) (interpreter.getContext().get(CONTEXT_VAR))
+              ).get(child2Alias)
+            ).getOriginalValue()
+          ).get("foo")
+        )
       )
-    )
       .isEqualTo("foo val");
 
     assertThat(
-      (((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar"))
-    )
+        (((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar"))
+      )
       .isEqualTo("bar val");
   }
 
@@ -204,25 +203,25 @@ public class EagerImportTagTest extends ImportTagTest {
     );
     assertThat(interpreter.getContext().get(CONTEXT_VAR)).isInstanceOf(PyMap.class);
     assertThat(
-      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2Alias)
-    )
+        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2Alias)
+      )
       .isInstanceOf(DeferredValue.class);
     assertThat(
-      (
         (
-          (Map<String, Object>) (
-            (DeferredValue) (
-              (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
-            ).get(child2Alias)
-          ).getOriginalValue()
-        ).get("foo")
+          (
+            (Map<String, Object>) (
+              (DeferredValue) (
+                (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
+              ).get(child2Alias)
+            ).getOriginalValue()
+          ).get("foo")
+        )
       )
-    )
       .isEqualTo("foo val");
 
     assertThat(
-      (((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar"))
-    )
+        (((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar"))
+      )
       .isEqualTo("bar val");
   }
 
@@ -248,14 +247,14 @@ public class EagerImportTagTest extends ImportTagTest {
     );
     assertThat(interpreter.getContext().get("foo")).isInstanceOf(DeferredValue.class);
     assertThat(
-      (((DeferredValue) (interpreter.getContext().get("foo"))).getOriginalValue())
-    )
+        (((DeferredValue) (interpreter.getContext().get("foo"))).getOriginalValue())
+      )
       .isEqualTo("foo val");
 
     assertThat(interpreter.getContext().get("bar")).isInstanceOf(DeferredValue.class);
     assertThat(
-      (((DeferredValue) (interpreter.getContext().get("bar"))).getOriginalValue())
-    )
+        (((DeferredValue) (interpreter.getContext().get("bar"))).getOriginalValue())
+      )
       .isEqualTo("bar val");
   }
 
@@ -292,25 +291,25 @@ public class EagerImportTagTest extends ImportTagTest {
     );
     assertThat(interpreter.getContext().get(CONTEXT_VAR)).isInstanceOf(Map.class);
     assertThat(
-      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child3Alias)
-    )
+        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child3Alias)
+      )
       .isInstanceOf(Map.class);
     assertThat(
-      (
-        (Map<String, Object>) (
-          (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
-        ).get(child3Alias)
-      ).get("foobar")
-    )
+        (
+          (Map<String, Object>) (
+            (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
+          ).get(child3Alias)
+        ).get("foobar")
+      )
       .isEqualTo("foobar val");
 
     assertThat(
-      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar")
-    )
+        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar")
+      )
       .isEqualTo("bar val");
     assertThat(
-      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("foo")
-    )
+        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("foo")
+      )
       .isEqualTo("foo val");
   }
 
@@ -348,33 +347,35 @@ public class EagerImportTagTest extends ImportTagTest {
     );
     assertThat(interpreter.getContext().get(CONTEXT_VAR)).isInstanceOf(Map.class);
     assertThat(
-      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2Alias)
-    )
+        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2Alias)
+      )
       .isInstanceOf(Map.class);
     assertThat(
-      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2BAlias)
-    )
+        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(
+            child2BAlias
+          )
+      )
       .isInstanceOf(Map.class);
     assertThat(
-      (
-        (Map<String, Object>) (
-          (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
-        ).get(child2Alias)
-      ).get("foo")
-    )
+        (
+          (Map<String, Object>) (
+            (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
+          ).get(child2Alias)
+        ).get("foo")
+      )
       .isEqualTo("foo val");
     assertThat(
-      (
-        (Map<String, Object>) (
-          (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
-        ).get(child2BAlias)
-      ).get("foo_b")
-    )
+        (
+          (Map<String, Object>) (
+            (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
+          ).get(child2BAlias)
+        ).get("foo_b")
+      )
       .isEqualTo("foo_b val");
 
     assertThat(
-      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar")
-    )
+        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar")
+      )
       .isEqualTo("bar val");
   }
 
@@ -458,7 +459,8 @@ public class EagerImportTagTest extends ImportTagTest {
           String fullName,
           Charset encoding,
           JinjavaInterpreter interpreter
-        ) throws IOException {
+        )
+          throws IOException {
           return Resources.toString(
             Resources.getResource(String.format("tags/eager/importtag/%s", fullName)),
             StandardCharsets.UTF_8

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -8,6 +8,7 @@ import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.FromTag;
+import com.hubspot.jinjava.lib.tag.ImportTag;
 import com.hubspot.jinjava.lib.tag.ImportTagTest;
 import com.hubspot.jinjava.lib.tag.Tag;
 import com.hubspot.jinjava.loader.LocationResolver;
@@ -42,7 +43,7 @@ public class EagerImportTagTest extends ImportTagTest {
           .build()
       );
     Tag tag = EagerTagFactory
-      .getEagerTagDecorator(FromTag.class)
+      .getEagerTagDecorator(new ImportTag())
       .orElseThrow(RuntimeException::new);
     context.registerTag(tag);
     context.put("deferred", DeferredValue.instance());
@@ -113,21 +114,21 @@ public class EagerImportTagTest extends ImportTagTest {
     );
     assertThat(interpreter.getContext().get(CONTEXT_VAR)).isInstanceOf(Map.class);
     assertThat(
-        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2Alias)
-      )
+      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2Alias)
+    )
       .isInstanceOf(Map.class);
     assertThat(
-        (
-          (Map<String, Object>) (
-            (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
-          ).get(child2Alias)
-        ).get("foo")
-      )
+      (
+        (Map<String, Object>) (
+          (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
+        ).get(child2Alias)
+      ).get("foo")
+    )
       .isEqualTo("foo val");
 
     assertThat(
-        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar")
-      )
+      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar")
+    )
       .isEqualTo("bar val");
   }
 
@@ -156,25 +157,25 @@ public class EagerImportTagTest extends ImportTagTest {
     );
     assertThat(interpreter.getContext().get(CONTEXT_VAR)).isInstanceOf(PyMap.class);
     assertThat(
-        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2Alias)
-      )
+      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2Alias)
+    )
       .isInstanceOf(DeferredValue.class);
     assertThat(
+      (
         (
-          (
-            (Map<String, Object>) (
-              (DeferredValue) (
-                (Map<String, Object>) (interpreter.getContext().get(CONTEXT_VAR))
-              ).get(child2Alias)
-            ).getOriginalValue()
-          ).get("foo")
-        )
+          (Map<String, Object>) (
+            (DeferredValue) (
+              (Map<String, Object>) (interpreter.getContext().get(CONTEXT_VAR))
+            ).get(child2Alias)
+          ).getOriginalValue()
+        ).get("foo")
       )
+    )
       .isEqualTo("foo val");
 
     assertThat(
-        (((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar"))
-      )
+      (((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar"))
+    )
       .isEqualTo("bar val");
   }
 
@@ -203,25 +204,25 @@ public class EagerImportTagTest extends ImportTagTest {
     );
     assertThat(interpreter.getContext().get(CONTEXT_VAR)).isInstanceOf(PyMap.class);
     assertThat(
-        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2Alias)
-      )
+      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2Alias)
+    )
       .isInstanceOf(DeferredValue.class);
     assertThat(
+      (
         (
-          (
-            (Map<String, Object>) (
-              (DeferredValue) (
-                (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
-              ).get(child2Alias)
-            ).getOriginalValue()
-          ).get("foo")
-        )
+          (Map<String, Object>) (
+            (DeferredValue) (
+              (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
+            ).get(child2Alias)
+          ).getOriginalValue()
+        ).get("foo")
       )
+    )
       .isEqualTo("foo val");
 
     assertThat(
-        (((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar"))
-      )
+      (((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar"))
+    )
       .isEqualTo("bar val");
   }
 
@@ -247,14 +248,14 @@ public class EagerImportTagTest extends ImportTagTest {
     );
     assertThat(interpreter.getContext().get("foo")).isInstanceOf(DeferredValue.class);
     assertThat(
-        (((DeferredValue) (interpreter.getContext().get("foo"))).getOriginalValue())
-      )
+      (((DeferredValue) (interpreter.getContext().get("foo"))).getOriginalValue())
+    )
       .isEqualTo("foo val");
 
     assertThat(interpreter.getContext().get("bar")).isInstanceOf(DeferredValue.class);
     assertThat(
-        (((DeferredValue) (interpreter.getContext().get("bar"))).getOriginalValue())
-      )
+      (((DeferredValue) (interpreter.getContext().get("bar"))).getOriginalValue())
+    )
       .isEqualTo("bar val");
   }
 
@@ -291,25 +292,25 @@ public class EagerImportTagTest extends ImportTagTest {
     );
     assertThat(interpreter.getContext().get(CONTEXT_VAR)).isInstanceOf(Map.class);
     assertThat(
-        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child3Alias)
-      )
+      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child3Alias)
+    )
       .isInstanceOf(Map.class);
     assertThat(
-        (
-          (Map<String, Object>) (
-            (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
-          ).get(child3Alias)
-        ).get("foobar")
-      )
+      (
+        (Map<String, Object>) (
+          (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
+        ).get(child3Alias)
+      ).get("foobar")
+    )
       .isEqualTo("foobar val");
 
     assertThat(
-        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar")
-      )
+      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar")
+    )
       .isEqualTo("bar val");
     assertThat(
-        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("foo")
-      )
+      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("foo")
+    )
       .isEqualTo("foo val");
   }
 
@@ -347,35 +348,33 @@ public class EagerImportTagTest extends ImportTagTest {
     );
     assertThat(interpreter.getContext().get(CONTEXT_VAR)).isInstanceOf(Map.class);
     assertThat(
-        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2Alias)
-      )
+      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2Alias)
+    )
       .isInstanceOf(Map.class);
     assertThat(
-        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(
-            child2BAlias
-          )
-      )
+      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2BAlias)
+    )
       .isInstanceOf(Map.class);
     assertThat(
-        (
-          (Map<String, Object>) (
-            (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
-          ).get(child2Alias)
-        ).get("foo")
-      )
+      (
+        (Map<String, Object>) (
+          (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
+        ).get(child2Alias)
+      ).get("foo")
+    )
       .isEqualTo("foo val");
     assertThat(
-        (
-          (Map<String, Object>) (
-            (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
-          ).get(child2BAlias)
-        ).get("foo_b")
-      )
+      (
+        (Map<String, Object>) (
+          (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
+        ).get(child2BAlias)
+      ).get("foo_b")
+    )
       .isEqualTo("foo_b val");
 
     assertThat(
-        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar")
-      )
+      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar")
+    )
       .isEqualTo("bar val");
   }
 
@@ -459,8 +458,7 @@ public class EagerImportTagTest extends ImportTagTest {
           String fullName,
           Charset encoding,
           JinjavaInterpreter interpreter
-        )
-          throws IOException {
+        ) throws IOException {
           return Resources.toString(
             Resources.getResource(String.format("tags/eager/importtag/%s", fullName)),
             StandardCharsets.UTF_8

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactoryTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactoryTest.java
@@ -15,8 +15,8 @@ public class EagerTagFactoryTest {
 
   @Test
   public void itGetsEagerTagDecoratorForOverrides() {
-    Set<EagerTagDecorator<?>> eagerTagDecoratorSet = EagerTagFactory.EAGER_TAG_OVERRIDES
-      .keySet()
+    Set<EagerTagDecorator<?>> eagerTagDecoratorSet = EagerTagFactory
+      .EAGER_TAG_OVERRIDES.keySet()
       .stream()
       .map(
         clazz -> {
@@ -35,11 +35,11 @@ public class EagerTagFactoryTest {
     assertThat(eagerTagDecoratorSet.size())
       .isEqualTo(EagerTagFactory.EAGER_TAG_OVERRIDES.keySet().size());
     assertThat(
-      eagerTagDecoratorSet
-        .stream()
-        .map(e -> e.getTag().getClass())
-        .collect(Collectors.toSet())
-    )
+        eagerTagDecoratorSet
+          .stream()
+          .map(e -> e.getTag().getClass())
+          .collect(Collectors.toSet())
+      )
       .isEqualTo(EagerTagFactory.EAGER_TAG_OVERRIDES.keySet());
   }
 


### PR DESCRIPTION
Bug fix for: https://github.com/HubSpot/jinjava/issues/532
---
As there could be Tag subclasses that where put onto the context in a special way, such as through an injector, we should use the instances that are initially instantiated on the context rather than creating a new Tag with the default constructor.

This PR updates all the Eager class overrides to include a constructor that takes an instance of the Tag class that it wraps to allow for more flexibility in the tags.