### PR TITLE
fix FormatFilterTest.testFormatFilter by setting the ENGLISh locale

### DIFF
--- a/src/test/java/com/hubspot/jinjava/lib/filter/FormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FormatFilterTest.java
@@ -6,9 +6,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.interpret.FatalTemplateErrorsException;
 import java.util.HashMap;
+import java.util.Locale;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class FormatFilterTest extends BaseJinjavaTest {
+
+  @BeforeClass
+  public static void beforeClass() {
+    Locale.setDefault(Locale.ENGLISH);
+  }
 
   @Test
   public void testFormatFilter() {


### PR DESCRIPTION
This test was on error on my machine.
I fixed it by setting the ENGLISH locale, which is expected in the test.