### PR TITLE
Catch ELException in TypeConvertingMapELResolver to support map methods

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/TypeConvertingMapELResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/TypeConvertingMapELResolver.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.el;
 
 import java.util.Map;
 import javax.el.ELContext;
+import javax.el.ELException;
 import javax.el.MapELResolver;
 
 public class TypeConvertingMapELResolver extends MapELResolver {
@@ -21,9 +22,13 @@ public class TypeConvertingMapELResolver extends MapELResolver {
 
     if (base instanceof Map && !((Map) base).isEmpty()) {
       Class<?> keyClass = ((Map) base).keySet().iterator().next().getClass();
-      value = ((Map) base).get(TYPE_CONVERTER.convert(property, keyClass));
-      if (value != null) {
-        context.setPropertyResolved(true);
+      try {
+        value = ((Map) base).get(TYPE_CONVERTER.convert(property, keyClass));
+        if (value != null) {
+          context.setPropertyResolved(true);
+        }
+      } catch (ELException ex) {
+        value = null;
       }
     }
 

--- a/src/test/java/com/hubspot/jinjava/el/ext/AstDictTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/AstDictTest.java
@@ -7,6 +7,7 @@ import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import java.util.Map;
+import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,6 +35,13 @@ public class AstDictTest {
   public void itGetsDictValuesWithEnumKeysUsingToString() {
     interpreter.getContext().put("foo", ImmutableMap.of(TestEnum.BAR, "test"));
     assertThat(interpreter.resolveELExpression("foo.barName", -1)).isEqualTo("test");
+  }
+
+  @Test
+  public void itDoesItemsMethodCall() {
+    interpreter.getContext().put("foo", ImmutableMap.of(TestEnum.BAR, "test"));
+    assertThat(interpreter.resolveELExpression("foo.items()", -1))
+      .isInstanceOf(Set.class);
   }
 
   @Test


### PR DESCRIPTION
Followup to #688 

The previous PR caused an issue when calling methods on a map object (e.g. `{{ map.items() }}`). It would throw an `ELException` which would get added to the interpreter and not render anything.

This PR fixes the issue by catching `ELExceptions` when trying to convert - we shouldn't be using any incompatible property names anyway.