### PR TITLE
Trim before checking if expression is quoted

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/WhitespaceUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/WhitespaceUtils.java
@@ -62,6 +62,9 @@ public final class WhitespaceUtils {
       return false;
     }
     char[] charArray = s.trim().toCharArray();
+    if (charArray.length == 1) {
+      return false;
+    }
     char quoteChar = 0;
     for (char c : QUOTE_CHARS) {
       if (charArray[0] == c) {
@@ -79,12 +82,12 @@ public final class WhitespaceUtils {
       }
       if (prevChar == '\\') {
         // Double escapes cancel out.
-        prevChar = 1;
+        prevChar = 0;
       } else {
         prevChar = charArray[i];
       }
     }
-    return prevChar != '\\' && prevChar != 0;
+    return prevChar != '\\';
   }
 
   public static String unquote(String s) {

--- a/src/main/java/com/hubspot/jinjava/util/WhitespaceUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/WhitespaceUtils.java
@@ -79,12 +79,12 @@ public final class WhitespaceUtils {
       }
       if (prevChar == '\\') {
         // Double escapes cancel out.
-        prevChar = 0;
+        prevChar = 1;
       } else {
         prevChar = charArray[i];
       }
     }
-    return prevChar != '\\';
+    return prevChar != '\\' && prevChar != 0;
   }
 
   public static String unquote(String s) {

--- a/src/main/java/com/hubspot/jinjava/util/WhitespaceUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/WhitespaceUtils.java
@@ -61,7 +61,7 @@ public final class WhitespaceUtils {
     if (Strings.isNullOrEmpty(s)) {
       return false;
     }
-    char[] charArray = s.toCharArray();
+    char[] charArray = s.trim().toCharArray();
     char quoteChar = 0;
     for (char c : QUOTE_CHARS) {
       if (charArray[0] == c) {

--- a/src/test/java/com/hubspot/jinjava/util/WhitespaceUtilsTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/WhitespaceUtilsTest.java
@@ -56,4 +56,10 @@ public class WhitespaceUtilsTest {
     assertThat(isExpressionQuoted("'foo' ")).isTrue();
     assertThat(isExpressionQuoted(" 'foo' ")).isTrue();
   }
+
+  @Test
+  public void itDoesntCountSingleQuoteChar() {
+    assertThat(isExpressionQuoted("'")).isFalse();
+    assertThat(isExpressionQuoted("\" ")).isFalse();
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/util/WhitespaceUtilsTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/WhitespaceUtilsTest.java
@@ -49,4 +49,11 @@ public class WhitespaceUtilsTest {
     assertThat(isExpressionQuoted("\"foo 'and' bar\"")).isTrue();
     assertThat(isExpressionQuoted("\"foo 'and' bar'")).isFalse();
   }
+
+  @Test
+  public void itKnowsUntrimmedExpressionIsQuoted() {
+    assertThat(isExpressionQuoted(" 'foo'")).isTrue();
+    assertThat(isExpressionQuoted("'foo' ")).isTrue();
+    assertThat(isExpressionQuoted(" 'foo' ")).isTrue();
+  }
 }


### PR DESCRIPTION
Modifies the `WhitespaceUtils.isExpressionQuoted()` method to trim the input beforehand so that ` "foo"` returns `true`. Also, properly return `false` when the trimmed input is a single character because that can't possibly be quoted.