### PR TITLE
[Eager Execution] Handle whitespace between a dot operation

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -163,7 +163,7 @@ public class ChunkResolver {
     StringBuilder miniChunkBuilder = new StringBuilder();
     StringBuilder tokenBuilder = new StringBuilder();
     while (nextPos < length) {
-      boolean isAfterWhitespace = prevChar == ' ' && !isFilterWhitespace(prevChar);
+      boolean isAfterWhitespace = prevChar == ' ' && !isOpWhitespace(prevChar);
       char c = value[nextPos++];
       if (inQuote) {
         if (c == quoteChar && prevChar != '\\') {
@@ -240,18 +240,22 @@ public class ChunkResolver {
     );
   }
 
-  private boolean isFilterWhitespace(char c) {
-    // If a pipe character is surrounded by whitespace on either side,
+  private boolean isOpWhitespace(char c) {
+    // If a pipe or full stop character is surrounded by whitespace on either side,
     // we don't want to split those tokens
     boolean isFilterWhitespace = false;
     if (c == ' ') {
       int prevPos = nextPos - 2;
       if (nextPos < length) {
-        isFilterWhitespace = value[nextPos] == ' ' || value[nextPos] == '|';
+        isFilterWhitespace =
+          value[nextPos] == ' ' || value[nextPos] == '|' || value[nextPos] == '.';
       }
       if (prevPos >= 0) {
         isFilterWhitespace =
-          isFilterWhitespace || value[prevPos] == ' ' || value[prevPos] == '|';
+          isFilterWhitespace ||
+          value[prevPos] == ' ' ||
+          value[prevPos] == '|' ||
+          value[prevPos] == '.';
       }
     }
     return isFilterWhitespace;

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -432,12 +432,21 @@ public class ChunkResolverTest {
   @Test
   public void itHandlesUnconventionalSpacing() {
     ChunkResolver chunkResolver = makeChunkResolver(
-      "(  range (0 , 3 ) [1] + deferred) ~ 'YES'| lower"
+      "(  range (0 , 3 ) [ 1] + deferred) ~ 'YES'| lower"
     );
     String result = WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunks());
     assertThat(result).isEqualTo("( 1 + deferred) ~ 'yes'");
     context.put("deferred", 2);
     assertThat(interpreter.resolveELExpression(result, 0)).isEqualTo("3yes");
+  }
+
+  @Test
+  public void itHandlesDotSpacing() {
+    context.put("bar", "fake");
+    context.put("foo", ImmutableMap.of("bar", "foobar"));
+    ChunkResolver chunkResolver = makeChunkResolver("foo . bar");
+    String result = WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunks());
+    assertThat(result).isEqualTo("foobar");
   }
 
   @Test


### PR DESCRIPTION
Follows up on https://github.com/HubSpot/jinjava/pull/606
I didn't handle the case where there could be whitespace between a dot operation like: `{{ foo . bar }}`, which is equivalent to `{{ foo.bar }}`. 
I had already handled this case with a pipe (`|`) character, so we can treat the full stop (`.`) character similarly.