### PR TITLE
Add method for getting last error

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -654,6 +654,12 @@ public class JinjavaInterpreter implements PyishSerializable {
     return errors.remove(index);
   }
 
+  public Optional<TemplateError> getLastError() {
+    return errors.isEmpty()
+      ? Optional.empty()
+      : Optional.of(errors.get(errors.size() - 1));
+  }
+
   public int getScopeDepth() {
     return scopeDepth;
   }


### PR DESCRIPTION
It can be useful to check the last error added to the interpreter. The current way to do this via getErrors() copies every error which isn't efficient for my particular use case.