### PR TITLE
Prevent NPE due to issue with collecting to map with null values

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -239,7 +239,10 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
         .entrySet()
         .stream()
         .filter(entry -> !entry.getKey().equals(GLOBAL_MACROS_SCOPE_KEY))
-        .filter(entry -> !(entry.getValue() instanceof DeferredValue)) // these are already set recursively
+        .filter(
+          entry ->
+            !(entry.getValue() instanceof DeferredValue) && entry.getValue() != null
+        ) // these are already set recursively
         .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
 
     return new EagerExecutionResult(result, sessionBindings);


### PR DESCRIPTION
In case the session bindings contain entries with null values, they should be filtered out to prevent NullPointerExceptions when calling `collect(Collectors.toMap())`