### PR TITLE
[Eager Execution] Don't escape newlines and tabs within pyish object mapper

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishBeanSerializerModifier.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishBeanSerializerModifier.java
@@ -19,17 +19,20 @@ public class PyishBeanSerializerModifier extends BeanSerializerModifier {
     BeanDescription beanDesc,
     JsonSerializer<?> serializer
   ) {
-    if (
-      nonPyishClasses
-        .stream()
-        .anyMatch(clazz -> (clazz.isAssignableFrom(beanDesc.getBeanClass())))
-    ) {
-      // Use the PyishSerializer if it extends the PyishSerializable class.
-      // For example, a Map implementation could then have custom string serialization.
-      if (!(PyishSerializable.class.isAssignableFrom(beanDesc.getBeanClass()))) {
-        return serializer;
+    try {
+      if (
+        nonPyishClasses
+          .stream()
+          .anyMatch(clazz -> (clazz.isAssignableFrom(beanDesc.getBeanClass()))) ||
+        beanDesc.getBeanClass().getMethod("toString").getDeclaringClass() == Object.class
+      ) {
+        // Use the PyishSerializer if it extends the PyishSerializable class.
+        // For example, a Map implementation could then have custom string serialization.
+        if (!(PyishSerializable.class.isAssignableFrom(beanDesc.getBeanClass()))) {
+          return serializer;
+        }
       }
-    }
+    } catch (NoSuchMethodException ignored) {}
     return PyishSerializer.INSTANCE;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishCharacterEscapes.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishCharacterEscapes.java
@@ -1,0 +1,28 @@
+package com.hubspot.jinjava.objects.serialization;
+
+import com.fasterxml.jackson.core.SerializableString;
+import com.fasterxml.jackson.core.io.CharacterEscapes;
+import java.util.Arrays;
+
+public class PyishCharacterEscapes extends CharacterEscapes {
+  public static final PyishCharacterEscapes INSTANCE = new PyishCharacterEscapes();
+  private final int[] asciiEscapes;
+
+  private PyishCharacterEscapes() {
+    int[] escapes = CharacterEscapes.standardAsciiEscapesForJSON();
+    escapes['\n'] = CharacterEscapes.ESCAPE_NONE;
+    escapes['\t'] = CharacterEscapes.ESCAPE_NONE;
+    escapes['\r'] = CharacterEscapes.ESCAPE_NONE;
+    asciiEscapes = escapes;
+  }
+
+  @Override
+  public int[] getEscapeCodesForAscii() {
+    return Arrays.copyOf(asciiEscapes, asciiEscapes.length);
+  }
+
+  @Override
+  public SerializableString getEscapeSequence(int i) {
+    return null;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -57,8 +57,6 @@ public class PyishObjectMapper {
       return getObjectWriter()
         .writeValueAsString(val)
         .replace("'", "\\'")
-        // Replace `\n` with a newline character
-        .replaceAll("(?<!\\\\)(\\\\\\\\)*(?:\\\\n)", "$1\n")
         // Replace double-quotes with single quote as they are preferred in Jinja
         .replaceAll("(?<!\\\\)(\\\\\\\\)*(?:\")", "$1'");
     } catch (JsonProcessingException e) {

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -25,13 +25,6 @@ public class PyishObjectMapper {
     if (parent == null) {
       this.nonPyishClasses = new HashSet<>();
       registerDefaults();
-      objectWriter =
-        new ObjectMapper()
-          .registerModule(
-            new SimpleModule()
-            .setSerializerModifier(new PyishBeanSerializerModifier(nonPyishClasses))
-          )
-          .writer(PyishPrettyPrinter.INSTANCE);
     }
   }
 
@@ -49,13 +42,7 @@ public class PyishObjectMapper {
       throw new UnsupportedOperationException();
     }
     nonPyishClasses.addAll(Arrays.asList(classes));
-  }
-
-  public ObjectWriter getObjectWriter() {
-    if (parent != null) {
-      return parent.getObjectWriter();
-    }
-    return objectWriter;
+    updateObjectWriter();
   }
 
   public String getAsUnquotedPyishString(Object val) {
@@ -77,5 +64,22 @@ public class PyishObjectMapper {
     } catch (JsonProcessingException e) {
       return Objects.toString(val, "");
     }
+  }
+
+  private void updateObjectWriter() {
+    objectWriter =
+      new ObjectMapper()
+        .registerModule(
+          new SimpleModule()
+          .setSerializerModifier(new PyishBeanSerializerModifier(nonPyishClasses))
+        )
+        .writer(PyishPrettyPrinter.INSTANCE);
+  }
+
+  private ObjectWriter getObjectWriter() {
+    if (parent != null) {
+      return parent.getObjectWriter();
+    }
+    return objectWriter;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
@@ -19,6 +19,7 @@ public class PyishSerializer extends JsonSerializer<Object> {
   )
     throws IOException {
     jsonGenerator.setPrettyPrinter(PyishPrettyPrinter.INSTANCE);
+    jsonGenerator.setCharacterEscapes(PyishCharacterEscapes.INSTANCE);
     String string;
     if (object instanceof PyishSerializable) {
       string = ((PyishSerializable) object).toPyishString();


### PR DESCRIPTION
Improvement for https://github.com/HubSpot/jinjava/issues/532
---
Use a custom `CharacterEscapes` class to not escape newline and tab characters so that we don't need to do it with regex later. (There was a bug where tab characters were outputting literally as `\t`, so this fixes that as well). Additionally, ensure that `Object.toString()` is never used for the "pyish" string representation of an object, because that is just a java string representation representing the reference to the object.