### PR TITLE
[Eager Execution] Default null values to the expression image in EagerCycleTag

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
@@ -55,10 +55,18 @@ public class EagerCycleTag extends EagerStateChangingTag<CycleTag> {
     } else {
       interpreter.getContext().putAll(eagerExecutionResult.getSpeculativeBindings());
     }
-    String resolvedExpression = eagerExecutionResult
-      .getResult()
-      .toString()
-      .replace(", ", ",");
+    String resolvedExpression;
+    if (
+      eagerExecutionResult
+        .getResult()
+        .toString()
+        .equals(EagerExpressionResolver.JINJAVA_EMPTY_STRING)
+    ) {
+      resolvedExpression = expression; // Cycle tag defaults to input on null
+    } else {
+      resolvedExpression = eagerExecutionResult.getResult().toString();
+    }
+    resolvedExpression = resolvedExpression.replace(", ", ",");
     resolvedExpression = resolvedExpression.substring(1, resolvedExpression.length() - 1);
     if (WhitespaceUtils.isWrappedWith(resolvedExpression, "[", "]")) {
       resolvedExpression =

--- a/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
@@ -21,8 +21,8 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 public class EagerExpressionResolver {
-  private static final String JINJAVA_NULL = "null";
-  private static final String JINJAVA_EMPTY_STRING = "''";
+  public static final String JINJAVA_NULL = "null";
+  public static final String JINJAVA_EMPTY_STRING = "''";
 
   private static final Set<String> RESERVED_KEYWORDS = ImmutableSet.of(
     "and",

--- a/src/test/java/com/hubspot/jinjava/lib/tag/CycleTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/CycleTagTest.java
@@ -1,0 +1,16 @@
+package com.hubspot.jinjava.lib.tag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.Maps;
+import com.hubspot.jinjava.BaseInterpretingTest;
+import org.junit.Test;
+
+public class CycleTagTest extends BaseInterpretingTest {
+
+  @Test
+  public void itDefaultsNullToImage() {
+    String template = "{% for item in [0,1] %}{% cycle {{item}} %}{% endfor %}";
+    assertThat(jinjava.render(template, Maps.newHashMap())).isEqualTo("{{item}}{{item}}");
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTagTest.java
@@ -1,0 +1,41 @@
+package com.hubspot.jinjava.lib.tag.eager;
+
+import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.LegacyOverrides;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.lib.tag.CycleTagTest;
+import com.hubspot.jinjava.lib.tag.Tag;
+import com.hubspot.jinjava.mode.EagerExecutionMode;
+import org.junit.After;
+import org.junit.Before;
+
+public class EagerCycleTagTest extends CycleTagTest {
+  private static final long MAX_OUTPUT_SIZE = 500L;
+  private Tag tag;
+
+  @Before
+  public void eagerSetup() {
+    interpreter =
+      new JinjavaInterpreter(
+        jinjava,
+        context,
+        JinjavaConfig
+          .newBuilder()
+          .withMaxOutputSize(MAX_OUTPUT_SIZE)
+          .withExecutionMode(EagerExecutionMode.instance())
+          .withLegacyOverrides(
+            LegacyOverrides.newBuilder().withUsePyishObjectMapper(true).build()
+          )
+          .build()
+      );
+
+    tag = new EagerCycleTag();
+    context.registerTag(tag);
+    context.registerTag(new EagerForTag());
+  }
+
+  @After
+  public void teardown() {
+    JinjavaInterpreter.popCurrent();
+  }
+}


### PR DESCRIPTION
The EagerCycleTag handled null values as blank when interpreted. However, default Jinjava is a bit strange in that null values default to the expression image so: `{% cycle !?! %}` would become `!?!` rather than a syntax error or just nothing.
This PR makes it so that the functionality is matched between default and eager execution.