### PR TITLE
Pass value of throwInterpreterErrors to child contexts

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -208,6 +208,7 @@ public class Context extends ScopeMap<String, Object> {
       this.unwrapRawOverride = parent.unwrapRawOverride;
       this.dynamicVariableResolver = parent.dynamicVariableResolver;
       this.deferredExecutionMode = parent.deferredExecutionMode;
+      this.throwInterpreterErrors = parent.throwInterpreterErrors;
     }
   }
 


### PR DESCRIPTION
To make this similar to other context attributes, let's pass it down to child contexts.
While this flag wasn't originally intended to be set outside of Jinjava code, there are scenarios where it can be helpful, such as running a custom `assert:equals` method.