### PR TITLE
[Eager Execution] Handle zero-padding when serializing numbers

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
@@ -28,7 +28,11 @@ public class PyishSerializer extends JsonSerializer<Object> {
     }
     try {
       Double.parseDouble(string);
-      jsonGenerator.writeNumber(string);
+      if (string.length() > 1 && string.charAt(0) == '0' && string.indexOf('.') != 1) {
+        jsonGenerator.writeString(string);
+      } else {
+        jsonGenerator.writeNumber(string);
+      }
     } catch (NumberFormatException e) {
       if ("true".equalsIgnoreCase(string) || "false".equalsIgnoreCase(string)) {
         jsonGenerator.writeBoolean(Boolean.parseBoolean(string));

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -369,6 +369,23 @@ public class ChunkResolverTest {
     assertThat(((Foo) dict.get("foo")).bar()).isEqualTo("bar");
   }
 
+  @Test
+  public void itLeavesPaddedZeros() {
+    context.put(
+      "zero_date",
+      ZonedDateTime.ofInstant(Instant.ofEpochMilli(0L), ZoneId.systemDefault())
+    );
+    ChunkResolver chunkResolver = makeChunkResolver("zero_date.strftime('%d')");
+    assertThat(WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunks()))
+      .isEqualTo("01");
+  }
+
+  @Test
+  public void itDoesntQuoteFloats() {
+    ChunkResolver chunkResolver = makeChunkResolver("0.4 + 0.1");
+    assertThat(chunkResolver.resolveChunks()).isEqualTo("0.5");
+  }
+
   public static void voidFunction(int nothing) {}
 
   public static boolean isNull(Object foo, Object bar) {


### PR DESCRIPTION
Found a mismatch in functionality when using `strftime` in the ChunkResolver. The result was supposed to be zero-padded, but it would be serialized as a number, and this would cause it to lose the zero-padding. Treat zero-padded strings separately by not writing them as numbers.