### PR TITLE
[Eager Execution] Refactor out "chunk" terminology

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBracket.java
@@ -1,7 +1,7 @@
 package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
-import com.hubspot.jinjava.util.ChunkResolver;
+import com.hubspot.jinjava.util.EagerExpressionResolver;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstBracket;
 import de.odysseus.el.tree.impl.ast.AstNode;
@@ -37,7 +37,7 @@ public class EagerAstBracket extends AstBracket implements EvalResultHolder {
       StringBuilder sb = new StringBuilder();
       if (((EvalResultHolder) prefix).hasEvalResult()) {
         sb.append(
-          ChunkResolver.getValueAsJinjavaStringSafe(
+          EagerExpressionResolver.getValueAsJinjavaStringSafe(
             ((EvalResultHolder) prefix).getAndClearEvalResult()
           )
         );
@@ -48,7 +48,9 @@ public class EagerAstBracket extends AstBracket implements EvalResultHolder {
           sb.append(
             String.format(
               "[%s]",
-              ChunkResolver.getValueAsJinjavaStringSafe(property.eval(bindings, context))
+              EagerExpressionResolver.getValueAsJinjavaStringSafe(
+                property.eval(bindings, context)
+              )
             )
           );
         } catch (DeferredParsingException e1) {

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
@@ -3,7 +3,7 @@ package com.hubspot.jinjava.el.ext.eager;
 import com.hubspot.jinjava.el.ext.AstMacroFunction;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.interpret.DeferredValueException;
-import com.hubspot.jinjava.util.ChunkResolver;
+import com.hubspot.jinjava.util.EagerExpressionResolver;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstParameters;
 import java.util.Arrays;
@@ -49,7 +49,7 @@ public class EagerAstMacroFunction extends AstMacroFunction implements EvalResul
         paramString =
           Arrays
             .stream(((AstParameters) params).eval(bindings, context))
-            .map(ChunkResolver::getValueAsJinjavaStringSafe)
+            .map(EagerExpressionResolver::getValueAsJinjavaStringSafe)
             .collect(Collectors.joining(", "));
       } catch (DeferredParsingException dpe) {
         paramString = dpe.getDeferredEvalResult();

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
@@ -2,7 +2,7 @@ package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.interpret.DeferredValueException;
-import com.hubspot.jinjava.util.ChunkResolver;
+import com.hubspot.jinjava.util.EagerExpressionResolver;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstMethod;
 import de.odysseus.el.tree.impl.ast.AstNode;
@@ -109,7 +109,9 @@ public class EagerAstMethod extends AstMethod implements EvalResultHolder {
     } else {
       try {
         paramString =
-          ChunkResolver.getValueAsJinjavaStringSafe(params.eval(bindings, context));
+          EagerExpressionResolver.getValueAsJinjavaStringSafe(
+            params.eval(bindings, context)
+          );
         // remove brackets so they can get replaced with parentheses
         paramString = paramString.substring(1, paramString.length() - 1);
       } catch (DeferredParsingException e) {

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
@@ -2,7 +2,7 @@ package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.el.ext.ExtendedParser;
-import com.hubspot.jinjava.util.ChunkResolver;
+import com.hubspot.jinjava.util.EagerExpressionResolver;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstIdentifier;
 import javax.el.ELContext;
@@ -33,13 +33,17 @@ public interface EvalResultHolder {
       partiallyResolvedImage = ((AstIdentifier) astNode).getName();
     } else if (astNode.hasEvalResult()) {
       partiallyResolvedImage =
-        ChunkResolver.getValueAsJinjavaStringSafe(astNode.getAndClearEvalResult());
+        EagerExpressionResolver.getValueAsJinjavaStringSafe(
+          astNode.getAndClearEvalResult()
+        );
     } else if (exception.getSourceNode() == astNode) {
       partiallyResolvedImage = exception.getDeferredEvalResult();
     } else {
       try {
         partiallyResolvedImage =
-          ChunkResolver.getValueAsJinjavaStringSafe(astNode.eval(bindings, context));
+          EagerExpressionResolver.getValueAsJinjavaStringSafe(
+            astNode.eval(bindings, context)
+          );
       } catch (DeferredParsingException e) {
         partiallyResolvedImage = e.getDeferredEvalResult();
       } finally {

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -592,14 +592,14 @@ public class JinjavaInterpreter {
   public void addError(TemplateError templateError) {
     if (context.getThrowInterpreterErrors()) {
       if (templateError.getSeverity() == ErrorType.FATAL) {
-        // Throw fatal errors when resolving chunks.
+        // Throw fatal errors when locating deferred words.
         throw new TemplateSyntaxException(
           this,
           templateError.getFieldName(),
           templateError.getMessage()
         );
       } else {
-        // Hide warning errors when resolving chunks.
+        // Hide warning errors when locating deferred words.
         return;
       }
     }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerExecutionResult.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerExecutionResult.java
@@ -4,32 +4,35 @@ import static com.hubspot.jinjava.lib.tag.eager.EagerTagDecorator.buildSetTagFor
 
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
-import com.hubspot.jinjava.util.ChunkResolver.ResolvedChunks;
+import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 /**
- * This represents the result of executing an expression, where if something got
- * deferred, then the <code>prefixToPreserveState</code> can be added to the output
+ * This represents the result of speculatively executing an expression, where if something
+ * got deferred, then the <code>prefixToPreserveState</code> can be added to the output
  * that would preserve the state for a second pass.
  */
-public class EagerStringResult {
-  private final ResolvedChunks result;
-  private final Map<String, Object> sessionBindings;
+public class EagerExecutionResult {
+  private final EagerExpressionResult result;
+  private final Map<String, Object> speculativeBindings;
   private String prefixToPreserveState;
 
-  public EagerStringResult(ResolvedChunks result, Map<String, Object> sessionBindings) {
+  public EagerExecutionResult(
+    EagerExpressionResult result,
+    Map<String, Object> speculativeBindings
+  ) {
     this.result = result;
-    this.sessionBindings = sessionBindings;
+    this.speculativeBindings = speculativeBindings;
   }
 
-  public ResolvedChunks getResult() {
+  public EagerExpressionResult getResult() {
     return result;
   }
 
-  public Map<String, Object> getSessionBindings() {
-    return sessionBindings;
+  public Map<String, Object> getSpeculativeBindings() {
+    return speculativeBindings;
   }
 
   public String getPrefixToPreserveState() {
@@ -38,7 +41,7 @@ public class EagerStringResult {
     }
     prefixToPreserveState =
       buildSetTagForDeferredInChildContext(
-        sessionBindings
+        speculativeBindings
           .entrySet()
           .stream()
           .collect(

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
@@ -8,7 +8,7 @@ import com.hubspot.jinjava.lib.tag.ElseTag;
 import com.hubspot.jinjava.lib.tag.IfTag;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.TagNode;
-import com.hubspot.jinjava.util.ChunkResolver.ResolvedChunks;
+import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import com.hubspot.jinjava.util.ObjectTruthValue;
 import org.apache.commons.lang3.StringUtils;
@@ -40,7 +40,7 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
     result.append(
       executeInChildContext(
           eagerInterpreter ->
-            ResolvedChunks.fromString(
+            EagerExpressionResult.fromString(
               getEagerImage(tagNode.getMaster(), eagerInterpreter) +
               renderChildren(tagNode, eagerInterpreter)
             ),

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
@@ -3,7 +3,7 @@ package com.hubspot.jinjava.lib.tag.eager;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.Tag;
 import com.hubspot.jinjava.tree.TagNode;
-import com.hubspot.jinjava.util.ChunkResolver.ResolvedChunks;
+import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
 import org.apache.commons.lang3.StringUtils;
 
 public class EagerStateChangingTag<T extends Tag> extends EagerTagDecorator<T> {
@@ -28,7 +28,7 @@ public class EagerStateChangingTag<T extends Tag> extends EagerTagDecorator<T> {
       result.append(
         executeInChildContext(
           eagerInterpreter ->
-            ResolvedChunks.fromString(renderChildren(tagNode, eagerInterpreter)),
+            EagerExpressionResult.fromString(renderChildren(tagNode, eagerInterpreter)),
           interpreter,
           false,
           false

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
@@ -24,7 +24,7 @@ import com.hubspot.jinjava.objects.collections.PyMap;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.DefaultTokenScannerSymbols;
 import com.hubspot.jinjava.tree.parse.TagToken;
-import com.hubspot.jinjava.util.ChunkResolver.ResolvedChunks;
+import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -90,11 +90,11 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
   @Test
   public void itExecutesInChildContextAndTakesNewValue() {
     context.put("foo", new ArrayList<Integer>());
-    EagerStringResult result = EagerTagDecorator.executeInChildContext(
+    EagerExecutionResult result = EagerTagDecorator.executeInChildContext(
       (
         interpreter1 -> {
           ((List<Integer>) interpreter1.getContext().get("foo")).add(1);
-          return ResolvedChunks.fromString("function return");
+          return EagerExpressionResult.fromString("function return");
         }
       ),
       interpreter,
@@ -110,14 +110,14 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
   @Test
   public void itExecutesInChildContextAndDefersNewValue() {
     context.put("foo", new ArrayList<Integer>());
-    EagerStringResult result = EagerTagDecorator.executeInChildContext(
+    EagerExecutionResult result = EagerTagDecorator.executeInChildContext(
       (
         interpreter1 -> {
           context.put(
             "foo",
             DeferredValue.instance(interpreter1.getContext().get("foo"))
           );
-          return ResolvedChunks.fromString("function return");
+          return EagerExpressionResult.fromString("function return");
         }
       ),
       interpreter,


### PR DESCRIPTION
After https://github.com/HubSpot/jinjava/pull/629, expressions aren't partially resolved in "chunks" anymore. The partial resolution is handled at the AST level so there is no longer a secondary parser that resolves the expression in different chunks. 

This PR refactors the terminology to be clearer to what is actually happening now, and turns what was the ChunkResolver (now called EagerExpressionResolver) into a static helper class, which is easier to call and use.

No functional changes are made here, I'm just trying to make the code clearer as it's current name doesn't fit as well as it did before.