### PR TITLE
[Eager Execution] Prevent import aliases from leaking outside of their scope

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -140,11 +140,15 @@ public class MacroFunction extends AbstractCallableMethod {
     LengthLimitingStringBuilder result = new LengthLimitingStringBuilder(
       interpreter.getConfig().getMaxOutputSize()
     );
+    int initialEagerTokenCount = interpreter.getContext().getEagerTokens().size();
 
     for (Node node : content) {
       result.append(node.render(interpreter));
     }
-    if (interpreter.getConfig().getExecutionMode().isPreserveRawTags()) {
+    if (
+      interpreter.getConfig().getExecutionMode().isPreserveRawTags() &&
+      initialEagerTokenCount == interpreter.getContext().getEagerTokens().size()
+    ) {
       try (
         TemporaryValueClosable<Boolean> c = interpreter
           .getContext()

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -108,20 +108,20 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
     String currentImportAlias
   ) {
     StringJoiner keyValueJoiner = new StringJoiner(",");
-    Object currentAliasMap = interpreter.getContext().get(currentImportAlias);
+    Object currentAliasMap = interpreter
+      .getContext()
+      .getSessionBindings()
+      .get(currentImportAlias);
     if ((!(currentAliasMap instanceof DeferredValue))) {
       // Make sure that the map is deferred.
       if (!(currentAliasMap instanceof Map)) {
         currentAliasMap = new PyMap(new HashMap<>());
       }
-      interpreter
-        .getContext()
-        .put(currentImportAlias, DeferredValue.instance(currentAliasMap));
+      currentAliasMap = DeferredValue.instance(currentAliasMap);
+      interpreter.getContext().put(currentImportAlias, currentAliasMap);
     }
     for (Map.Entry<String, Object> entry : (
-      (Map<String, Object>) (
-        (DeferredValue) interpreter.getContext().get(currentImportAlias)
-      ).getOriginalValue()
+      (Map<String, Object>) ((DeferredValue) currentAliasMap).getOriginalValue()
     ).entrySet()) {
       if (entry.getValue() instanceof DeferredValue) {
         keyValueJoiner.add(String.format("'%s': %s", entry.getKey(), entry.getKey()));
@@ -207,7 +207,11 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
     String currentImportAlias,
     JinjavaInterpreter child
   ) {
-    Object parentValueForChild = child.getContext().getParent().get(currentImportAlias);
+    Object parentValueForChild = child
+      .getContext()
+      .getParent()
+      .getSessionBindings()
+      .get(currentImportAlias);
     if (parentValueForChild instanceof Map) {
       return (Map<String, Object>) parentValueForChild;
     } else if (parentValueForChild instanceof DeferredValue) {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -523,6 +523,16 @@ public class EagerImportTagTest extends ImportTagTest {
   }
 
   @Test
+  public void itKeepsImportAliasVariablesInsideOwnScope() {
+    setupResourceLocator();
+    String result = interpreter.render(
+      "{% set printer = {'key': 'val'} %}{% import 'intermediate-b.jinja' as inter %}" +
+      "{{ printer }}-{{ inter.print() }}"
+    );
+    assertThat(result.trim()).isEqualTo("{'key': 'val'}-B_inter_B");
+  }
+
+  @Test
   public void itKeepsDeferredImportAliasesInsideOwnScope() {
     setupResourceLocator();
     String result = interpreter.render(

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -512,6 +512,27 @@ public class EagerImportTagTest extends ImportTagTest {
     assertThat(result).isEqualTo("here");
   }
 
+  @Test
+  public void itKeepsImportAliasesInsideOwnScope() {
+    setupResourceLocator();
+    String result = interpreter.render(
+      "{% import 'printer-a.jinja' as printer %}{% import 'intermediate-b.jinja' as inter %}" +
+      "{{ printer.print() }}-{{ inter.print() }}"
+    );
+    assertThat(result.trim()).isEqualTo("A_A_A-B_inter_B");
+  }
+
+  @Test
+  public void itKeepsDeferredImportAliasesInsideOwnScope() {
+    setupResourceLocator();
+    String result = interpreter.render(
+      "{% import 'printer-a.jinja' as printer %}{% import 'intermediate-b.jinja' as inter %}" +
+      "{{ printer.print(deferred) }}-{{ inter.print(deferred) }}"
+    );
+    context.put("deferred", "resolved");
+    assertThat(interpreter.render(result)).isEqualTo("A_resolved_A-B_resolved_B");
+  }
+
   private static JinjavaInterpreter getChildInterpreter(
     JinjavaInterpreter interpreter,
     String alias

--- a/src/test/resources/tags/eager/importtag/intermediate-b.jinja
+++ b/src/test/resources/tags/eager/importtag/intermediate-b.jinja
@@ -1,0 +1,4 @@
+{% import 'printer-b.jinja' as printer %}
+{% macro print(x='inter') -%}
+{{ printer.print(x) }}
+{%- endmacro %}

--- a/src/test/resources/tags/eager/importtag/printer-a.jinja
+++ b/src/test/resources/tags/eager/importtag/printer-a.jinja
@@ -1,0 +1,3 @@
+{% macro print(x='A') -%}
+A_{{ x }}_A
+{%- endmacro %}

--- a/src/test/resources/tags/eager/importtag/printer-b.jinja
+++ b/src/test/resources/tags/eager/importtag/printer-b.jinja
@@ -1,0 +1,3 @@
+{% macro print(x='B') -%}
+B_{{ x }}_B
+{%- endmacro %}


### PR DESCRIPTION
This fixes a bug where when using eager execution, import aliases could leak outside of the scope they were declared in due to calling `parent.getContext().get()` rather than `parent.getContext().getSessionBindings().get()`. If the parent had a variable present in its parent's context, then we would override that value rather than creating a new HashMap.

This can be demonstrated with an example with 3 files that will be imported:
1. `print-a.jinja`
```
{% macro print() %}
A
{% endmacro %}
```
2. `intermediate-b.jinja`
```
{% import 'print-b.jinja' %}
```
3. `print-b.jinja`
```
{% macro print() %}
B
{% endmacro %}
```
Rendering:
```
{% import 'print-a.jinja' as printer %}
{% import 'intermediate-b.jinja' as inter %}
{{ printer.print() }}
```
Should result in `A`, but the bug caused `printer` to be overridden as the import from `print-b.jinja`, and the turned the result to `B`.