### PR TITLE
[Eager Execution] Defer other time-based functions

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -126,20 +126,6 @@ public class Functions {
     }
   )
   public static ZonedDateTime today(String... var) {
-    if (
-      JinjavaInterpreter
-        .getCurrentMaybe()
-        .map(JinjavaInterpreter::getConfig)
-        .map(JinjavaConfig::getExecutionMode)
-        .map(ExecutionMode::useEagerParser)
-        .orElse(false)
-    ) {
-      throw new DeferredValueException(
-        "today() is deferred",
-        JinjavaInterpreter.getCurrent().getLineNumber(),
-        JinjavaInterpreter.getCurrent().getPosition()
-      );
-    }
     ZoneId zoneOffset = ZoneOffset.UTC;
     if (var.length > 0) {
       String timezone = var[0];
@@ -213,6 +199,20 @@ public class Functions {
     ZonedDateTime d = null;
 
     if (var == null) {
+      if (
+        JinjavaInterpreter
+          .getCurrentMaybe()
+          .map(JinjavaInterpreter::getConfig)
+          .map(JinjavaConfig::getExecutionMode)
+          .map(ExecutionMode::useEagerParser)
+          .orElse(false)
+      ) {
+        throw new DeferredValueException(
+          "Time is deferred",
+          JinjavaInterpreter.getCurrent().getLineNumber(),
+          JinjavaInterpreter.getCurrent().getPosition()
+        );
+      }
       d = ZonedDateTime.now(zoneOffset);
     } else if (var instanceof Number) {
       d =

--- a/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
@@ -2,6 +2,12 @@ package com.hubspot.jinjava.lib.fn;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.interpret.Context;
+import com.hubspot.jinjava.interpret.DeferredValueException;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.mode.EagerExecutionMode;
 import java.time.ZonedDateTime;
 import org.junit.Test;
 
@@ -24,5 +30,24 @@ public class UnixTimestampFunctionTest {
         )
       )
       .isLessThan(1000);
+  }
+
+  @Test(expected = DeferredValueException.class)
+  public void itDefersWhenExecutingEagerly() {
+    JinjavaInterpreter.pushCurrent(
+      new JinjavaInterpreter(
+        new Jinjava(),
+        new Context(),
+        JinjavaConfig
+          .newBuilder()
+          .withExecutionMode(EagerExecutionMode.instance())
+          .build()
+      )
+    );
+    try {
+      Functions.unixtimestamp(null);
+    } finally {
+      JinjavaInterpreter.popCurrent();
+    }
   }
 }


### PR DESCRIPTION
Instead of just throwing from the `today()` function, throw a DeferredValueException before `ZonedDateTime.now()` is called when doing deferred evaluation with Eager Execution.
This is so that the time can be a dynamic value that can be evaluated at a later time.