### PR TITLE
Split resolved expressions in default execution mode

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -71,10 +71,7 @@ public class ExpressionResolver {
     expression = expression.trim();
     interpreter.getContext().addResolvedExpression(expression);
 
-    if (
-      interpreter.getConfig().getExecutionMode().useEagerParser() &&
-      WhitespaceUtils.isWrappedWith(expression, "[", "]")
-    ) {
+    if (WhitespaceUtils.isWrappedWith(expression, "[", "]")) {
       Arrays
         .stream(expression.substring(1, expression.length() - 1).split(","))
         .forEach(


### PR DESCRIPTION
The change from https://github.com/HubSpot/jinjava/pull/650 should not just be limited to eager execution due to the improvement made to set tag parsing https://github.com/HubSpot/jinjava/blob/master/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java#L116
(That change allows commas in the string value that an object is set to).

Because of it, to maintain consistency with how resolved expressions have worked in the past, we should also split them for default execution mode. Because set tags used to evaluate each value separately.