### PR TITLE
[Eager Execution] When importing and removing reference cycles, filter on equality

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -259,6 +259,14 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
             .orElse(currentImportAlias)
             .split("\\.")
         )
+        .filter(
+          key ->
+            mapForCurrentContextAlias.equals(
+              childBindings.get(key) instanceof DeferredValue
+                ? ((DeferredValue) childBindings.get(key)).getOriginalValue()
+                : childBindings.get(key)
+            )
+        )
         .forEach(childBindings::remove);
       // Remove meta keys
       childBindings.remove(Context.GLOBAL_MACROS_SCOPE_KEY);

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -261,7 +261,8 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
         )
         .filter(
           key ->
-            mapForCurrentContextAlias.equals(
+            mapForCurrentContextAlias ==
+            (
               childBindings.get(key) instanceof DeferredValue
                 ? ((DeferredValue) childBindings.get(key)).getOriginalValue()
                 : childBindings.get(key)

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -436,6 +436,15 @@ public class EagerImportTagTest extends ImportTagTest {
     assertThat(interpreter.render(result).trim()).isEqualTo("12345 cbaabaaba");
   }
 
+  @Test
+  public void itImportsDoublyNamed() {
+    setupResourceLocator();
+    String result = interpreter.render(
+      "{% import 'variables.jinja' as foo %}{{ foo.foo['foo'].bar }}"
+    );
+    assertThat(result).isEqualTo("here");
+  }
+
   private static JinjavaInterpreter getChildInterpreter(
     JinjavaInterpreter interpreter,
     String alias

--- a/src/test/resources/tags/eager/importtag/variables.jinja
+++ b/src/test/resources/tags/eager/importtag/variables.jinja
@@ -1,0 +1,1 @@
+{% set foo = {'foo': {bar: 'here'}} %}


### PR DESCRIPTION
Instead of naively removing those keys that match the current import alias, first check to make sure they are equal. We are trying to prevent reference cycles, so we can check if the references actually equal each other before removing the key from the child bindings.

Eager execution may result in an import alias deferring itself, so that's why it's necessary to prevent the reference cycle.