### PR TITLE
[Eager Execution] Support legacy dictionary creation

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -60,9 +60,8 @@ public class JinjavaConfig {
   private final InterpreterFactory interpreterFactory;
   private TokenScannerSymbols tokenScannerSymbols;
   private final ELResolver elResolver;
-  private final boolean iterateOverMapKeys;
   private final ExecutionMode executionMode;
-  private final boolean legacyFunctionality;
+  private final LegacyOverrides legacyOverrides;
 
   public static Builder newBuilder() {
     return new Builder();
@@ -113,9 +112,8 @@ public class JinjavaConfig {
     interpreterFactory = builder.interpreterFactory;
     tokenScannerSymbols = builder.tokenScannerSymbols;
     elResolver = builder.elResolver;
-    iterateOverMapKeys = builder.iterateOverMapKeys;
     executionMode = builder.executionMode;
-    legacyFunctionality = builder.legacyFunctionality;
+    legacyOverrides = builder.legacyOverrides;
   }
 
   public Charset getCharset() {
@@ -206,16 +204,20 @@ public class JinjavaConfig {
     return elResolver;
   }
 
+  /**
+   * @deprecated  Replaced by {@link LegacyOverrides#isIterateOverMapKeys()}
+   */
+  @Deprecated
   public boolean isIterateOverMapKeys() {
-    return iterateOverMapKeys;
+    return legacyOverrides.isIterateOverMapKeys();
   }
 
   public ExecutionMode getExecutionMode() {
     return executionMode;
   }
 
-  public boolean isLegacyFunctionality() {
-    return legacyFunctionality;
+  public LegacyOverrides getLegacyOverrides() {
+    return legacyOverrides;
   }
 
   public static class Builder {
@@ -241,11 +243,10 @@ public class JinjavaConfig {
     private InterpreterFactory interpreterFactory = new JinjavaInterpreterFactory();
     private TokenScannerSymbols tokenScannerSymbols = new DefaultTokenScannerSymbols();
     private ELResolver elResolver = JinjavaInterpreterResolver.DEFAULT_RESOLVER_READ_ONLY;
-    private boolean iterateOverMapKeys;
     private int maxListSize = Integer.MAX_VALUE;
     private int maxMapSize = Integer.MAX_VALUE;
     private ExecutionMode executionMode = DefaultExecutionMode.instance();
-    private boolean legacyFunctionality = true;
+    private LegacyOverrides legacyOverrides = LegacyOverrides.NONE;
 
     private Builder() {}
 
@@ -364,9 +365,17 @@ public class JinjavaConfig {
       return this;
     }
 
+    /**
+     * @deprecated  Replaced by {@link LegacyOverrides.Builder#withIterateOverMapKeys(boolean)} ()}
+     */
+    @Deprecated
     public Builder withIterateOverMapKeys(boolean iterateOverMapKeys) {
-      this.iterateOverMapKeys = iterateOverMapKeys;
-      return this;
+      return withLegacyOverrides(
+        LegacyOverrides
+          .Builder.from(legacyOverrides)
+          .withIterateOverMapKeys(iterateOverMapKeys)
+          .build()
+      );
     }
 
     public Builder withExecutionMode(ExecutionMode executionMode) {
@@ -374,8 +383,8 @@ public class JinjavaConfig {
       return this;
     }
 
-    public Builder withLegacyFunctionality(boolean legacyFunctionality) {
-      this.legacyFunctionality = legacyFunctionality;
+    public Builder withLegacyOverrides(LegacyOverrides legacyOverrides) {
+      this.legacyOverrides = legacyOverrides;
       return this;
     }
 

--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -62,6 +62,7 @@ public class JinjavaConfig {
   private final ELResolver elResolver;
   private final boolean iterateOverMapKeys;
   private final ExecutionMode executionMode;
+  private final boolean legacyFunctionality;
 
   public static Builder newBuilder() {
     return new Builder();
@@ -114,6 +115,7 @@ public class JinjavaConfig {
     elResolver = builder.elResolver;
     iterateOverMapKeys = builder.iterateOverMapKeys;
     executionMode = builder.executionMode;
+    legacyFunctionality = builder.legacyFunctionality;
   }
 
   public Charset getCharset() {
@@ -212,6 +214,10 @@ public class JinjavaConfig {
     return executionMode;
   }
 
+  public boolean isLegacyFunctionality() {
+    return legacyFunctionality;
+  }
+
   public static class Builder {
     private Charset charset = StandardCharsets.UTF_8;
     private Locale locale = Locale.ENGLISH;
@@ -239,6 +245,7 @@ public class JinjavaConfig {
     private int maxListSize = Integer.MAX_VALUE;
     private int maxMapSize = Integer.MAX_VALUE;
     private ExecutionMode executionMode = DefaultExecutionMode.instance();
+    private boolean legacyFunctionality = true;
 
     private Builder() {}
 
@@ -364,6 +371,11 @@ public class JinjavaConfig {
 
     public Builder withExecutionMode(ExecutionMode executionMode) {
       this.executionMode = executionMode;
+      return this;
+    }
+
+    public Builder withLegacyFunctionality(boolean legacyFunctionality) {
+      this.legacyFunctionality = legacyFunctionality;
       return this;
     }
 

--- a/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
+++ b/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
@@ -1,0 +1,55 @@
+package com.hubspot.jinjava;
+
+/**
+ * This class allows Jinjava to be configured to override legacy behaviour.
+ * LegacyOverrides.NONE signifies that none of the legacy functionality will be overridden.
+ */
+public class LegacyOverrides {
+  public static final LegacyOverrides NONE = new LegacyOverrides.Builder().build();
+  private final boolean evaluateMapKeys;
+  private final boolean iterateOverMapKeys;
+
+  private LegacyOverrides(Builder builder) {
+    evaluateMapKeys = builder.evaluateMapKeys;
+    iterateOverMapKeys = builder.iterateOverMapKeys;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public boolean isEvaluateMapKeys() {
+    return evaluateMapKeys;
+  }
+
+  public boolean isIterateOverMapKeys() {
+    return iterateOverMapKeys;
+  }
+
+  public static class Builder {
+    private boolean evaluateMapKeys = false;
+    private boolean iterateOverMapKeys = false;
+
+    private Builder() {}
+
+    public LegacyOverrides build() {
+      return new LegacyOverrides(this);
+    }
+
+    public static Builder from(LegacyOverrides legacyOverrides) {
+      return new Builder()
+        .withEvaluateMapKeys(legacyOverrides.evaluateMapKeys)
+        .withIterateOverMapKeys(legacyOverrides.iterateOverMapKeys);
+    }
+
+    public Builder withEvaluateMapKeys(boolean evaluateMapKeys) {
+      this.evaluateMapKeys = evaluateMapKeys;
+      return this;
+    }
+
+    public Builder withIterateOverMapKeys(boolean iterateOverMapKeys) {
+      this.iterateOverMapKeys = iterateOverMapKeys;
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
@@ -24,25 +24,34 @@ public class AstDict extends AstLiteral {
   public Object eval(Bindings bindings, ELContext context) {
     Map<String, Object> resolved = new LinkedHashMap<>();
 
+    JinjavaInterpreter interpreter = (JinjavaInterpreter) context
+      .getELResolver()
+      .getValue(context, null, ExtendedParser.INTERPRETER);
+
     for (Map.Entry<AstNode, AstNode> entry : dict.entrySet()) {
       String key;
+      AstNode entryKey = entry.getKey();
 
-      if (entry.getKey() instanceof AstString) {
-        key = Objects.toString(entry.getKey().eval(bindings, context));
-      } else if (entry.getKey() instanceof AstIdentifier) {
-        key = ((AstIdentifier) entry.getKey()).getName();
+      if (entryKey instanceof AstString) {
+        key = Objects.toString(entryKey.eval(bindings, context));
+      } else if (entryKey instanceof AstIdentifier) {
+        if (interpreter.getConfig().getLegacyOverrides().isEvaluateMapKeys()) {
+          Object result = entryKey.eval(bindings, context);
+          key =
+            result == null
+              ? ((AstIdentifier) entryKey).getName() // this is for compatibility with the previous behavior
+              : result.toString();
+        } else {
+          key = ((AstIdentifier) entryKey).getName();
+        }
       } else {
         throw new TemplateStateException(
-          "Dict key must be a string or identifier, was: " + entry.getKey()
+          "Dict key must be a string or identifier, was: " + entryKey
         );
       }
 
       resolved.put(key, entry.getValue().eval(bindings, context));
     }
-
-    JinjavaInterpreter interpreter = (JinjavaInterpreter) context
-      .getELResolver()
-      .getValue(context, null, ExtendedParser.INTERPRETER);
 
     return new SizeLimitingPyMap(resolved, interpreter.getConfig().getMaxMapSize());
   }

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -183,7 +183,18 @@ public class ChunkResolver {
         tokenBuilder.append(prevChar);
         continue;
       } else if (isTokenSplitter(c)) {
-        String resolvedToken = resolveToken(tokenBuilder.toString());
+        String resolvedToken;
+        if (
+          c == ':' &&
+          chunkLevelMarker != null &&
+          '{' == chunkLevelMarker &&
+          interpreter.getConfig().isLegacyFunctionality()
+        ) {
+          resolvedToken =
+            '\'' + WhitespaceUtils.unquoteAndUnescape(tokenBuilder.toString()) + '\'';
+        } else {
+          resolvedToken = resolveToken(tokenBuilder.toString());
+        }
         if (StringUtils.isNotEmpty(resolvedToken)) {
           miniChunkBuilder.append(resolvedToken);
         }

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -188,7 +188,7 @@ public class ChunkResolver {
           c == ':' &&
           chunkLevelMarker != null &&
           '{' == chunkLevelMarker &&
-          interpreter.getConfig().isLegacyFunctionality()
+          !interpreter.getConfig().getLegacyOverrides().isEvaluateMapKeys()
         ) {
           resolvedToken =
             '\'' + WhitespaceUtils.unquoteAndUnescape(tokenBuilder.toString()) + '\'';

--- a/src/main/java/com/hubspot/jinjava/util/ObjectIterator.java
+++ b/src/main/java/com/hubspot/jinjava/util/ObjectIterator.java
@@ -45,7 +45,11 @@ public final class ObjectIterator {
     if (obj instanceof Map) {
       boolean iterateOverMapKeys =
         JinjavaInterpreter.getCurrent() != null &&
-        JinjavaInterpreter.getCurrent().getConfig().isIterateOverMapKeys();
+        JinjavaInterpreter
+          .getCurrent()
+          .getConfig()
+          .getLegacyOverrides()
+          .isIterateOverMapKeys();
       Collection<Object> clt = iterateOverMapKeys
         ? ((Map<Object, Object>) obj).keySet()
         : ((Map<Object, Object>) obj).values();

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
@@ -272,7 +272,7 @@ public class PyMapTest extends BaseJinjavaTest {
   }
 
   @Test
-  public void itSetsKeysWithVariableName() {
+  public void itDoesntSetKeysWithVariableNameByDefault() {
     assertThat(
         jinjava.render(
           "{% set keyName = \"key1\" %}" +
@@ -282,6 +282,10 @@ public class PyMapTest extends BaseJinjavaTest {
         )
       )
       .isEqualTo("value1");
+  }
+
+  @Test
+  public void itSetsKeysWithVariableName() {
     jinjava =
       new Jinjava(
         JinjavaConfig
@@ -328,7 +332,30 @@ public class PyMapTest extends BaseJinjavaTest {
   }
 
   @Test
+  public void itDoesntUpdateKeysWithVariableNameByDefault() {
+    assertThat(
+        jinjava.render(
+          "{% set test = {\"key1\": \"value1\"} %}" +
+          "{% set keyName = \"key1\" %}" +
+          "{% do test.update({keyName: \"value2\"}) %}" +
+          "{{ test['key1'] }}",
+          Collections.emptyMap()
+        )
+      )
+      .isEqualTo("value1");
+  }
+
+  @Test
   public void itUpdatesKeysWithVariableName() {
+    jinjava =
+      new Jinjava(
+        JinjavaConfig
+          .newBuilder()
+          .withLegacyOverrides(
+            LegacyOverrides.newBuilder().withEvaluateMapKeys(true).build()
+          )
+          .build()
+      );
     assertThat(
         jinjava.render(
           "{% set test = {\"key1\": \"value1\"} %}" +


### PR DESCRIPTION
Since Jinjava doesn't support variables names in dictionaries, we shouldn't support it in Eager Execution.

At the same time, it doesn't seem entirely right to make changes to this repo which aims to mirror Jinja that make it more different from Jinja without providing an alternative.

@boulter I have this idea to use a new config parameter `legacyFunctionality` to control whether Jinjava uses its legacy functionality or if it uses breaking functionality that closer mirrors Jinja functionality. This config would allow https://github.com/HubSpot/jinjava/pull/403 to be used if that flag is set to false. HubSpot would be using `legacyFunctionality=true`, but others may care more about having functionality that's like Jinja than supporting legacy functionality. There are other places where we've been unable to make changes to Jinjava as they would break existing templates, but a flag like this would give us freedom to fix such issues.