### PR TITLE
[Eager Execution] Add meta context variables set

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -110,6 +110,7 @@ public class Context extends ScopeMap<String, Object> {
   private boolean partialMacroEvaluation = false;
   private boolean unwrapRawOverride = false;
   private DynamicVariableResolver dynamicVariableResolver = null;
+  private final Set<String> metaContextVariables; // These variable names aren't tracked in eager execution
 
   public Context() {
     this(null, null, null, true);
@@ -199,6 +200,8 @@ public class Context extends ScopeMap<String, Object> {
     this.tagLibrary = new TagLibrary(parent == null, disabled.get(Library.TAG));
     this.functionLibrary =
       new FunctionLibrary(parent == null, disabled.get(Library.FUNCTION));
+    this.metaContextVariables =
+      parent == null ? new HashSet<>() : parent.metaContextVariables;
     if (parent != null) {
       this.expressionStrategy = parent.expressionStrategy;
       this.partialMacroEvaluation = parent.partialMacroEvaluation;
@@ -333,6 +336,10 @@ public class Context extends ScopeMap<String, Object> {
     if (getParent() != null) {
       getParent().addResolvedFunction(function);
     }
+  }
+
+  public Set<String> getMetaContextVariables() {
+    return metaContextVariables;
   }
 
   public void handleDeferredNode(Node node) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -1,7 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
 import static com.hubspot.jinjava.interpret.Context.GLOBAL_MACROS_SCOPE_KEY;
-import static com.hubspot.jinjava.interpret.Context.IMPORT_RESOURCE_PATH_KEY;
 
 import com.hubspot.jinjava.el.ext.AbstractCallableMethod;
 import com.hubspot.jinjava.interpret.Context.Library;
@@ -162,15 +161,12 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
   ) {
     EagerExpressionResult result;
     Map<String, Integer> initiallyResolvedHashes = new HashMap<>();
+    Set<String> metaContextVariables = interpreter.getContext().getMetaContextVariables();
     interpreter
       .getContext()
       .entrySet()
       .stream()
-      .filter(
-        e ->
-          !e.getKey().equals(GLOBAL_MACROS_SCOPE_KEY) &&
-          !e.getKey().equals(IMPORT_RESOURCE_PATH_KEY)
-      )
+      .filter(e -> !metaContextVariables.contains(e.getKey()))
       .filter(
         entry -> !(entry.getValue() instanceof DeferredValue) && entry.getValue() != null
       )
@@ -317,12 +313,11 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
           !(interpreter.getContext().get(w) instanceof DeferredValue)
       )
       .forEach(
-        w -> {
+        w ->
           deferredMap.put(
             w,
             PyishObjectMapper.getAsPyishString(interpreter.getContext().get(w))
-          );
-        }
+          )
       );
     return buildSetTagForDeferredInChildContext(deferredMap, interpreter, true);
   }

--- a/src/main/java/com/hubspot/jinjava/mode/EagerExecutionMode.java
+++ b/src/main/java/com/hubspot/jinjava/mode/EagerExecutionMode.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.mode;
 
+import com.google.common.collect.ImmutableSet;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.lib.expression.EagerExpressionStrategy;
 import com.hubspot.jinjava.lib.tag.eager.EagerTagDecorator;
@@ -35,5 +36,15 @@ public class EagerExecutionMode implements ExecutionMode {
       .filter(Optional::isPresent)
       .forEach(maybeEagerTag -> context.registerTag(maybeEagerTag.get()));
     context.setExpressionStrategy(new EagerExpressionStrategy());
+    context
+      .getMetaContextVariables()
+      .addAll(
+        ImmutableSet.of(
+          Context.GLOBAL_MACROS_SCOPE_KEY,
+          Context.IMPORT_RESOURCE_PATH_KEY,
+          Context.DEFERRED_IMPORT_RESOURCE_PATH_KEY,
+          Context.IMPORT_RESOURCE_ALIAS_KEY
+        )
+      );
   }
 }


### PR DESCRIPTION
This PR makes the variables that are mutable during deferred execution mode of eager execution extensible. Rather than hardcoding, these variables can be added to the `metaContextVariables` set on the context. This set is shared by the entire context parent-children tree.

Variables on the context that may be mutable during deferred execution mode are those that may be getting modified behind-the-scenes rather than those that appear within the template. Use of such variable extension in conjunction with eager execution may require additional logic and it may not make sense for it to be treated like other variables that are set into the context if their value changes while doing something like speculatively executing an if branch:
```
{% if deferred %}
   {{ custom_function() }}
{% endif %}
```
This would be used in HubL's extension of Jinjava to ignore certain meta variables.