### PR TITLE
Make LazyExpression memoization disable-able

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/LazyExpression.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/LazyExpression.java
@@ -6,26 +6,35 @@ import java.util.function.Supplier;
 public class LazyExpression implements Supplier {
   private final Supplier supplier;
   private final String image;
-  private final boolean memoize;
+  private final MEMOIZATION memoization;
   private Object jsonValue = null;
 
-  private LazyExpression(Supplier supplier, String image, boolean memoize) {
+  public enum MEMOIZATION {
+    ON,
+    OFF
+  }
+
+  private LazyExpression(Supplier supplier, String image, MEMOIZATION memoization) {
     this.supplier = supplier;
     this.image = image;
-    this.memoize = memoize;
+    this.memoization = memoization;
   }
 
   public static LazyExpression of(Supplier supplier, String image) {
-    return new LazyExpression(supplier, image, true);
+    return new LazyExpression(supplier, image, MEMOIZATION.ON);
   }
 
-  public static LazyExpression of(Supplier supplier, String image, boolean memoize) {
-    return new LazyExpression(supplier, image, memoize);
+  public static LazyExpression of(
+    Supplier supplier,
+    String image,
+    MEMOIZATION memoization
+  ) {
+    return new LazyExpression(supplier, image, memoization);
   }
 
   @Override
   public Object get() {
-    if (jsonValue == null || !memoize) {
+    if (jsonValue == null || memoization == MEMOIZATION.OFF) {
       jsonValue = supplier.get();
     }
     return jsonValue;

--- a/src/main/java/com/hubspot/jinjava/interpret/LazyExpression.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/LazyExpression.java
@@ -20,7 +20,7 @@ public class LazyExpression implements Supplier {
   }
 
   public static LazyExpression of(Supplier supplier, String image, boolean memoize) {
-    return new LazyExpression(supplier, image, false);
+    return new LazyExpression(supplier, image, memoize);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/interpret/LazyExpression.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/LazyExpression.java
@@ -6,20 +6,26 @@ import java.util.function.Supplier;
 public class LazyExpression implements Supplier {
   private final Supplier supplier;
   private final String image;
+  private final boolean memoize;
   private Object jsonValue = null;
 
-  private LazyExpression(Supplier supplier, String image) {
+  private LazyExpression(Supplier supplier, String image, boolean memoize) {
     this.supplier = supplier;
     this.image = image;
+    this.memoize = memoize;
   }
 
   public static LazyExpression of(Supplier supplier, String image) {
-    return new LazyExpression(supplier, image);
+    return new LazyExpression(supplier, image, true);
+  }
+
+  public static LazyExpression of(Supplier supplier, String image, boolean memoize) {
+    return new LazyExpression(supplier, image, false);
   }
 
   @Override
   public Object get() {
-    if (jsonValue == null) {
+    if (jsonValue == null || !memoize) {
       jsonValue = supplier.get();
     }
     return jsonValue;

--- a/src/main/java/com/hubspot/jinjava/interpret/LazyExpression.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/LazyExpression.java
@@ -6,35 +6,35 @@ import java.util.function.Supplier;
 public class LazyExpression implements Supplier {
   private final Supplier supplier;
   private final String image;
-  private final MEMOIZATION memoization;
+  private final Memoization memoization;
   private Object jsonValue = null;
 
-  public enum MEMOIZATION {
+  public enum Memoization {
     ON,
     OFF
   }
 
-  private LazyExpression(Supplier supplier, String image, MEMOIZATION memoization) {
+  private LazyExpression(Supplier supplier, String image, Memoization memoization) {
     this.supplier = supplier;
     this.image = image;
     this.memoization = memoization;
   }
 
   public static LazyExpression of(Supplier supplier, String image) {
-    return new LazyExpression(supplier, image, MEMOIZATION.ON);
+    return new LazyExpression(supplier, image, Memoization.ON);
   }
 
   public static LazyExpression of(
     Supplier supplier,
     String image,
-    MEMOIZATION memoization
+    Memoization memoization
   ) {
     return new LazyExpression(supplier, image, memoization);
   }
 
   @Override
   public Object get() {
-    if (jsonValue == null || memoization == MEMOIZATION.OFF) {
+    if (jsonValue == null || memoization == Memoization.OFF) {
       jsonValue = supplier.get();
     }
     return jsonValue;

--- a/src/test/java/com/hubspot/jinjava/interpret/LazyExpressionTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/LazyExpressionTest.java
@@ -1,10 +1,12 @@
 package com.hubspot.jinjava.interpret;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import java.util.List;
 import org.junit.Test;
 
 public class LazyExpressionTest {
@@ -28,5 +30,23 @@ public class LazyExpressionTest {
       "{}"
     );
     assertThat(new ObjectMapper().writeValueAsString(expression)).isEqualTo("\"\"");
+  }
+
+  @Test
+  public void itMemoizesByDefault() {
+    List mock = mock(List.class);
+    LazyExpression expression = LazyExpression.of(mock::isEmpty, "");
+    expression.get();
+    expression.get();
+    verify(mock, times(1)).isEmpty();
+  }
+
+  @Test
+  public void itAllowsMemoizationToBeDisabled() {
+    List mock = mock(List.class);
+    LazyExpression expression = LazyExpression.of(mock::isEmpty, "", false);
+    expression.get();
+    expression.get();
+    verify(mock, times(2)).isEmpty();
   }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/LazyExpressionTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/LazyExpressionTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import com.hubspot.jinjava.interpret.LazyExpression.MEMOIZATION;
 import java.util.List;
 import org.junit.Test;
 
@@ -44,9 +45,18 @@ public class LazyExpressionTest {
   @Test
   public void itAllowsMemoizationToBeDisabled() {
     List mock = mock(List.class);
-    LazyExpression expression = LazyExpression.of(mock::isEmpty, "", false);
+    LazyExpression expression = LazyExpression.of(mock::isEmpty, "", MEMOIZATION.OFF);
     expression.get();
     expression.get();
     verify(mock, times(2)).isEmpty();
+  }
+
+  @Test
+  public void itAllowsMemoizationToBeEnabled() {
+    List mock = mock(List.class);
+    LazyExpression expression = LazyExpression.of(mock::isEmpty, "", MEMOIZATION.ON);
+    expression.get();
+    expression.get();
+    verify(mock, times(1)).isEmpty();
   }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/LazyExpressionTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/LazyExpressionTest.java
@@ -39,7 +39,7 @@ public class LazyExpressionTest {
     LazyExpression expression = LazyExpression.of(mock::isEmpty, "");
     expression.get();
     expression.get();
-    verify(mock, times(1)).isEmpty();
+    verify(mock).isEmpty();
   }
 
   @Test
@@ -57,6 +57,6 @@ public class LazyExpressionTest {
     LazyExpression expression = LazyExpression.of(mock::isEmpty, "", Memoization.ON);
     expression.get();
     expression.get();
-    verify(mock, times(1)).isEmpty();
+    verify(mock).isEmpty();
   }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/LazyExpressionTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/LazyExpressionTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
-import com.hubspot.jinjava.interpret.LazyExpression.MEMOIZATION;
+import com.hubspot.jinjava.interpret.LazyExpression.Memoization;
 import java.util.List;
 import org.junit.Test;
 
@@ -45,7 +45,7 @@ public class LazyExpressionTest {
   @Test
   public void itAllowsMemoizationToBeDisabled() {
     List mock = mock(List.class);
-    LazyExpression expression = LazyExpression.of(mock::isEmpty, "", MEMOIZATION.OFF);
+    LazyExpression expression = LazyExpression.of(mock::isEmpty, "", Memoization.OFF);
     expression.get();
     expression.get();
     verify(mock, times(2)).isEmpty();
@@ -54,7 +54,7 @@ public class LazyExpressionTest {
   @Test
   public void itAllowsMemoizationToBeEnabled() {
     List mock = mock(List.class);
-    LazyExpression expression = LazyExpression.of(mock::isEmpty, "", MEMOIZATION.ON);
+    LazyExpression expression = LazyExpression.of(mock::isEmpty, "", Memoization.ON);
     expression.get();
     expression.get();
     verify(mock, times(1)).isEmpty();


### PR DESCRIPTION
Adds an additional factory `of(Supplier, String, Memoization)` which allows for memoization of `LazyExpression` objects to be explicitly enabled or disabled.

The original factory `of(Supplier, String)` retains the original, memoized behavior.