### PR TITLE
[Eager Execution] Filter out non null before calling findAny()

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -397,6 +398,7 @@ public class ChunkResolver {
         (
           val instanceof Collection ? (Collection<?>) val : ((Map<?, ?>) val).values()
         ).stream()
+          .filter(Objects::nonNull)
           .findAny();
       if (item.isPresent()) {
         return RESOLVABLE_CLASSES


### PR DESCRIPTION
This prevents a NullPointerException that occurs if there are any null values in a collection or a map's values.