### PR TITLE
[Eager Execution] Add config for turning on deferred context reverting

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -227,26 +227,31 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
             )
           );
       initiallyResolvedAsStrings = new HashMap<>();
-
-      initiallyResolvedHashes
-        .keySet()
-        .stream()
-        .filter(
-          key ->
-            EagerExpressionResolver.isResolvableObject(interpreter.getContext().get(key))
-        )
-        .forEach(
-          key -> {
-            try {
-              initiallyResolvedAsStrings.put(
-                key,
-                PyishObjectMapper.getAsUnquotedPyishString(
-                  interpreter.getContext().get(key)
-                )
-              );
-            } catch (Exception ignored) {}
-          }
-        );
+      // This creates a stringified snapshot of the context
+      // so it can be disabled via the config because it may cause performance issues.
+      if (interpreter.getConfig().getExecutionMode().useEagerContextReverting()) {
+        initiallyResolvedHashes
+          .keySet()
+          .stream()
+          .filter(
+            key ->
+              EagerExpressionResolver.isResolvableObject(
+                interpreter.getContext().get(key)
+              )
+          )
+          .forEach(
+            key -> {
+              try {
+                initiallyResolvedAsStrings.put(
+                  key,
+                  PyishObjectMapper.getAsUnquotedPyishString(
+                    interpreter.getContext().get(key)
+                  )
+                );
+              } catch (Exception ignored) {}
+            }
+          );
+      }
     } else {
       initiallyResolvedHashes = Collections.emptyMap();
       initiallyResolvedAsStrings = Collections.emptyMap();

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -226,25 +226,27 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
                   : entry.getValue()
             )
           );
-      initiallyResolvedAsStrings =
-        initiallyResolvedHashes
-          .keySet()
-          .stream()
-          .filter(
-            key ->
-              EagerExpressionResolver.isResolvableObject(
-                interpreter.getContext().get(key)
-              )
-          )
-          .collect(
-            Collectors.toMap(
-              Function.identity(),
-              key ->
+      initiallyResolvedAsStrings = new HashMap<>();
+
+      initiallyResolvedHashes
+        .keySet()
+        .stream()
+        .filter(
+          key ->
+            EagerExpressionResolver.isResolvableObject(interpreter.getContext().get(key))
+        )
+        .forEach(
+          key -> {
+            try {
+              initiallyResolvedAsStrings.put(
+                key,
                 PyishObjectMapper.getAsUnquotedPyishString(
                   interpreter.getContext().get(key)
                 )
-            )
-          );
+              );
+            } catch (Exception ignored) {}
+          }
+        );
     } else {
       initiallyResolvedHashes = Collections.emptyMap();
       initiallyResolvedAsStrings = Collections.emptyMap();

--- a/src/main/java/com/hubspot/jinjava/mode/EagerExecutionMode.java
+++ b/src/main/java/com/hubspot/jinjava/mode/EagerExecutionMode.java
@@ -27,6 +27,11 @@ public class EagerExecutionMode implements ExecutionMode {
   }
 
   @Override
+  public boolean useEagerContextReverting() {
+    return true;
+  }
+
+  @Override
   public void prepareContext(Context context) {
     context
       .getAllTags()

--- a/src/main/java/com/hubspot/jinjava/mode/ExecutionMode.java
+++ b/src/main/java/com/hubspot/jinjava/mode/ExecutionMode.java
@@ -11,5 +11,9 @@ public interface ExecutionMode {
     return false;
   }
 
+  default boolean useEagerContextReverting() {
+    return false;
+  }
+
   default void prepareContext(Context context) {}
 }


### PR DESCRIPTION
The feature in eager execution of reverting the context to a values deserialized from a stringified snapshot is performance heavy so this allows it to be set via Execution Mode. Providing a custom execution mode that does eager execution can turn it off. 
It will only happen anyway when doing eager execution and evaluating in `deferredExecutionMode`, which is the speculative mode where the results may not be committed in the final version.
Also, when building the context snapshot, if there's an error serializing a value on the context, we can ignore it because it most likely won't change. If it does, then we can throw a DeferredValueException. This doesn't remove any functionality, as it would only cause DeferredValueException to be thrown if an exception was thrown when trying to serialize it.