### PR TITLE
[Eager Execution] Reserve null keyword in ChunkResolver

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -265,7 +265,7 @@ public class ChunkResolver {
       String resolvedChunk;
       Object val = interpreter.resolveELExpression(chunk, token.getLineNumber());
       if (val == null) {
-        return JINJAVA_NULL;
+        resolvedChunk = JINJAVA_NULL;
       } else {
         resolvedChunk =
           interpreter.getContext().getPyishObjectMapper().getAsPyishString(val);

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -38,6 +38,9 @@ public class ChunkResolver {
     "pluralize",
     "recursive",
     "trans",
+    "null",
+    "true",
+    "false",
     "__macros__"
   );
 

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -340,6 +340,14 @@ public class ChunkResolverTest {
       .isEqualTo("false");
   }
 
+  @Test
+  public void itDoesntDeferNull() {
+    ChunkResolver chunkResolver = makeChunkResolver("range(deferred, nothing)");
+    assertThat(chunkResolver.resolveChunks()).isEqualTo("range(deferred, null)");
+    assertThat(chunkResolver.getDeferredWords())
+      .containsExactlyInAnyOrder("range", "deferred");
+  }
+
   public static void voidFunction(int nothing) {}
 
   public static boolean isNull(Object foo, Object bar) {


### PR DESCRIPTION
Improves https://github.com/HubSpot/jinjava/issues/532
---

Since we don't ever want `null` to be put on the context as a deferred word, we can add it to the set of reserved words here. Additionally, to allow for some short-circuiting, we can add `true` and `false` here as well as we know these are words should be reserved from ever being deferred as well.