### PR TITLE
Fix tuple parsing bug

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -283,13 +283,20 @@ public class ExtendedParser extends Parser {
         break;
       case LPAREN:
         int i = 0;
-        Symbol s;
-        do {
-          s = lookahead(i++).getSymbol();
-          if (s == Symbol.COMMA) {
-            return new AstTuple(params());
+        Symbol s = lookahead(i++).getSymbol();
+        int depth = 0;
+        while (s != Symbol.EOF && (depth > 0 || s != Symbol.RPAREN)) {
+          if (s == LPAREN || s == LBRACK) {
+            depth++;
+          } else if (depth > 0 && (s == RPAREN || s == RBRACK)) {
+            depth--;
+          } else if (depth == 0) {
+            if (s == Symbol.COMMA) {
+              return new AstTuple(params());
+            }
           }
-        } while (s != Symbol.RPAREN && s != Symbol.EOF);
+          s = lookahead(i++).getSymbol();
+        }
 
         consumeToken();
         v = expr(true);

--- a/src/test/java/com/hubspot/jinjava/el/ext/ExtendedParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/ExtendedParserTest.java
@@ -113,8 +113,8 @@ public class ExtendedParserTest {
   }
 
   @Test
-  public void itParsesTupleCommasAsTuple() {
-    AstNode astNode = buildExpressionNodes("#{(range(0,1),2)}");
+  public void itChecksForTupleUntilFinalParentheses() {
+    AstNode astNode = buildExpressionNodes("#{((0),2)}");
     assertThat(astNode).isInstanceOf(AstTuple.class);
   }
 

--- a/src/test/java/com/hubspot/jinjava/el/ext/ExtendedParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/ExtendedParserTest.java
@@ -7,6 +7,7 @@ import de.odysseus.el.tree.impl.Builder;
 import de.odysseus.el.tree.impl.ast.AstBinary;
 import de.odysseus.el.tree.impl.ast.AstIdentifier;
 import de.odysseus.el.tree.impl.ast.AstMethod;
+import de.odysseus.el.tree.impl.ast.AstNested;
 import de.odysseus.el.tree.impl.ast.AstNode;
 import de.odysseus.el.tree.impl.ast.AstParameters;
 import de.odysseus.el.tree.impl.ast.AstString;
@@ -103,6 +104,18 @@ public class ExtendedParserTest {
 
     assertForExpression(left, "a", "b", "exptest:equalto");
     assertForExpression(right, "c", "d", "exptest:equalto");
+  }
+
+  @Test
+  public void itParsesNestedCommasNotAsTuple() {
+    AstNode astNode = buildExpressionNodes("#{(range(0,range(0,2)[1]))}");
+    assertThat(astNode).isInstanceOf(AstNested.class);
+  }
+
+  @Test
+  public void itParsesTupleCommasAsTuple() {
+    AstNode astNode = buildExpressionNodes("#{(range(0,1),2)}");
+    assertThat(astNode).isInstanceOf(AstTuple.class);
   }
 
   private void assertForExpression(


### PR DESCRIPTION
In Jinjava, we parse something surrounded with parentheses either as an `AstTuple` or an `AstNested`. When there is a single element inside the parentheses, we'll parse it as `AstNested`, otherwise it will become an `AstTuple`.

This check was done by seeing if there are any commas before the first `)`. However, this is inadequate for two reasons:
1. We can have an expression like: `#{(range(0,1))}`. Clearly this shouldn't be parsed as a tuple, but this bug caused it to be.
2. We can have an expression like: `#{((1),2)}`. Clearly this should be parsed as a tuple, but the bug causes it to be parsed as an `AstNested`

The fix here simply maintains a counter of depth into parentheses or brackets, and only checks for the existence of a comma symbol when at 0 depth. We don't need to worry about matching `(` to `)` and `[` to `]` here because if they are mismatched, the correct parsing exception will get thrown down the line anyway.