### PR TITLE
add rangeLimit to JinjavaConfig (1000 by default)

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -15,6 +15,8 @@
  **********************************************************************/
 package com.hubspot.jinjava;
 
+import static com.hubspot.jinjava.lib.fn.Functions.DEFAULT_RANGE_LIMIT;
+
 import com.hubspot.jinjava.el.JinjavaInterpreterResolver;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.Context.Library;
@@ -56,6 +58,7 @@ public class JinjavaConfig {
   private final long maxStringLength;
   private final int maxListSize;
   private final int maxMapSize;
+  private final int rangeLimit;
   private final InterpreterFactory interpreterFactory;
   private TokenScannerSymbols tokenScannerSymbols;
   private final ELResolver elResolver;
@@ -107,6 +110,7 @@ public class JinjavaConfig {
     maxStringLength = builder.maxStringLength;
     maxListSize = builder.maxListSize;
     maxMapSize = builder.maxMapSize;
+    rangeLimit = builder.rangeLimit;
     interpreterFactory = builder.interpreterFactory;
     tokenScannerSymbols = builder.tokenScannerSymbols;
     elResolver = builder.elResolver;
@@ -140,6 +144,10 @@ public class JinjavaConfig {
 
   public int getMaxMapSize() {
     return maxMapSize;
+  }
+
+  public int getRangeLimit() {
+    return rangeLimit;
   }
 
   public RandomNumberGeneratorStrategy getRandomNumberGeneratorStrategy() {
@@ -233,6 +241,7 @@ public class JinjavaConfig {
       RandomNumberGeneratorStrategy.THREAD_LOCAL;
     private boolean validationMode = false;
     private long maxStringLength = 0;
+    private int rangeLimit = DEFAULT_RANGE_LIMIT;
     private InterpreterFactory interpreterFactory = new JinjavaInterpreterFactory();
     private TokenScannerSymbols tokenScannerSymbols = new DefaultTokenScannerSymbols();
     private ELResolver elResolver = JinjavaInterpreterResolver.DEFAULT_RESOLVER_READ_ONLY;
@@ -340,6 +349,11 @@ public class JinjavaConfig {
 
     public Builder withMaxMapSize(int maxMapSize) {
       this.maxMapSize = maxMapSize;
+      return this;
+    }
+
+    public Builder withRangeLimit(int rangeLimit) {
+      this.rangeLimit = rangeLimit;
       return this;
     }
 

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -1,6 +1,8 @@
 package com.hubspot.jinjava.lib.fn;
 
+import static com.hubspot.jinjava.interpret.JinjavaInterpreter.getCurrent;
 import static com.hubspot.jinjava.util.Logging.ENGINE_LOG;
+import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.Lists;
 import com.hubspot.jinjava.JinjavaConfig;
@@ -34,7 +36,7 @@ public class Functions {
   public static final String STRING_TO_TIME_FUNCTION = "stringToTime";
   public static final String STRING_TO_DATE_FUNCTION = "stringToDate";
 
-  public static final int RANGE_LIMIT = 1000;
+  public static final int DEFAULT_RANGE_LIMIT = 1000;
 
   @JinjavaDoc(
     value = "Only usable within blocks, will render the contents of the parent block by calling super.",
@@ -50,7 +52,7 @@ public class Functions {
     }
   )
   public static String renderSuperBlock() {
-    JinjavaInterpreter interpreter = JinjavaInterpreter.getCurrent();
+    JinjavaInterpreter interpreter = getCurrent();
     LengthLimitingStringBuilder result = new LengthLimitingStringBuilder(
       interpreter.getConfig().getMaxOutputSize()
     );
@@ -386,8 +388,8 @@ public class Functions {
     "With two parameters, the range will start at the first value and increment by 1 up to (but not including) the second value. " +
     "The third parameter specifies the step increment. All values can be negative. Impossible ranges will return an empty list. " +
     "Ranges can generate a maximum of " +
-    RANGE_LIMIT +
-    " values.",
+    DEFAULT_RANGE_LIMIT +
+    " values by default, but this integer value is configurable.",
     params = {
       @JinjavaParam(value = "start", type = "number", defaultValue = "0"),
       @JinjavaParam(value = "end", type = "number"),
@@ -395,6 +397,12 @@ public class Functions {
     }
   )
   public static List<Integer> range(Object arg1, Object... args) {
+    int rangeLimit = requireNonNull(
+        JinjavaInterpreter.getCurrent(),
+        "No JinjavaInterpreter instance available to use range function"
+      )
+      .getConfig()
+      .getRangeLimit();
     List<Integer> result = new ArrayList<>();
 
     int start = 0;
@@ -404,19 +412,19 @@ public class Functions {
     switch (args.length) {
       case 0:
         if (NumberUtils.isNumber(arg1.toString())) {
-          end = NumberUtils.toInt(arg1.toString(), RANGE_LIMIT);
+          end = NumberUtils.toInt(arg1.toString(), rangeLimit);
         }
         break;
       case 1:
         start = NumberUtils.toInt(arg1.toString());
         if (args[0] != null && NumberUtils.isNumber(args[0].toString())) {
-          end = NumberUtils.toInt(args[0].toString(), start + RANGE_LIMIT);
+          end = NumberUtils.toInt(args[0].toString(), start + rangeLimit);
         }
         break;
       default:
         start = NumberUtils.toInt(arg1.toString());
         if (args[0] != null && NumberUtils.isNumber(args[0].toString())) {
-          end = NumberUtils.toInt(args[0].toString(), start + RANGE_LIMIT);
+          end = NumberUtils.toInt(args[0].toString(), start + rangeLimit);
         }
         if (args[1] != null) {
           step = NumberUtils.toInt(args[1].toString(), 1);
@@ -433,7 +441,7 @@ public class Functions {
       }
 
       for (int i = start; i < end; i += step) {
-        if (result.size() >= RANGE_LIMIT) {
+        if (result.size() >= rangeLimit) {
           break;
         }
         result.add(i);
@@ -444,7 +452,7 @@ public class Functions {
       }
 
       for (int i = start; i > end; i += step) {
-        if (result.size() >= RANGE_LIMIT) {
+        if (result.size() >= rangeLimit) {
           break;
         }
         result.add(i);

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -1,8 +1,6 @@
 package com.hubspot.jinjava.lib.fn;
 
-import static com.hubspot.jinjava.interpret.JinjavaInterpreter.getCurrent;
 import static com.hubspot.jinjava.util.Logging.ENGINE_LOG;
-import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.Lists;
 import com.hubspot.jinjava.JinjavaConfig;
@@ -52,7 +50,7 @@ public class Functions {
     }
   )
   public static String renderSuperBlock() {
-    JinjavaInterpreter interpreter = getCurrent();
+    JinjavaInterpreter interpreter = JinjavaInterpreter.getCurrent();
     LengthLimitingStringBuilder result = new LengthLimitingStringBuilder(
       interpreter.getConfig().getMaxOutputSize()
     );
@@ -389,7 +387,7 @@ public class Functions {
     "The third parameter specifies the step increment. All values can be negative. Impossible ranges will return an empty list. " +
     "Ranges can generate a maximum of " +
     DEFAULT_RANGE_LIMIT +
-    " values by default, but this integer value is configurable.",
+    " values.",
     params = {
       @JinjavaParam(value = "start", type = "number", defaultValue = "0"),
       @JinjavaParam(value = "end", type = "number"),
@@ -397,12 +395,7 @@ public class Functions {
     }
   )
   public static List<Integer> range(Object arg1, Object... args) {
-    int rangeLimit = requireNonNull(
-        JinjavaInterpreter.getCurrent(),
-        "No JinjavaInterpreter instance available to use range function"
-      )
-      .getConfig()
-      .getRangeLimit();
+    int rangeLimit = JinjavaInterpreter.getCurrent().getConfig().getRangeLimit();
     List<Integer> result = new ArrayList<>();
 
     int start = 0;

--- a/src/test/java/com/hubspot/jinjava/lib/fn/RangeFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/RangeFunctionTest.java
@@ -33,9 +33,7 @@ public class RangeFunctionTest {
   @Test
   public void interpreterInstanceIsMandatory() {
     JinjavaInterpreter.popCurrent();
-    assertThatThrownBy(() -> Functions.range(1))
-      .isInstanceOf(NullPointerException.class)
-      .hasMessage("No JinjavaInterpreter instance available to use range function");
+    assertThatThrownBy(() -> Functions.range(1)).isInstanceOf(NullPointerException.class);
   }
 
   @Test


### PR DESCRIPTION
Changes: 
 - we need a JinjavaInterpreter instance to execute range function because we now retrieve the rangeLimit from the configuration instead of an hardcoded value
 - default range limit is still 1000 to avoid any breaking change
 - add 2 units test and update an existing one
 - mvn prettier:write ok
