### PR TITLE
Expose template errors during eager execution expression resolving

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -48,7 +48,11 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
         : ""
     );
     if (chunkResolver.getDeferredWords().isEmpty()) {
-      String result = WhitespaceUtils.unquoteAndUnescape(resolvedExpression.getResult());
+      String fullyResolved = chunkResolver.resolveChunk(
+        resolvedExpression.getResult(),
+        ""
+      );
+      String result = WhitespaceUtils.unquoteAndUnescape(fullyResolved);
       if (
         !StringUtils.equals(result, master.getImage()) &&
         (

--- a/src/test/resources/eager/handles-unknown-function-errors.expected.jinja
+++ b/src/test/resources/eager/handles-unknown-function-errors.expected.jinja
@@ -1,0 +1,2 @@
+Some () expression
+Nothing: ()

--- a/src/test/resources/eager/handles-unknown-function-errors.jinja
+++ b/src/test/resources/eager/handles-unknown-function-errors.jinja
@@ -1,0 +1,3 @@
+Some ({{ unknown(null) }}) expression
+{%- set foo = unknown(null) -%}
+Nothing: ({{ foo }})


### PR DESCRIPTION
Improves https://github.com/HubSpot/jinjava/issues/532
---

I found that fatal errors were not being added properly in eager execution, and this also was causing some discrepancies in the HTML output when there were fatal errors comparing eager execution mode with default execution mode. Before this PR, `{{ unknown(null) }}` would resolve to `unknown(null)` instead of ` ` (blank).

This PR changes it so that the final `resolveChunk()` call is made in the EagerExpressionStrategy*, which will have template errors that are thrown get put onto the interpreter, rather than being hidden. 

*Note that this cannot be done in the ChunkResolver because it is used to resolve expressions like `1,2,3` which throw syntax errors, as they are invalid expressions, but are used in places such as SetTags. We are hiding errors like these within the ChunkResolver with `interpreter.getContext().setThrowInterpreterErrors(true)` which will throw fatal errors rather than adding them to the error list, and ignore warning errors.