### PR TITLE
[Eager Execution] Ensure form feed is escaped properly when resolving strings

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishCharacterEscapes.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishCharacterEscapes.java
@@ -13,6 +13,7 @@ public class PyishCharacterEscapes extends CharacterEscapes {
     escapes['\n'] = CharacterEscapes.ESCAPE_NONE;
     escapes['\t'] = CharacterEscapes.ESCAPE_NONE;
     escapes['\r'] = CharacterEscapes.ESCAPE_NONE;
+    escapes['\f'] = CharacterEscapes.ESCAPE_NONE;
     asciiEscapes = escapes;
   }
 

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -403,6 +403,14 @@ public class ChunkResolverTest {
       .isEqualTo(interpreter.resolveELExpression(lowerFilterString, 0));
   }
 
+  @Test
+  public void itEscapesFormFeed() {
+    context.put("foo", "Form feed\f");
+    ChunkResolver chunkResolver = makeChunkResolver("foo");
+    assertThat(WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunks()))
+      .isEqualTo("Form feed\f");
+  }
+
   public static void voidFunction(int nothing) {}
 
   public static boolean isNull(Object foo, Object bar) {


### PR DESCRIPTION
Don't want the form feed character `\f` to be escaped when serialising to json, otherwise it would end up in the output containing the characters `\` and `f`. Similar to how `\t`, `\r`, and `\n` are custom escaped, the form feed character should be included there.