### PR TITLE
Support Assignment Blocks with Set tags

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/FlexibleTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/FlexibleTag.java
@@ -1,0 +1,7 @@
+package com.hubspot.jinjava.lib.tag;
+
+import com.hubspot.jinjava.tree.TagNode;
+
+public interface FlexibleTag {
+  boolean hasEndTag(TagNode tagNode);
+}

--- a/src/main/java/com/hubspot/jinjava/lib/tag/FlexibleTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/FlexibleTag.java
@@ -1,7 +1,7 @@
 package com.hubspot.jinjava.lib.tag;
 
-import com.hubspot.jinjava.tree.TagNode;
+import com.hubspot.jinjava.tree.parse.TagToken;
 
 public interface FlexibleTag {
-  boolean hasEndTag(TagNode tagNode);
+  boolean hasEndTag(TagToken tagToken);
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
@@ -148,17 +148,20 @@ public class SetTag implements Tag, FlexibleTag {
         Collections.singletonList(sb.toString()),
         false
       );
-      Object finalVal = interpreter.resolveELExpression(
-        tagNode.getHelpers().trim(),
-        tagNode.getMaster().getLineNumber()
-      );
-      executeSet(
-        (TagToken) tagNode.getMaster(),
-        interpreter,
-        varAsArray,
-        Collections.singletonList(finalVal),
-        false
-      );
+      if (filterPos >= 0) {
+        // apply and save the filtered result
+        Object finalVal = interpreter.resolveELExpression(
+          tagNode.getHelpers().trim(),
+          tagNode.getMaster().getLineNumber()
+        );
+        executeSet(
+          (TagToken) tagNode.getMaster(),
+          interpreter,
+          varAsArray,
+          Collections.singletonList(finalVal),
+          false
+        );
+      }
     } catch (DeferredValueException e) {
       DeferredValueUtils.deferVariables(varAsArray, interpreter.getContext());
       throw e;

--- a/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
@@ -123,7 +123,11 @@ public class SetTag implements Tag, FlexibleTag {
   }
 
   public String interpretBlockSet(TagNode tagNode, JinjavaInterpreter interpreter) {
+    int filterPos = tagNode.getHelpers().indexOf('|');
     String var = tagNode.getHelpers().trim();
+    if (filterPos >= 0) {
+      var = tagNode.getHelpers().substring(0, filterPos).trim();
+    }
     StringBuilder sb = new StringBuilder();
     for (Node child : tagNode.getChildren()) {
       sb.append(child.render(interpreter));
@@ -135,6 +139,17 @@ public class SetTag implements Tag, FlexibleTag {
         interpreter,
         varAsArray,
         Collections.singletonList(sb.toString()),
+        false
+      );
+      Object finalVal = interpreter.resolveELExpression(
+        tagNode.getHelpers().trim(),
+        tagNode.getMaster().getLineNumber()
+      );
+      executeSet(
+        (TagToken) tagNode.getMaster(),
+        interpreter,
+        varAsArray,
+        Collections.singletonList(finalVal),
         false
       );
     } catch (DeferredValueException e) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
@@ -230,7 +230,7 @@ public class SetTag implements Tag, FlexibleTag {
   }
 
   @Override
-  public boolean hasEndTag(TagNode tagNode) {
-    return !tagNode.getHelpers().contains("=");
+  public boolean hasEndTag(TagToken tagToken) {
+    return !tagToken.getHelpers().contains("=");
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
@@ -64,6 +64,13 @@ import org.apache.commons.lang3.StringUtils;
       code = "{% set var_one = \"String 1\" %}\n" +
       "{% set var_two = \"String 2\" %}\n" +
       "{% set sequence = [var_one,  var_two] %}"
+    ),
+    @JinjavaSnippet(
+      desc = "You can set a value to the string value within a block",
+      code = "{% set name = 'Jack' %}\n" +
+      "{% set message %}\n" +
+      "My name is {{ name }}\n" +
+      "{% end_set %}"
     )
   }
 )

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTag.java
@@ -4,7 +4,9 @@ import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
+import com.hubspot.jinjava.lib.tag.FlexibleTag;
 import com.hubspot.jinjava.lib.tag.SetTag;
+import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
 import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
@@ -15,7 +17,7 @@ import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
-public class EagerSetTag extends EagerStateChangingTag<SetTag> {
+public class EagerSetTag extends EagerStateChangingTag<SetTag> implements FlexibleTag {
 
   public EagerSetTag() {
     super(new SetTag());
@@ -163,5 +165,10 @@ public class EagerSetTag extends EagerStateChangingTag<SetTag> {
     // Update the alias map to the value of the set variable.
     varList.forEach(var -> updateString.add(String.format("'%s': %s", var, var)));
     return "{" + updateString.toString() + "}";
+  }
+
+  @Override
+  public boolean hasEndTag(TagNode tagNode) {
+    return getTag().hasEndTag(tagNode);
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTag.java
@@ -6,7 +6,6 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.tag.FlexibleTag;
 import com.hubspot.jinjava.lib.tag.SetTag;
-import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
 import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
@@ -168,7 +167,7 @@ public class EagerSetTag extends EagerStateChangingTag<SetTag> implements Flexib
   }
 
   @Override
-  public boolean hasEndTag(TagNode tagNode) {
-    return getTag().hasEndTag(tagNode);
+  public boolean hasEndTag(TagToken tagToken) {
+    return false; // not yet implemented
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
@@ -5,6 +5,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.FlexibleTag;
 import com.hubspot.jinjava.lib.tag.Tag;
 import com.hubspot.jinjava.tree.TagNode;
+import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
 import org.apache.commons.lang3.StringUtils;
 
@@ -46,7 +47,10 @@ public class EagerStateChangingTag<T extends Tag> extends EagerTagDecorator<T> {
     // Currently always false
     if (
       StringUtils.isNotBlank(tagNode.getEndName()) &&
-      (!(getTag() instanceof FlexibleTag) || ((FlexibleTag) getTag()).hasEndTag(tagNode))
+      (
+        !(getTag() instanceof FlexibleTag) ||
+        ((FlexibleTag) getTag()).hasEndTag((TagToken) tagNode.getMaster())
+      )
     ) {
       result.append(reconstructEnd(tagNode));
     }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.lib.tag.eager;
 
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.lib.tag.FlexibleTag;
 import com.hubspot.jinjava.lib.tag.Tag;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
@@ -43,7 +44,10 @@ public class EagerStateChangingTag<T extends Tag> extends EagerTagDecorator<T> {
     }
 
     // Currently always false
-    if (StringUtils.isNotBlank(tagNode.getEndName())) {
+    if (
+      StringUtils.isNotBlank(tagNode.getEndName()) &&
+      (!(getTag() instanceof FlexibleTag) || ((FlexibleTag) getTag()).hasEndTag(tagNode))
+    ) {
       result.append(reconstructEnd(tagNode));
     }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
@@ -30,7 +30,6 @@ public class EagerStateChangingTag<T extends Tag> extends EagerTagDecorator<T> {
       getEagerImage(buildToken(tagNode, e, interpreter.getLineNumber()), interpreter)
     );
 
-    // Currently always false
     if (!tagNode.getChildren().isEmpty()) {
       result.append(
         executeInChildContext(
@@ -44,7 +43,6 @@ public class EagerStateChangingTag<T extends Tag> extends EagerTagDecorator<T> {
       );
     }
 
-    // Currently always false
     if (
       StringUtils.isNotBlank(tagNode.getEndName()) &&
       (

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 public abstract class EagerTagDecorator<T extends Tag> implements Tag {
-  private T tag;
+  private final T tag;
 
   public EagerTagDecorator(T tag) {
     this.tag = tag;

--- a/src/main/java/com/hubspot/jinjava/tree/TagNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TagNode.java
@@ -102,7 +102,7 @@ public class TagNode extends Node {
 
     if (
       getEndName() != null &&
-      (!(tag instanceof FlexibleTag) || ((FlexibleTag) tag).hasEndTag(this))
+      (!(tag instanceof FlexibleTag) || ((FlexibleTag) tag).hasEndTag(master))
     ) {
       builder.append(reconstructEnd());
     }

--- a/src/main/java/com/hubspot/jinjava/tree/TagNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TagNode.java
@@ -21,6 +21,7 @@ import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.OutputTooBigException;
+import com.hubspot.jinjava.lib.tag.FlexibleTag;
 import com.hubspot.jinjava.lib.tag.Tag;
 import com.hubspot.jinjava.tree.output.OutputNode;
 import com.hubspot.jinjava.tree.output.RenderedOutputNode;
@@ -99,7 +100,10 @@ public class TagNode extends Node {
       builder.append(n.reconstructImage());
     }
 
-    if (getEndName() != null) {
+    if (
+      getEndName() != null &&
+      (!(tag instanceof FlexibleTag) || ((FlexibleTag) tag).hasEndTag(this))
+    ) {
       builder.append(reconstructEnd());
     }
 

--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -228,8 +228,7 @@ public class TreeParser {
 
     if (
       node.getEndName() != null &&
-      !(tag instanceof FlexibleTag) ||
-      ((FlexibleTag) tag).hasEndTag(node)
+      (!(tag instanceof FlexibleTag) || ((FlexibleTag) tag).hasEndTag(node))
     ) {
       parent.getChildren().add(node);
       parent = node;

--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -228,7 +228,7 @@ public class TreeParser {
 
     if (
       node.getEndName() != null &&
-      (!(tag instanceof FlexibleTag) || ((FlexibleTag) tag).hasEndTag(node))
+      (!(tag instanceof FlexibleTag) || ((FlexibleTag) tag).hasEndTag(tagToken))
     ) {
       parent.getChildren().add(node);
       parent = node;

--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -28,6 +28,7 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.interpret.UnexpectedTokenException;
 import com.hubspot.jinjava.interpret.UnknownTagException;
 import com.hubspot.jinjava.lib.tag.EndTag;
+import com.hubspot.jinjava.lib.tag.FlexibleTag;
 import com.hubspot.jinjava.lib.tag.Tag;
 import com.hubspot.jinjava.tree.parse.ExpressionToken;
 import com.hubspot.jinjava.tree.parse.TagToken;
@@ -225,7 +226,11 @@ public class TreeParser {
     TagNode node = new TagNode(tag, tagToken, symbols);
     node.setParent(parent);
 
-    if (node.getEndName() != null) {
+    if (
+      node.getEndName() != null &&
+      !(tag instanceof FlexibleTag) ||
+      ((FlexibleTag) tag).hasEndTag(node)
+    ) {
       parent.getChildren().add(node);
       parent = node;
       return null;

--- a/src/test/java/com/hubspot/jinjava/lib/tag/SetTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/SetTagTest.java
@@ -283,6 +283,17 @@ public class SetTagTest extends BaseInterpretingTest {
     assertThat(result).isEqualTo("barbaz");
   }
 
+  @Test
+  public void itDoesBlock() {
+    Map<String, Object> dict = new HashMap<>();
+    dict.put("foo", "bar");
+    context.put("dict", dict);
+    String template = "{% set foo %}eee{% endset %}{{ foo }}";
+    final String result = interpreter.render(template);
+
+    assertThat(result).isEqualTo("eee");
+  }
+
   private Node fixture(String name) {
     try {
       return new TreeParser(

--- a/src/test/java/com/hubspot/jinjava/lib/tag/SetTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/SetTagTest.java
@@ -284,14 +284,19 @@ public class SetTagTest extends BaseInterpretingTest {
   }
 
   @Test
-  public void itDoesBlock() {
-    Map<String, Object> dict = new HashMap<>();
-    dict.put("foo", "bar");
-    context.put("dict", dict);
-    String template = "{% set foo %}eee{% endset %}{{ foo }}";
+  public void itSetsBlock() {
+    String template = "{% set foo %}bar{% endset %}{{ foo }}";
     final String result = interpreter.render(template);
 
-    assertThat(result).isEqualTo("eee");
+    assertThat(result).isEqualTo("bar");
+  }
+
+  @Test
+  public void itSetsBlockWithFilter() {
+    String template = "{% set foo | upper %}bar{% endset %}{{ foo }}";
+    final String result = interpreter.render(template);
+
+    assertThat(result).isEqualTo("BAR");
   }
 
   private Node fixture(String name) {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagTest.java
@@ -122,4 +122,16 @@ public class EagerSetTagTest extends SetTagTest {
   public void itThrowsAndDefersMultiVarWhenValContainsDeferred() {
     // Deferred values are handled differently. Test does not apply.
   }
+
+  @Test
+  @Ignore
+  public void itSetsBlock() {
+    // not implemented yet
+  }
+
+  @Test
+  @Ignore
+  public void itSetsBlockWithFilter() {
+    // not implemented yet
+  }
 }


### PR DESCRIPTION
For https://github.com/HubSpot/jinjava/issues/693 and https://github.com/HubSpot/jinjava/issues/422
Jinja 2.8 adds support for block set assignments (https://jinja.palletsprojects.com/en/3.0.x/templates/#block-assignments)

Add support for set tags with the notation:
```
{% set foo %}
A value of {{ 1 + 1 }}
{% endset %}
```
`foo = 'A value of 2'`

Additionally, Jinja 2.10 adds support for filters in the assignments:
```
{% set foo | upper %}
hello
{% endset %}
```
`foo = 'HELLO'`.

---
The `FlexibleTag` interface adds a way to determine Node-based eligibility for requiring an `EndTag` rather than Tag-based eligibility through the `hasEndTag(TagToken tagToken)` method. Since this method takes a `TagToken` as the parameter, whether or not the tag will have a corresponding endtag depends on what is in the TagToken. For `SetTag`, it depends on whether there is an `=` in the helpers.

I'm opening this PR separately from the logic to handle this change with Eager Execution because those changes are much larger.