### PR TITLE
[Eager Execution] Treat non-standard number representations as strings

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
@@ -28,7 +28,10 @@ public class PyishSerializer extends JsonSerializer<Object> {
     }
     try {
       Double.parseDouble(string);
-      if (string.length() > 1 && string.charAt(0) == '0' && string.indexOf('.') != 1) {
+      if (
+        string.length() > 1 &&
+        ((string.charAt(0) == '0' && string.indexOf('.') != 1) || string.charAt(0) == '+')
+      ) {
         jsonGenerator.writeString(string);
       } else {
         jsonGenerator.writeNumber(string);

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
@@ -8,6 +8,9 @@ import java.util.Objects;
 
 public class PyishSerializer extends JsonSerializer<Object> {
   public static final PyishSerializer INSTANCE = new PyishSerializer();
+  // Excludes things like "-0", "+5", "02"
+  private static final String STRICT_NUMBER_REGEX =
+    "^0|((-?[1-9][0-9]*)(\\.[0-9]+)?)|(-?0(\\.[0-9]+))$";
 
   private PyishSerializer() {}
 
@@ -28,13 +31,10 @@ public class PyishSerializer extends JsonSerializer<Object> {
     }
     try {
       Double.parseDouble(string);
-      if (
-        string.length() > 1 &&
-        ((string.charAt(0) == '0' && string.indexOf('.') != 1) || string.charAt(0) == '+')
-      ) {
-        jsonGenerator.writeString(string);
-      } else {
+      if (string.matches(STRICT_NUMBER_REGEX)) {
         jsonGenerator.writeNumber(string);
+      } else {
+        jsonGenerator.writeString(string);
       }
     } catch (NumberFormatException e) {
       if ("true".equalsIgnoreCase(string) || "false".equalsIgnoreCase(string)) {

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -125,7 +125,7 @@ public class ChunkResolver {
   /**
    * Chunkify and resolve variables and expressions within the string.
    * Rather than concatenating the chunks, they are split by mini-chunks,
-   * with the comma splitter ommitted from the list of results.
+   * with the comma splitter omitted from the list of results.
    * Therefore an expression of "1, 1 + 1, 1 + range(deferred)" becomes a List of ["1", "2", "1 + range(deferred)"].
    *
    * @return List of the expression chunk which is split into mini-chunks.
@@ -330,6 +330,10 @@ public class ChunkResolver {
         } else {
           resolvedChunk =
             interpreter.getContext().getPyishObjectMapper().getAsPyishString(val);
+        }
+        if (val instanceof Number && chunk.trim().charAt(0) == '+') {
+          // Resolving a phone number without dashes strips the leading plus sign
+          resolvedChunk = '+' + resolvedChunk;
         }
       }
     } catch (TemplateSyntaxException ignored) {} catch (Exception e) {

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -331,10 +331,6 @@ public class ChunkResolver {
           resolvedChunk =
             interpreter.getContext().getPyishObjectMapper().getAsPyishString(val);
         }
-        if (val instanceof Number && chunk.trim().charAt(0) == '+') {
-          // Resolving a phone number without dashes strips the leading plus sign
-          resolvedChunk = '+' + resolvedChunk;
-        }
       }
     } catch (TemplateSyntaxException ignored) {} catch (Exception e) {
       deferredWords.addAll(findDeferredWords(chunk));

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -460,6 +460,22 @@ public class ChunkResolverTest {
     }
   }
 
+  @Test
+  public void itKeepsPlusSignPrefix() {
+    context.put("foo", "+12223334444");
+    ChunkResolver chunkResolver = makeChunkResolver("foo");
+    assertThat(WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunks()))
+      .isEqualTo("+12223334444");
+  }
+
+  @Test
+  public void itHandlesPhoneNumbers() {
+    context.put("foo", "+1(123)456-7890");
+    ChunkResolver chunkResolver = makeChunkResolver("foo");
+    assertThat(WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunks()))
+      .isEqualTo("+1(123)456-7890");
+  }
+
   public static void voidFunction(int nothing) {}
 
   public static boolean isNull(Object foo, Object bar) {

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -476,6 +476,14 @@ public class ChunkResolverTest {
       .isEqualTo("+1(123)456-7890");
   }
 
+  @Test
+  public void itHandlesNegativeZero() {
+    context.put("foo", "-0");
+    ChunkResolver chunkResolver = makeChunkResolver("foo");
+    assertThat(WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunks()))
+      .isEqualTo("-0");
+  }
+
   public static void voidFunction(int nothing) {}
 
   public static boolean isNull(Object foo, Object bar) {


### PR DESCRIPTION
A phone number such as `+12223334444` would resolve as `12223334444` before this PR. This happened because when we converted that into a pyish object, we didn't surround it with quotes because it was interpretable as a double.

This PR makes it so that we write it a plus sign-prefixed string is written as a string, rather than a number. This means it is surrounded with quotes.