### PR TITLE
[Eager Execution] Track null values as completed in EvalResultHolders

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBinary.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBinary.java
@@ -8,6 +8,7 @@ import javax.el.ELContext;
 
 public class EagerAstBinary extends AstBinary implements EvalResultHolder {
   protected Object evalResult;
+  protected boolean hasEvalResult;
   protected final EvalResultHolder left;
   protected final EvalResultHolder right;
   protected final Operator operator;
@@ -35,6 +36,7 @@ public class EagerAstBinary extends AstBinary implements EvalResultHolder {
   public Object eval(Bindings bindings, ELContext context) {
     try {
       evalResult = super.eval(bindings, context);
+      hasEvalResult = true;
       return evalResult;
     } catch (DeferredParsingException e) {
       String sb =
@@ -52,11 +54,12 @@ public class EagerAstBinary extends AstBinary implements EvalResultHolder {
   public Object getAndClearEvalResult() {
     Object temp = evalResult;
     evalResult = null;
+    hasEvalResult = false;
     return temp;
   }
 
   @Override
   public boolean hasEvalResult() {
-    return evalResult != null;
+    return hasEvalResult;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBracket.java
@@ -9,6 +9,7 @@ import javax.el.ELContext;
 
 public class EagerAstBracket extends AstBracket implements EvalResultHolder {
   protected Object evalResult;
+  protected boolean hasEvalResult;
 
   public EagerAstBracket(
     AstNode base,
@@ -30,6 +31,7 @@ public class EagerAstBracket extends AstBracket implements EvalResultHolder {
   public Object eval(Bindings bindings, ELContext context) {
     try {
       evalResult = super.eval(bindings, context);
+      hasEvalResult = true;
       return evalResult;
     } catch (DeferredParsingException e) {
       StringBuilder sb = new StringBuilder();
@@ -64,12 +66,13 @@ public class EagerAstBracket extends AstBracket implements EvalResultHolder {
   public Object getAndClearEvalResult() {
     Object temp = evalResult;
     evalResult = null;
+    hasEvalResult = false;
     return temp;
   }
 
   @Override
   public boolean hasEvalResult() {
-    return evalResult != null;
+    return hasEvalResult;
   }
 
   public AstNode getPrefix() {

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoice.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoice.java
@@ -9,6 +9,7 @@ import javax.el.ELException;
 
 public class EagerAstChoice extends AstChoice implements EvalResultHolder {
   protected Object evalResult;
+  protected boolean hasEvalResult;
   protected final EvalResultHolder question;
   protected final EvalResultHolder yes;
   protected final EvalResultHolder no;
@@ -36,6 +37,7 @@ public class EagerAstChoice extends AstChoice implements EvalResultHolder {
   public Object eval(Bindings bindings, ELContext context) throws ELException {
     try {
       evalResult = super.eval(bindings, context);
+      hasEvalResult = true;
       return evalResult;
     } catch (DeferredParsingException e) {
       if (question.getAndClearEvalResult() != null) {
@@ -60,11 +62,12 @@ public class EagerAstChoice extends AstChoice implements EvalResultHolder {
   public Object getAndClearEvalResult() {
     Object temp = evalResult;
     evalResult = null;
+    hasEvalResult = false;
     return temp;
   }
 
   @Override
   public boolean hasEvalResult() {
-    return evalResult != null;
+    return hasEvalResult;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDict.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDict.java
@@ -11,7 +11,8 @@ import java.util.StringJoiner;
 import javax.el.ELContext;
 
 public class EagerAstDict extends AstDict implements EvalResultHolder {
-  private Object evalResult;
+  protected Object evalResult;
+  protected boolean hasEvalResult;
 
   public EagerAstDict(Map<AstNode, AstNode> dict) {
     super(dict);
@@ -21,6 +22,7 @@ public class EagerAstDict extends AstDict implements EvalResultHolder {
   public Object eval(Bindings bindings, ELContext context) {
     try {
       evalResult = super.eval(bindings, context);
+      hasEvalResult = true;
       return evalResult;
     } catch (DeferredParsingException e) {
       JinjavaInterpreter interpreter = (JinjavaInterpreter) context
@@ -78,11 +80,12 @@ public class EagerAstDict extends AstDict implements EvalResultHolder {
   public Object getAndClearEvalResult() {
     Object temp = evalResult;
     evalResult = null;
+    hasEvalResult = false;
     return temp;
   }
 
   @Override
   public boolean hasEvalResult() {
-    return evalResult != null;
+    return hasEvalResult;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDot.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDot.java
@@ -8,9 +8,10 @@ import javax.el.ELContext;
 import javax.el.ELException;
 
 public class EagerAstDot extends AstDot implements EvalResultHolder {
-  private Object evalResult;
-  private final EvalResultHolder base;
-  private final String property;
+  protected Object evalResult;
+  protected boolean hasEvalResult;
+  protected final EvalResultHolder base;
+  protected final String property;
 
   public EagerAstDot(
     AstNode base,
@@ -41,6 +42,7 @@ public class EagerAstDot extends AstDot implements EvalResultHolder {
   public Object eval(Bindings bindings, ELContext context) throws ELException {
     try {
       evalResult = super.eval(bindings, context);
+      hasEvalResult = true;
       return evalResult;
     } catch (DeferredParsingException e) {
       throw new DeferredParsingException(
@@ -56,12 +58,13 @@ public class EagerAstDot extends AstDot implements EvalResultHolder {
   public Object getAndClearEvalResult() {
     Object temp = evalResult;
     evalResult = null;
+    hasEvalResult = false;
     return temp;
   }
 
   @Override
   public boolean hasEvalResult() {
-    return evalResult != null;
+    return hasEvalResult;
   }
 
   public AstNode getPrefix() {

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifier.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifier.java
@@ -5,7 +5,8 @@ import de.odysseus.el.tree.impl.ast.AstIdentifier;
 import javax.el.ELContext;
 
 public class EagerAstIdentifier extends AstIdentifier implements EvalResultHolder {
-  private Object evalResult;
+  protected Object evalResult;
+  protected boolean hasEvalResult;
 
   public EagerAstIdentifier(String name, int index, boolean ignoreReturnType) {
     super(name, index, ignoreReturnType);
@@ -14,6 +15,7 @@ public class EagerAstIdentifier extends AstIdentifier implements EvalResultHolde
   @Override
   public Object eval(Bindings bindings, ELContext context) {
     evalResult = super.eval(bindings, context);
+    hasEvalResult = true;
     return evalResult;
   }
 
@@ -21,11 +23,12 @@ public class EagerAstIdentifier extends AstIdentifier implements EvalResultHolde
   public Object getAndClearEvalResult() {
     Object temp = evalResult;
     evalResult = null;
+    hasEvalResult = false;
     return temp;
   }
 
   @Override
   public boolean hasEvalResult() {
-    return evalResult != null;
+    return hasEvalResult;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstList.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstList.java
@@ -8,7 +8,8 @@ import java.util.StringJoiner;
 import javax.el.ELContext;
 
 public class EagerAstList extends AstList implements EvalResultHolder {
-  private Object evalResult;
+  protected Object evalResult;
+  protected boolean hasEvalResult;
 
   public EagerAstList(AstParameters elements) {
     super(elements);
@@ -44,11 +45,12 @@ public class EagerAstList extends AstList implements EvalResultHolder {
   public Object getAndClearEvalResult() {
     Object temp = evalResult;
     evalResult = null;
+    hasEvalResult = false;
     return temp;
   }
 
   @Override
   public boolean hasEvalResult() {
-    return evalResult != null;
+    return hasEvalResult;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
@@ -12,6 +12,7 @@ import javax.el.ELContext;
 
 public class EagerAstMacroFunction extends AstMacroFunction implements EvalResultHolder {
   protected Object evalResult;
+  protected boolean hasEvalResult;
   // instanceof AstParameters
   protected EvalResultHolder params;
 
@@ -38,6 +39,7 @@ public class EagerAstMacroFunction extends AstMacroFunction implements EvalResul
   public Object eval(Bindings bindings, ELContext context) {
     try {
       evalResult = super.eval(bindings, context);
+      hasEvalResult = true;
       return evalResult;
     } catch (DeferredValueException e) {
       StringBuilder sb = new StringBuilder();
@@ -63,11 +65,12 @@ public class EagerAstMacroFunction extends AstMacroFunction implements EvalResul
   public Object getAndClearEvalResult() {
     Object temp = evalResult;
     evalResult = null;
+    hasEvalResult = false;
     return temp;
   }
 
   @Override
   public boolean hasEvalResult() {
-    return evalResult != null;
+    return hasEvalResult;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
@@ -11,7 +11,8 @@ import de.odysseus.el.tree.impl.ast.AstProperty;
 import javax.el.ELContext;
 
 public class EagerAstMethod extends AstMethod implements EvalResultHolder {
-  private Object evalResult;
+  protected Object evalResult;
+  protected boolean hasEvalResult;
   // instanceof AstProperty
   protected final EvalResultHolder property;
   // instanceof AstParameters
@@ -34,6 +35,7 @@ public class EagerAstMethod extends AstMethod implements EvalResultHolder {
   public Object eval(Bindings bindings, ELContext context) {
     try {
       evalResult = super.eval(bindings, context);
+      hasEvalResult = true;
       return evalResult;
     } catch (DeferredParsingException e) {
       throw new DeferredParsingException(
@@ -50,12 +52,13 @@ public class EagerAstMethod extends AstMethod implements EvalResultHolder {
   public Object getAndClearEvalResult() {
     Object temp = evalResult;
     evalResult = null;
+    hasEvalResult = false;
     return temp;
   }
 
   @Override
   public boolean hasEvalResult() {
-    return evalResult != null;
+    return hasEvalResult;
   }
 
   /**

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNamedParameter.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNamedParameter.java
@@ -10,9 +10,10 @@ import javax.el.ELContext;
 public class EagerAstNamedParameter
   extends AstNamedParameter
   implements EvalResultHolder {
-  private Object evalResult;
-  private final AstIdentifier name;
-  private final EvalResultHolder value;
+  protected boolean hasEvalResult;
+  protected Object evalResult;
+  protected final AstIdentifier name;
+  protected final EvalResultHolder value;
 
   public EagerAstNamedParameter(AstIdentifier name, AstNode value) {
     this(name, EagerAstNodeDecorator.getAsEvalResultHolder(value));
@@ -28,6 +29,7 @@ public class EagerAstNamedParameter
   public Object eval(Bindings bindings, ELContext context) {
     try {
       evalResult = super.eval(bindings, context);
+      hasEvalResult = true;
       return evalResult;
     } catch (DeferredParsingException e) {
       throw new DeferredParsingException(
@@ -43,11 +45,12 @@ public class EagerAstNamedParameter
   public Object getAndClearEvalResult() {
     Object temp = evalResult;
     evalResult = null;
+    hasEvalResult = false;
     return temp;
   }
 
   @Override
   public boolean hasEvalResult() {
-    return evalResult != null;
+    return hasEvalResult;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNested.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNested.java
@@ -11,8 +11,9 @@ import javax.el.ELContext;
  * AstNested is final so this decorates AstRightValue.
  */
 public class EagerAstNested extends AstRightValue implements EvalResultHolder {
-  private Object evalResult;
-  private final AstNode child;
+  protected Object evalResult;
+  protected boolean hasEvalResult;
+  protected final AstNode child;
 
   public EagerAstNested(AstNode child) {
     this.child = child;
@@ -29,6 +30,7 @@ public class EagerAstNested extends AstRightValue implements EvalResultHolder {
   public Object eval(Bindings bindings, ELContext context) {
     try {
       evalResult = child.eval(bindings, context);
+      hasEvalResult = true;
       return evalResult;
     } catch (DeferredParsingException e) {
       throw new DeferredParsingException(
@@ -49,12 +51,13 @@ public class EagerAstNested extends AstRightValue implements EvalResultHolder {
   public Object getAndClearEvalResult() {
     Object temp = evalResult;
     evalResult = null;
+    hasEvalResult = false;
     return temp;
   }
 
   @Override
   public boolean hasEvalResult() {
-    return evalResult != null;
+    return hasEvalResult;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNodeDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNodeDecorator.java
@@ -14,7 +14,8 @@ import javax.el.ValueReference;
  */
 public class EagerAstNodeDecorator extends AstNode implements EvalResultHolder {
   private final AstNode astNode;
-  private Object evalResult;
+  protected Object evalResult;
+  protected boolean hasEvalResult;
 
   public static EvalResultHolder getAsEvalResultHolder(AstNode astNode) {
     if (astNode instanceof EvalResultHolder) {
@@ -34,12 +35,13 @@ public class EagerAstNodeDecorator extends AstNode implements EvalResultHolder {
   public Object getAndClearEvalResult() {
     Object temp = evalResult;
     evalResult = null;
+    hasEvalResult = false;
     return temp;
   }
 
   @Override
   public boolean hasEvalResult() {
-    return evalResult != null;
+    return hasEvalResult;
   }
 
   @Override
@@ -50,6 +52,7 @@ public class EagerAstNodeDecorator extends AstNode implements EvalResultHolder {
   @Override
   public Object eval(Bindings bindings, ELContext elContext) {
     evalResult = astNode.eval(bindings, elContext);
+    hasEvalResult = true;
     return evalResult;
   }
 
@@ -106,7 +109,7 @@ public class EagerAstNodeDecorator extends AstNode implements EvalResultHolder {
     Class<?>[] classes,
     Object[] objects
   ) {
-    if (evalResult != null) {
+    if (hasEvalResult) {
       return evalResult;
     }
     evalResult = astNode.invoke(bindings, elContext, aClass, classes, objects);

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstParameters.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstParameters.java
@@ -10,8 +10,9 @@ import java.util.stream.Collectors;
 import javax.el.ELContext;
 
 public class EagerAstParameters extends AstParameters implements EvalResultHolder {
-  private Object[] evalResult;
-  private final List<AstNode> nodes;
+  protected Object[] evalResult;
+  protected boolean hasEvalResult;
+  protected final List<AstNode> nodes;
 
   public EagerAstParameters(List<AstNode> nodes) {
     this( // to avoid converting nodes twice, call separate constructor
@@ -33,6 +34,7 @@ public class EagerAstParameters extends AstParameters implements EvalResultHolde
   public Object[] eval(Bindings bindings, ELContext context) {
     try {
       evalResult = super.eval(bindings, context);
+      hasEvalResult = true;
       return evalResult;
     } catch (DeferredParsingException e) {
       StringJoiner joiner = new StringJoiner(", ");
@@ -55,11 +57,12 @@ public class EagerAstParameters extends AstParameters implements EvalResultHolde
   public Object[] getAndClearEvalResult() {
     Object[] temp = evalResult;
     evalResult = null;
+    hasEvalResult = false;
     return temp;
   }
 
   @Override
   public boolean hasEvalResult() {
-    return evalResult != null;
+    return hasEvalResult;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstRangeBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstRangeBracket.java
@@ -8,6 +8,7 @@ import javax.el.ELContext;
 
 public class EagerAstRangeBracket extends AstRangeBracket implements EvalResultHolder {
   protected Object evalResult;
+  protected boolean hasEvalResult;
 
   public EagerAstRangeBracket(
     AstNode base,
@@ -31,6 +32,7 @@ public class EagerAstRangeBracket extends AstRangeBracket implements EvalResultH
   public Object eval(Bindings bindings, ELContext context) {
     try {
       evalResult = super.eval(bindings, context);
+      hasEvalResult = true;
       return evalResult;
     } catch (DeferredParsingException e) {
       String sb =
@@ -76,11 +78,12 @@ public class EagerAstRangeBracket extends AstRangeBracket implements EvalResultH
   public Object getAndClearEvalResult() {
     Object temp = evalResult;
     evalResult = null;
+    hasEvalResult = false;
     return temp;
   }
 
   @Override
   public boolean hasEvalResult() {
-    return evalResult != null;
+    return hasEvalResult;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstTuple.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstTuple.java
@@ -8,7 +8,8 @@ import java.util.StringJoiner;
 import javax.el.ELContext;
 
 public class EagerAstTuple extends AstTuple implements EvalResultHolder {
-  private Object evalResult;
+  protected Object evalResult;
+  protected boolean hasEvalResult;
 
   public EagerAstTuple(AstParameters elements) {
     super(elements);
@@ -18,6 +19,7 @@ public class EagerAstTuple extends AstTuple implements EvalResultHolder {
   public Object eval(Bindings bindings, ELContext context) {
     try {
       evalResult = super.eval(bindings, context);
+      hasEvalResult = true;
       return evalResult;
     } catch (DeferredParsingException e) {
       StringJoiner joiner = new StringJoiner(", ");
@@ -44,11 +46,12 @@ public class EagerAstTuple extends AstTuple implements EvalResultHolder {
   public Object getAndClearEvalResult() {
     Object temp = evalResult;
     evalResult = null;
+    hasEvalResult = false;
     return temp;
   }
 
   @Override
   public boolean hasEvalResult() {
-    return evalResult != null;
+    return hasEvalResult;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstUnary.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstUnary.java
@@ -7,7 +7,8 @@ import de.odysseus.el.tree.impl.ast.AstUnary;
 import javax.el.ELContext;
 
 public class EagerAstUnary extends AstUnary implements EvalResultHolder {
-  private Object evalResult;
+  protected Object evalResult;
+  protected boolean hasEvalResult;
   protected final EvalResultHolder child;
   protected final Operator operator;
 
@@ -25,6 +26,7 @@ public class EagerAstUnary extends AstUnary implements EvalResultHolder {
   public Object eval(Bindings bindings, ELContext context) {
     try {
       evalResult = super.eval(bindings, context);
+      hasEvalResult = true;
       return evalResult;
     } catch (DeferredParsingException e) {
       String sb =
@@ -40,11 +42,12 @@ public class EagerAstUnary extends AstUnary implements EvalResultHolder {
   public Object getAndClearEvalResult() {
     Object temp = evalResult;
     evalResult = null;
+    hasEvalResult = false;
     return temp;
   }
 
   @Override
   public boolean hasEvalResult() {
-    return evalResult != null;
+    return hasEvalResult;
   }
 }

--- a/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifierTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifierTest.java
@@ -1,0 +1,39 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hubspot.jinjava.BaseInterpretingTest;
+import com.hubspot.jinjava.el.JinjavaELContext;
+import com.hubspot.jinjava.el.JinjavaInterpreterResolver;
+import de.odysseus.el.tree.Bindings;
+import java.lang.reflect.Method;
+import javax.el.ValueExpression;
+import org.junit.Before;
+import org.junit.Test;
+
+public class EagerAstIdentifierTest extends BaseInterpretingTest {
+  private JinjavaELContext elContext;
+
+  @Before
+  public void setup() {
+    elContext =
+      new JinjavaELContext(interpreter, new JinjavaInterpreterResolver(interpreter));
+  }
+
+  @Test
+  public void itSavesNullEvalResult() {
+    EagerAstIdentifier identifier = new EagerAstIdentifier("foo", 0, true);
+    identifier.eval(
+      new Bindings(
+        new Method[] {},
+        new ValueExpression[] {
+          jinjava
+            .getEagerExpressionFactory()
+            .createValueExpression(elContext, "#{foo}", Object.class)
+        }
+      ),
+      elContext
+    );
+    assertThat(identifier.hasEvalResult()).isTrue();
+  }
+}


### PR DESCRIPTION
With the EvalResultHolders, if `super.eval()` returns null, we should count that as having an evaluation result. Therefore we need a separate boolean to keep track of if there's an eval result rather than simply tracking if the `evalResult != null`. A strong example is a custom void function. It will return null when evaluated, but we want to track that it has been called already (in case of a DeferredParsingException) so that it doesn't get called twice.

Instead of writing test classes for every kind of AstNode, I just wrote a simple one for EagerAstIdentifier that makes sure a null context value will be stored as the eval result and that we know that the AstIdentifier has already been evaluated when it finds that.

This was found/is needed to make a test case pass in https://github.com/HubSpot/jinjava/pull/632 after it's merge with master due to https://github.com/HubSpot/jinjava/pull/629