### PR TITLE
Revert "[Eager Execution] Don't remove the import resource path from the context in EagerImportTag"

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -181,6 +181,7 @@ public class ImportTag implements Tag {
         interpreter.getContext().addGlobalMacro(macro);
       }
       childBindings.remove(Context.GLOBAL_MACROS_SCOPE_KEY);
+      childBindings.remove(Context.IMPORT_RESOURCE_PATH_KEY);
       childBindings
         .keySet()
         .forEach(key -> interpreter.getContext().put(key, DeferredValue.instance()));
@@ -194,6 +195,7 @@ public class ImportTag implements Tag {
         childBindings.put(macroEntry.getKey(), macro);
       }
       childBindings.remove(Context.GLOBAL_MACROS_SCOPE_KEY);
+      childBindings.remove(Context.IMPORT_RESOURCE_PATH_KEY);
       interpreter.getContext().put(contextVar, DeferredValue.instance(childBindings));
     }
   }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
@@ -7,14 +7,12 @@ import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaHasCodeBody;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
 import com.hubspot.jinjava.tree.TagNode;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -90,14 +88,13 @@ public class MacroTag implements Tag {
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     String name;
     String args;
-    final String parentName;
+    String parentName = "";
     Matcher childMatcher = CHILD_MACRO_PATTERN.matcher(tagNode.getHelpers());
     if (childMatcher.find()) {
       parentName = childMatcher.group(1);
       name = childMatcher.group(2);
       args = Strings.nullToEmpty(childMatcher.group(3));
     } else {
-      parentName = "";
       Matcher matcher = MACRO_PATTERN.matcher(tagNode.getHelpers());
       if (!matcher.find()) {
         throw new TemplateSyntaxException(
@@ -120,55 +117,16 @@ public class MacroTag implements Tag {
       args,
       argNamesWithDefaults
     );
-    MacroFunction macro;
-    String contextImportResourcePath = (String) interpreter
-      .getContext()
-      .get(Context.IMPORT_RESOURCE_PATH_KEY, "");
-    String stackImportResourcePath = interpreter
-      .getContext()
-      .getCurrentPathStack()
-      .peek()
-      .orElse("");
-    try {
-      if (!contextImportResourcePath.equals(stackImportResourcePath)) {
-        interpreter.enterScope();
-        interpreter
-          .getContext()
-          .put(Context.IMPORT_RESOURCE_PATH_KEY, contextImportResourcePath);
-      }
-      if (StringUtils.isNotEmpty(parentName)) {
-        interpreter.enterScope();
-        Object parentAliasMap = interpreter
-          .getContext()
-          .get(parentName, Collections.emptyMap());
-        if (parentAliasMap instanceof DeferredValue) {
-          parentAliasMap = ((DeferredValue) parentAliasMap).getOriginalValue();
-        }
-        String parentImportResourcePath = (String) (
-          (Map<String, Object>) parentAliasMap
-        ).get(Context.IMPORT_RESOURCE_PATH_KEY);
-        interpreter
-          .getContext()
-          .put(Context.IMPORT_RESOURCE_PATH_KEY, parentImportResourcePath);
-      }
-      macro =
-        new MacroFunction(
-          tagNode.getChildren(),
-          name,
-          argNamesWithDefaults,
-          false,
-          interpreter.getContext(),
-          interpreter.getLineNumber(),
-          interpreter.getPosition()
-        );
-    } finally {
-      if (
-        StringUtils.isNotEmpty(parentName) ||
-        !contextImportResourcePath.equals(stackImportResourcePath)
-      ) {
-        interpreter.leaveScope();
-      }
-    }
+
+    MacroFunction macro = new MacroFunction(
+      tagNode.getChildren(),
+      name,
+      argNamesWithDefaults,
+      false,
+      interpreter.getContext(),
+      interpreter.getLineNumber(),
+      interpreter.getPosition()
+    );
     macro.setDeferred(deferred);
 
     if (StringUtils.isNotEmpty(parentName)) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -137,11 +137,7 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
       }
     }
     if (keyValueJoiner.length() > 0) {
-      return buildDoUpdateTag(
-        currentImportAlias,
-        "{" + keyValueJoiner.toString() + "}",
-        interpreter
-      );
+      return buildDoUpdateTag(currentImportAlias, keyValueJoiner.toString(), interpreter);
     }
     return "";
   }
@@ -242,6 +238,7 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
         parent.getContext().addGlobalMacro(macro);
       }
       childBindings.remove(Context.GLOBAL_MACROS_SCOPE_KEY);
+      childBindings.remove(Context.IMPORT_RESOURCE_PATH_KEY);
       childBindings.remove(Context.IMPORT_RESOURCE_ALIAS_KEY);
       parent.getContext().putAll(childBindings);
     } else {
@@ -274,6 +271,7 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
         .forEach(childBindings::remove);
       // Remove meta keys
       childBindings.remove(Context.GLOBAL_MACROS_SCOPE_KEY);
+      childBindings.remove(Context.IMPORT_RESOURCE_PATH_KEY);
       childBindings.remove(Context.IMPORT_RESOURCE_ALIAS_KEY);
       mapForCurrentContextAlias.putAll(childBindings);
     }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTag.java
@@ -132,6 +132,6 @@ public class EagerSetTag extends EagerStateChangingTag<SetTag> {
     StringJoiner updateString = new StringJoiner(",");
     // Update the alias map to the value of the set variable.
     varList.forEach(var -> updateString.add(String.format("'%s': %s", var, var)));
-    return "{" + updateString.toString() + "}";
+    return updateString.toString();
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -403,7 +403,7 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
     return new LengthLimitingStringJoiner(interpreter.getConfig().getMaxOutputSize(), " ")
       .add(interpreter.getConfig().getTokenScannerSymbols().getExpressionStartWithTag())
       .add(DoTag.TAG_NAME)
-      .add(String.format("%s.update(%s)", currentImportAlias, updateString))
+      .add(String.format("%s.update({%s})", currentImportAlias, updateString))
       .add(interpreter.getConfig().getTokenScannerSymbols().getExpressionEndWithTag())
       .toString();
   }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/IncludeTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/IncludeTagTest.java
@@ -102,6 +102,19 @@ public class IncludeTagTest extends BaseInterpretingTest {
   }
 
   @Test
+  public void itIncludesFileWithInternalMacroCall() throws IOException {
+    RenderResult result = jinjava.renderForResult(
+      Resources.toString(
+        Resources.getResource("tags/macrotag/include-two-macros.jinja"),
+        StandardCharsets.UTF_8
+      ),
+      new HashMap<>()
+    );
+
+    assertThat(result.getErrors()).isEmpty();
+  }
+
+  @Test
   public void itIncludesFileViaRelativePath() throws IOException {
     jinjava = new Jinjava();
     jinjava.setResourceLocator(

--- a/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
@@ -11,6 +11,7 @@ import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.TagNode;

--- a/src/test/resources/eager/handles-deferred-import-vars.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-import-vars.expected.jinja
@@ -7,6 +7,6 @@ bar: {{ bar }}
 ---{% set myname = deferred + 7 %}
 {% set bar = myname + 19 %}{% set simple = {} %}{% do simple.update({'bar': bar}) %}
 Hello {{ myname }}
-{% do simple.update({'import_resource_path': 'macro-and-set.jinja'}) %}
-simple.foo: {% do simple.update({'import_resource_path': 'macro-and-set.jinja'}) %}{% macro simple.foo() %}Hello {{ myname }}{% endmacro %}{{ simple.foo() }}
+
+simple.foo: {% macro simple.foo() %}Hello {{ myname }}{% endmacro %}{{ simple.foo() }}
 simple.bar: {{ simple.bar }}

--- a/src/test/resources/eager/puts-deferred-fromed-macro-in-output.expected.jinja
+++ b/src/test/resources/eager/puts-deferred-fromed-macro-in-output.expected.jinja
@@ -1,2 +1,2 @@
 {% set myname = deferred + 3 %}
-{% set import_resource_path = 'simple-with-call.jinja' %}{% macro getPath() %}Hello {{ myname }}{% endmacro %}{% set import_resource_path = '' %}{% print getPath() %}
+{% macro getPath() %}Hello {{ myname }}{% endmacro %}{% print getPath() %}

--- a/src/test/resources/eager/puts-deferred-imported-macro-in-output.expected.jinja
+++ b/src/test/resources/eager/puts-deferred-imported-macro-in-output.expected.jinja
@@ -1,2 +1,2 @@
 {% set myname = deferred + 3 %}
-{% set simple = {'import_resource_path': 'simple-with-call.jinja'} %}{% macro simple.getPath() %}Hello {{ myname }}{% endmacro %}{% print simple.getPath() %}
+{% macro simple.getPath() %}Hello {{ myname }}{% endmacro %}{% print simple.getPath() %}

--- a/src/test/resources/tags/eager/importtag/import-macro.jinja
+++ b/src/test/resources/tags/eager/importtag/import-macro.jinja
@@ -1,4 +1,0 @@
-{% macro print_path_macro(var) %}
-{{ var|print_path }}
-{{ var }}
-{% endmacro %}

--- a/src/test/resources/tags/macrotag/include-two-macros.jinja
+++ b/src/test/resources/tags/macrotag/include-two-macros.jinja
@@ -1,0 +1,3 @@
+{% from "tags/macrotag/two-macros.jinja" import macro2 %}
+
+{{ macro2() }}

--- a/src/test/resources/tags/macrotag/two-macros.jinja
+++ b/src/test/resources/tags/macrotag/two-macros.jinja
@@ -1,0 +1,9 @@
+{% macro macro1(options={}) %}
+  <!-- code here, renders HTML ->
+{% endmacro %}
+
+{% macro macro2(options={}) %}
+  <!-- some code, mainly formats passed options -->
+
+  {% call macro1() %}{% endcall %}
+{% endmacro %}


### PR DESCRIPTION
Reverts HubSpot/jinjava#604

I added the test case that works before this commit.