### PR TITLE
Fix bug with whitespace controls not applying properly

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -62,7 +62,7 @@ public class TreeParser {
       if (node != null) {
         if (node instanceof TextNode && getLastSibling() instanceof TextNode) {
           // merge adjacent text nodes so whitespace control properly applies
-          getLastSibling().getMaster().mergeImage(node.getMaster());
+          getLastSibling().getMaster().mergeImageAndContent(node.getMaster());
         } else {
           parent.getChildren().add(node);
         }

--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -94,9 +94,6 @@ public class TreeParser {
 
   private Node nextNode() {
     Token token = scanner.next();
-    if (token.getImage().isEmpty()) {
-      return null;
-    }
 
     if (token.getType() == symbols.getFixed()) {
       return text((TextToken) token);
@@ -154,7 +151,7 @@ public class TreeParser {
       }
     }
 
-    Node lastSibling = getLastSibling();
+    final Node lastSibling = getLastSibling();
 
     // if last sibling was a tag and has rightTrimAfterEnd, strip whitespace
     if (lastSibling instanceof TagNode && lastSibling.getMaster().isRightTrimAfterEnd()) {

--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -17,7 +17,6 @@ package com.hubspot.jinjava.tree;
 
 import com.google.common.collect.Iterators;
 import com.google.common.collect.PeekingIterator;
-import com.google.common.collect.Streams;
 import com.hubspot.jinjava.interpret.DisabledException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.MissingEndTagException;
@@ -37,7 +36,6 @@ import com.hubspot.jinjava.tree.parse.Token;
 import com.hubspot.jinjava.tree.parse.TokenScanner;
 import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
 import org.apache.commons.lang3.StringUtils;
-import org.w3c.dom.Text;
 
 public class TreeParser {
   private final PeekingIterator<Token> scanner;
@@ -63,6 +61,7 @@ public class TreeParser {
 
       if (node != null) {
         if (node instanceof TextNode && getLastSibling() instanceof TextNode) {
+          // merge adjacent text nodes so whitespace control properly applies
           getLastSibling().getMaster().mergeImage(node.getMaster());
         } else {
           parent.getChildren().add(node);

--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -146,7 +146,7 @@ public class TreeParser {
       }
     }
 
-    final Node lastSibling = getLastSibling();
+    Node lastSibling = getLastSibling();
 
     // if last sibling was a tag and has rightTrimAfterEnd, strip whitespace
     if (lastSibling instanceof TagNode && lastSibling.getMaster().isRightTrimAfterEnd()) {
@@ -155,7 +155,9 @@ public class TreeParser {
 
     // for first TextNode child of TagNode where rightTrim is enabled, mark it for left trim
     if (
-      parent instanceof TagNode && lastSibling == null && parent.getMaster().isRightTrim()
+      parent instanceof TagNode &&
+      (lastSibling == null || lastSibling instanceof TextNode) &&
+      parent.getMaster().isRightTrim()
     ) {
       textToken.setLeftTrim(true);
     }

--- a/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
@@ -50,7 +50,7 @@ public abstract class Token implements Serializable {
     return image;
   }
 
-  public void mergeImage(Token otherToken) {
+  public void mergeImageAndContent(Token otherToken) {
     this.image = image + otherToken.image;
     this.content = content + otherToken.content;
   }

--- a/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
@@ -21,7 +21,7 @@ import java.io.Serializable;
 public abstract class Token implements Serializable {
   private static final long serialVersionUID = 3359084948763661809L;
 
-  protected final String image;
+  protected String image;
   // useful for some token type
   protected String content;
 
@@ -48,6 +48,11 @@ public abstract class Token implements Serializable {
 
   public String getImage() {
     return image;
+  }
+
+  public void mergeImage(Token otherToken) {
+    this.image = image + otherToken.image;
+    this.content = content + otherToken.content;
   }
 
   public int getLineNumber() {

--- a/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
@@ -26,8 +26,24 @@ public class TreeParserTest extends BaseInterpretingTest {
   }
 
   @Test
+  public void itStripsRightWhiteSpaceWithComment() throws Exception {
+    String expression =
+      "{% for foo in [1,2,3] -%} \n {#- comment -#} \n {#- comment -#} .{{ foo }}\n{% endfor %}";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo(".1\n.2\n.3\n");
+  }
+
+  @Test
   public void itStripsLeftWhiteSpace() throws Exception {
     String expression = "{% for foo in [1,2,3] %}\n{{ foo }}. \n {%- endfor %}";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo("\n1.\n2.\n3.");
+  }
+
+  @Test
+  public void itStripsLeftWhiteSpaceWithComment() throws Exception {
+    String expression =
+      "{% for foo in [1,2,3] %}\n{{ foo }}. \n {#- comment -#} {%- endfor %}";
     final Node tree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(tree)).isEqualTo("\n1.\n2.\n3.");
   }
@@ -42,7 +58,7 @@ public class TreeParserTest extends BaseInterpretingTest {
   @Test
   public void itStripsLeftAndRightWhiteSpaceWithComment() throws Exception {
     String expression =
-      "{% for foo in [1,2,3] -%} \n {#- comment -#} \n {#- comment -#} .{{ foo }}. \n {%- endfor %}";
+      "{% for foo in [1,2,3] -%} \n {#- comment -#} \n {#- comment -#} .{{ foo }}. \n {#- comment -#} \n {#- comment -#} {%- endfor %}";
     final Node tree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(tree)).isEqualTo(".1..2..3.");
   }
@@ -56,8 +72,24 @@ public class TreeParserTest extends BaseInterpretingTest {
   }
 
   @Test
+  public void itPreservesInnerWhiteSpaceWithComment() throws Exception {
+    String expression =
+      "{% for foo in [1,2,3] -%}\n {#- comment -#} \n {#- comment -#}L{% if true %}\n{{ foo }}\n{% endif %}R\n {#- comment -#} \n {#- comment -#}{%- endfor %}";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo("L\n1\nRL\n2\nRL\n3\nR");
+  }
+
+  @Test
   public void itStripsLeftWhiteSpaceBeforeTag() throws Exception {
     String expression = ".\n {%- for foo in [1,2,3] %} {{ foo }} {% endfor %} \n.";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo(". 1  2  3  \n.");
+  }
+
+  @Test
+  public void itStripsLeftWhiteSpaceBeforeTagWithComment() throws Exception {
+    String expression =
+      ".\n {#- comment -#} \n {#- comment -#} {%- for foo in [1,2,3] %} {{ foo }} {% endfor %} \n.";
     final Node tree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(tree)).isEqualTo(". 1  2  3  \n.");
   }
@@ -70,8 +102,24 @@ public class TreeParserTest extends BaseInterpretingTest {
   }
 
   @Test
+  public void itStripsRightWhiteSpaceAfterTagWithComment() throws Exception {
+    String expression =
+      ".\n {% for foo in [1,2,3] %} {{ foo }} {% endfor -%} \n {#- comment -#} \n {#- comment -#}.";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo(".\n  1  2  3 .");
+  }
+
+  @Test
   public void itStripsAllOuterWhiteSpace() throws Exception {
     String expression = ".\n {%- for foo in [1,2,3] -%} {{ foo }} {%- endfor -%} \n.";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo(".123.");
+  }
+
+  @Test
+  public void itStripsAllOuterWhiteSpaceWithComment() throws Exception {
+    String expression =
+      ".\n {#- comment -#} \n {#- comment -#} {%- for foo in [1,2,3] -%} {{ foo }} {%- endfor -%} \n {#- comment -#} \n {#- comment -#}.";
     final Node tree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(tree)).isEqualTo(".123.");
   }

--- a/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
@@ -40,6 +40,14 @@ public class TreeParserTest extends BaseInterpretingTest {
   }
 
   @Test
+  public void itStripsLeftAndRightWhiteSpaceWithComment() throws Exception {
+    String expression =
+      "{% for foo in [1,2,3] -%} \n {#- comment -#} \n {#- comment -#} .{{ foo }}. \n {%- endfor %}";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo(".1..2..3.");
+  }
+
+  @Test
   public void itPreservesInnerWhiteSpace() throws Exception {
     String expression =
       "{% for foo in [1,2,3] -%}\nL{% if true %}\n{{ foo }}\n{% endif %}R\n{%- endfor %}";


### PR DESCRIPTION
Whitespace controls operate on the assumption that textnodes cannot be adjacent. You can break up text nodes with a comment node `\n {# comment #} \n`. This should not affect the whitespace control but it does under the current code. In order to solve for this I merged adjacent text nodes. I did try a few other approaches over a couple of hours to try to get the same effect but could not solve for the case where there are more than 2 text nodes stacked next to each other.