### PR TITLE
[Eager Execution] Handle spacing between pipe character for filters

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -217,12 +217,12 @@ public class ChunkResolver {
   }
 
   private boolean isFilterWhitespace(char c) {
+    // If a pipe character is surrounded by whitespace on either side,
+    // we don't want to split those tokens
     int curPos = nextPos - 1;
     boolean isFilterWhitespace = false;
     if (c == ' ') {
       if (curPos + 2 < length) {
-        // If a pipe character is surrounded by whitespace on either side,
-        // we don't want to split those tokens
         isFilterWhitespace = (value[curPos + 1] == '|' && value[curPos + 2] != '|');
       }
       if (curPos >= 2) {

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -219,19 +219,15 @@ public class ChunkResolver {
   private boolean isFilterWhitespace(char c) {
     // If a pipe character is surrounded by whitespace on either side,
     // we don't want to split those tokens
-    int curPos = nextPos - 1;
     boolean isFilterWhitespace = false;
     if (c == ' ') {
-      if (curPos + 2 < length) {
-        isFilterWhitespace =
-          value[curPos + 1] == ' ' ||
-          (value[curPos + 1] == '|' && value[curPos + 2] != '|');
+      int prevPos = nextPos - 2;
+      if (nextPos < length) {
+        isFilterWhitespace = value[nextPos] == ' ' || value[nextPos] == '|';
       }
-      if (curPos >= 2) {
+      if (prevPos >= 0) {
         isFilterWhitespace =
-          isFilterWhitespace ||
-          value[curPos - 1] == ' ' ||
-          (value[curPos - 1] == '|' && value[curPos - 2] != '|');
+          isFilterWhitespace || value[prevPos] == ' ' || value[prevPos] == '|';
       }
     }
     return isFilterWhitespace;

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -223,11 +223,15 @@ public class ChunkResolver {
     boolean isFilterWhitespace = false;
     if (c == ' ') {
       if (curPos + 2 < length) {
-        isFilterWhitespace = (value[curPos + 1] == '|' && value[curPos + 2] != '|');
+        isFilterWhitespace =
+          value[curPos + 1] == ' ' ||
+          (value[curPos + 1] == '|' && value[curPos + 2] != '|');
       }
       if (curPos >= 2) {
         isFilterWhitespace =
-          isFilterWhitespace || (value[curPos - 1] == '|' && value[curPos - 2] != '|');
+          isFilterWhitespace ||
+          value[curPos - 1] == ' ' ||
+          (value[curPos - 1] == '|' && value[curPos - 2] != '|');
       }
     }
     return isFilterWhitespace;

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -394,6 +394,14 @@ public class ChunkResolverTest {
       .isEqualTo(interpreter.resolveELExpression(lowerFilterString, 0));
   }
 
+  @Test
+  public void itHandlesMultipleWhitespaceAroundPipe() {
+    String lowerFilterString = "'A'   |   lower";
+    ChunkResolver chunkResolver = makeChunkResolver(lowerFilterString);
+    assertThat(WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunks()))
+      .isEqualTo(interpreter.resolveELExpression(lowerFilterString, 0));
+  }
+
   public static void voidFunction(int nothing) {}
 
   public static boolean isNull(Object foo, Object bar) {

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -388,7 +388,8 @@ public class ChunkResolverTest {
 
   @Test
   public void itHandlesWhitespaceAroundPipe() {
-    String lowerFilterString = "'A' | lower ~ 'B' |lower ~ 'C'| lower";
+    String lowerFilterString =
+      "'AB' | truncate(1) ~ 'BC' |truncate(1) ~ 'CD'| truncate(1)";
     ChunkResolver chunkResolver = makeChunkResolver(lowerFilterString);
     assertThat(WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunks()))
       .isEqualTo(interpreter.resolveELExpression(lowerFilterString, 0));
@@ -396,7 +397,7 @@ public class ChunkResolverTest {
 
   @Test
   public void itHandlesMultipleWhitespaceAroundPipe() {
-    String lowerFilterString = "'A'   |   lower";
+    String lowerFilterString = "'AB'   |   truncate(1)";
     ChunkResolver chunkResolver = makeChunkResolver(lowerFilterString);
     assertThat(WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunks()))
       .isEqualTo(interpreter.resolveELExpression(lowerFilterString, 0));

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -386,6 +386,14 @@ public class ChunkResolverTest {
     assertThat(chunkResolver.resolveChunks()).isEqualTo("0.5");
   }
 
+  @Test
+  public void itHandlesWhitespaceAroundPipe() {
+    String lowerFilterString = "'A' | lower ~ 'B' |lower ~ 'C'| lower";
+    ChunkResolver chunkResolver = makeChunkResolver(lowerFilterString);
+    assertThat(WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunks()))
+      .isEqualTo(interpreter.resolveELExpression(lowerFilterString, 0));
+  }
+
   public static void voidFunction(int nothing) {}
 
   public static boolean isNull(Object foo, Object bar) {

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -73,9 +73,9 @@ public class ChunkResolverTest {
   @Test
   public void itResolvesDeferredBoolean() {
     context.put("foo", "foo_val");
-    ChunkResolver chunkResolver = makeChunkResolver("(111 == 112) || (foo == deferred)");
+    ChunkResolver chunkResolver = makeChunkResolver("(111 == 112) or (foo == deferred)");
     String partiallyResolved = chunkResolver.resolveChunks();
-    assertThat(partiallyResolved).isEqualTo("false || ('foo_val' == deferred)");
+    assertThat(partiallyResolved).isEqualTo("false or ('foo_val' == deferred)");
     assertThat(chunkResolver.getDeferredWords()).containsExactly("deferred");
 
     context.put("deferred", "foo_val");


### PR DESCRIPTION
Since it's valid to have spaces between the filter operator, we still don't want to resolve the filtering function without the first argument. Therefore, we don't want to resolve the parts before and after the pipe separately so add logic to check if there is whitespace surrounding the `|` so that we can prevent splitting this token apart.
Ex: `{{ 'Something Here' | truncate(10) }}` -> `something here`. We don't want to try and resolve `truncate(10)` on its own.