### PR TITLE
Add method to remove error from interpreter

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -650,6 +650,10 @@ public class JinjavaInterpreter implements PyishSerializable {
     }
   }
 
+  public void removeError(int index) {
+    errors.remove(index);
+  }
+
   public int getScopeDepth() {
     return scopeDepth;
   }

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -650,8 +650,8 @@ public class JinjavaInterpreter implements PyishSerializable {
     }
   }
 
-  public void removeError(int index) {
-    errors.remove(index);
+  public TemplateError removeError(int index) {
+    return errors.remove(index);
   }
 
   public int getScopeDepth() {


### PR DESCRIPTION
The change here https://github.com/HubSpot/jinjava/pull/222 made it so copies of errors are returned on getErrors(). This adds a method to at least remove an error at a specific index.