### PR TITLE
[Eager Execution] Optimize context change validation

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -28,13 +28,16 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
     ExpressionToken master,
     JinjavaInterpreter interpreter
   ) {
-    EagerExecutionResult eagerExecutionResult = EagerTagDecorator.executeInChildContext(
-      eagerInterpreter ->
-        EagerExpressionResolver.resolveExpression(master.getExpr(), interpreter),
-      interpreter,
-      true,
-      interpreter.getConfig().isNestedInterpretationEnabled()
-    );
+    EagerExecutionResult eagerExecutionResult;
+    eagerExecutionResult =
+      EagerTagDecorator.executeInChildContext(
+        eagerInterpreter ->
+          EagerExpressionResolver.resolveExpression(master.getExpr(), interpreter),
+        interpreter,
+        true,
+        interpreter.getConfig().isNestedInterpretationEnabled(),
+        interpreter.getContext().isDeferredExecutionMode()
+      );
     StringBuilder prefixToPreserveState = new StringBuilder();
     if (interpreter.getContext().isDeferredExecutionMode()) {
       prefixToPreserveState.append(eagerExecutionResult.getPrefixToPreserveState());

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
@@ -47,7 +47,7 @@ public class EagerCycleTag extends EagerStateChangingTag<CycleTag> {
       interpreter,
       true,
       false,
-      false
+      interpreter.getContext().isDeferredExecutionMode()
     );
 
     StringBuilder prefixToPreserveState = new StringBuilder();

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
@@ -46,6 +46,7 @@ public class EagerCycleTag extends EagerStateChangingTag<CycleTag> {
         EagerExpressionResolver.resolveExpression(expression, interpreter),
       interpreter,
       true,
+      false,
       false
     );
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
@@ -46,7 +46,8 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
             ),
           interpreter,
           false,
-          false
+          false,
+          true
         )
         .asTemplateString()
     );

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
@@ -53,7 +53,8 @@ public class EagerPrintTag extends EagerStateChangingTag<PrintTag> {
       eagerInterpreter -> EagerExpressionResolver.resolveExpression(expr, interpreter),
       interpreter,
       true,
-      false
+      false,
+      interpreter.getContext().isDeferredExecutionMode()
     );
     StringBuilder prefixToPreserveState = new StringBuilder();
     if (interpreter.getContext().isDeferredExecutionMode()) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTag.java
@@ -45,7 +45,8 @@ public class EagerSetTag extends EagerStateChangingTag<SetTag> {
         EagerExpressionResolver.resolveExpression('[' + expression + ']', interpreter),
       interpreter,
       true,
-      false
+      false,
+      interpreter.getContext().isDeferredExecutionMode()
     );
 
     String[] varTokens = variables.split(",");

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
@@ -31,7 +31,8 @@ public class EagerStateChangingTag<T extends Tag> extends EagerTagDecorator<T> {
             EagerExpressionResult.fromString(renderChildren(tagNode, eagerInterpreter)),
           interpreter,
           false,
-          false
+          false,
+          true
         )
       );
     }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
@@ -89,7 +89,7 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
 
   @Test
   public void itExecutesInChildContextAndTakesNewValue() {
-    context.put("foo", new ArrayList<Integer>());
+    context.put("foo", new PyList(new ArrayList<>()));
     EagerExecutionResult result = EagerTagDecorator.executeInChildContext(
       (
         interpreter1 -> {
@@ -99,7 +99,8 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
       ),
       interpreter,
       true,
-      false
+      false,
+      true
     );
     assertThat(result.getResult().toString()).isEqualTo("function return");
     assertThat(result.getPrefixToPreserveState()).isEqualTo("{% set foo = [1] %}");
@@ -122,7 +123,8 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
       ),
       interpreter,
       false,
-      false
+      false,
+      true
     );
     assertThat(result.getResult().toString()).isEqualTo("function return");
     assertThat(result.getPrefixToPreserveState()).isEqualTo("{% set foo = [] %}");


### PR DESCRIPTION
Checking for changes in the context can be slow, and in many instances, it is not necessary. It is only needed when reconstructing the image for a tag or when running in deferred execution mode (such as speculative if-branch execution).

We can skip parsing the context when we don't need to prevent changes from being made to it. In certain cases, this will provide a dramatic performance increase.

Additionally, to prevent unnecessary calls to `hashCode()`, we can just call `hashCode()` for PyLists and PyMaps as other objects either cannot be modified or cannot be reconstructed anyway.