### PR TITLE
Output pyish versions of objects using legacy override flag

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -51,7 +51,6 @@ public class JinjavaConfig {
   private final Map<Context.Library, Set<String>> disabled;
   private final boolean failOnUnknownTokens;
   private final boolean nestedInterpretationEnabled;
-  private final boolean usePyishObjectMapper;
   private final RandomNumberGeneratorStrategy randomNumberGenerator;
   private final boolean validationMode;
   private final long maxStringLength;
@@ -103,7 +102,6 @@ public class JinjavaConfig {
     failOnUnknownTokens = builder.failOnUnknownTokens;
     maxOutputSize = builder.maxOutputSize;
     nestedInterpretationEnabled = builder.nestedInterpretationEnabled;
-    usePyishObjectMapper = builder.usePyishObjectMapper;
     randomNumberGenerator = builder.randomNumberGeneratorStrategy;
     validationMode = builder.validationMode;
     maxStringLength = builder.maxStringLength;
@@ -176,10 +174,6 @@ public class JinjavaConfig {
     return nestedInterpretationEnabled;
   }
 
-  public boolean isUsePyishObjectMapper() {
-    return usePyishObjectMapper;
-  }
-
   public boolean isValidationMode() {
     return validationMode;
   }
@@ -235,7 +229,6 @@ public class JinjavaConfig {
     private int maxMacroRecursionDepth;
     private boolean failOnUnknownTokens;
     private boolean nestedInterpretationEnabled = true;
-    private boolean usePyishObjectMapper = false;
     private RandomNumberGeneratorStrategy randomNumberGeneratorStrategy =
       RandomNumberGeneratorStrategy.THREAD_LOCAL;
     private boolean validationMode = false;
@@ -330,11 +323,6 @@ public class JinjavaConfig {
       return this;
     }
 
-    public Builder withUsePyishObjectMapper(boolean usePyishObjectMapper) {
-      this.usePyishObjectMapper = usePyishObjectMapper;
-      return this;
-    }
-
     public Builder withValidationMode(boolean validationMode) {
       this.validationMode = validationMode;
       return this;
@@ -366,7 +354,7 @@ public class JinjavaConfig {
     }
 
     /**
-     * @deprecated  Replaced by {@link LegacyOverrides.Builder#withIterateOverMapKeys(boolean)} ()}
+     * @deprecated  Replaced by {@link LegacyOverrides.Builder#withIterateOverMapKeys(boolean)}}
      */
     @Deprecated
     public Builder withIterateOverMapKeys(boolean iterateOverMapKeys) {

--- a/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
+++ b/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
@@ -8,10 +8,12 @@ public class LegacyOverrides {
   public static final LegacyOverrides NONE = new LegacyOverrides.Builder().build();
   private final boolean evaluateMapKeys;
   private final boolean iterateOverMapKeys;
+  private final boolean usePyishObjectMapper;
 
   private LegacyOverrides(Builder builder) {
     evaluateMapKeys = builder.evaluateMapKeys;
     iterateOverMapKeys = builder.iterateOverMapKeys;
+    usePyishObjectMapper = builder.usePyishObjectMapper;
   }
 
   public static Builder newBuilder() {
@@ -26,9 +28,14 @@ public class LegacyOverrides {
     return iterateOverMapKeys;
   }
 
+  public boolean isUsePyishObjectMapper() {
+    return usePyishObjectMapper;
+  }
+
   public static class Builder {
     private boolean evaluateMapKeys = false;
     private boolean iterateOverMapKeys = false;
+    private boolean usePyishObjectMapper = false;
 
     private Builder() {}
 
@@ -39,7 +46,8 @@ public class LegacyOverrides {
     public static Builder from(LegacyOverrides legacyOverrides) {
       return new Builder()
         .withEvaluateMapKeys(legacyOverrides.evaluateMapKeys)
-        .withIterateOverMapKeys(legacyOverrides.iterateOverMapKeys);
+        .withIterateOverMapKeys(legacyOverrides.iterateOverMapKeys)
+        .withUsePyishObjectMapper(legacyOverrides.usePyishObjectMapper);
     }
 
     public Builder withEvaluateMapKeys(boolean evaluateMapKeys) {
@@ -49,6 +57,11 @@ public class LegacyOverrides {
 
     public Builder withIterateOverMapKeys(boolean iterateOverMapKeys) {
       this.iterateOverMapKeys = iterateOverMapKeys;
+      return this;
+    }
+
+    public Builder withUsePyishObjectMapper(boolean usePyishObjectMapper) {
+      this.usePyishObjectMapper = usePyishObjectMapper;
       return this;
     }
   }

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -479,7 +479,7 @@ public class JinjavaInterpreter {
   }
 
   public String getAsString(Object object) {
-    if (config.isUsePyishObjectMapper()) {
+    if (config.getLegacyOverrides().isUsePyishObjectMapper()) {
       return PyishObjectMapper.getAsUnquotedPyishString(object);
     }
     return Objects.toString(object, "");

--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -11,7 +11,6 @@ import com.hubspot.jinjava.tree.output.RenderedOutputNode;
 import com.hubspot.jinjava.tree.parse.ExpressionToken;
 import com.hubspot.jinjava.util.ChunkResolver;
 import com.hubspot.jinjava.util.Logging;
-import com.hubspot.jinjava.util.WhitespaceUtils;
 import org.apache.commons.lang3.StringUtils;
 
 public class EagerExpressionStrategy implements ExpressionStrategy {
@@ -48,11 +47,12 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
         : ""
     );
     if (chunkResolver.getDeferredWords().isEmpty()) {
-      String fullyResolved = chunkResolver.resolveChunk(
-        resolvedExpression.getResult(),
-        ""
+      String result = interpreter.getAsString(
+        interpreter.resolveELExpression(
+          resolvedExpression.getResult(),
+          interpreter.getLineNumber()
+        )
       );
-      String result = WhitespaceUtils.unquoteAndUnescape(fullyResolved);
       if (
         !StringUtils.equals(result, master.getImage()) &&
         (

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
@@ -6,7 +6,6 @@ import com.hubspot.jinjava.lib.tag.PrintTag;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.ChunkResolver;
 import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
-import com.hubspot.jinjava.util.WhitespaceUtils;
 import org.apache.commons.lang3.StringUtils;
 
 public class EagerPrintTag extends EagerStateChangingTag<PrintTag> {
@@ -72,17 +71,16 @@ public class EagerPrintTag extends EagerStateChangingTag<PrintTag> {
         : ""
     );
     if (chunkResolver.getDeferredWords().isEmpty()) {
+      String result = interpreter.getAsString(
+        interpreter.resolveELExpression(
+          resolvedExpression.getResult(),
+          interpreter.getLineNumber()
+        )
+      );
       // Possible macro/set tag in front of this one.
       return (
         prefixToPreserveState.toString() +
-        (
-          includeExpressionResult
-            ? wrapInRawIfNeeded(
-              WhitespaceUtils.unquote(resolvedExpression.getResult()),
-              interpreter
-            )
-            : ""
-        )
+        (includeExpressionResult ? wrapInRawIfNeeded(result, interpreter) : "")
       );
     }
     prefixToPreserveState.append(

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
@@ -71,16 +71,22 @@ public class EagerPrintTag extends EagerStateChangingTag<PrintTag> {
         : ""
     );
     if (chunkResolver.getDeferredWords().isEmpty()) {
-      String result = interpreter.getAsString(
-        interpreter.resolveELExpression(
-          resolvedExpression.getResult(),
-          interpreter.getLineNumber()
-        )
-      );
       // Possible macro/set tag in front of this one.
       return (
         prefixToPreserveState.toString() +
-        (includeExpressionResult ? wrapInRawIfNeeded(result, interpreter) : "")
+        (
+          includeExpressionResult
+            ? wrapInRawIfNeeded(
+              interpreter.getAsString(
+                interpreter.resolveELExpression(
+                  resolvedExpression.getResult(),
+                  interpreter.getLineNumber()
+                )
+              ),
+              interpreter
+            )
+            : ""
+        )
       );
     }
     prefixToPreserveState.append(

--- a/src/test/java/com/hubspot/jinjava/BaseJinjavaTest.java
+++ b/src/test/java/com/hubspot/jinjava/BaseJinjavaTest.java
@@ -8,6 +8,13 @@ public abstract class BaseJinjavaTest {
   @Before
   public void baseSetup() {
     jinjava =
-      new Jinjava(JinjavaConfig.newBuilder().withUsePyishObjectMapper(true).build());
+      new Jinjava(
+        JinjavaConfig
+          .newBuilder()
+          .withLegacyOverrides(
+            LegacyOverrides.newBuilder().withUsePyishObjectMapper(true).build()
+          )
+          .build()
+      );
   }
 }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -67,7 +67,9 @@ public class EagerTest {
       .withRandomNumberGeneratorStrategy(RandomNumberGeneratorStrategy.DEFERRED)
       .withExecutionMode(EagerExecutionMode.instance())
       .withNestedInterpretationEnabled(true)
-      .withUsePyishObjectMapper(true)
+      .withLegacyOverrides(
+        LegacyOverrides.newBuilder().withUsePyishObjectMapper(true).build()
+      )
       .withMaxMacroRecursionDepth(5)
       .withEnableRecursiveMacroCalls(true)
       .build();
@@ -712,7 +714,9 @@ public class EagerTest {
       .withRandomNumberGeneratorStrategy(RandomNumberGeneratorStrategy.DEFERRED)
       .withExecutionMode(EagerExecutionMode.instance())
       .withNestedInterpretationEnabled(false)
-      .withUsePyishObjectMapper(true)
+      .withLegacyOverrides(
+        LegacyOverrides.newBuilder().withUsePyishObjectMapper(true).build()
+      )
       .build();
     JinjavaInterpreter parentInterpreter = new JinjavaInterpreter(
       jinjava,

--- a/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.lib.expression;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.LegacyOverrides;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.mode.EagerExecutionMode;
@@ -44,7 +45,9 @@ public class EagerExpressionStrategyTest extends ExpressionNodeTest {
         JinjavaConfig
           .newBuilder()
           .withNestedInterpretationEnabled(false)
-          .withUsePyishObjectMapper(true)
+          .withLegacyOverrides(
+            LegacyOverrides.newBuilder().withUsePyishObjectMapper(true).build()
+          )
           .withExecutionMode(EagerExecutionMode.instance())
           .build()
       );

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerDoTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerDoTagTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hubspot.jinjava.ExpectedNodeInterpreter;
 import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.LegacyOverrides;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
@@ -29,7 +30,9 @@ public class EagerDoTagTest extends DoTagTest {
           .newBuilder()
           .withMaxOutputSize(MAX_OUTPUT_SIZE)
           .withExecutionMode(EagerExecutionMode.instance())
-          .withUsePyishObjectMapper(true)
+          .withLegacyOverrides(
+            LegacyOverrides.newBuilder().withUsePyishObjectMapper(true).build()
+          )
           .build()
       );
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerDoTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerDoTagTest.java
@@ -29,6 +29,7 @@ public class EagerDoTagTest extends DoTagTest {
           .newBuilder()
           .withMaxOutputSize(MAX_OUTPUT_SIZE)
           .withExecutionMode(EagerExecutionMode.instance())
+          .withUsePyishObjectMapper(true)
           .build()
       );
 
@@ -63,15 +64,5 @@ public class EagerDoTagTest extends DoTagTest {
     assertThat(interpreter.getErrors()).hasSize(1);
     assertThat(interpreter.getErrors().get(0).getReason())
       .isEqualTo(ErrorReason.OUTPUT_TOO_BIG);
-  }
-
-  /** This is broken in normal Jinjava as <code>hey</code> does not get output in quotes.
-   * It works in Eager Jinjava as <code>hey</code> is quoted properly.
-   */
-  @Test
-  @Override
-  public void itResolvesExpressions() {
-    String template = "{% set output = [] %}{% do output.append('hey') %}{{ output }}";
-    assertThat(interpreter.render(template)).isEqualTo("['hey']");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.io.Resources;
 import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.LegacyOverrides;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -39,7 +40,9 @@ public class EagerImportTagTest extends ImportTagTest {
         JinjavaConfig
           .newBuilder()
           .withExecutionMode(EagerExecutionMode.instance())
-          .withUsePyishObjectMapper(true)
+          .withLegacyOverrides(
+            LegacyOverrides.newBuilder().withUsePyishObjectMapper(true).build()
+          )
           .build()
       );
     Tag tag = EagerTagFactory

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -39,6 +39,7 @@ public class EagerImportTagTest extends ImportTagTest {
         JinjavaConfig
           .newBuilder()
           .withExecutionMode(EagerExecutionMode.instance())
+          .withUsePyishObjectMapper(true)
           .build()
       );
     Tag tag = EagerTagFactory

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -288,7 +288,7 @@ public class ChunkResolverTest {
     // don't prematurely resolve date because of datetime functions.
     assertThat(WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunks()))
       .isEqualTo("date");
-    assertThat(WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunk("date", "")))
+    assertThat(WhitespaceUtils.unquoteAndUnescape(interpreter.resolveString("date", -1)))
       .isEqualTo(date.toString());
   }
 


### PR DESCRIPTION
This is mainly a PR for eager execution, but it also refactors the `usePyishObjectMapper` flag.
Only output the pyish version of an object to the rendered output if `usePyishObjectMapper` is true. Previously, in eager execution, whenever something like `{{ foo }}` was rendered, it would output the pyish version. If it were a map, it would look like:
```
{'a': some a', 'b': 'some b'}
```
But with default jinjava and the default value for this flag, it would output like:
```
{a=some a, b=some b}
```
This PR makes eager execution output respect that flag the same way that default jinjava execution does. `usePyishObjectMapper` is also refactored to be in the **LegacyOverrides** builder because it is a legacy functionality override.