### PR TITLE
[Eager Execution] Override macro function hashcode

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -11,6 +11,7 @@ import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -167,5 +168,27 @@ public class MacroFunction extends AbstractCallableMethod {
       return content.get(0).getParent().reconstructImage();
     }
     return "";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MacroFunction that = (MacroFunction) o;
+    return (
+      caller == that.caller &&
+      definitionLineNumber == that.definitionLineNumber &&
+      definitionStartPosition == that.definitionStartPosition &&
+      content.equals(that.content)
+    );
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(content, caller, definitionLineNumber, definitionStartPosition);
   }
 }

--- a/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
@@ -143,6 +143,7 @@ public class DeferredValueUtils {
     props
       .stream()
       .filter(prop -> !(context.get(prop) instanceof DeferredValue))
+      .filter(prop -> !context.getMetaContextVariables().contains(prop))
       .forEach(
         prop -> {
           if (context.get(prop) != null) {


### PR DESCRIPTION
For eager execution we are using the hash code of some items on the context to see if they change. Here we specifically define which parts of the MacroFunction we want to make up its hashcode. We can omit the `localContextScope` as we don't need to hash it. That may be expensive and unnecessary to do.