### PR TITLE
[Eager Execution] Split on double pipe in chunk resolver as it means "or"

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -235,6 +235,9 @@ public class ChunkResolver {
   }
 
   private boolean isTokenSplitter(char c) {
+    if (c == '|' && prevChar == '|') { // or operator
+      return true;
+    }
     return (
       !Character.isLetterOrDigit(c) && c != '_' && c != '.' && c != '|' && c != ' '
     );

--- a/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ChunkResolverTest.java
@@ -523,6 +523,16 @@ public class ChunkResolverTest {
       .isEqualTo("yes");
   }
 
+  @Test
+  public void itHandlesOrOperator() {
+    assertThat(
+        WhitespaceUtils.unquoteAndUnescape(
+          makeChunkResolver("false == true || (true) ? 'yes' : 'no'").resolveChunks()
+        )
+      )
+      .isEqualTo("yes");
+  }
+
   public static void voidFunction(int nothing) {}
 
   public static boolean isNull(Object foo, Object bar) {


### PR DESCRIPTION
There's a bug currently in the chunk resolver where an expression like the one in the test:
```
{{ false == true || (true) ? 'yes' : 'no' }}
```
Results in `no` because the `||` isn't split on and it ends up having these tokens: `false`, `true || (true)`, which continues on to become `false == true ? 'yes' : 'no'`.
It should have these tokens: `false`, `true`, `(true)` so that the order of operations is correct.
