### PR TITLE
Allow replace filter on non-strings

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/ReplaceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ReplaceFilter.java
@@ -65,7 +65,7 @@ public class ReplaceFilter implements Filter {
       );
     }
 
-    String s = (String) var;
+    String s = var.toString();
     String toReplace = args[0];
     String replaceWith = args[1];
     Integer count = null;

--- a/src/test/java/com/hubspot/jinjava/lib/filter/ReplaceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/ReplaceFilterTest.java
@@ -46,4 +46,10 @@ public class ReplaceFilterTest extends BaseInterpretingTest {
       )
       .isEqualTo("d'oh, d'oh, aaargh");
   }
+
+  @Test
+  public void replaceBoolean() {
+    assertThat(filter.filter(true, interpreter, "true", "TRUEEE").toString())
+      .isEqualTo("TRUEEE");
+  }
 }


### PR DESCRIPTION
Unlike other filters, the ReplaceFilter does not check if `var instanceof String` before casting it to a String. This results in a FATAL error if something besides a string is passed into the filter. I have seen a template that actually makes use of this logic unintentionally with code like `{{ my_list.append(obj)|replace(true, '') }}`. So, in order to fix this bug while maintaining the same output for legacy templates, this adds the functionality to the replace filter of calling `toString()` to allow it to be called on non-string objects. 

Since the `String` class in Java is `final`, and `String.toString()` returns `this`, this will not change the functionality for any replace filtering on strings as the filter is intended for. However, using this filter on something like a boolean or a number will call toString on the object to convert it to a String, rather than throwing a ClassCastException and resulting in a FATAL error.