### PR TITLE
[Eager Execution] Consistency for Deferred execution mode

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -207,6 +207,7 @@ public class Context extends ScopeMap<String, Object> {
       this.partialMacroEvaluation = parent.partialMacroEvaluation;
       this.unwrapRawOverride = parent.unwrapRawOverride;
       this.dynamicVariableResolver = parent.dynamicVariableResolver;
+      this.deferredExecutionMode = parent.deferredExecutionMode;
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -258,7 +258,9 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
     // Don't create new call stacks to prevent hitting max recursion with this silent new scope
     Map<String, Object> sessionBindings;
     try (InterpreterScopeClosable c = interpreter.enterNonStackingScope()) {
-      interpreter.getContext().setDeferredExecutionMode(true);
+      if (checkForContextChanges) {
+        interpreter.getContext().setDeferredExecutionMode(true);
+      }
       interpreter.getContext().setPartialMacroEvaluation(partialMacroEvaluation);
       result = function.apply(interpreter);
       sessionBindings = interpreter.getContext().getSessionBindings();

--- a/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
@@ -121,7 +121,20 @@ public class EagerExpressionStrategyTest extends ExpressionNodeTest {
   @Test
   public void itGoesIntoDeferredExecutionMode() {
     assertExpectedOutput(
-      "{{ is_deferred_execution_mode() }}{% if deferred %}{{ is_deferred_execution_mode() }}{% endif %}{{ is_deferred_execution_mode() }}",
+      "{{ is_deferred_execution_mode() }}" +
+      "{% if deferred %}{{ is_deferred_execution_mode() }}{% endif %}" +
+      "{{ is_deferred_execution_mode() }}",
+      "false{% if deferred %}true{% endif %}false"
+    );
+  }
+
+  @Test
+  public void itGoesIntoDeferredExecutionModeWithMacro() {
+    assertExpectedOutput(
+      "{% macro def() %}{{ is_deferred_execution_mode() }}{% endmacro %}" +
+      "{{ def() }}" +
+      "{% if deferred %}{{ def() }}{% endif %}" +
+      "{{ def() }}",
       "false{% if deferred %}true{% endif %}false"
     );
   }

--- a/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
@@ -6,6 +6,7 @@ import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.LegacyOverrides;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.lib.fn.ELFunctionDefinition;
 import com.hubspot.jinjava.mode.EagerExecutionMode;
 import com.hubspot.jinjava.objects.collections.PyList;
 import com.hubspot.jinjava.tree.ExpressionNodeTest;
@@ -17,7 +18,16 @@ import org.junit.Test;
 public class EagerExpressionStrategyTest extends ExpressionNodeTest {
 
   @Before
-  public void eagerSetup() {
+  public void eagerSetup() throws Exception {
+    jinjava
+      .getGlobalContext()
+      .registerFunction(
+        new ELFunctionDefinition(
+          "",
+          "is_deferred_execution_mode",
+          this.getClass().getDeclaredMethod("isDeferredExecutionMode")
+        )
+      );
     interpreter =
       new JinjavaInterpreter(
         jinjava,
@@ -108,7 +118,26 @@ public class EagerExpressionStrategyTest extends ExpressionNodeTest {
     );
   }
 
+  @Test
+  public void itGoesIntoDeferredExecutionMode() {
+    assertExpectedOutput(
+      "{{ is_deferred_execution_mode() }}{% if deferred %}{{ is_deferred_execution_mode() }}{% endif %}{{ is_deferred_execution_mode() }}",
+      "false{% if deferred %}true{% endif %}false"
+    );
+  }
+
+  @Test
+  public void itDoesNotGoIntoDeferredExecutionModeUnnecessarily() {
+    assertExpectedOutput("{{ is_deferred_execution_mode() }}", "false");
+    interpreter.getContext().setDeferredExecutionMode(true);
+    assertExpectedOutput("{{ is_deferred_execution_mode() }}", "true");
+  }
+
   private void assertExpectedOutput(String inputTemplate, String expectedOutput) {
     assertThat(interpreter.render(inputTemplate)).isEqualTo(expectedOutput);
+  }
+
+  public static boolean isDeferredExecutionMode() {
+    return JinjavaInterpreter.getCurrent().getContext().isDeferredExecutionMode();
   }
 }


### PR DESCRIPTION
The flag `context.isDeferredExecutionMode()` is used to determine whether the interpreter should currently be evaluating in a deferred context mode such that changes to the context should not always be applied because it's unknown if the code currently being evaluated will actually be run. The simplest example is with a deferred `IfTag`, where we don't know which branch should actually be executed, and we thus execute all the possibilities with `deferredExecutionMode = true`.

This PR adds consistency because it was the case that whenever evaluating in a child context, we were setting this flag, but many times it was not necessary, such as with just an expression evaluation.

With this change, the flag should only be true when evaluating indeterminately, where we won't know if the result should be committed. I have added a couple of tests with a static function that prints out the value of this flag to demonstrate when the flag should be on or off.