### PR TITLE
[Eager Execution] Split resolved expressions

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -22,7 +22,9 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.interpret.UnknownTokenException;
 import com.hubspot.jinjava.interpret.errorcategory.BasicTemplateErrorCategory;
 import com.hubspot.jinjava.lib.fn.ELFunctionDefinition;
+import com.hubspot.jinjava.util.WhitespaceUtils;
 import de.odysseus.el.tree.TreeBuilderException;
+import java.util.Arrays;
 import java.util.List;
 import javax.el.ELException;
 import javax.el.ExpressionFactory;
@@ -66,12 +68,21 @@ public class ExpressionResolver {
     if (StringUtils.isBlank(expression)) {
       return null;
     }
+    expression = expression.trim();
+    interpreter.getContext().addResolvedExpression(expression);
 
-    interpreter.getContext().addResolvedExpression(expression.trim());
-
+    if (
+      interpreter.getConfig().getExecutionMode().useEagerParser() &&
+      WhitespaceUtils.isWrappedWith(expression, "[", "]")
+    ) {
+      Arrays
+        .stream(expression.substring(1, expression.length() - 1).split(","))
+        .forEach(
+          substring -> interpreter.getContext().addResolvedExpression(substring.trim())
+        );
+    }
     try {
-      String elExpression =
-        EXPRESSION_START_TOKEN + expression.trim() + EXPRESSION_END_TOKEN;
+      String elExpression = EXPRESSION_START_TOKEN + expression + EXPRESSION_END_TOKEN;
       ValueExpression valueExp = expressionFactory.createValueExpression(
         elContext,
         elExpression,

--- a/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
@@ -665,14 +665,21 @@ public class EagerExpressionResolverTest {
       .isEqualTo("yes");
   }
 
+  @Test
+  public void itSplitsResolvedExpression() {
+    eagerResolveExpression("['a', 'b']");
+    assertThat(context.getResolvedExpressions())
+      .containsExactlyInAnyOrder("['a', 'b']", "'a'", "'b'");
+  }
+
   public static void voidFunction(int nothing) {}
 
   public static boolean isNull(Object foo, Object bar) {
     return foo == null && bar == null;
   }
 
-  private class Foo {
-    private String bar;
+  private static class Foo {
+    private final String bar;
 
     Foo(String bar) {
       this.bar = bar;


### PR DESCRIPTION
When doing eager parsing, we'll wrap set and cycle tags in `[]` so that commas can be handled. Let's add both the bracketed expression as well as splitting the expression by commas to the `resolvedExpressions`.
This way, a template such as: `{% set foo, bar = 'foobar', 'barbar' %}` will have these resolved expressions:
- `'foobar'`
- `'barbar'`
- `['foobar', 'barbar']` (instead of just this one)