### PR TITLE
Handle spaces better in for loop expressions

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -4,19 +4,17 @@ import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.tag.ForTag;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
-import com.hubspot.jinjava.util.HelperStringTokenizer;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
 
 public class EagerForTag extends EagerTagDecorator<ForTag> {
 
@@ -83,22 +81,10 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
 
   @Override
   public String getEagerTagImage(TagToken tagToken, JinjavaInterpreter interpreter) {
-    List<String> helperTokens = new HelperStringTokenizer(tagToken.getHelpers())
-      .splitComma(true)
-      .allTokens();
-    List<String> loopVars = getTag().getLoopVars(helperTokens);
-    Optional<String> maybeLoopExpr = getTag().getLoopExpression(tagToken.getHelpers());
-
-    if (loopVars.size() >= helperTokens.size() || !maybeLoopExpr.isPresent()) {
-      throw new TemplateSyntaxException(
-        tagToken.getHelpers().trim(),
-        "Tag 'for' expects valid 'in' clause, got: " + tagToken.getHelpers(),
-        tagToken.getLineNumber(),
-        tagToken.getStartPosition()
-      );
-    }
-
-    String loopExpression = maybeLoopExpr.get();
+    Pair<List<String>, String> loopVarsAndExpression = getTag()
+      .getLoopVarsAndExpression(tagToken);
+    List<String> loopVars = loopVarsAndExpression.getLeft();
+    String loopExpression = loopVarsAndExpression.getRight();
 
     EagerExpressionResult eagerExpressionResult = EagerExpressionResolver.resolveExpression(
       loopExpression,

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
@@ -279,6 +279,15 @@ public class ForTagTest extends BaseInterpretingTest {
     assertThat(rendered).isEqualTo("Found item having something: 4");
   }
 
+  @Test
+  public void itShouldHandleSpaces() {
+    String template =
+      "{% for item in ['foo', 'bar'] %}" + "{{ item }}\n" + "{% endfor %}";
+
+    String rendered = jinjava.render(template, context);
+    assertThat(rendered).isEqualTo("foo\nbar\n");
+  }
+
   private Node fixture(String name) {
     try {
       return new TreeParser(

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
@@ -280,12 +280,14 @@ public class ForTagTest extends BaseInterpretingTest {
   }
 
   @Test
-  public void itShouldHandleSpaces() {
+  public void itShouldHandleSpacesInMaps() {
     String template =
-      "{% for item in ['foo', 'bar'] %}" + "{{ item }}\n" + "{% endfor %}";
+      "{% for item in [{'key': 'foo?'}, {'key': 'bar?'}] %}" +
+      "{{ item.key }}\n" +
+      "{% endfor %}";
 
     String rendered = jinjava.render(template, context);
-    assertThat(rendered).isEqualTo("foo\nbar\n");
+    assertThat(rendered).isEqualTo("foo?\nbar?\n");
   }
 
   private Node fixture(String name) {


### PR DESCRIPTION
The logic for "For loop" expressions is pretty wonky. Let's clean it up a bit and allow Jinjava to support for loops with maps that contain spaces. For example:
```
{% for item in [{'key': 'foo?'}, {'key': 'bar?'}] %}
```
Currently this gets transformed into:
```
{% for item in [{'key':,'foo?'},{'key':,'bar?'}] %}
```
which is invalid syntax. (Notice the commas after the colons)
This PR makes that not happen by never splitting up the expression. Instead we look for `" in "` and treat everything after that as the loop expression. The previous logic did this, but in a more convoluted way by first splitting up all the helpers (treating spaces and commas the same way) and then rejoining them with commas.