### PR TITLE
Intial support for vsCodeTagSnippets

### DIFF
--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
@@ -308,19 +308,31 @@ public class JinjavaDocFactory {
     snippet.append(tag.getName());
     int i = 1;
     for (JinjavaParam param : docAnnotation.input()) {
-      snippet.append(" ${" + i + ":" + param.value() + "}");
+      String inputValue = "${" + i + ":" + param.value() + "}";
+      if (param.value().equalsIgnoreCase("path")) {
+        inputValue = "'" + inputValue + "'";
+      } else if (param.value().equalsIgnoreCase("argument_names")) {
+        inputValue = "(" + inputValue + ")";
+      }
+      snippet.append(" " + inputValue);
       i++;
     }
 
     for (JinjavaParam param : docAnnotation.params()) {
-      snippet.append(" ${" + i + ":" + param.value() + "}");
+      String paramValue = "${" + i + ":" + param.value() + "}";
+      if (param.value().equalsIgnoreCase("path")) {
+        paramValue = "'" + paramValue + "'";
+      } else if (param.value().equalsIgnoreCase("argument_names")) {
+        paramValue = "(" + paramValue + ")";
+      }
+      snippet.append(" " + paramValue);
       i++;
     }
 
     snippet.append(" %}");
 
     if (tag.getClass().getAnnotation(JinjavaHasCodeBody.class) != null) {
-      snippet.append("\n${" + i + ":Code}");
+      snippet.append("\n$0");
     }
     if (tag.getEndTagName() != null) {
       snippet.append("\n{% " + tag.getEndTagName() + " %}");

--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
@@ -4,6 +4,7 @@ import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.doc.annotations.JinjavaMetaValue;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.doc.annotations.JinjavaVSCodeSnippet;
 import com.hubspot.jinjava.lib.exptest.ExpTest;
 import com.hubspot.jinjava.lib.filter.Filter;
 import com.hubspot.jinjava.lib.fn.ELFunctionDefinition;
@@ -293,6 +294,12 @@ public class JinjavaDocFactory {
   }
 
   private String getTagSnippet(Tag tag) {
+    JinjavaVSCodeSnippet annotation = tag
+      .getClass()
+      .getAnnotation(JinjavaVSCodeSnippet.class);
+    if (annotation != null) {
+      return annotation.code();
+    }
     com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation = getJinjavaDocAnnotation(
       tag.getClass()
     );

--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
@@ -1,10 +1,11 @@
 package com.hubspot.jinjava.doc;
 
 import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.doc.annotations.JinjavaHasCodeBody;
 import com.hubspot.jinjava.doc.annotations.JinjavaMetaValue;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.doc.annotations.JinjavaVSCodeSnippet;
+import com.hubspot.jinjava.doc.annotations.JinjavaTextMateSnippet;
 import com.hubspot.jinjava.lib.exptest.ExpTest;
 import com.hubspot.jinjava.lib.filter.Filter;
 import com.hubspot.jinjava.lib.fn.ELFunctionDefinition;
@@ -294,9 +295,9 @@ public class JinjavaDocFactory {
   }
 
   private String getTagSnippet(Tag tag) {
-    JinjavaVSCodeSnippet annotation = tag
+    JinjavaTextMateSnippet annotation = tag
       .getClass()
-      .getAnnotation(JinjavaVSCodeSnippet.class);
+      .getAnnotation(JinjavaTextMateSnippet.class);
     if (annotation != null) {
       return annotation.code();
     }
@@ -318,6 +319,9 @@ public class JinjavaDocFactory {
 
     snippet.append(" %}");
 
+    if (tag.getClass().getAnnotation(JinjavaHasCodeBody.class) != null) {
+      snippet.append("\n${" + i + ":Code}");
+    }
     if (tag.getEndTagName() != null) {
       snippet.append("\n{% " + tag.getEndTagName() + " %}");
     }

--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
@@ -43,6 +43,18 @@ public class JinjavaDocFactory {
     return doc;
   }
 
+  public String getVSCodeTagSnippets() {
+    StringBuffer snippets = new StringBuffer();
+    for (Tag tag : jinjava.getGlobalContextCopy().getAllTags()) {
+      if (tag instanceof EndTag) {
+        continue;
+      }
+      snippets.append(getTagSnippet(tag));
+      snippets.append("\n\n");
+    }
+    return snippets.toString();
+  }
+
   private void addExpTests(JinjavaDoc doc) {
     for (ExpTest t : jinjava.getGlobalContextCopy().getAllExpTests()) {
       com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation = getJinjavaDocAnnotation(
@@ -278,5 +290,31 @@ public class JinjavaDocFactory {
     }
 
     return clazz.getAnnotation(com.hubspot.jinjava.doc.annotations.JinjavaDoc.class);
+  }
+
+  private String getTagSnippet(Tag tag) {
+    com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation = getJinjavaDocAnnotation(
+      tag.getClass()
+    );
+    StringBuilder snippet = new StringBuilder("{% ");
+    snippet.append(tag.getName());
+    int i = 1;
+    for (JinjavaParam param : docAnnotation.input()) {
+      snippet.append(" ${" + i + ":" + param.value() + "}");
+      i++;
+    }
+
+    for (JinjavaParam param : docAnnotation.params()) {
+      snippet.append(" ${" + i + ":" + param.value() + "}");
+      i++;
+    }
+
+    snippet.append(" %}");
+
+    if (tag.getEndTagName() != null) {
+      snippet.append("\n{% " + tag.getEndTagName() + " %}");
+    }
+
+    return snippet.toString();
   }
 }

--- a/src/main/java/com/hubspot/jinjava/doc/annotations/JinjavaHasCodeBody.java
+++ b/src/main/java/com/hubspot/jinjava/doc/annotations/JinjavaHasCodeBody.java
@@ -1,0 +1,11 @@
+package com.hubspot.jinjava.doc.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface JinjavaHasCodeBody {
+}

--- a/src/main/java/com/hubspot/jinjava/doc/annotations/JinjavaTextMateSnippet.java
+++ b/src/main/java/com/hubspot/jinjava/doc/annotations/JinjavaTextMateSnippet.java
@@ -7,7 +7,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.METHOD })
-public @interface JinjavaVSCodeSnippet {
+public @interface JinjavaTextMateSnippet {
   String desc() default "";
 
   String code();

--- a/src/main/java/com/hubspot/jinjava/doc/annotations/JinjavaVSCodeSnippet.java
+++ b/src/main/java/com/hubspot/jinjava/doc/annotations/JinjavaVSCodeSnippet.java
@@ -1,0 +1,16 @@
+package com.hubspot.jinjava.doc.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface JinjavaVSCodeSnippet {
+  String desc() default "";
+
+  String code();
+
+  String output() default "";
+}

--- a/src/main/java/com/hubspot/jinjava/lib/tag/BlockTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/BlockTag.java
@@ -16,6 +16,7 @@
 package com.hubspot.jinjava.lib.tag;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaHasCodeBody;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -48,6 +49,7 @@ import com.hubspot.jinjava.util.WhitespaceUtils;
     )
   }
 )
+@JinjavaHasCodeBody
 public class BlockTag implements Tag {
   public static final String TAG_NAME = "block";
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/CallTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/CallTag.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.lib.tag;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.doc.annotations.JinjavaTextMateSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
@@ -47,6 +48,9 @@ import java.util.LinkedHashMap;
       " {% endcall %}"
     )
   }
+)
+@JinjavaTextMateSnippet(
+  code = "{% call ${1:macro_name}(${2:argument_names}) %}\n" + "$0\n" + "{% endcall %}"
 )
 public class CallTag implements Tag {
   public static final String TAG_NAME = "call";

--- a/src/main/java/com/hubspot/jinjava/lib/tag/DoTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/DoTag.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.lib.tag;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.doc.annotations.JinjavaTextMateSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.tree.TagNode;
@@ -11,6 +12,7 @@ import org.apache.commons.lang3.StringUtils;
   value = "Evaluates expression without printing out result.",
   snippets = { @JinjavaSnippet(code = "{% do list.append('value 2') %}") }
 )
+@JinjavaTextMateSnippet(code = "{% do ${1:expr} %}")
 public class DoTag implements Tag {
   public static final String TAG_NAME = "do";
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ElseIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ElseIfTag.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.lib.tag;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaHasCodeBody;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.tree.TagNode;
@@ -16,6 +17,7 @@ import com.hubspot.jinjava.tree.TagNode;
   },
   hidden = true
 )
+@JinjavaHasCodeBody
 public class ElseIfTag implements Tag {
   public static final String TAG_NAME = "elif";
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ElseIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ElseIfTag.java
@@ -1,10 +1,21 @@
 package com.hubspot.jinjava.lib.tag;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.tree.TagNode;
 
-@JinjavaDoc(value = "", hidden = true)
+@JinjavaDoc(
+  value = "",
+  params = {
+    @JinjavaParam(
+      value = "condition",
+      type = "conditional expression",
+      desc = "An expression that evaluates to either true or false"
+    )
+  },
+  hidden = true
+)
 public class ElseIfTag implements Tag {
   public static final String TAG_NAME = "elif";
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ElseTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ElseTag.java
@@ -16,10 +16,12 @@ limitations under the License.
 package com.hubspot.jinjava.lib.tag;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaHasCodeBody;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.tree.TagNode;
 
 @JinjavaDoc(value = "", hidden = true)
+@JinjavaHasCodeBody
 public class ElseTag implements Tag {
   public static final String TAG_NAME = "else";
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -20,6 +20,7 @@ import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaHasCodeBody;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.doc.annotations.JinjavaTextMateSnippet;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -81,6 +82,9 @@ import org.apache.commons.lang3.StringUtils;
   }
 )
 @JinjavaHasCodeBody
+@JinjavaTextMateSnippet(
+  code = "{% for ${1:items} in ${2:list} %}\n" + "{{ ${1} }}$0\n" + "{% endfor %}"
+)
 public class ForTag implements Tag {
   public static final String TAG_NAME = "for";
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -17,6 +17,7 @@ package com.hubspot.jinjava.lib.tag;
 
 import com.google.common.collect.Lists;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaHasCodeBody;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.DeferredValueException;
@@ -79,6 +80,7 @@ import org.apache.commons.lang3.StringUtils;
     )
   }
 )
+@JinjavaHasCodeBody
 public class ForTag implements Tag {
   public static final String TAG_NAME = "for";
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/FromTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/FromTag.java
@@ -6,6 +6,7 @@ import com.google.common.collect.PeekingIterator;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.doc.annotations.JinjavaTextMateSnippet;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
@@ -55,6 +56,7 @@ import java.util.Optional;
     )
   }
 )
+@JinjavaTextMateSnippet(code = "{% from '${1:path}' import ${2:macro_name} %}")
 public class FromTag implements Tag {
   public static final String TAG_NAME = "from";
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IfTag.java
@@ -16,6 +16,7 @@
 package com.hubspot.jinjava.lib.tag;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.OutputTooBigException;
@@ -30,6 +31,13 @@ import org.apache.commons.lang3.StringUtils;
 
 @JinjavaDoc(
   value = "Outputs inner content if expression evaluates to true, otherwise evaluates any elif blocks, finally outputting content of any else block present",
+  params = {
+    @JinjavaParam(
+      value = "condition",
+      type = "conditional expression",
+      desc = "An expression that evaluates to either true or false"
+    )
+  },
   snippets = {
     @JinjavaSnippet(
       code = "{% if condition %}\n" +

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IfTag.java
@@ -16,6 +16,7 @@
 package com.hubspot.jinjava.lib.tag;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaHasCodeBody;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -57,6 +58,7 @@ import org.apache.commons.lang3.StringUtils;
     )
   }
 )
+@JinjavaHasCodeBody
 public class IfTag implements Tag {
   public static final String TAG_NAME = "if";
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IfchangedTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IfchangedTag.java
@@ -16,6 +16,7 @@
 package com.hubspot.jinjava.lib.tag;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaHasCodeBody;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
@@ -34,6 +35,7 @@ import org.apache.commons.lang3.StringUtils;
     )
   }
 )
+@JinjavaHasCodeBody
 public class IfchangedTag implements Tag {
   public static final String TAG_NAME = "ifchanged";
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.doc.annotations.JinjavaTextMateSnippet;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
@@ -61,6 +62,7 @@ import org.apache.commons.lang3.StringUtils;
     )
   }
 )
+@JinjavaTextMateSnippet(code = "{% import '${1:path}' ${2: as ${3:import_name}} %}")
 public class ImportTag implements Tag {
   public static final String TAG_NAME = "import";
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
@@ -4,6 +4,7 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaHasCodeBody;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.DeferredValue;
@@ -54,6 +55,7 @@ import org.apache.commons.lang3.StringUtils;
     )
   }
 )
+@JinjavaHasCodeBody
 public class MacroTag implements Tag {
   public static final String TAG_NAME = "macro";
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
@@ -18,6 +18,7 @@ package com.hubspot.jinjava.lib.tag;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.doc.annotations.JinjavaVSCodeSnippet;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -63,6 +64,7 @@ import org.apache.commons.lang3.StringUtils;
     )
   }
 )
+@JinjavaVSCodeSnippet(code = "{% set ${1:var} = ${2:expr} %}")
 public class SetTag implements Tag {
   public static final String TAG_NAME = "set";
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
@@ -18,7 +18,7 @@ package com.hubspot.jinjava.lib.tag;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.doc.annotations.JinjavaVSCodeSnippet;
+import com.hubspot.jinjava.doc.annotations.JinjavaTextMateSnippet;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -64,7 +64,7 @@ import org.apache.commons.lang3.StringUtils;
     )
   }
 )
-@JinjavaVSCodeSnippet(code = "{% set ${1:var} = ${2:expr} %}")
+@JinjavaTextMateSnippet(code = "{% set ${1:var} = ${2:expr} %}")
 public class SetTag implements Tag {
   public static final String TAG_NAME = "set";
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/UnlessTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/UnlessTag.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.lib.tag;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaHasCodeBody;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -27,6 +28,7 @@ import com.hubspot.jinjava.util.ObjectTruthValue;
     code = "{% unless x < 0 %} x is greater than zero {% endunless %}"
   )
 )
+@JinjavaHasCodeBody
 public class UnlessTag extends IfTag {
   public static final String TAG_NAME = "unless";
 


### PR DESCRIPTION
Added new method to produce a string of tag snippets formatted for use in the hubspot vscode plugin.

Updated
(1/29) Output:
```
{% import ${1:path} ${2:import_name} %}

{% elif ${1:condition} %}

{% autoescape %}
{% endautoescape %}

{% from ${1:path} ${2:macro_name} %}

{% macro ${1:macro_name} ${2:argument_names} %}
{% endmacro %}

{% raw %}
{% endraw %}

{% else %}

{% if ${1:condition} %}
{% endif %}

{% print ${1:expr} %}

{% do %}

{% cycle ${1:string_to_print} %}

{% unless ${1:expr} %}
{% endunless %}

{% include ${1:path} %}

{% ifchanged %}
{% endifchanged %}

{% set ${1:var} = ${2:expr} %}

{% block ${1:block_name} %}
{% endblock %}

{% call %}
{% endcall %}

{% extends ${1:path} %}

{% for ${1:items_to_iterate} %}
{% endfor %}
```