### PR TITLE
[Eager Execution] Small bug fixes

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoice.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoice.java
@@ -40,7 +40,7 @@ public class EagerAstChoice extends AstChoice implements EvalResultHolder {
       hasEvalResult = true;
       return evalResult;
     } catch (DeferredParsingException e) {
-      if (question.getAndClearEvalResult() != null) {
+      if (question.hasEvalResult()) {
         // the question was evaluated so jump to either yes or no
         throw new DeferredParsingException(this, e.getDeferredEvalResult());
       }

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -376,7 +376,14 @@ public class Context extends ScopeMap<String, Object> {
       );
     }
     eagerTokens.add(eagerToken);
-    DeferredValueUtils.findAndMarkDeferredProperties(this, eagerToken);
+    if (
+      eagerToken.getImportResourcePath() == null ||
+      eagerToken
+        .getImportResourcePath()
+        .equals(this.get(Context.IMPORT_RESOURCE_PATH_KEY))
+    ) {
+      DeferredValueUtils.findAndMarkDeferredProperties(this, eagerToken);
+    }
     if (getParent() != null) {
       Context parent = getParent();
       //Ignore global context

--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -70,6 +70,7 @@ public class MacroFunction extends AbstractCallableMethod {
     JinjavaInterpreter interpreter = JinjavaInterpreter.getCurrent();
     Optional<String> importFile = getImportFile(interpreter);
     try (InterpreterScopeClosable c = interpreter.enterScope()) {
+      interpreter.getContext().setDeferredExecutionMode(false);
       String result = getEvaluationResult(argMap, kwargMap, varArgs, interpreter);
 
       if (

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -136,6 +136,7 @@ public class ImportTag implements Tag {
       );
     } finally {
       interpreter.getContext().getCurrentPathStack().pop();
+      interpreter.getContext().getImportPathStack().pop();
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -68,7 +68,13 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
       false,
       true
     );
-    if (!eagerExecutionResult.getSpeculativeBindings().isEmpty()) {
+    if (
+      eagerExecutionResult
+        .getSpeculativeBindings()
+        .keySet()
+        .stream()
+        .anyMatch(key -> !(interpreter.getContext().get(key) instanceof DeferredValue))
+    ) {
       // Values cannot be modified within a for loop because we don't know many times, if any it will run
       throw new DeferredValueException(
         "Modified values in deferred for loop: " +

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -99,6 +99,7 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
       );
     } finally {
       interpreter.getContext().getCurrentPathStack().pop();
+      interpreter.getContext().getImportPathStack().pop();
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerToken.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerToken.java
@@ -1,5 +1,7 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.hubspot.jinjava.interpret.Context;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.tree.parse.Token;
 import java.util.Collections;
 import java.util.Set;
@@ -12,10 +14,13 @@ public class EagerToken {
   // These words are those which will be set to a value which has been deferred.
   private final Set<String> setDeferredWords;
 
+  private final String importResourcePath;
+
   public EagerToken(Token token, Set<String> usedDeferredWords) {
     this.token = token;
     this.usedDeferredWords = usedDeferredWords;
     this.setDeferredWords = Collections.emptySet();
+    importResourcePath = acquireImportResourcePath();
   }
 
   public EagerToken(
@@ -26,6 +31,7 @@ public class EagerToken {
     this.token = token;
     this.usedDeferredWords = usedDeferredWords;
     this.setDeferredWords = setDeferredWords;
+    importResourcePath = acquireImportResourcePath();
   }
 
   public Token getToken() {
@@ -38,5 +44,17 @@ public class EagerToken {
 
   public Set<String> getSetDeferredWords() {
     return setDeferredWords;
+  }
+
+  public String getImportResourcePath() {
+    return importResourcePath;
+  }
+
+  private static String acquireImportResourcePath() {
+    return (String) JinjavaInterpreter
+      .getCurrentMaybe()
+      .map(interpreter -> interpreter.getContext().get(Context.IMPORT_RESOURCE_PATH_KEY))
+      .filter(path -> path instanceof String)
+      .orElse(null);
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
@@ -129,13 +129,13 @@ public class EagerExpressionStrategyTest extends ExpressionNodeTest {
   }
 
   @Test
-  public void itGoesIntoDeferredExecutionModeWithMacro() {
+  public void itDoesNotGoIntoDeferredExecutionModeWithMacro() {
     assertExpectedOutput(
       "{% macro def() %}{{ is_deferred_execution_mode() }}{% endmacro %}" +
       "{{ def() }}" +
       "{% if deferred %}{{ def() }}{% endif %}" +
       "{{ def() }}",
-      "false{% if deferred %}true{% endif %}false"
+      "false{% if deferred %}false{% endif %}false"
     );
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -403,9 +403,12 @@ public class EagerImportTagTest extends ImportTagTest {
   public void itDefersTripleLayer() {
     setupResourceLocator();
     context.put("a_val", DeferredValue.instance("a"));
+
     context.put("b_val", "b");
     context.put("c_val", "c");
-    String result = interpreter.render("{% import 'import-tree-c.jinja' as c %}{{ c }}");
+    String result = interpreter.render(
+      "{% import 'import-tree-c.jinja' as c %}{{ c|dictsort(false, 'key') }}"
+    );
     assertThat(interpreter.render("{{ c.b.a.foo_a }}")).isEqualTo("{{ c.b.a.foo_a }}");
     assertThat(interpreter.render("{{ c.b.foo_b }}")).isEqualTo("{{ c.b.foo_b }}");
     assertThat(interpreter.render("{{ c.foo_c }}")).isEqualTo("{{ c.foo_c }}");
@@ -413,12 +416,9 @@ public class EagerImportTagTest extends ImportTagTest {
     // There are some extras due to deferred values copying up the context stack.
     assertThat(interpreter.render(result).trim())
       .isEqualTo(
-        "{'b': {'foo_b': 'ba', 'a': " +
-        "{'foo_a': 'a', 'import_resource_path': 'import-tree-a.jinja', 'something': 'somn'}, " +
-        "'foo_a': 'a', 'import_resource_path': 'import-tree-b.jinja'}, " +
-        "'foo_c': 'cbaa', 'a': {'foo_a': 'a', 'import_resource_path': " +
-        "'import-tree-a.jinja', 'something': 'somn'}, " +
-        "'foo_b': 'ba', 'foo_a': 'a', 'import_resource_path': 'import-tree-c.jinja'}"
+        interpreter.render(
+          "{% import 'import-tree-c.jinja' as c %}{{ c|dictsort(false, 'key') }}"
+        )
       );
   }
 

--- a/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
@@ -592,6 +592,8 @@ public class EagerExpressionResolverTest {
       .isEqualTo("deferred");
     assertThat(eagerResolveExpression("false ? foo : deferred").toString())
       .isEqualTo("deferred");
+    assertThat(eagerResolveExpression("null ? foo : deferred").toString())
+      .isEqualTo("deferred");
   }
 
   @Test


### PR DESCRIPTION
- For eager execution we are using the hash code of some items on the context to see if they change. Here we specifically define which parts of the MacroFunction we want to make up its hashcode. We can omit the `localContextScope` as we don't need to hash it. That may be expensive and unnecessary to do.
- EagerAstChoice should use `hasEvalResult` to handle null values correctly
- Don't defer values from an imported context onto the main context.
- Don't start running macro functions in deferred execution mode because they use separate variables
- Only prevent modification of non-deferred values in deferred for loops.