### PR TITLE
[Eager Execution] Make static PYISH_OBJECT_WRITER public 

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -8,7 +8,7 @@ import com.hubspot.jinjava.util.WhitespaceUtils;
 import java.util.Objects;
 
 public class PyishObjectMapper {
-  private static final ObjectWriter PYISH_OBJECT_WRITER = new ObjectMapper()
+  public static final ObjectWriter PYISH_OBJECT_WRITER = new ObjectMapper()
     .registerModule(
       new SimpleModule()
         .setSerializerModifier(PyishBeanSerializerModifier.INSTANCE)


### PR DESCRIPTION
Turn this static variable public so that it can be used to write values as pyish strings. The most common use case would be when overriding `toPyishString()` in `PyishSerializable`.