### PR TITLE
[Eager Execution] Fix cycle tag escaping bug

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -45,7 +45,7 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
     } else {
       interpreter.getContext().putAll(eagerStringResult.getSessionBindings());
     }
-    if (chunkResolver.getDeferredWords().isEmpty()) {
+    if (eagerStringResult.getResult().isFullyResolved()) {
       String result = eagerStringResult.getResult().toString(true);
       if (
         !StringUtils.equals(result, master.getImage()) &&

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
@@ -101,8 +101,8 @@ public class EagerCycleTag extends EagerStateChangingTag<CycleTag> {
           tagToken,
           interpreter,
           resolvedValues,
-          chunkResolver,
-          resolvedExpression
+          resolvedExpression,
+          eagerStringResult.getResult().isFullyResolved()
         )
       );
     } else if (helper.size() == 3) {
@@ -113,8 +113,8 @@ public class EagerCycleTag extends EagerStateChangingTag<CycleTag> {
           interpreter,
           resolvedValues,
           helper,
-          chunkResolver,
-          resolvedExpression
+          resolvedExpression,
+          eagerStringResult.getResult().isFullyResolved()
         )
       );
     } else {
@@ -131,11 +131,11 @@ public class EagerCycleTag extends EagerStateChangingTag<CycleTag> {
     JinjavaInterpreter interpreter,
     List<String> values,
     List<String> helper,
-    ChunkResolver chunkResolver,
-    String resolvedExpression
+    String resolvedExpression,
+    boolean fullyResolved
   ) {
     String var = helper.get(2);
-    if (!chunkResolver.getDeferredWords().isEmpty()) {
+    if (!fullyResolved) {
       return EagerTagDecorator.buildSetTagForDeferredInChildContext(
         ImmutableMap.of(
           var,
@@ -153,8 +153,8 @@ public class EagerCycleTag extends EagerStateChangingTag<CycleTag> {
     TagToken tagToken,
     JinjavaInterpreter interpreter,
     List<String> values,
-    ChunkResolver chunkResolver,
-    String resolvedExpression
+    String resolvedExpression,
+    boolean fullyResolved
   ) {
     if (interpreter.getContext().isDeferredExecutionMode()) {
       return reconstructCycleTag(resolvedExpression, tagToken);
@@ -169,17 +169,14 @@ public class EagerCycleTag extends EagerStateChangingTag<CycleTag> {
     }
     if (values.size() == 1) {
       String var = values.get(0);
-      if (!chunkResolver.getDeferredWords().isEmpty()) {
+      if (!fullyResolved) {
         return getIsIterable(var, forindex, tagToken);
       } else {
         return values.get(forindex % values.size());
       }
     }
     String item = values.get(forindex % values.size());
-    if (
-      !chunkResolver.getDeferredWords().isEmpty() &&
-      ChunkResolver.shouldBeEvaluated(item, tagToken, interpreter)
-    ) {
+    if (!fullyResolved && ChunkResolver.shouldBeEvaluated(item, tagToken, interpreter)) {
       return String.format("{{ %s }}", values.get(forindex % values.size()));
     }
     return item;

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
@@ -62,7 +62,7 @@ public class EagerPrintTag extends EagerStateChangingTag<PrintTag> {
     } else {
       interpreter.getContext().putAll(eagerStringResult.getSessionBindings());
     }
-    if (chunkResolver.getDeferredWords().isEmpty()) {
+    if (eagerStringResult.getResult().isFullyResolved()) {
       // Possible macro/set tag in front of this one.
       return (
         prefixToPreserveState.toString() +

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTag.java
@@ -55,7 +55,7 @@ public class EagerSetTag extends EagerStateChangingTag<SetTag> {
     String[] varTokens = variables.split(",");
 
     if (
-      chunkResolver.getDeferredWords().isEmpty() &&
+      eagerStringResult.getResult().isFullyResolved() &&
       !interpreter.getContext().isDeferredExecutionMode()
     ) {
       try {

--- a/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/ChunkResolver.java
@@ -286,6 +286,10 @@ public class ChunkResolver {
       throw new DeferredValueException("Object is not resolved");
     }
 
+    public boolean isFullyResolved() {
+      return fullyResolved;
+    }
+
     /**
      * Method to wrap a string value in the ResolvedChunks class.
      * It is not evaluated, rather it's allows a the class to be manually

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -789,6 +789,11 @@ public class EagerTest {
   }
 
   @Test
+  public void itHandlesCycleWithQuote() {
+    expectedTemplateInterpreter.assertExpectedOutput("handles-cycle-with-quote");
+  }
+
+  @Test
   public void itHandlesUnknownFunctionErrors() {
     JinjavaInterpreter eagerInterpreter = new JinjavaInterpreter(
       jinjava,

--- a/src/test/resources/eager/handles-cycle-with-quote.expected.jinja
+++ b/src/test/resources/eager/handles-cycle-with-quote.expected.jinja
@@ -1,0 +1,2 @@
+<div style=''></div>
+<div style=""></div>

--- a/src/test/resources/eager/handles-cycle-with-quote.jinja
+++ b/src/test/resources/eager/handles-cycle-with-quote.jinja
@@ -1,0 +1,3 @@
+{% for i in range(2) -%}
+{% cycle "<div style=''></div>",'<div style=""></div>' %}
+{% endfor %}


### PR DESCRIPTION
The AST-level deferred value handling allows us to easily address this bug where the result from a cycle tag would have escaped characters unnecessarily (due to JSON serialization to a list and then removing the brackets). We can avoid this scenario by taking the list of resolved objects (wrapped in the ResolvedChunks class) and converting them individually to strings.