### PR TITLE
[Eager Execution] PyishSerializable should extend PyWrapper

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
@@ -1,6 +1,8 @@
 package com.hubspot.jinjava.objects.serialization;
 
-public interface PyishSerializable {
+import com.hubspot.jinjava.objects.PyWrapper;
+
+public interface PyishSerializable extends PyWrapper {
   /**
    * Allows for a class to specify a custom string representation in Jinjava.
    * By default, this will refer to the <code>toString()</code> method,


### PR DESCRIPTION
Something that is a PyishSerializable should also have the safe effects applied to it as something that is a PyWrapper.
PyishSerializable should be a sub-type of PyWrapper so there is consistency with object wrapping.