### PR TITLE
[Eager Execution] Just unwrap raw tags in macro function execution

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -28,7 +28,6 @@ import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.el.ExpressionResolver;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
-import com.hubspot.jinjava.interpret.Context.TemporaryValueClosable;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
@@ -205,9 +204,7 @@ public class JinjavaInterpreter {
         return template;
       } else {
         context.setRenderDepth(depth + 1);
-        try (TemporaryValueClosable<Boolean> c = context.withUnwrapRawOverride()) {
-          return render(parse(template), false);
-        }
+        return render(parse(template), false);
       }
     } finally {
       context.setRenderDepth(depth);

--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.lib.fn;
 
 import com.hubspot.jinjava.el.ext.AbstractCallableMethod;
 import com.hubspot.jinjava.interpret.Context;
+import com.hubspot.jinjava.interpret.Context.TemporaryValueClosable;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
@@ -144,7 +145,13 @@ public class MacroFunction extends AbstractCallableMethod {
       result.append(node.render(interpreter));
     }
     if (interpreter.getConfig().getExecutionMode().isPreserveRawTags()) {
-      return interpreter.renderFlat(result.toString());
+      try (
+        TemporaryValueClosable<Boolean> c = interpreter
+          .getContext()
+          .withUnwrapRawOverride()
+      ) {
+        return interpreter.renderFlat(result.toString());
+      }
     }
     return result.toString();
   }


### PR DESCRIPTION
Modification of https://github.com/HubSpot/jinjava/pull/619

This should only be necessary to use when evaluating macro tags.
With Eager Execution, a nested expression like `{{ '{% raw %}{{something}}{% endraw %}' }}` should result in `{% raw %}{{something}}{% endraw %}` rather than having the raw tags removed. They should be preserved so that a second pass would result in the text output: `{{something}}`