### PR TITLE
Track correct path for multiple level of Extends inheritance

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -34,6 +34,7 @@ import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import com.hubspot.jinjava.interpret.errorcategory.BasicTemplateErrorCategory;
 import com.hubspot.jinjava.lib.tag.ExtendsTag;
+import com.hubspot.jinjava.lib.tag.eager.EagerGenericTag;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.objects.serialization.PyishSerializable;
 import com.hubspot.jinjava.random.ConstantZeroRandomNumberGenerator;
@@ -352,7 +353,20 @@ public class JinjavaInterpreter implements PyishSerializable {
   }
 
   private boolean isExtendsTag(Node node) {
-    return node instanceof TagNode && ((TagNode) node).getTag() instanceof ExtendsTag;
+    return (
+      node instanceof TagNode &&
+      (
+        ((TagNode) node).getTag() instanceof ExtendsTag ||
+        isEagerExtendsTag((TagNode) node)
+      )
+    );
+  }
+
+  private boolean isEagerExtendsTag(TagNode node) {
+    return (
+      node.getTag() instanceof EagerGenericTag &&
+      ((EagerGenericTag) node.getTag()).getTag() instanceof ExtendsTag
+    );
   }
 
   @SuppressFBWarnings(

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -33,11 +33,13 @@ import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import com.hubspot.jinjava.interpret.errorcategory.BasicTemplateErrorCategory;
+import com.hubspot.jinjava.lib.tag.ExtendsTag;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.objects.serialization.PyishSerializable;
 import com.hubspot.jinjava.random.ConstantZeroRandomNumberGenerator;
 import com.hubspot.jinjava.random.DeferredRandomNumberGenerator;
 import com.hubspot.jinjava.tree.Node;
+import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.TreeParser;
 import com.hubspot.jinjava.tree.output.BlockInfo;
 import com.hubspot.jinjava.tree.output.BlockPlaceholderOutputNode;
@@ -305,30 +307,37 @@ public class JinjavaInterpreter implements PyishSerializable {
 
     // render all extend parents, keeping the last as the root output
     if (processExtendRoots) {
+      Optional<String> extendPath = context.getExtendPathStack().peek();
       while (!extendParentRoots.isEmpty()) {
         context
           .getCurrentPathStack()
           .push(
-            context.getExtendPathStack().peek().orElse(""),
+            extendPath.orElse(""),
             context.getExtendPathStack().getTopLineNumber(),
             context.getExtendPathStack().getTopStartPosition()
           );
         Node parentRoot = extendParentRoots.removeFirst();
         output = new OutputList(config.getMaxOutputSize());
 
+        boolean hasNestedExtends = false;
         for (Node node : parentRoot.getChildren()) {
           lineNumber = node.getLineNumber() - 1; // The line number is off by one when rendering the extend parent
           position = node.getStartPosition();
           try {
             OutputNode out = node.render(this);
             output.addNode(out);
+            if (isExtendsTag(node)) {
+              hasNestedExtends = true;
+            }
           } catch (OutputTooBigException e) {
             addError(TemplateError.fromOutputTooBigException(e));
             return output.getValue();
           }
         }
 
-        context.getExtendPathStack().pop();
+        Optional<String> currentExtendPath = context.getExtendPathStack().pop();
+        extendPath =
+          hasNestedExtends ? currentExtendPath : context.getExtendPathStack().peek();
         context.getCurrentPathStack().pop();
       }
     }
@@ -340,6 +349,10 @@ public class JinjavaInterpreter implements PyishSerializable {
 
   private void resolveBlockStubs(OutputList output) {
     resolveBlockStubs(output, new Stack<>());
+  }
+
+  private boolean isExtendsTag(Node node) {
+    return node instanceof TagNode && ((TagNode) node).getTag() instanceof ExtendsTag;
   }
 
   @SuppressFBWarnings(

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ExtendsTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ExtendsTagTest.java
@@ -252,7 +252,8 @@ public class ExtendsTagTest extends BaseInterpretingTest {
       String fullName,
       Charset encoding,
       JinjavaInterpreter interpreter
-    ) throws IOException {
+    )
+      throws IOException {
       return fixture(fullName);
     }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ExtendsTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ExtendsTagTest.java
@@ -164,6 +164,19 @@ public class ExtendsTagTest extends BaseInterpretingTest {
   }
 
   @Test
+  public void itResolvesRelativePathsWithMultipleLevelsOfInheritance()
+    throws IOException {
+    jinjava
+      .getGlobalContext()
+      .put(CURRENT_PATH_CONTEXT_KEY, "relative/nested-relative-extends.jinja");
+    String result = jinjava.render(
+      locator.fixture("relative/nested-relative-extends.jinja"),
+      new HashMap<>()
+    );
+    assertThat(result).contains("hello");
+  }
+
+  @Test
   public void itSetsErrorLineNumbersCorrectlyInBlocksInExtendingTemplate()
     throws IOException {
     RenderResult result = jinjava.renderForResult(
@@ -239,8 +252,7 @@ public class ExtendsTagTest extends BaseInterpretingTest {
       String fullName,
       Charset encoding,
       JinjavaInterpreter interpreter
-    )
-      throws IOException {
+    ) throws IOException {
       return fixture(fullName);
     }
 

--- a/src/test/resources/tags/extendstag/nested-relative-inheritance.html
+++ b/src/test/resources/tags/extendstag/nested-relative-inheritance.html
@@ -1,0 +1,1 @@
+{% include "./hello.html" %}

--- a/src/test/resources/tags/extendstag/relative/nested-relative-extends-2.jinja
+++ b/src/test/resources/tags/extendstag/relative/nested-relative-extends-2.jinja
@@ -1,0 +1,1 @@
+{% extends "./../nested-relative-inheritance.html" %}

--- a/src/test/resources/tags/extendstag/relative/nested-relative-extends.jinja
+++ b/src/test/resources/tags/extendstag/relative/nested-relative-extends.jinja
@@ -1,0 +1,2 @@
+{% extends "./nested-relative-extends-2.jinja" %}
+


### PR DESCRIPTION
We're not tracking the currentPath correctly when dealing with multiple levels of inheritance via `extends` tags, which is leading to incorrect relative path resolution.

Prior to this PR, the test example: https://github.com/HubSpot/jinjava/pull/667/files#diff-2970b2d908f3ae9b6918c9b1bd9c7b678a92a8a054cb2c9bded5817bd4a41a9eR1

would resolve `./hello.html` to `/tags/extendstag/relative/hello.html` because it was incorrectly using `tags/extendstag/relative/nested-relative-extends-2.jinja` as the current path.