### PR TITLE
[Eager Execution] Execute deferred branches of if tag in separate contexts

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
@@ -184,6 +184,9 @@ public class SetTag implements Tag {
         ((Namespace) namespace).put(varArray[1], value);
         return;
       }
+      if (namespace instanceof DeferredValue) {
+        throw new DeferredValueException("Deferred Namespace");
+      }
     }
     interpreter.getContext().put(var, value);
   }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTag.java
@@ -133,6 +133,21 @@ public class EagerSetTag extends EagerStateChangingTag<SetTag> {
         )
       );
     }
+    if (
+      eagerExecutionResult.getResult().isFullyResolved() &&
+      interpreter.getContext().isDeferredExecutionMode()
+    ) {
+      try {
+        getTag()
+          .executeSet(
+            tagToken,
+            interpreter,
+            varTokens,
+            eagerExecutionResult.getResult().toList(),
+            true
+          );
+      } catch (DeferredValueException ignored) {}
+    }
     return wrapInAutoEscapeIfNeeded(
       prefixToPreserveState + joiner.toString() + suffixToPreserveState.toString(),
       interpreter

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -267,7 +267,13 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
         .entrySet()
         .stream()
         .filter(
-          entry -> !entry.getValue().equals(interpreter.getContext().get(entry.getKey()))
+          entry ->
+            entry.getValue() != null &&
+            !entry.getValue().equals(interpreter.getContext().get(entry.getKey()))
+        )
+        .filter(
+          entry ->
+            !(interpreter.getContext().get(entry.getKey()) instanceof DeferredValue)
         )
         .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
     if (checkForContextChanges) {

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -423,7 +423,7 @@ public class EagerTest {
     assertThat(localContext).containsKey("varSetInside");
     Object varSetInside = localContext.get("varSetInside");
     assertThat(varSetInside).isInstanceOf(DeferredValue.class);
-    assertThat(output).contains("{{ varSetInside }}");
+    assertThat(output).contains("{{ varSetInside }}").contains("xyz");
     assertThat(context.get("a")).isInstanceOf(DeferredValue.class);
     assertThat(context.get("b")).isInstanceOf(DeferredValue.class);
     assertThat(context.get("c")).isInstanceOf(DeferredValue.class);

--- a/src/test/resources/deferred/set-in-deferred.jinja
+++ b/src/test/resources/deferred/set-in-deferred.jinja
@@ -2,5 +2,6 @@
 {% if reference == 'resolved' %}
    {% set varSetInside = 'set inside' %}
    {% set a, b, c = 'x','y','z' %}
+   {{ a ~ b ~ c }}
 {% endif %}
 {{ varSetInside }}

--- a/src/test/resources/deferred/set-in-deferred.jinja
+++ b/src/test/resources/deferred/set-in-deferred.jinja
@@ -1,6 +1,6 @@
 {% set reference = deferredValue %}
 {% if reference == 'resolved' %}
    {% set varSetInside = 'set inside' %}
-   {% set a, b, c = ['x','y','z'] %}
+   {% set a, b, c = 'x','y','z' %}
 {% endif %}
 {{ varSetInside }}

--- a/src/test/resources/eager/defers-eager-child-scoped-vars.expected.jinja
+++ b/src/test/resources/eager/defers-eager-child-scoped-vars.expected.jinja
@@ -1,5 +1,5 @@
 {% if deferred %}
 {% set foo = 1 %}
-{{ foo }}
+1
 {% endif %}
 We don't know if someone wanted to access {{ foo }} here!

--- a/src/test/resources/eager/defers-on-immutable-mode.expected.jinja
+++ b/src/test/resources/eager/defers-on-immutable-mode.expected.jinja
@@ -1,7 +1,7 @@
 {% set foo = 1 %}{% if deferred %}
 {% set foo = 2 %}
 {% else %}
-{% set foo = foo + 2 %}//best we can do
+{% set foo = 3 %}//best we can do
 {% endif %}
 {{ foo }}
 

--- a/src/test/resources/eager/defers-on-immutable-mode.expected.jinja
+++ b/src/test/resources/eager/defers-on-immutable-mode.expected.jinja
@@ -1,7 +1,7 @@
 {% set foo = 1 %}{% if deferred %}
 {% set foo = 2 %}
 {% else %}
-{% set foo = 3 %}//best we can do
+{% set foo = 3 %}
 {% endif %}
 {{ foo }}
 

--- a/src/test/resources/eager/defers-on-immutable-mode.jinja
+++ b/src/test/resources/eager/defers-on-immutable-mode.jinja
@@ -2,7 +2,7 @@
 {% if deferred %}
 {% set foo = foo + 1 %}
 {% else %}
-{% set foo = foo + 2 %}//best we can do
+{% set foo = foo + 2 %}
 {% endif %}
 {{ foo }}
 


### PR DESCRIPTION
As the name suggests, when speculatively evaluating if tag branches, use separate contexts for each branch to maximize the values that can be resolved.
```
{% set foo = 1 %}
{% if deferred %}
{% set foo = 2 %}
{% else %}
{{ foo }}
{% endif %}
```
This change allows us to know that `foo=1` when evaluating `{{ foo }}`, rather than have it already be deferred. Since we set deferred values in a waterfall-like fashion, we can temporarily override a deferred value by setting the value on the lowest child context (it will still be deferred on the parent contexts).