### PR TITLE
Propogate Global AutoEscape

### DIFF
--- a/src/main/java/com/hubspot/jinjava/Jinjava.java
+++ b/src/main/java/com/hubspot/jinjava/Jinjava.java
@@ -326,6 +326,7 @@ public class Jinjava {
     globalContext.getAllFilters().forEach(context::registerFilter);
     globalContext.getAllFunctions().forEach(context::registerFunction);
     globalContext.getAllTags().forEach(context::registerTag);
+    context.setAutoEscape(globalContext.isAutoEscape());
     context.setDynamicVariableResolver(globalContext.getDynamicVariableResolver());
     return context;
   }


### PR DESCRIPTION
This pull request is to solve the following issue:
https://github.com/HubSpot/jinjava/issues/511

The pull request is to allow the code: ```jinjava.getGlobalContext().setAutoEscape(true);``` to turn on global autoscaping.

e.g.
```
@Test
    public void AutoEscapeTest() {
        Jinjava jinjava = new Jinjava();
        jinjava.getGlobalContext().setAutoEscape(true);
        assertThat("&lt;b&gt;").isEqualTo(jinjava.render("{{ unsafe }}", Collections.singletonMap("unsafe", "<b>")));
    }
```
@Joeoh for previously dealing with the issue linked to this pull request