### PR TITLE
[Eager Execution] Filter out metaContextVariables from session bindings

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -1,7 +1,5 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
-import static com.hubspot.jinjava.interpret.Context.GLOBAL_MACROS_SCOPE_KEY;
-
 import com.hubspot.jinjava.el.ext.AbstractCallableMethod;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.interpret.Context.Library;
@@ -316,7 +314,7 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
       sessionBindings
         .entrySet()
         .stream()
-        .filter(entry -> !entry.getKey().equals(GLOBAL_MACROS_SCOPE_KEY))
+        .filter(entry -> !metaContextVariables.contains(entry.getKey()))
         .filter(
           entry ->
             !(entry.getValue() instanceof DeferredValue) && entry.getValue() != null


### PR DESCRIPTION
After the `metaContextVariables` key set was added in https://github.com/HubSpot/jinjava/pull/647, this could've been done so that those variables aren't included in the session bindings which may cause a deferred set tag to be created. For example, if the `import_resource_path` variable is modified multiple times while in deferred execution mode, we wouldn't want to defer that value because it's a meta value and linked to an import tag. Otherwise, we might see something like:
```
{% set import_resource_path = '/foo' %}
```