### PR TITLE
[Eager Execution] Similarly to the dot operator, don't split on the bar character

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -206,7 +206,7 @@ public class ChunkResolver {
   }
 
   private boolean isTokenSplitter(char c) {
-    return (!Character.isLetterOrDigit(c) && c != '_' && c != '.');
+    return (!Character.isLetterOrDigit(c) && c != '_' && c != '.' && c != '|');
   }
 
   private boolean isMiniChunkSplitter(char c) {

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -348,6 +348,13 @@ public class ChunkResolverTest {
       .containsExactlyInAnyOrder("range", "deferred");
   }
 
+  @Test
+  public void itDoesntSplitOnBar() {
+    context.put("date", new PyishDate(0L));
+    ChunkResolver chunkResolver = makeChunkResolver("date|datetimeformat('%Y')");
+    assertThat(chunkResolver.resolveChunks()).isEqualTo("1970");
+  }
+
   public static void voidFunction(int nothing) {}
 
   public static boolean isNull(Object foo, Object bar) {


### PR DESCRIPTION
Improves https://github.com/HubSpot/jinjava/issues/532
---
Don't split on the bar operator so that the whole filter operation is resolved at once rather than resolving the parts before and after the bar separately.