### PR TITLE
[Eager Execution] Prevent stack overflow when deferring macro functions

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
@@ -139,7 +139,7 @@ public class EagerMacroFunction extends AbstractCallableMethod {
         AstMacroFunction.checkAndPushMacroStack(interpreter, fullName)
       )
     ) {
-      result = macroFunction.reconstructImage();
+      return "";
     } else {
       try {
         String evaluation = (String) evaluate(

--- a/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.lib.fn.eager;
 
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.el.ext.AbstractCallableMethod;
+import com.hubspot.jinjava.el.ext.AstMacroFunction;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
@@ -131,18 +132,32 @@ public class EagerMacroFunction extends AbstractCallableMethod {
     }
 
     String result;
-    try {
-      String evaluation = (String) evaluate(
-        macroFunction
-          .getArguments()
-          .stream()
-          .map(arg -> DeferredValue.instance())
-          .toArray()
-      );
-      result = (getStartTag(interpreter) + evaluation + getEndTag(interpreter));
-    } catch (DeferredValueException e) {
-      // In case something not eager-supported encountered a deferred value
+    if (
+      interpreter.getContext().getMacroStack().contains(macroFunction.getName()) ||
+      (
+        !macroFunction.isCaller() &&
+        AstMacroFunction.checkAndPushMacroStack(interpreter, fullName)
+      )
+    ) {
       result = macroFunction.reconstructImage();
+    } else {
+      try {
+        String evaluation = (String) evaluate(
+          macroFunction
+            .getArguments()
+            .stream()
+            .map(arg -> DeferredValue.instance())
+            .toArray()
+        );
+        result = (getStartTag(interpreter) + evaluation + getEndTag(interpreter));
+      } catch (DeferredValueException e) {
+        // In case something not eager-supported encountered a deferred value
+        result = macroFunction.reconstructImage();
+      } finally {
+        if (!macroFunction.isCaller()) {
+          interpreter.getContext().getMacroStack().pop();
+        }
+      }
     }
     return prefix + result + suffix;
   }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -45,6 +45,8 @@ public class EagerImportTagTest extends ImportTagTest {
           .withLegacyOverrides(
             LegacyOverrides.newBuilder().withUsePyishObjectMapper(true).build()
           )
+          .withEnableRecursiveMacroCalls(true)
+          .withMaxMacroRecursionDepth(10)
           .build()
       );
     Tag tag = EagerTagFactory


### PR DESCRIPTION
When deferring macro functions and reconstructing them, the logic of pushing to the macro stack was missing. This allowed for stack overflow to occur if the deferred macro function used recursion. This is fixed by making use of the macro stack to both prevent it from going over the maximum and by checking if the deferred macro function is using recursion, in which case it needn't be reconstructed more than once.

Example:
```
{% macro rec(num=0) %}
  {% if num > 0 %}
    {{ num }}-{{ rec(num - 1) }} {# while reconstructing, once we get here we don't need to recursively reconstruct, because it won't change #}
  {% endif %}
{% endmacro %}
```