### PR TITLE
[Eager Execution] Don't prematurely resolve PyishDate's in the ChunkResolver

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
@@ -1,7 +1,6 @@
 package com.hubspot.jinjava.objects.date;
 
 import com.hubspot.jinjava.objects.PyWrapper;
-import com.hubspot.jinjava.objects.serialization.PyishSerializable;
 import java.io.Serializable;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -18,9 +17,7 @@ import org.apache.commons.lang3.math.NumberUtils;
  * @author jstehler
  *
  */
-public final class PyishDate
-  extends Date
-  implements Serializable, PyWrapper, PyishSerializable {
+public final class PyishDate extends Date implements Serializable, PyWrapper {
   private static final long serialVersionUID = 1L;
   public static final String PYISH_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
 

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -270,7 +270,11 @@ public class ChunkResolverTest {
     );
     context.put("date", date);
     ChunkResolver chunkResolver = makeChunkResolver("date");
+
+    // don't prematurely resolve date because of datetime functions.
     assertThat(WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunks()))
+      .isEqualTo("date");
+    assertThat(WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunk("date", "")))
       .isEqualTo(date.toString());
   }
 


### PR DESCRIPTION
Filters such as DateTimeFormatFilter require a Date object rather than a string object. This change makes it so that PyishDate objects aren't prematurely resolved in the chunk resolver (see https://github.com/HubSpot/jinjava/pull/595). Resolving them as a string loses the milliseconds info, with the default `PYISH_DATE_FORMAT`, and will cause a `FATAL` error if used in a DateTimeFormatFilter.