### PR TITLE
Fix capitalize and title filters

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/CapitalizeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/CapitalizeFilter.java
@@ -35,7 +35,7 @@ public class CapitalizeFilter implements Filter {
 
     if (var instanceof String) {
       String value = (String) var;
-      return StringUtils.capitalize(value);
+      return StringUtils.capitalize(value.toLowerCase());
     }
     return var;
   }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TitleFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TitleFilter.java
@@ -32,7 +32,7 @@ public class TitleFilter implements Filter {
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
     if (var instanceof String) {
       String value = (String) var;
-      return WordUtils.capitalize(value);
+      return WordUtils.capitalize(value.toLowerCase());
     }
     return var;
   }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/CapitalizeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/CapitalizeFilterTest.java
@@ -7,7 +7,19 @@ import org.junit.Test;
 public class CapitalizeFilterTest {
 
   @Test
-  public void testCapitalize() {
+  public void itCapitalizesNormalValues() {
     assertThat(new CapitalizeFilter().filter("foo", null)).isEqualTo("Foo");
+  }
+
+  @Test
+  public void itCapitalizesSentences() {
+    assertThat(new CapitalizeFilter().filter("foo is the best", null))
+      .isEqualTo("Foo is the best");
+  }
+
+  @Test
+  public void itLowercasesUppercasedCharsInSentences() {
+    assertThat(new CapitalizeFilter().filter("foo is the bEST", null))
+      .isEqualTo("Foo is the best");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/TitleFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/TitleFilterTest.java
@@ -7,8 +7,20 @@ import org.junit.Test;
 public class TitleFilterTest {
 
   @Test
-  public void testTitleCase() {
+  public void itTitleCasesNormalString() {
     assertThat(new TitleFilter().filter("this is string", null))
+      .isEqualTo("This Is String");
+  }
+
+  @Test
+  public void itDoesNotChangeAlreadyTitleCasedString() {
+    assertThat(new TitleFilter().filter("This Is String", null))
+      .isEqualTo("This Is String");
+  }
+
+  @Test
+  public void itLowercasesOtherUppercasedCharactersInString() {
+    assertThat(new TitleFilter().filter("this is sTRING", null))
       .isEqualTo("This Is String");
   }
 }


### PR DESCRIPTION
The filters were not matching spec as shown in the test cases. I validated that this behavior is consistent with the jinja2 implementation.