### PR TITLE
[Eager Execution] Allow PyishSerializable to represent maps, lists

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -32,7 +32,6 @@ import com.hubspot.jinjava.lib.fn.MacroFunction;
 import com.hubspot.jinjava.lib.tag.Tag;
 import com.hubspot.jinjava.lib.tag.TagLibrary;
 import com.hubspot.jinjava.lib.tag.eager.EagerToken;
-import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.util.DeferredValueUtils;
 import com.hubspot.jinjava.util.ScopeMap;
@@ -90,7 +89,6 @@ public class Context extends ScopeMap<String, Object> {
   private final FilterLibrary filterLibrary;
   private final FunctionLibrary functionLibrary;
   private final TagLibrary tagLibrary;
-  private final PyishObjectMapper pyishObjectMapper;
 
   private ExpressionStrategy expressionStrategy = new DefaultExpressionStrategy();
 
@@ -195,8 +193,6 @@ public class Context extends ScopeMap<String, Object> {
     this.tagLibrary = new TagLibrary(parent == null, disabled.get(Library.TAG));
     this.functionLibrary =
       new FunctionLibrary(parent == null, disabled.get(Library.FUNCTION));
-    this.pyishObjectMapper =
-      new PyishObjectMapper(parent != null ? parent.pyishObjectMapper : null);
     if (parent != null) {
       this.expressionStrategy = parent.expressionStrategy;
       this.partialMacroEvaluation = parent.partialMacroEvaluation;
@@ -525,14 +521,6 @@ public class Context extends ScopeMap<String, Object> {
 
   public void registerTag(Tag t) {
     tagLibrary.addTag(t);
-  }
-
-  public void registerNonPyishClasses(Class<?>... classes) {
-    pyishObjectMapper.registerNonPyishClasses(classes);
-  }
-
-  public PyishObjectMapper getPyishObjectMapper() {
-    return pyishObjectMapper;
   }
 
   public ExpressionStrategy getExpressionStrategy() {

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -31,6 +31,7 @@ import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import com.hubspot.jinjava.interpret.errorcategory.BasicTemplateErrorCategory;
+import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.random.ConstantZeroRandomNumberGenerator;
 import com.hubspot.jinjava.random.DeferredRandomNumberGenerator;
 import com.hubspot.jinjava.tree.Node;
@@ -479,7 +480,7 @@ public class JinjavaInterpreter {
 
   public String getAsString(Object object) {
     if (config.isUsePyishObjectMapper()) {
-      return context.getPyishObjectMapper().getAsUnquotedPyishString(object);
+      return PyishObjectMapper.getAsUnquotedPyishString(object);
     }
     return Objects.toString(object, "");
   }

--- a/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
@@ -65,14 +65,13 @@ public class EagerMacroFunction extends AbstractCallableMethod {
 
   public String getStartTag(JinjavaInterpreter interpreter) {
     StringJoiner argJoiner = new StringJoiner(", ");
-    PyishObjectMapper pyishObjectMapper = interpreter.getContext().getPyishObjectMapper();
     for (String arg : macroFunction.getArguments()) {
       if (macroFunction.getDefaults().get(arg) != null) {
         argJoiner.add(
           String.format(
             "%s=%s",
             arg,
-            pyishObjectMapper.getAsPyishString(macroFunction.getDefaults().get(arg))
+            PyishObjectMapper.getAsPyishString(macroFunction.getDefaults().get(arg))
           )
         );
         continue;
@@ -117,10 +116,7 @@ public class EagerMacroFunction extends AbstractCallableMethod {
           EagerTagDecorator.buildSetTagForDeferredInChildContext(
             ImmutableMap.of(
               Context.IMPORT_RESOURCE_PATH_KEY,
-              interpreter
-                .getContext()
-                .getPyishObjectMapper()
-                .getAsPyishString(importFile.get())
+              PyishObjectMapper.getAsPyishString(importFile.get())
             ),
             interpreter,
             false
@@ -134,10 +130,7 @@ public class EagerMacroFunction extends AbstractCallableMethod {
           EagerTagDecorator.buildSetTagForDeferredInChildContext(
             ImmutableMap.of(
               Context.IMPORT_RESOURCE_PATH_KEY,
-              interpreter
-                .getContext()
-                .getPyishObjectMapper()
-                .getAsPyishString(currentImportResource)
+              PyishObjectMapper.getAsPyishString(currentImportResource)
             ),
             interpreter,
             false
@@ -172,10 +165,7 @@ public class EagerMacroFunction extends AbstractCallableMethod {
       prefix =
         EagerTagDecorator.buildDoUpdateTag(
           importAlias,
-          interpreter
-            .getContext()
-            .getPyishObjectMapper()
-            .getAsPyishString(deferredAliasMap),
+          PyishObjectMapper.getAsPyishString(deferredAliasMap),
           interpreter
         );
     } else if (aliasMap instanceof Map) {
@@ -185,10 +175,7 @@ public class EagerMacroFunction extends AbstractCallableMethod {
         EagerTagDecorator.buildSetTagForDeferredInChildContext(
           ImmutableMap.of(
             importAlias,
-            interpreter
-              .getContext()
-              .getPyishObjectMapper()
-              .getAsPyishString(deferredAliasMap)
+            PyishObjectMapper.getAsPyishString(deferredAliasMap)
           ),
           interpreter,
           false

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -118,7 +118,6 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
         .getContext()
         .put(currentImportAlias, DeferredValue.instance(currentAliasMap));
     }
-    PyishObjectMapper pyishObjectMapper = interpreter.getContext().getPyishObjectMapper();
     for (Map.Entry<String, Object> entry : (
       (Map<String, Object>) (
         (DeferredValue) interpreter.getContext().get(currentImportAlias)
@@ -131,7 +130,7 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
           String.format(
             "'%s': %s",
             entry.getKey(),
-            pyishObjectMapper.getAsPyishString(entry.getValue())
+            PyishObjectMapper.getAsPyishString(entry.getValue())
           )
         );
       }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -159,7 +159,6 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
   ) {
     StringBuilder result = new StringBuilder();
     Map<String, Integer> initiallyResolvedHashes = new HashMap<>();
-    PyishObjectMapper pyishObjectMapper = interpreter.getContext().getPyishObjectMapper();
     interpreter
       .getContext()
       .entrySet()
@@ -195,12 +194,12 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
           Entry::getKey,
           e -> {
             if (e.getValue() instanceof DeferredValue) {
-              return pyishObjectMapper.getAsPyishString(
+              return PyishObjectMapper.getAsPyishString(
                 ((DeferredValue) e.getValue()).getOriginalValue()
               );
             }
             if (takeNewValue) {
-              return pyishObjectMapper.getAsPyishString(e.getValue());
+              return PyishObjectMapper.getAsPyishString(e.getValue());
             }
 
             // Previous value could not be mapped to a string
@@ -304,7 +303,6 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
       return ""; // This will be handled outside of the deferred execution mode.
     }
     Map<String, String> deferredMap = new HashMap<>();
-    PyishObjectMapper pyishObjectMapper = interpreter.getContext().getPyishObjectMapper();
     deferredWords
       .stream()
       .map(w -> w.split("\\.", 2)[0]) // get base prop
@@ -317,7 +315,7 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
         w -> {
           deferredMap.put(
             w,
-            pyishObjectMapper.getAsPyishString(interpreter.getContext().get(w))
+            PyishObjectMapper.getAsPyishString(interpreter.getContext().get(w))
           );
         }
       );

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishBeanSerializerModifier.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishBeanSerializerModifier.java
@@ -4,14 +4,11 @@ import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
-import java.util.Set;
 
 public class PyishBeanSerializerModifier extends BeanSerializerModifier {
-  private final Set<Class<?>> nonPyishClasses;
+  public static final PyishBeanSerializerModifier INSTANCE = new PyishBeanSerializerModifier();
 
-  public PyishBeanSerializerModifier(Set<Class<?>> nonPyishClasses) {
-    this.nonPyishClasses = nonPyishClasses;
-  }
+  private PyishBeanSerializerModifier() {}
 
   @Override
   public JsonSerializer<?> modifySerializer(
@@ -21,9 +18,6 @@ public class PyishBeanSerializerModifier extends BeanSerializerModifier {
   ) {
     try {
       if (
-        nonPyishClasses
-          .stream()
-          .anyMatch(clazz -> (clazz.isAssignableFrom(beanDesc.getBeanClass()))) ||
         beanDesc.getBeanClass().getMethod("toString").getDeclaringClass() == Object.class
       ) {
         // Use the PyishSerializer if it extends the PyishSerializable class.

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -1,12 +1,21 @@
 package com.hubspot.jinjava.objects.serialization;
 
-import static com.hubspot.jinjava.objects.serialization.PyishSerializable.PYISH_OBJECT_WRITER;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.hubspot.jinjava.util.WhitespaceUtils;
 import java.util.Objects;
 
 public class PyishObjectMapper {
+  private static final ObjectWriter PYISH_OBJECT_WRITER = new ObjectMapper()
+    .registerModule(
+      new SimpleModule()
+        .setSerializerModifier(PyishBeanSerializerModifier.INSTANCE)
+        .addSerializer(PyishSerializable.class, PyishSerializer.INSTANCE)
+    )
+    .writer(PyishPrettyPrinter.INSTANCE)
+    .with(PyishCharacterEscapes.INSTANCE);
 
   public static String getAsUnquotedPyishString(Object val) {
     if (val != null) {

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -69,7 +69,8 @@ public class PyishObjectMapper {
       new ObjectMapper()
         .registerModule(
           new SimpleModule()
-          .setSerializerModifier(new PyishBeanSerializerModifier(nonPyishClasses))
+            .setSerializerModifier(new PyishBeanSerializerModifier(nonPyishClasses))
+            .addSerializer(PyishSerializable.class, PyishSerializer.INSTANCE)
         )
         .writer(PyishPrettyPrinter.INSTANCE);
   }

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -1,60 +1,23 @@
 package com.hubspot.jinjava.objects.serialization;
 
+import static com.hubspot.jinjava.objects.serialization.PyishSerializable.PYISH_OBJECT_WRITER;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.hubspot.jinjava.util.WhitespaceUtils;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 public class PyishObjectMapper {
-  private final PyishObjectMapper parent;
-  private Set<Class<?>> nonPyishClasses;
-  private ObjectWriter objectWriter;
 
-  public PyishObjectMapper() {
-    this(null);
-  }
-
-  public PyishObjectMapper(PyishObjectMapper parent) {
-    this.parent = parent;
-    if (parent == null) {
-      this.nonPyishClasses = new HashSet<>();
-      registerDefaults();
-    }
-  }
-
-  private void registerDefaults() {
-    registerNonPyishClasses(Map.class);
-  }
-
-  /**
-   * Reigisters classes that are serialized to a string using jackson's default
-   * json serialization rather than calling toString on the object.
-   * @param classes Classes that don't have a pythonic <code>toString()</code> implementation
-   */
-  public void registerNonPyishClasses(Class<?>... classes) {
-    if (parent != null) {
-      throw new UnsupportedOperationException();
-    }
-    nonPyishClasses.addAll(Arrays.asList(classes));
-    updateObjectWriter();
-  }
-
-  public String getAsUnquotedPyishString(Object val) {
+  public static String getAsUnquotedPyishString(Object val) {
     if (val != null) {
       return WhitespaceUtils.unquoteAndUnescape(getAsPyishString(val));
     }
     return "";
   }
 
-  public String getAsPyishString(Object val) {
+  public static String getAsPyishString(Object val) {
     try {
-      return getObjectWriter()
+      return PYISH_OBJECT_WRITER
         .writeValueAsString(val)
         .replace("'", "\\'")
         // Replace double-quotes with single quote as they are preferred in Jinja
@@ -62,23 +25,5 @@ public class PyishObjectMapper {
     } catch (JsonProcessingException e) {
       return Objects.toString(val, "");
     }
-  }
-
-  private void updateObjectWriter() {
-    objectWriter =
-      new ObjectMapper()
-        .registerModule(
-          new SimpleModule()
-            .setSerializerModifier(new PyishBeanSerializerModifier(nonPyishClasses))
-            .addSerializer(PyishSerializable.class, PyishSerializer.INSTANCE)
-        )
-        .writer(PyishPrettyPrinter.INSTANCE);
-  }
-
-  private ObjectWriter getObjectWriter() {
-    if (parent != null) {
-      return parent.getObjectWriter();
-    }
-    return objectWriter;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
@@ -1,8 +1,20 @@
 package com.hubspot.jinjava.objects.serialization;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.hubspot.jinjava.objects.PyWrapper;
+import java.util.Objects;
 
 public interface PyishSerializable extends PyWrapper {
+  ObjectWriter PYISH_OBJECT_WRITER = new ObjectMapper()
+    .registerModule(
+      new SimpleModule()
+        .setSerializerModifier(PyishBeanSerializerModifier.INSTANCE)
+        .addSerializer(PyishSerializable.class, PyishSerializer.INSTANCE)
+    )
+    .writer(PyishPrettyPrinter.INSTANCE);
   /**
    * Allows for a class to specify a custom string representation in Jinjava.
    * By default, this will refer to the <code>toString()</code> method,
@@ -12,6 +24,20 @@ public interface PyishSerializable extends PyWrapper {
    * @return A pythonic/json string representation of the object
    */
   default String toPyishString() {
-    return '"' + toString() + '"';
+    return '"' + writeValueAsString(this) + '"';
+  }
+
+  /**
+   * Utility method to assist implementations of PyishSerializable in
+   * overriding <code>toPyishString()</code>.
+   * @param value Value to write to a string
+   * @return Pyish string value in JSON format
+   */
+  static String writeValueAsString(Object value) {
+    try {
+      return PYISH_OBJECT_WRITER.writeValueAsString(value);
+    } catch (JsonProcessingException e) {
+      return Objects.toString(value);
+    }
   }
 }

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
@@ -8,6 +8,7 @@ public interface PyishSerializable extends PyWrapper {
    * By default, this will refer to the <code>toString()</code> method,
    * but this method can be overriden to provide a representation separate from the
    * normal <code>toString()</code> result.
+   * This should use double quotes to wrap json keys/values.
    * @return A pythonic/json string representation of the object
    */
   default String toPyishString() {

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
@@ -11,6 +11,6 @@ public interface PyishSerializable extends PyWrapper {
    * @return A pythonic/json string representation of the object
    */
   default String toPyishString() {
-    return toString();
+    return '"' + toString() + '"';
   }
 }

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
@@ -22,22 +22,22 @@ public class PyishSerializer extends JsonSerializer<Object> {
     jsonGenerator.setCharacterEscapes(PyishCharacterEscapes.INSTANCE);
     String string;
     if (object instanceof PyishSerializable) {
-      string = ((PyishSerializable) object).toPyishString();
+      jsonGenerator.writeRaw(((PyishSerializable) object).toPyishString());
     } else {
       string = Objects.toString(object, "");
-    }
-    try {
-      Double.parseDouble(string);
-      if (string.length() > 1 && string.charAt(0) == '0' && string.indexOf('.') != 1) {
-        jsonGenerator.writeString(string);
-      } else {
-        jsonGenerator.writeNumber(string);
-      }
-    } catch (NumberFormatException e) {
-      if ("true".equalsIgnoreCase(string) || "false".equalsIgnoreCase(string)) {
-        jsonGenerator.writeBoolean(Boolean.parseBoolean(string));
-      } else {
-        jsonGenerator.writeString(string);
+      try {
+        Double.parseDouble(string);
+        if (string.length() > 1 && string.charAt(0) == '0' && string.indexOf('.') != 1) {
+          jsonGenerator.writeString(string);
+        } else {
+          jsonGenerator.writeNumber(string);
+        }
+      } catch (NumberFormatException e) {
+        if ("true".equalsIgnoreCase(string) || "false".equalsIgnoreCase(string)) {
+          jsonGenerator.writeBoolean(Boolean.parseBoolean(string));
+        } else {
+          jsonGenerator.writeString(string);
+        }
       }
     }
   }

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -6,6 +6,7 @@ import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.interpret.UnknownTokenException;
+import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.objects.serialization.PyishSerializable;
 import com.hubspot.jinjava.tree.parse.Token;
 import java.util.ArrayList;
@@ -288,8 +289,7 @@ public class ChunkResolver {
         if (val == null || !isResolvableObject(val)) {
           resolvedToken = token;
         } else {
-          resolvedToken =
-            interpreter.getContext().getPyishObjectMapper().getAsPyishString(val);
+          resolvedToken = PyishObjectMapper.getAsPyishString(val);
         }
       }
     } catch (DeferredValueException e) {
@@ -328,8 +328,7 @@ public class ChunkResolver {
         } else if (JINJAVA_NULL.equals(nullDefault) && !isResolvableObject(val)) {
           resolvedChunk = chunk;
         } else {
-          resolvedChunk =
-            interpreter.getContext().getPyishObjectMapper().getAsPyishString(val);
+          resolvedChunk = PyishObjectMapper.getAsPyishString(val);
         }
       }
     } catch (TemplateSyntaxException ignored) {} catch (Exception e) {

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -14,6 +14,7 @@ import com.hubspot.jinjava.lib.fn.ELFunctionDefinition;
 import com.hubspot.jinjava.objects.collections.PyMap;
 import com.hubspot.jinjava.objects.date.PyishDate;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
+import com.hubspot.jinjava.objects.serialization.PyishSerializable;
 import com.hubspot.jinjava.tree.parse.DefaultTokenScannerSymbols;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
@@ -458,6 +459,26 @@ public class ChunkResolverTest {
     } finally {
       JinjavaInterpreter.popCurrent();
     }
+  }
+
+  @Test
+  public void itHandlesPyishSerializable() {
+    context.put(
+      "foo",
+      new PyishSerializable() {
+
+        @Override
+        public String toPyishString() {
+          return "[\"yes\"]";
+        }
+      }
+    );
+    assertThat(
+        interpreter.render(
+          String.format("{{ %s[0] }}", makeChunkResolver("foo").resolveChunks())
+        )
+      )
+      .isEqualTo("yes");
   }
 
   public static void voidFunction(int nothing) {}

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -463,19 +463,10 @@ public class ChunkResolverTest {
 
   @Test
   public void itHandlesPyishSerializable() {
-    context.put(
-      "foo",
-      new PyishSerializable() {
-
-        @Override
-        public String toPyishString() {
-          return "[\"yes\"]";
-        }
-      }
-    );
+    context.put("foo", new SomethingPyish("yes"));
     assertThat(
         interpreter.render(
-          String.format("{{ %s[0] }}", makeChunkResolver("foo").resolveChunks())
+          String.format("{{ %s.name }}", makeChunkResolver("foo").resolveChunks())
         )
       )
       .isEqualTo("yes");
@@ -496,6 +487,18 @@ public class ChunkResolverTest {
 
     String bar() {
       return bar;
+    }
+  }
+
+  public class SomethingPyish implements PyishSerializable {
+    private String name;
+
+    public SomethingPyish(String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return name;
     }
   }
 }


### PR DESCRIPTION
Rework `PyishSerializable` to allow for string representations of maps and lists that can be deserialized into a map or list. This requires writing the result of `toPyishString()` to json raw, rather than as a string so that it's not wrapped in an extra set of quotes.