### PR TITLE
[Eager Execution] Check all values when determining resolvability

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -15,7 +15,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -411,19 +410,16 @@ public class ChunkResolver {
       ) {
         return true;
       }
-      // Naively check if any element within val is resolvable,
-      // rather than checking all of them, which may be costly.
-      Optional<?> item =
-        (
-          val instanceof Collection ? (Collection<?>) val : ((Map<?, ?>) val).values()
-        ).stream()
-          .filter(Objects::nonNull)
-          .findAny();
-      if (item.isPresent()) {
-        return RESOLVABLE_CLASSES
-          .stream()
-          .anyMatch(clazz -> clazz.isAssignableFrom(item.get().getClass()));
-      }
+      return (
+        val instanceof Collection ? (Collection<?>) val : ((Map<?, ?>) val).values()
+      ).stream()
+        .filter(Objects::nonNull)
+        .allMatch(
+          item ->
+            RESOLVABLE_CLASSES
+              .stream()
+              .anyMatch(clazz -> clazz.isAssignableFrom(item.getClass()))
+        );
     }
     return false;
   }

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -396,6 +396,13 @@ public class ChunkResolver {
   }
 
   private static boolean isResolvableObject(Object val) {
+    return isResolvableObjectRec(val, 0);
+  }
+
+  private static boolean isResolvableObjectRec(Object val, int depth) {
+    if (depth > 10) {
+      return false;
+    }
     boolean isResolvable = RESOLVABLE_CLASSES
       .stream()
       .anyMatch(clazz -> clazz.isAssignableFrom(val.getClass()));
@@ -414,12 +421,7 @@ public class ChunkResolver {
         val instanceof Collection ? (Collection<?>) val : ((Map<?, ?>) val).values()
       ).stream()
         .filter(Objects::nonNull)
-        .allMatch(
-          item ->
-            RESOLVABLE_CLASSES
-              .stream()
-              .anyMatch(clazz -> clazz.isAssignableFrom(item.getClass()))
-        );
+        .allMatch(item -> isResolvableObjectRec(item, depth + 1));
     }
     return false;
   }


### PR DESCRIPTION
When resolving prematurely with the chunk resolver, in the case when it's a map or collection, we should check that all values within it are resolvable. This ensures that no data is if there's a collection with different types of objects in it, and some of them can't be resolved to a string.