### PR TITLE
Add function and filter to convert string to date

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/FilterLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FilterLibrary.java
@@ -58,6 +58,7 @@ public class FilterLibrary extends SimpleLibrary<Filter> {
       MinusTimeFilter.class,
       BetweenTimesFilter.class,
       StringToTimeFilter.class,
+      StringToDateFilter.class,
       UnionFilter.class,
       IntersectFilter.class,
       DifferenceFilter.class,

--- a/src/main/java/com/hubspot/jinjava/lib/filter/StringToDateFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/StringToDateFilter.java
@@ -1,0 +1,36 @@
+package com.hubspot.jinjava.lib.filter;
+
+import com.hubspot.jinjava.interpret.InvalidInputException;
+import com.hubspot.jinjava.interpret.InvalidReason;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
+import com.hubspot.jinjava.lib.fn.Functions;
+
+public class StringToDateFilter implements Filter {
+
+  @Override
+  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+    if (args.length < 1) {
+      throw new TemplateSyntaxException(
+        interpreter,
+        getName(),
+        "requires 1 argument (date format string)"
+      );
+    }
+
+    if (var == null) {
+      return null;
+    }
+
+    if (!(var instanceof String)) {
+      throw new InvalidInputException(interpreter, this, InvalidReason.STRING);
+    }
+
+    return Functions.stringToDate((String) var, args[0]);
+  }
+
+  @Override
+  public String getName() {
+    return "strtodate";
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/lib/filter/StringToDateFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/StringToDateFilter.java
@@ -17,7 +17,7 @@ import com.hubspot.jinjava.lib.fn.Functions;
       value = "dateFormat",
       desc = "Format of the date string",
       required = true
-    ),
+    )
   },
   snippets = { @JinjavaSnippet(code = "{{ '3/3/21'|strtodate('M/d/yy') }}") }
 )

--- a/src/main/java/com/hubspot/jinjava/lib/filter/StringToDateFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/StringToDateFilter.java
@@ -3,8 +3,6 @@ package com.hubspot.jinjava.lib.filter;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.InvalidInputException;
-import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.fn.Functions;
@@ -38,7 +36,7 @@ public class StringToDateFilter implements Filter {
     }
 
     if (!(var instanceof String)) {
-      throw new InvalidInputException(interpreter, this, InvalidReason.STRING);
+      var = String.valueOf(var);
     }
 
     return Functions.stringToDate((String) var, args[0]);

--- a/src/main/java/com/hubspot/jinjava/lib/filter/StringToDateFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/StringToDateFilter.java
@@ -1,11 +1,26 @@
 package com.hubspot.jinjava.lib.filter;
 
+import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
+import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.fn.Functions;
 
+@JinjavaDoc(
+  value = "Converts a date string and date format to a date object",
+  input = @JinjavaParam(value = "dateString", desc = "Date string", required = true),
+  params = {
+    @JinjavaParam(
+      value = "dateFormat",
+      desc = "Format of the date string",
+      required = true
+    ),
+  },
+  snippets = { @JinjavaSnippet(code = "{{ '3/3/21'|strtodate('M/d/yy') }}") }
+)
 public class StringToDateFilter implements Filter {
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/fn/FunctionLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/FunctionLibrary.java
@@ -67,6 +67,16 @@ public class FunctionLibrary extends SimpleLibrary<ELFunctionDefinition> {
         String.class
       )
     );
+    register(
+      new ELFunctionDefinition(
+        "",
+        "strtodate",
+        Functions.class,
+        Functions.STRING_TO_DATE_FUNCTION,
+        String.class,
+        String.class
+      )
+    );
 
     register(new ELFunctionDefinition("", "super", Functions.class, "renderSuperBlock"));
 

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -16,6 +16,7 @@ import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import java.time.DateTimeException;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -44,7 +45,7 @@ public class Functions {
         "    ...\n" +
         "    {{ super() }}\n" +
         "{% endblock %}"
-      )
+      ),
     }
   )
   public static String renderSuperBlock() {
@@ -75,7 +76,7 @@ public class Functions {
         type = "string",
         defaultValue = "utc",
         desc = "timezone"
-      )
+      ),
     }
   )
   public static ZonedDateTime today(String... var) {
@@ -105,7 +106,7 @@ public class Functions {
         value = "timezone",
         defaultValue = "utc",
         desc = "Time zone of output date"
-      )
+      ),
     }
   )
   public static String dateTimeFormat(Object var, String... format) {
@@ -178,7 +179,7 @@ public class Functions {
   @JinjavaDoc(
     value = "gets the unix timestamp milliseconds value of a datetime",
     params = {
-      @JinjavaParam(value = "var", type = "date", defaultValue = "current time")
+      @JinjavaParam(value = "var", type = "date", defaultValue = "current time"),
     }
   )
   public static long unixtimestamp(Object... var) {
@@ -202,7 +203,7 @@ public class Functions {
         value = "var",
         type = "datetimeFormat",
         desc = "format of the datetime string"
-      )
+      ),
     }
   )
   public static PyishDate stringToTime(String datetimeString, String datetimeFormat) {
@@ -241,6 +242,56 @@ public class Functions {
     }
   }
 
+  @JinjavaDoc(
+    value = "converts a string and datetime format into a datetime object",
+    params = {
+      @JinjavaParam(value = "var", type = "datetimeString", desc = "datetime as string"),
+      @JinjavaParam(
+        value = "var",
+        type = "datetimeFormat",
+        desc = "format of the datetime string"
+      ),
+    }
+  )
+  public static PyishDate stringToDate(String dateString, String dateFormat) {
+    if (dateString == null) {
+      return null;
+    }
+
+    if (dateFormat == null) {
+      throw new InterpretException(
+        String.format("%s() requires non-null datetime format", STRING_TO_TIME_FUNCTION)
+      );
+    }
+
+    try {
+      String convertedFormat = StrftimeFormatter.toJavaDateTimeFormat(dateFormat);
+      return new PyishDate(
+        LocalDate
+          .parse(dateString, DateTimeFormatter.ofPattern(convertedFormat))
+          .atTime(0, 0)
+          .toInstant(ZoneOffset.UTC)
+      );
+    } catch (DateTimeParseException e) {
+      throw new InterpretException(
+        String.format(
+          "%s() could not match datetime input %s with datetime format %s",
+          STRING_TO_TIME_FUNCTION,
+          dateString,
+          dateFormat
+        )
+      );
+    } catch (IllegalArgumentException e) {
+      throw new InterpretException(
+        String.format(
+          "%s() requires valid datetime format, was %s",
+          STRING_TO_TIME_FUNCTION,
+          dateFormat
+        )
+      );
+    }
+  }
+
   private static final int DEFAULT_TRUNCATE_LENGTH = 255;
   private static final String DEFAULT_END = "...";
 
@@ -269,7 +320,7 @@ public class Functions {
         value = "end",
         defaultValue = "...",
         desc = "The characters that will be added to indicate where the text was truncated"
-      )
+      ),
     }
   )
   public static Object truncate(Object var, Object... arg) {
@@ -339,7 +390,7 @@ public class Functions {
     params = {
       @JinjavaParam(value = "start", type = "number", defaultValue = "0"),
       @JinjavaParam(value = "end", type = "number"),
-      @JinjavaParam(value = "step", type = "number", defaultValue = "1")
+      @JinjavaParam(value = "step", type = "number", defaultValue = "1"),
     }
   )
   public static List<Integer> range(Object arg1, Object... args) {

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -32,6 +32,7 @@ import org.apache.commons.lang3.math.NumberUtils;
 
 public class Functions {
   public static final String STRING_TO_TIME_FUNCTION = "stringToTime";
+  public static final String STRING_TO_DATE_FUNCTION = "stringToDate";
 
   public static final int RANGE_LIMIT = 1000;
 
@@ -243,13 +244,13 @@ public class Functions {
   }
 
   @JinjavaDoc(
-    value = "converts a string and datetime format into a datetime object",
+    value = "converts a string and date format into a date object",
     params = {
-      @JinjavaParam(value = "var", type = "datetimeString", desc = "datetime as string"),
+      @JinjavaParam(value = "dateString", type = "string", desc = "date as string"),
       @JinjavaParam(
-        value = "var",
-        type = "datetimeFormat",
-        desc = "format of the datetime string"
+        value = "dateFormat",
+        type = "string",
+        desc = "format of the date string"
       ),
     }
   )
@@ -260,7 +261,7 @@ public class Functions {
 
     if (dateFormat == null) {
       throw new InterpretException(
-        String.format("%s() requires non-null datetime format", STRING_TO_TIME_FUNCTION)
+        String.format("%s() requires non-null date format", STRING_TO_DATE_FUNCTION)
       );
     }
 
@@ -275,8 +276,8 @@ public class Functions {
     } catch (DateTimeParseException e) {
       throw new InterpretException(
         String.format(
-          "%s() could not match datetime input %s with datetime format %s",
-          STRING_TO_TIME_FUNCTION,
+          "%s() could not match date input %s with date format %s",
+          STRING_TO_DATE_FUNCTION,
           dateString,
           dateFormat
         )
@@ -284,8 +285,8 @@ public class Functions {
     } catch (IllegalArgumentException e) {
       throw new InterpretException(
         String.format(
-          "%s() requires valid datetime format, was %s",
-          STRING_TO_TIME_FUNCTION,
+          "%s() requires valid date format, was %s",
+          STRING_TO_DATE_FUNCTION,
           dateFormat
         )
       );

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -46,7 +46,7 @@ public class Functions {
         "    ...\n" +
         "    {{ super() }}\n" +
         "{% endblock %}"
-      ),
+      )
     }
   )
   public static String renderSuperBlock() {
@@ -77,7 +77,7 @@ public class Functions {
         type = "string",
         defaultValue = "utc",
         desc = "timezone"
-      ),
+      )
     }
   )
   public static ZonedDateTime today(String... var) {
@@ -107,7 +107,7 @@ public class Functions {
         value = "timezone",
         defaultValue = "utc",
         desc = "Time zone of output date"
-      ),
+      )
     }
   )
   public static String dateTimeFormat(Object var, String... format) {
@@ -180,7 +180,7 @@ public class Functions {
   @JinjavaDoc(
     value = "gets the unix timestamp milliseconds value of a datetime",
     params = {
-      @JinjavaParam(value = "var", type = "date", defaultValue = "current time"),
+      @JinjavaParam(value = "var", type = "date", defaultValue = "current time")
     }
   )
   public static long unixtimestamp(Object... var) {
@@ -204,7 +204,7 @@ public class Functions {
         value = "var",
         type = "datetimeFormat",
         desc = "format of the datetime string"
-      ),
+      )
     }
   )
   public static PyishDate stringToTime(String datetimeString, String datetimeFormat) {
@@ -251,7 +251,7 @@ public class Functions {
         value = "dateFormat",
         type = "string",
         desc = "format of the date string"
-      ),
+      )
     }
   )
   public static PyishDate stringToDate(String dateString, String dateFormat) {
@@ -321,7 +321,7 @@ public class Functions {
         value = "end",
         defaultValue = "...",
         desc = "The characters that will be added to indicate where the text was truncated"
-      ),
+      )
     }
   )
   public static Object truncate(Object var, Object... arg) {
@@ -391,7 +391,7 @@ public class Functions {
     params = {
       @JinjavaParam(value = "start", type = "number", defaultValue = "0"),
       @JinjavaParam(value = "end", type = "number"),
-      @JinjavaParam(value = "step", type = "number", defaultValue = "1"),
+      @JinjavaParam(value = "step", type = "number", defaultValue = "1")
     }
   )
   public static List<Integer> range(Object arg1, Object... args) {

--- a/src/test/java/com/hubspot/jinjava/lib/fn/StringToDateFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/StringToDateFunctionTest.java
@@ -1,0 +1,21 @@
+package com.hubspot.jinjava.lib.fn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hubspot.jinjava.objects.date.PyishDate;
+import org.junit.Test;
+
+public class StringToDateFunctionTest {
+
+  @Test
+  public void itConvertsStringToDate() {
+    String dateString = "3/3/21";
+    String dateFormat = "M/d/yy";
+
+    PyishDate date = Functions.stringToDate(dateString, dateFormat);
+
+    assertThat(date.getDay()).isEqualTo(3);
+    assertThat(date.getMonth()).isEqualTo(3);
+    assertThat(date.getYear()).isEqualTo(2021);
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/lib/fn/StringToDateFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/StringToDateFunctionTest.java
@@ -1,21 +1,50 @@
 package com.hubspot.jinjava.lib.fn;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.objects.date.PyishDate;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import org.junit.Test;
 
 public class StringToDateFunctionTest {
 
   @Test
   public void itConvertsStringToDate() {
-    String dateString = "3/3/21";
-    String dateFormat = "M/d/yy";
+    String dateString = "3/4/21";
+    String format = "M/d/yy";
+    PyishDate expected = new PyishDate(
+      LocalDate.of(2021, 3, 4).atTime(0, 0).toInstant(ZoneOffset.UTC)
+    );
+    assertThat(Functions.stringToDate(dateString, format)).isEqualTo(expected);
+  }
 
-    PyishDate date = Functions.stringToDate(dateString, dateFormat);
+  @Test
+  public void itFailsOnInvalidFormat() {
+    String dateString = "3/4/21";
+    String format = "blah blah";
 
-    assertThat(date.getDay()).isEqualTo(3);
-    assertThat(date.getMonth()).isEqualTo(3);
-    assertThat(date.getYear()).isEqualTo(2021);
+    assertThatThrownBy(() -> Functions.stringToDate(dateString, format))
+      .isInstanceOf(InterpretException.class);
+  }
+
+  @Test
+  public void itFailsOnTimeFormatMismatch() {
+    String dateString = "3/4/21";
+    String format = "M/d/yyyy";
+
+    assertThatThrownBy(() -> Functions.stringToDate(dateString, format))
+      .isInstanceOf(InterpretException.class);
+  }
+
+  @Test
+  public void itFailsOnNullDatetimeFormat() {
+    String dateString = "3/4/21";
+    String format = null;
+
+    assertThatThrownBy(() -> Functions.stringToDate(dateString, format))
+      .isInstanceOf(InterpretException.class);
   }
 }


### PR DESCRIPTION
We currently have the `strtotime` function and filter that can be used to convert a string object into a `DateTime` object. However, we don't have a good way to do this for `Date` objects that don't include a time.

For instance, there's no good way to convert the string `3/4/21` to a different format, since it doesn't include the time.

This PR adds the new `strtodate` function/filter that can convert dates without time.

For instance, you can do something like this:
```
{{ "3/4/21"|strtodate('d/M/yy')|datetimeformat('%B %e, %Y') }}
```
To output the following:
`March 4, 2021`