### PR TITLE
Use interpreter config timezone as default instead of UTC

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -141,7 +141,7 @@ public class Functions {
       );
     }
     ZoneId zoneOffset = getDefaultZoneId();
-    if (var.length > 0) {
+    if (var.length > 0 && var[0] != null) {
       String timezone = var[0];
       try {
         zoneOffset = ZoneId.of(timezone);

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -326,12 +326,6 @@ public class Functions {
 
     try {
       String convertedFormat = StrftimeFormatter.toJavaDateTimeFormat(dateFormat);
-      ZonedDateTime.of(
-        LocalDate
-          .parse(dateString, DateTimeFormatter.ofPattern(convertedFormat))
-          .atTime(0, 0),
-        getDefaultZoneId()
-      );
 
       return new PyishDate(
         ZonedDateTime.of(

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -21,7 +21,6 @@ import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
@@ -3,9 +3,13 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hubspot.jinjava.BaseInterpretingTest;
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.fn.Functions;
 import com.hubspot.jinjava.objects.date.InvalidDateFormatException;
 import com.hubspot.jinjava.objects.date.StrftimeFormatter;
+import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Locale;
@@ -13,9 +17,16 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class DateTimeFormatFilterTest extends BaseInterpretingTest {
-  DateTimeFormatFilter filter;
+  private static final JinjavaConfig JAPANESE_LOCALE_CONFIG = new JinjavaConfig(
+    StandardCharsets.UTF_8,
+    new Locale("ja", "JA"),
+    ZoneOffset.ofHours(9),
+    10
+  );
 
-  ZonedDateTime d;
+  private DateTimeFormatFilter filter;
+
+  private ZonedDateTime d;
 
   @Before
   public void setup() {
@@ -110,5 +121,27 @@ public class DateTimeFormatFilterTest extends BaseInterpretingTest {
         )
       )
       .isEqualTo(Functions.dateTimeFormat(d, "%A, %e %B", "UTC", "America/Los_Angeles"));
+  }
+
+  @Test
+  public void itUsesConfigZoneAsDefault() {
+    JinjavaInterpreter japaneseInterpreter = new Jinjava(JAPANESE_LOCALE_CONFIG)
+    .newInterpreter();
+
+    try {
+      JinjavaInterpreter.pushCurrent(japaneseInterpreter);
+
+      // before UTC midnight on 6/10 (or 6/11 in Japanese timezone)
+      japaneseInterpreter.getContext().put("d", 1623337200000L);
+
+      assertThat(
+          japaneseInterpreter.renderFlat(
+            "{{ d|datetimeformat('%m') }}/{{ d|datetimeformat('%e') }}"
+          )
+        )
+        .isEqualTo("06/11");
+    } finally {
+      JinjavaInterpreter.popCurrent();
+    }
   }
 }


### PR DESCRIPTION
The interpreter config allows you to set a timezone, however we are not using that config value in our datetime functions leading to unexpected datetimeformat output.