### PR TITLE
[Eager Execution] Don't prematurely resolve complex objects

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -333,7 +333,7 @@ public class Context extends ScopeMap<String, Object> {
 
   public void handleEagerToken(EagerToken eagerToken) {
     eagerTokens.add(eagerToken);
-    DeferredValueUtils.findAndMarkDeferredProperties(this);
+    DeferredValueUtils.findAndMarkDeferredProperties(this, eagerToken);
     if (getParent() != null) {
       Context parent = getParent();
       //Ignore global context

--- a/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.objects.date;
 
 import com.hubspot.jinjava.objects.PyWrapper;
+import com.hubspot.jinjava.objects.serialization.PyishSerializable;
 import java.io.Serializable;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -17,7 +18,9 @@ import org.apache.commons.lang3.math.NumberUtils;
  * @author jstehler
  *
  */
-public final class PyishDate extends Date implements Serializable, PyWrapper {
+public final class PyishDate
+  extends Date
+  implements Serializable, PyWrapper, PyishSerializable {
   private static final long serialVersionUID = 1L;
   public static final String PYISH_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
 

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -384,6 +384,13 @@ public class ChunkResolver {
       return true;
     }
     if (val instanceof Collection || val instanceof Map) {
+      if (
+        val instanceof Collection
+          ? ((Collection<?>) val).isEmpty()
+          : ((Map<?, ?>) val).isEmpty()
+      ) {
+        return true;
+      }
       // Naively check if any element within val is resolvable,
       // rather than checking all of them, which may be costly.
       Optional<?> item =

--- a/src/test/resources/eager/defers-macro-in-if.expected.jinja
+++ b/src/test/resources/eager/defers-macro-in-if.expected.jinja
@@ -1,3 +1,3 @@
-{% set my_list = [] %}{% set my_list = [] %}{% macro macro_append(num) %}{% do my_list.append(num) %}{{ my_list }}{% endmacro %}{% if my_list == macro_append(deferred)|split(',',2) %}
+{% set my_list = [] %}{% set my_list = [] %}{% macro macro_append(num) %}{% do my_list.append(num) %}{{ my_list }}{% endmacro %}{% if [] == macro_append(deferred)|split(',',2) %}
 {{ my_list }}
 {% endif %}

--- a/src/test/resources/eager/defers-macro-in-if.expected.jinja
+++ b/src/test/resources/eager/defers-macro-in-if.expected.jinja
@@ -1,3 +1,3 @@
-{% set my_list = [] %}{% set my_list = [] %}{% macro macro_append(num) %}{% do my_list.append(num) %}{{ my_list }}{% endmacro %}{% if [] == macro_append(deferred)|split(',',2) %}
+{% set my_list = [] %}{% set my_list = [] %}{% macro macro_append(num) %}{% do my_list.append(num) %}{{ my_list }}{% endmacro %}{% if my_list == macro_append(deferred)|split(',',2) %}
 {{ my_list }}
 {% endif %}


### PR DESCRIPTION
Fixes a diff that I found where an expression like `{{ foo.update({'bar': bar}) }}` was being resolved, except `bar` was a class that could not be serialised to a string while being able to retain the functionality. Basically, serializing and then deserializing `bar` would yield a much different object.

After consideration for how the chunk resolver aims to resolve as much as possible when there happens to be a deferred value, I modified it so that it will only do the premature evaluation of certain object classes: `String`, `Number`, `Boolean`, and `PyishSerializable`, as well as Collections and Maps of these. If there are other classes such as some arbitrary class `Person`, for example, then it will not be converted to a string. It will wait until the final evaluation call in the chunk resolver to actually resolve the value within an entire expression. With this, evaluating `{{ foo.update({'bar': bar}) }}` through the chunk resolver will result in `foo.bar` being equivalent to `bar`.

I also am making a change to DeferredValueUtils as with these changes, I exposed a minor bug that's fixed by just passing in the most recent `EagerToken` when deferring new values. This change prevents variables in the different context scopes, but with the same name both becoming deferred if one of them becomes deferred.