### PR TITLE
Add support for partially deferred values

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBracket.java
@@ -45,7 +45,7 @@ public class EagerAstBracket extends AstBracket implements EvalResultHolder {
           context,
           (EvalResultHolder) prefix,
           e,
-          false
+          true
         ),
         EvalResultHolder.reconstructNode(
           bindings,

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBracket.java
@@ -1,11 +1,12 @@
 package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
-import com.hubspot.jinjava.util.EagerExpressionResolver;
+import com.hubspot.jinjava.interpret.DeferredValueException;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstBracket;
 import de.odysseus.el.tree.impl.ast.AstNode;
 import javax.el.ELContext;
+import javax.el.ELException;
 
 public class EagerAstBracket extends AstBracket implements EvalResultHolder {
   protected Object evalResult;
@@ -33,31 +34,28 @@ public class EagerAstBracket extends AstBracket implements EvalResultHolder {
       evalResult = super.eval(bindings, context);
       hasEvalResult = true;
       return evalResult;
-    } catch (DeferredParsingException e) {
-      StringBuilder sb = new StringBuilder();
-      if (((EvalResultHolder) prefix).hasEvalResult()) {
-        sb.append(
-          EagerExpressionResolver.getValueAsJinjavaStringSafe(
-            ((EvalResultHolder) prefix).getAndClearEvalResult()
-          )
-        );
-        sb.append(String.format("[%s]", e.getDeferredEvalResult()));
-      } else {
-        sb.append(e.getDeferredEvalResult());
-        try {
-          sb.append(
-            String.format(
-              "[%s]",
-              EagerExpressionResolver.getValueAsJinjavaStringSafe(
-                property.eval(bindings, context)
-              )
-            )
-          );
-        } catch (DeferredParsingException e1) {
-          sb.append(String.format("[%s]", e1.getDeferredEvalResult()));
-        }
-      }
-      throw new DeferredParsingException(this, sb.toString());
+    } catch (DeferredValueException | ELException originalException) {
+      DeferredParsingException e = EvalResultHolder.convertToDeferredParsingException(
+        originalException
+      );
+      String sb = String.format(
+        "%s[%s]",
+        EvalResultHolder.reconstructNode(
+          bindings,
+          context,
+          (EvalResultHolder) prefix,
+          e,
+          false
+        ),
+        EvalResultHolder.reconstructNode(
+          bindings,
+          context,
+          (EvalResultHolder) property,
+          e,
+          false
+        )
+      );
+      throw new DeferredParsingException(this, sb);
     } finally {
       ((EvalResultHolder) prefix).getAndClearEvalResult();
       ((EvalResultHolder) property).getAndClearEvalResult();

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDot.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDot.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.interpret.DeferredValueException;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstDot;
 import de.odysseus.el.tree.impl.ast.AstNode;
@@ -44,10 +45,18 @@ public class EagerAstDot extends AstDot implements EvalResultHolder {
       evalResult = super.eval(bindings, context);
       hasEvalResult = true;
       return evalResult;
-    } catch (DeferredParsingException e) {
+    } catch (DeferredValueException | ELException originalException) {
+      DeferredParsingException e = EvalResultHolder.convertToDeferredParsingException(
+        originalException
+      );
+
       throw new DeferredParsingException(
         this,
-        String.format("%s.%s", e.getDeferredEvalResult(), this.property)
+        String.format(
+          "%s.%s",
+          EvalResultHolder.reconstructNode(bindings, context, base, e, false),
+          property
+        )
       );
     } finally {
       base.getAndClearEvalResult();

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDot.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDot.java
@@ -54,7 +54,7 @@ public class EagerAstDot extends AstDot implements EvalResultHolder {
         this,
         String.format(
           "%s.%s",
-          EvalResultHolder.reconstructNode(bindings, context, base, e, false),
+          EvalResultHolder.reconstructNode(bindings, context, base, e, true),
           property
         )
       );

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifier.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifier.java
@@ -1,9 +1,11 @@
 package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.interpret.DeferredValueException;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstIdentifier;
 import javax.el.ELContext;
+import javax.el.ELException;
 
 public class EagerAstIdentifier extends AstIdentifier implements EvalResultHolder {
   protected Object evalResult;
@@ -19,7 +21,8 @@ public class EagerAstIdentifier extends AstIdentifier implements EvalResultHolde
       evalResult = super.eval(bindings, context);
       hasEvalResult = true;
       return evalResult;
-    } catch (DeferredParsingException e) {
+    } catch (DeferredValueException | ELException originalException) {
+      EvalResultHolder.convertToDeferredParsingException(originalException);
       throw new DeferredParsingException(this, getName());
     }
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
@@ -40,17 +40,10 @@ public class EagerAstMacroFunction extends AstMacroFunction implements EvalResul
       evalResult = super.eval(bindings, context);
       hasEvalResult = true;
       return evalResult;
-    } catch (DeferredValueException | ELException e) {
-      DeferredValueException e1;
-      if (!(e instanceof DeferredValueException)) {
-        if (e.getCause() instanceof DeferredValueException) {
-          e1 = (DeferredValueException) e.getCause();
-        } else {
-          throw e;
-        }
-      } else {
-        e1 = (DeferredValueException) e;
-      }
+    } catch (DeferredValueException | ELException originalException) {
+      DeferredParsingException e = EvalResultHolder.convertToDeferredParsingException(
+        originalException
+      );
       StringBuilder sb = new StringBuilder();
       sb.append(getName());
       try {
@@ -61,9 +54,7 @@ public class EagerAstMacroFunction extends AstMacroFunction implements EvalResul
               bindings,
               context,
               (EvalResultHolder) ((AstParameters) params).getChild(i),
-              e1 instanceof DeferredParsingException
-                ? (DeferredParsingException) e1
-                : null,
+              e,
               false
             )
           );

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
@@ -38,20 +38,14 @@ public class EagerAstMethod extends AstMethod implements EvalResultHolder {
       evalResult = super.eval(bindings, context);
       hasEvalResult = true;
       return evalResult;
-    } catch (DeferredParsingException | ELException e) {
-      DeferredParsingException e1;
-      if (!(e instanceof DeferredParsingException)) {
-        if (e.getCause() instanceof DeferredParsingException) {
-          e1 = (DeferredParsingException) e.getCause();
-        } else {
-          throw e;
-        }
-      } else {
-        e1 = (DeferredParsingException) e;
-      }
+    } catch (DeferredValueException | ELException originalException) {
+      DeferredParsingException e = EvalResultHolder.convertToDeferredParsingException(
+        originalException
+      );
+
       throw new DeferredParsingException(
         this,
-        getPartiallyResolved(bindings, context, e1)
+        getPartiallyResolved(bindings, context, e)
       );
     } finally {
       property.getAndClearEvalResult();
@@ -115,7 +109,10 @@ public class EagerAstMethod extends AstMethod implements EvalResultHolder {
         true
       );
     String paramString;
-    if (deferredParsingException.getSourceNode() == params) {
+    if (
+      deferredParsingException != null &&
+      deferredParsingException.getSourceNode() == params
+    ) {
       paramString = deferredParsingException.getDeferredEvalResult();
     } else {
       try {

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstRangeBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstRangeBracket.java
@@ -46,7 +46,7 @@ public class EagerAstRangeBracket extends AstRangeBracket implements EvalResultH
           context,
           (EvalResultHolder) prefix,
           e,
-          false
+          true
         ) +
         "[" +
         EvalResultHolder.reconstructNode(

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstRangeBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstRangeBracket.java
@@ -2,9 +2,11 @@ package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.AstRangeBracket;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.interpret.DeferredValueException;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstNode;
 import javax.el.ELContext;
+import javax.el.ELException;
 
 public class EagerAstRangeBracket extends AstRangeBracket implements EvalResultHolder {
   protected Object evalResult;
@@ -34,7 +36,10 @@ public class EagerAstRangeBracket extends AstRangeBracket implements EvalResultH
       evalResult = super.eval(bindings, context);
       hasEvalResult = true;
       return evalResult;
-    } catch (DeferredParsingException e) {
+    } catch (DeferredValueException | ELException originalException) {
+      DeferredParsingException e = EvalResultHolder.convertToDeferredParsingException(
+        originalException
+      );
       String sb =
         EvalResultHolder.reconstructNode(
           bindings,

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.el.ext.ExtendedParser;
+import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstIdentifier;
@@ -51,5 +52,24 @@ public interface EvalResultHolder {
       }
     }
     return partiallyResolvedImage;
+  }
+
+  static DeferredParsingException convertToDeferredParsingException(
+    RuntimeException original
+  ) {
+    DeferredValueException deferredValueException;
+    if (!(original instanceof DeferredValueException)) {
+      if (original.getCause() instanceof DeferredValueException) {
+        deferredValueException = (DeferredValueException) original.getCause();
+      } else {
+        throw original;
+      }
+    } else {
+      deferredValueException = (DeferredValueException) original;
+    }
+    if (deferredValueException instanceof DeferredParsingException) {
+      return (DeferredParsingException) deferredValueException;
+    }
+    return null;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/DeferredMap.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/DeferredMap.java
@@ -1,7 +1,0 @@
-package com.hubspot.jinjava.interpret;
-
-/**
- * An interface for a type of DeferredValue that as a whole is not deferred,
- * but certain attributes within it are deferred.
- */
-public interface DeferredMap extends DeferredValue {}

--- a/src/main/java/com/hubspot/jinjava/interpret/DeferredMap.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/DeferredMap.java
@@ -1,0 +1,7 @@
+package com.hubspot.jinjava.interpret;
+
+/**
+ * An interface for a type of DeferredValue that as a whole is not deferred,
+ * but certain attributes within it are deferred.
+ */
+public interface DeferredMap extends DeferredValue {}

--- a/src/main/java/com/hubspot/jinjava/interpret/DeferredValue.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/DeferredValue.java
@@ -5,26 +5,14 @@ package com.hubspot.jinjava.interpret;
  * this part of the template, if the object is resolved from the context.
  *
  */
-public class DeferredValue {
-  private static final DeferredValue INSTANCE = new DeferredValue();
+public interface DeferredValue {
+  Object getOriginalValue();
 
-  private Object originalValue;
-
-  private DeferredValue() {}
-
-  private DeferredValue(Object originalValue) {
-    this.originalValue = originalValue;
+  static DeferredValue instance() {
+    return DeferredValueImpl.instance();
   }
 
-  public Object getOriginalValue() {
-    return originalValue;
-  }
-
-  public static DeferredValue instance() {
-    return INSTANCE;
-  }
-
-  public static DeferredValue instance(Object originalValue) {
-    return new DeferredValue(originalValue);
+  static DeferredValue instance(Object originalValue) {
+    return DeferredValueImpl.instance(originalValue);
   }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/DeferredValueImpl.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/DeferredValueImpl.java
@@ -1,0 +1,25 @@
+package com.hubspot.jinjava.interpret;
+
+public class DeferredValueImpl implements DeferredValue {
+  private static final DeferredValue INSTANCE = new DeferredValueImpl();
+
+  private Object originalValue;
+
+  private DeferredValueImpl() {}
+
+  private DeferredValueImpl(Object originalValue) {
+    this.originalValue = originalValue;
+  }
+
+  public Object getOriginalValue() {
+    return originalValue;
+  }
+
+  public static DeferredValue instance() {
+    return INSTANCE;
+  }
+
+  public static DeferredValue instance(Object originalValue) {
+    return new DeferredValueImpl(originalValue);
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -453,7 +453,7 @@ public class JinjavaInterpreter implements PyishSerializable {
       obj = context.getDynamicVariableResolver().apply(varName);
     }
     if (obj != null) {
-      if (obj instanceof DeferredValue && !(obj instanceof DeferredMap)) {
+      if (obj instanceof DeferredValue && !(obj instanceof PartiallyDeferredValue)) {
         if (config.getExecutionMode().useEagerParser()) {
           throw new DeferredParsingException(this, variable);
         } else {

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -453,7 +453,7 @@ public class JinjavaInterpreter implements PyishSerializable {
       obj = context.getDynamicVariableResolver().apply(varName);
     }
     if (obj != null) {
-      if (obj instanceof DeferredValue) {
+      if (obj instanceof DeferredValue && !(obj instanceof DeferredMap)) {
         if (config.getExecutionMode().useEagerParser()) {
           throw new DeferredParsingException(this, variable);
         } else {

--- a/src/main/java/com/hubspot/jinjava/interpret/PartiallyDeferredValue.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/PartiallyDeferredValue.java
@@ -1,0 +1,7 @@
+package com.hubspot.jinjava.interpret;
+
+/**
+ * An interface for a type of DeferredValue that as a whole is not deferred,
+ * but certain attributes or methods within it are deferred.
+ */
+public interface PartiallyDeferredValue extends DeferredValue {}

--- a/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.el.ELException;
 import org.apache.commons.lang3.StringUtils;
 
 public class EagerExpressionResolver {
@@ -172,7 +173,7 @@ public class EagerExpressionResolver {
       }
       // don't defer numbers, values such as true/false, etc.
       return interpreter.resolveELExpression(w, interpreter.getLineNumber()) == null;
-    } catch (DeferredValueException | TemplateSyntaxException e) {
+    } catch (ELException | DeferredValueException | TemplateSyntaxException e) {
       return true;
     }
   }

--- a/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstDotTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstDotTest.java
@@ -6,10 +6,10 @@ import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.LegacyOverrides;
 import com.hubspot.jinjava.interpret.Context;
-import com.hubspot.jinjava.interpret.DeferredMap;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.PartiallyDeferredValue;
 import com.hubspot.jinjava.mode.EagerExecutionMode;
 import com.hubspot.jinjava.random.RandomNumberGeneratorStrategy;
 import org.junit.Before;
@@ -52,7 +52,7 @@ public class EagerAstDotTest extends BaseInterpretingTest {
     assertThat(interpreter.render("{{ foo.resolved }}")).isEqualTo("resolved");
   }
 
-  public static class Foo implements DeferredMap {
+  public static class Foo implements PartiallyDeferredValue {
 
     public String getDeferred() {
       throw new DeferredValueException("foo.deferred is deferred");

--- a/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstDotTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstDotTest.java
@@ -1,0 +1,70 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hubspot.jinjava.BaseInterpretingTest;
+import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.LegacyOverrides;
+import com.hubspot.jinjava.interpret.Context;
+import com.hubspot.jinjava.interpret.DeferredMap;
+import com.hubspot.jinjava.interpret.DeferredValue;
+import com.hubspot.jinjava.interpret.DeferredValueException;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.mode.EagerExecutionMode;
+import com.hubspot.jinjava.random.RandomNumberGeneratorStrategy;
+import org.junit.Before;
+import org.junit.Test;
+
+public class EagerAstDotTest extends BaseInterpretingTest {
+
+  @Before
+  public void setup() {
+    JinjavaConfig config = JinjavaConfig
+      .newBuilder()
+      .withRandomNumberGeneratorStrategy(RandomNumberGeneratorStrategy.DEFERRED)
+      .withExecutionMode(EagerExecutionMode.instance())
+      .withNestedInterpretationEnabled(true)
+      .withLegacyOverrides(
+        LegacyOverrides.newBuilder().withUsePyishObjectMapper(true).build()
+      )
+      .withMaxMacroRecursionDepth(5)
+      .withEnableRecursiveMacroCalls(true)
+      .build();
+    JinjavaInterpreter parentInterpreter = new JinjavaInterpreter(
+      jinjava,
+      new Context(),
+      config
+    );
+    interpreter = new JinjavaInterpreter(parentInterpreter);
+
+    interpreter.getContext().put("deferred", DeferredValue.instance());
+  }
+
+  @Test
+  public void itDefersWhenDotThrowsDeferredValueException() {
+    interpreter.getContext().put("foo", new Foo());
+    assertThat(interpreter.render("{{ foo.deferred }}")).isEqualTo("{{ foo.deferred }}");
+  }
+
+  @Test
+  public void itResolvedDeferredMapWithDot() {
+    interpreter.getContext().put("foo", new Foo());
+    assertThat(interpreter.render("{{ foo.resolved }}")).isEqualTo("resolved");
+  }
+
+  public static class Foo implements DeferredMap {
+
+    public String getDeferred() {
+      throw new DeferredValueException("foo.deferred is deferred");
+    }
+
+    public String getResolved() {
+      return "resolved";
+    }
+
+    @Override
+    public Object getOriginalValue() {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
It is possible that some object may be added to the context that has some methods or attributes that should be deferred, but others that should be resolved.

This PR modifies the structure of Deferred values by changing `DeferredValue` to be an interface and adding a `DeferredValueImpl` which is what all normal deferred values will be. And a new interface `PartiallyDeferredValue` is added such that when `JinjavaInterpreterResolver` encounters one of these, it doesn't immediately throw a `DeferredValueException`. This is how it differs from any `DeferredValueImpl`. It and its attributes or methods can be accessed, but when they throw a `DeferredValueException`, we won't try to reconstruct it using a `{% set %}` tag.

In this PR, I'm also making some changes to EagerAstNodes because if a `DeferredValueException` is thrown in this code within AstProperty and AstIdentifier:
```
Object result = context.getELResolver().getValue(context, base, property);
```
, then it gets wrapped in ELException, and needs to be unwrapped.