### PR TITLE
[Eager Execution] Stricter number-writing logic

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
@@ -8,9 +8,6 @@ import java.util.Objects;
 
 public class PyishSerializer extends JsonSerializer<Object> {
   public static final PyishSerializer INSTANCE = new PyishSerializer();
-  // Excludes things like "-0", "+5", "02"
-  private static final String STRICT_NUMBER_REGEX =
-    "^0|((-?[1-9][0-9]*)(\\.[0-9]+)?)|(-?0(\\.[0-9]+))$";
 
   private PyishSerializer() {}
 
@@ -29,8 +26,11 @@ public class PyishSerializer extends JsonSerializer<Object> {
     } else {
       string = Objects.toString(object, "");
       try {
-        Double.parseDouble(string);
-        if (string.matches(STRICT_NUMBER_REGEX)) {
+        double number = Double.parseDouble(string);
+        if (
+          string.equals(String.valueOf(number)) ||
+          string.equals(String.valueOf((long) number))
+        ) {
           jsonGenerator.writeNumber(string);
         } else {
           jsonGenerator.writeString(string);

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -399,12 +399,21 @@ public class ChunkResolverTest {
   }
 
   @Test
-  public void itPreservesLengthyDoubles() {
+  public void itPreservesLengthyDoubleStrings() {
     // does not convert to scientific notation
     context.put("small", "0.0000000001");
     ChunkResolver chunkResolver = makeChunkResolver("small");
     assertThat(WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunks()))
       .isEqualTo("0.0000000001");
+  }
+
+  @Test
+  public void itConvertsDoubles() {
+    // does convert to scientific notation
+    context.put("small", 0.0000000001);
+    ChunkResolver chunkResolver = makeChunkResolver("small");
+    assertThat(WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunks()))
+      .isEqualTo("1.0E-10");
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -399,6 +399,15 @@ public class ChunkResolverTest {
   }
 
   @Test
+  public void itPreservesLengthyDoubles() {
+    // does not convert to scientific notation
+    context.put("small", "0.0000000001");
+    ChunkResolver chunkResolver = makeChunkResolver("small");
+    assertThat(WhitespaceUtils.unquoteAndUnescape(chunkResolver.resolveChunks()))
+      .isEqualTo("0.0000000001");
+  }
+
+  @Test
   public void itDoesntQuoteFloats() {
     ChunkResolver chunkResolver = makeChunkResolver("0.4 + 0.1");
     assertThat(chunkResolver.resolveChunks()).isEqualTo("0.5");


### PR DESCRIPTION
Only write a value as a number if when converted to a number and then back to a string, it maintains the same value. The general theme of the diffs that popped up because of the logic here is that if there are multiple ways to represent the same value, then there will be a discrepancy if we try to write it as a number. So for these string values that cause a discrepancy, just write them as a string. We can check by converting back to a string and seeing if there is any change.