### PR TITLE
Ensure lazy expressions that supply null don't cause template errors

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
@@ -294,6 +294,9 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
 
     if (value instanceof LazyExpression) {
       value = ((LazyExpression) value).get();
+      if (value == null) {
+        return null;
+      }
     }
 
     if (value instanceof PyWrapper) {

--- a/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
@@ -206,6 +206,9 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
 
             if (base instanceof LazyExpression) {
               base = ((LazyExpression) base).get();
+              if (base == null) {
+                return null;
+              }
             }
 
             // java doesn't natively support negative array indices, so the
@@ -240,6 +243,9 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
 
             if (value instanceof LazyExpression) {
               value = ((LazyExpression) value).get();
+              if (value == null) {
+                return null;
+              }
             }
 
             if (value instanceof DeferredValue) {

--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
@@ -568,6 +568,14 @@ public class ExpressionResolverTest {
   }
 
   @Test
+  public void itResolvesNullLazyExpressions() {
+    Supplier<Object> lazyNull = () -> null;
+    context.put("nullobj", LazyExpression.of(lazyNull, ""));
+    assertThat(interpreter.resolveELExpression("nullobj", -1)).isNull();
+    assertThat(interpreter.getErrors()).isEmpty();
+  }
+
+  @Test
   public void itResolvesSuppliersOnlyIfResolved() {
     TestClass testClass = new TestClass();
     Supplier<String> lazyString = () -> result("hallelujah", testClass);


### PR DESCRIPTION
In the current code, if a LazyExpression supplies `null`, then `JinjavaInterpreterResolver#wrap` generates a NullPointerException which becomes a TemplateError due to calling `getClass()` on `null` post-resolution. This prevents that from happening.