### PR TITLE
[Eager Execution] Don't run macro functions twice

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -140,21 +140,11 @@ public class MacroFunction extends AbstractCallableMethod {
     LengthLimitingStringBuilder result = new LengthLimitingStringBuilder(
       interpreter.getConfig().getMaxOutputSize()
     );
-    int initialEagerTokenCount = interpreter.getContext().getEagerTokens().size();
-
-    for (Node node : content) {
-      result.append(node.render(interpreter));
-    }
-    if (
-      interpreter.getConfig().getExecutionMode().isPreserveRawTags() &&
-      initialEagerTokenCount == interpreter.getContext().getEagerTokens().size()
+    try (
+      TemporaryValueClosable<Boolean> c = interpreter.getContext().withUnwrapRawOverride()
     ) {
-      try (
-        TemporaryValueClosable<Boolean> c = interpreter
-          .getContext()
-          .withUnwrapRawOverride()
-      ) {
-        return interpreter.renderFlat(result.toString());
+      for (Node node : content) {
+        result.append(node.render(interpreter));
       }
     }
     return result.toString();


### PR DESCRIPTION
Instead of running macro functions twice to remove remaining raw expressions, just run them once using the `unwrapRawOverride` to not preserve raw tags. It is more efficient this way, and it fixes a problem where macro functions that produced comment-like output would get altered. (containing `{#`)