### PR TITLE
Fix missed variable substitution

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -76,7 +76,6 @@ public class ChunkResolver {
   private char prevChar = 0;
   private boolean inQuote = false;
   private char quoteChar = 0;
-  private boolean isAfterWhitespace = false;
 
   public ChunkResolver(String s, Token token, JinjavaInterpreter interpreter) {
     value = s.toCharArray();
@@ -163,7 +162,7 @@ public class ChunkResolver {
     StringBuilder miniChunkBuilder = new StringBuilder();
     StringBuilder tokenBuilder = new StringBuilder();
     while (nextPos < length) {
-      isAfterWhitespace = prevChar == ' ' && !isFilterWhitespace(prevChar);
+      boolean isAfterWhitespace = prevChar == ' ' && !isFilterWhitespace(prevChar);
       char c = value[nextPos++];
       if (inQuote) {
         if (c == quoteChar && prevChar != '\\') {
@@ -186,7 +185,7 @@ public class ChunkResolver {
       } else if (isTokenSplitter(c)) {
         String resolvedToken = resolveToken(tokenBuilder.toString());
         if (StringUtils.isNotEmpty(resolvedToken)) {
-          miniChunkBuilder.append(resolveToken(tokenBuilder.toString()));
+          miniChunkBuilder.append(resolvedToken);
         }
         tokenBuilder = new StringBuilder();
         if (isMiniChunkSplitter(c)) {


### PR DESCRIPTION
Since `resolvedToken` is just saved, don't call `resolveToken()` again. This code smell is just a result of wrapping that line with `StringUtils.isNotEmpty()` and forgetting to substitute the variable.