### PR TITLE
[Eager Execution] Defer today() and random

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/DeferredParsingException.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/DeferredParsingException.java
@@ -6,6 +6,12 @@ public class DeferredParsingException extends DeferredValueException {
   private final String deferredEvalResult;
   private final Object sourceNode;
 
+  public DeferredParsingException(String message) {
+    super(message);
+    this.deferredEvalResult = message;
+    this.sourceNode = null;
+  }
+
   public DeferredParsingException(Object sourceNode, String deferredEvalResult) {
     super(
       String.format(

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
@@ -9,6 +9,7 @@ import de.odysseus.el.tree.impl.ast.AstParameters;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 import javax.el.ELContext;
+import javax.el.ELException;
 
 public class EagerAstMacroFunction extends AstMacroFunction implements EvalResultHolder {
   protected Object evalResult;
@@ -41,7 +42,15 @@ public class EagerAstMacroFunction extends AstMacroFunction implements EvalResul
       evalResult = super.eval(bindings, context);
       hasEvalResult = true;
       return evalResult;
-    } catch (DeferredValueException e) {
+    } catch (DeferredValueException | ELException e) {
+      if (
+        !(
+          e instanceof DeferredValueException ||
+          e.getCause() instanceof DeferredValueException
+        )
+      ) {
+        throw e;
+      }
       StringBuilder sb = new StringBuilder();
       sb.append(getName());
       String paramString;

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
@@ -9,6 +9,7 @@ import de.odysseus.el.tree.impl.ast.AstNode;
 import de.odysseus.el.tree.impl.ast.AstParameters;
 import de.odysseus.el.tree.impl.ast.AstProperty;
 import javax.el.ELContext;
+import javax.el.ELException;
 
 public class EagerAstMethod extends AstMethod implements EvalResultHolder {
   protected Object evalResult;
@@ -37,10 +38,20 @@ public class EagerAstMethod extends AstMethod implements EvalResultHolder {
       evalResult = super.eval(bindings, context);
       hasEvalResult = true;
       return evalResult;
-    } catch (DeferredParsingException e) {
+    } catch (DeferredParsingException | ELException e) {
+      DeferredParsingException e1;
+      if (!(e instanceof DeferredParsingException)) {
+        if (e.getCause() instanceof DeferredParsingException) {
+          e1 = (DeferredParsingException) e.getCause();
+        } else {
+          throw e;
+        }
+      } else {
+        e1 = (DeferredParsingException) e;
+      }
       throw new DeferredParsingException(
         this,
-        getPartiallyResolved(bindings, context, e)
+        getPartiallyResolved(bindings, context, e1)
       );
     } finally {
       property.getAndClearEvalResult();

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -28,11 +28,13 @@ import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.el.ExpressionResolver;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.el.ext.ExtendedParser;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import com.hubspot.jinjava.interpret.errorcategory.BasicTemplateErrorCategory;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
+import com.hubspot.jinjava.objects.serialization.PyishSerializable;
 import com.hubspot.jinjava.random.ConstantZeroRandomNumberGenerator;
 import com.hubspot.jinjava.random.DeferredRandomNumberGenerator;
 import com.hubspot.jinjava.tree.Node;
@@ -60,7 +62,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
-public class JinjavaInterpreter {
+public class JinjavaInterpreter implements PyishSerializable {
   private final Multimap<String, BlockInfo> blocks = ArrayListMultimap.create();
   private final LinkedList<Node> extendParentRoots = new LinkedList<>();
 
@@ -744,5 +746,10 @@ public class JinjavaInterpreter {
         templateError.getMessage()
       );
     }
+  }
+
+  @Override
+  public String toPyishString() {
+    return ExtendedParser.INTERPRETER;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -7,8 +7,10 @@ import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.mode.ExecutionMode;
 import com.hubspot.jinjava.objects.date.InvalidDateFormatException;
 import com.hubspot.jinjava.objects.date.PyishDate;
 import com.hubspot.jinjava.objects.date.StrftimeFormatter;
@@ -81,6 +83,20 @@ public class Functions {
     }
   )
   public static ZonedDateTime today(String... var) {
+    if (
+      JinjavaInterpreter
+        .getCurrentMaybe()
+        .map(JinjavaInterpreter::getConfig)
+        .map(JinjavaConfig::getExecutionMode)
+        .map(ExecutionMode::useEagerParser)
+        .orElse(false)
+    ) {
+      throw new DeferredValueException(
+        "today() is deferred",
+        JinjavaInterpreter.getCurrent().getLineNumber(),
+        JinjavaInterpreter.getCurrent().getPosition()
+      );
+    }
     ZoneId zoneOffset = ZoneOffset.UTC;
     if (var.length > 0) {
       String timezone = var[0];

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
@@ -22,7 +22,7 @@ public class PyishSerializer extends JsonSerializer<Object> {
     jsonGenerator.setCharacterEscapes(PyishCharacterEscapes.INSTANCE);
     String string;
     if (object instanceof PyishSerializable) {
-      jsonGenerator.writeRaw(((PyishSerializable) object).toPyishString());
+      jsonGenerator.writeRawValue(((PyishSerializable) object).toPyishString());
     } else {
       string = Objects.toString(object, "");
       try {

--- a/src/main/java/com/hubspot/jinjava/random/DeferredRandomNumberGenerator.java
+++ b/src/main/java/com/hubspot/jinjava/random/DeferredRandomNumberGenerator.java
@@ -1,6 +1,6 @@
 package com.hubspot.jinjava.random;
 
-import com.hubspot.jinjava.interpret.DeferredValueException;
+import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import java.util.Random;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
@@ -14,42 +14,42 @@ public class DeferredRandomNumberGenerator extends Random {
 
   @Override
   protected int next(int bits) {
-    throw new DeferredValueException(EXCEPTION_MESSAGE);
+    throw new DeferredParsingException(EXCEPTION_MESSAGE);
   }
 
   @Override
   public int nextInt() {
-    throw new DeferredValueException(EXCEPTION_MESSAGE);
+    throw new DeferredParsingException(EXCEPTION_MESSAGE);
   }
 
   @Override
   public int nextInt(int bound) {
-    throw new DeferredValueException(EXCEPTION_MESSAGE);
+    throw new DeferredParsingException(EXCEPTION_MESSAGE);
   }
 
   @Override
   public long nextLong() {
-    throw new DeferredValueException(EXCEPTION_MESSAGE);
+    throw new DeferredParsingException(EXCEPTION_MESSAGE);
   }
 
   @Override
   public boolean nextBoolean() {
-    throw new DeferredValueException(EXCEPTION_MESSAGE);
+    throw new DeferredParsingException(EXCEPTION_MESSAGE);
   }
 
   @Override
   public float nextFloat() {
-    throw new DeferredValueException(EXCEPTION_MESSAGE);
+    throw new DeferredParsingException(EXCEPTION_MESSAGE);
   }
 
   @Override
   public double nextDouble() {
-    throw new DeferredValueException(EXCEPTION_MESSAGE);
+    throw new DeferredParsingException(EXCEPTION_MESSAGE);
   }
 
   @Override
   public synchronized double nextGaussian() {
-    throw new DeferredValueException(EXCEPTION_MESSAGE);
+    throw new DeferredParsingException(EXCEPTION_MESSAGE);
   }
 
   @Override

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -290,7 +290,8 @@ public class EagerTest {
   @Test
   public void itPreservesRandomness() {
     String output = interpreter.render("{{ [1, 2, 3]|shuffle }}");
-    assertThat(output).isEqualTo("{{ [1, 2, 3]|shuffle }}");
+    assertThat(output)
+      .isEqualTo("{{ filter:shuffle.filter([1, 2, 3], ____int3rpr3t3r____) }}");
     assertThat(interpreter.getErrors()).isEmpty();
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/fn/TodayFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/TodayFunctionTest.java
@@ -2,6 +2,12 @@ package com.hubspot.jinjava.lib.fn;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.interpret.Context;
+import com.hubspot.jinjava.interpret.DeferredValueException;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.mode.EagerExecutionMode;
 import com.hubspot.jinjava.objects.date.InvalidDateFormatException;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -25,5 +31,24 @@ public class TodayFunctionTest {
   @Test(expected = InvalidDateFormatException.class)
   public void itThrowsExceptionOnInvalidTimezone() {
     ZonedDateTime zonedDateTime = Functions.today("Not a timezone");
+  }
+
+  @Test(expected = DeferredValueException.class)
+  public void itDefersWhenExecutingEagerly() {
+    JinjavaInterpreter.pushCurrent(
+      new JinjavaInterpreter(
+        new Jinjava(),
+        new Context(),
+        JinjavaConfig
+          .newBuilder()
+          .withExecutionMode(EagerExecutionMode.instance())
+          .build()
+      )
+    );
+    try {
+      Functions.today("America/New_York");
+    } finally {
+      JinjavaInterpreter.popCurrent();
+    }
   }
 }

--- a/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
@@ -672,6 +672,13 @@ public class EagerExpressionResolverTest {
       .containsExactlyInAnyOrder("['a', 'b']", "'a'", "'b'");
   }
 
+  @Test
+  public void itHandlesToday() {
+    context.put("foo", "bar");
+    assertThat(eagerResolveExpression("foo ~ today()").toString())
+      .isEqualTo("'bar' ~ today()");
+  }
+
   public static void voidFunction(int nothing) {}
 
   public static boolean isNull(Object foo, Object bar) {

--- a/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
@@ -18,6 +18,7 @@ import com.hubspot.jinjava.objects.collections.PyMap;
 import com.hubspot.jinjava.objects.date.PyishDate;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.objects.serialization.PyishSerializable;
+import com.hubspot.jinjava.random.RandomNumberGeneratorStrategy;
 import com.hubspot.jinjava.tree.parse.DefaultTokenScannerSymbols;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
@@ -52,6 +53,7 @@ public class EagerExpressionResolverTest {
       JinjavaConfig
         .newBuilder()
         .withExecutionMode(EagerExecutionMode.instance())
+        .withRandomNumberGeneratorStrategy(RandomNumberGeneratorStrategy.DEFERRED)
         .withLegacyOverrides(
           LegacyOverrides.newBuilder().withEvaluateMapKeys(evaluateMapKeys).build()
         )
@@ -677,6 +679,12 @@ public class EagerExpressionResolverTest {
     context.put("foo", "bar");
     assertThat(eagerResolveExpression("foo ~ today()").toString())
       .isEqualTo("'bar' ~ today()");
+  }
+
+  @Test
+  public void itHandlesRandom() {
+    assertThat(eagerResolveExpression("range(1)|random").toString())
+      .isEqualTo("filter:random.filter([0], ____int3rpr3t3r____)");
   }
 
   public static void voidFunction(int nothing) {}


### PR DESCRIPTION
When the `today()` function is called using eager execution, the result should be deferred because the purpose of eager execution is to allow all constant expressions to be evaluated, and that function does not return a constant result. Similarly, neither does random generation which is what the `DeferredRandomNumberGenerator` is for. In this PR, I am also migrating the `DeferredRandomNumberGenerator` to throw `DeferredParsingException` so that it can be handled better with eager execution.

In testing these changes, I found there was a bug that resulted from using `jsonGenerator.writeRaw()` rather than `jsonGenerator.writeRawValue()` because:
>writeRaw(String text)
Method that will force generator to copy input text verbatim with no modifications (including that no escaping is done and no separators are added even if context [array, object] would otherwise require such).

That caused the commas to be missing if a value in an array was written raw.
Also, since `method.invoke()` wraps exceptions, I am unwrapping the `DeferredParsingException` in `EagerAstMethod` and `EagerAstMacroFunction`.