### PR TITLE
Support "not in"

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
@@ -68,8 +68,9 @@ public class CollectionMembershipOperator extends SimpleOperator {
   public static final Scanner.ExtensionToken TOKEN = new Scanner.ExtensionToken("in");
 
   public static final ExtensionHandler HANDLER = getHandler(false);
+  public static final ExtensionHandler EAGER_HANDLER = getHandler(true);
 
-  public static ExtensionHandler getHandler(boolean eager) {
+  private static ExtensionHandler getHandler(boolean eager) {
     return new ExtensionHandler(ExtensionPoint.CMP) {
 
       @Override

--- a/src/main/java/com/hubspot/jinjava/el/ext/CollectionNonMembershipOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/CollectionNonMembershipOperator.java
@@ -26,8 +26,9 @@ public class CollectionNonMembershipOperator extends SimpleOperator {
   public static final Scanner.ExtensionToken TOKEN = new Scanner.ExtensionToken("not in");
 
   public static final ExtensionHandler HANDLER = getHandler(false);
+  public static final ExtensionHandler EAGER_HANDLER = getHandler(true);
 
-  public static ExtensionHandler getHandler(boolean eager) {
+  private static ExtensionHandler getHandler(boolean eager) {
     return new ExtensionHandler(ExtensionPoint.CMP) {
 
       @Override

--- a/src/main/java/com/hubspot/jinjava/el/ext/CollectionNonMembershipOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/CollectionNonMembershipOperator.java
@@ -1,0 +1,41 @@
+package com.hubspot.jinjava.el.ext;
+
+import com.hubspot.jinjava.el.ext.eager.EagerAstBinary;
+import de.odysseus.el.misc.TypeConverter;
+import de.odysseus.el.tree.impl.Parser.ExtensionHandler;
+import de.odysseus.el.tree.impl.Parser.ExtensionPoint;
+import de.odysseus.el.tree.impl.Scanner;
+import de.odysseus.el.tree.impl.ast.AstBinary;
+import de.odysseus.el.tree.impl.ast.AstBinary.SimpleOperator;
+import de.odysseus.el.tree.impl.ast.AstNode;
+
+public class CollectionNonMembershipOperator extends SimpleOperator {
+
+  @Override
+  public Object apply(TypeConverter converter, Object o1, Object o2) {
+    return !(Boolean) IN_OP.apply(converter, o1, o2);
+  }
+
+  @Override
+  public String toString() {
+    return TOKEN.getImage();
+  }
+
+  public static final CollectionNonMembershipOperator NOT_IN_OP = new CollectionNonMembershipOperator();
+  public static final CollectionMembershipOperator IN_OP = new CollectionMembershipOperator();
+  public static final Scanner.ExtensionToken TOKEN = new Scanner.ExtensionToken("not in");
+
+  public static final ExtensionHandler HANDLER = getHandler(false);
+
+  public static ExtensionHandler getHandler(boolean eager) {
+    return new ExtensionHandler(ExtensionPoint.CMP) {
+
+      @Override
+      public AstNode createAstNode(AstNode... children) {
+        return eager
+          ? new EagerAstBinary(children[0], children[1], NOT_IN_OP)
+          : new AstBinary(children[0], children[1], NOT_IN_OP);
+      }
+    };
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -461,6 +461,13 @@ public class ExtendedParser extends Parser {
           ) {
             consumeToken(); // 'is'
             v = buildAstMethodForIdentifier(v, "evaluate");
+          } else if ("in".equals(getToken().getImage())) {
+            v = buildAstMethodForIdentifier(v, "evaluate");
+          } else if (
+            "not".equals(getToken().getImage()) && "in".equals(lookahead(0).getImage())
+          ) {
+            consumeToken(); // 'not'
+            v = buildAstMethodForIdentifier(v, "evaluateNegated");
           }
 
           return v;

--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -107,7 +107,7 @@ public class ExtendedParser extends Parser {
     );
     putExtensionHandler(
       CollectionNonMembershipOperator.TOKEN,
-      CollectionNonMembershipOperator.getHandler(false)
+      CollectionNonMembershipOperator.HANDLER
     );
 
     putExtensionHandler(

--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -90,6 +90,7 @@ public class ExtendedParser extends Parser {
     ExtendedScanner.addKeyToken(PowerOfOperator.TOKEN);
 
     ExtendedScanner.addKeyToken(CollectionMembershipOperator.TOKEN);
+    ExtendedScanner.addKeyToken(CollectionNonMembershipOperator.TOKEN);
   }
 
   public ExtendedParser(Builder context, String input) {
@@ -103,6 +104,10 @@ public class ExtendedParser extends Parser {
     putExtensionHandler(
       CollectionMembershipOperator.TOKEN,
       CollectionMembershipOperator.HANDLER
+    );
+    putExtensionHandler(
+      CollectionNonMembershipOperator.TOKEN,
+      CollectionNonMembershipOperator.getHandler(false)
     );
 
     putExtensionHandler(
@@ -344,6 +349,51 @@ public class ExtendedParser extends Parser {
     return super.literal();
   }
 
+  @Override
+  protected AstNode cmp(boolean required) throws ScanException, ParseException {
+    AstNode v = add(required);
+    if (v == null) {
+      return null;
+    }
+    while (true) {
+      switch (getToken().getSymbol()) {
+        case LT:
+          consumeToken();
+          v = createAstBinary(v, add(true), AstBinary.LT);
+          break;
+        case LE:
+          consumeToken();
+          v = createAstBinary(v, add(true), AstBinary.LE);
+          break;
+        case GE:
+          consumeToken();
+          v = createAstBinary(v, add(true), AstBinary.GE);
+          break;
+        case GT:
+          consumeToken();
+          v = createAstBinary(v, add(true), AstBinary.GT);
+          break;
+        case EXTENSION:
+          if (getExtensionHandler(getToken()).getExtensionPoint() == ExtensionPoint.CMP) {
+            v = getExtensionHandler(consumeToken()).createAstNode(v, add(true));
+            break;
+          }
+        default:
+          if (
+            "not".equals(getToken().getImage()) && "in".equals(lookahead(0).getImage())
+          ) {
+            consumeToken(); // not
+            consumeToken(); // in
+            v =
+              getExtensionHandler(CollectionNonMembershipOperator.TOKEN)
+                .createAstNode(v, add(true));
+            break;
+          }
+      }
+      return v;
+    }
+  }
+
   protected AstRightValue createAstNested(AstNode node) {
     return new AstNested(node);
   }
@@ -461,13 +511,6 @@ public class ExtendedParser extends Parser {
           ) {
             consumeToken(); // 'is'
             v = buildAstMethodForIdentifier(v, "evaluate");
-          } else if ("in".equals(getToken().getImage())) {
-            v = buildAstMethodForIdentifier(v, "evaluate");
-          } else if (
-            "not".equals(getToken().getImage()) && "in".equals(lookahead(0).getImage())
-          ) {
-            consumeToken(); // 'not'
-            v = buildAstMethodForIdentifier(v, "evaluateNegated");
           }
 
           return v;

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerExtendedParser.java
@@ -49,12 +49,12 @@ public class EagerExtendedParser extends ExtendedParser {
 
     putExtensionHandler(
       CollectionMembershipOperator.TOKEN,
-      CollectionMembershipOperator.getHandler(true)
+      CollectionMembershipOperator.EAGER_HANDLER
     );
 
     putExtensionHandler(
       CollectionNonMembershipOperator.TOKEN,
-      CollectionNonMembershipOperator.getHandler(true)
+      CollectionNonMembershipOperator.EAGER_HANDLER
     );
   }
 

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerExtendedParser.java
@@ -6,6 +6,7 @@ import com.hubspot.jinjava.el.ext.AstList;
 import com.hubspot.jinjava.el.ext.AstRangeBracket;
 import com.hubspot.jinjava.el.ext.AstTuple;
 import com.hubspot.jinjava.el.ext.CollectionMembershipOperator;
+import com.hubspot.jinjava.el.ext.CollectionNonMembershipOperator;
 import com.hubspot.jinjava.el.ext.ExtendedParser;
 import com.hubspot.jinjava.el.ext.NamedParameterOperator;
 import com.hubspot.jinjava.el.ext.PowerOfOperator;
@@ -49,6 +50,11 @@ public class EagerExtendedParser extends ExtendedParser {
     putExtensionHandler(
       CollectionMembershipOperator.TOKEN,
       CollectionMembershipOperator.getHandler(true)
+    );
+
+    putExtensionHandler(
+      CollectionNonMembershipOperator.TOKEN,
+      CollectionNonMembershipOperator.getHandler(true)
     );
   }
 

--- a/src/test/java/com/hubspot/jinjava/el/ext/CollectionNonMembershipOperatorTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/CollectionNonMembershipOperatorTest.java
@@ -1,0 +1,41 @@
+package com.hubspot.jinjava.el.ext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CollectionNonMembershipOperatorTest {
+  private JinjavaInterpreter interpreter;
+
+  @Before
+  public void setup() {
+    interpreter = new Jinjava().newInterpreter();
+  }
+
+  @Test
+  public void itChecksIfStringDoesntContainChar() {
+    assertThat(interpreter.resolveELExpression("'a' not in 'pastrami'", -1))
+      .isEqualTo(false);
+    assertThat(interpreter.resolveELExpression("'o' not in 'pastrami'", -1))
+      .isEqualTo(true);
+  }
+
+  @Test
+  public void itChecksIfArrayDoesntContainValue() {
+    assertThat(interpreter.resolveELExpression("11 not in [11, 12, 13]", -1))
+      .isEqualTo(false);
+    assertThat(interpreter.resolveELExpression("14 not in [11, 12, 13]", -1))
+      .isEqualTo(true);
+  }
+
+  @Test
+  public void itChecksIfDictionaryDoesntContainKey() {
+    assertThat(interpreter.resolveELExpression("'a' not in {'a': 1, 'b': 2}", -1))
+      .isEqualTo(false);
+    assertThat(interpreter.resolveELExpression("'c' not in {'a': 1, 'b': 2}", -1))
+      .isEqualTo(true);
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsInExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsInExpTestTest.java
@@ -29,4 +29,14 @@ public class IsInExpTestTest extends BaseJinjavaTest {
     assertThatThrownBy(() -> jinjava.render("{{ 2 is in null }}", new HashMap<>()))
       .hasMessageContaining("1st argument with value 'null' must be iterable");
   }
+
+  @Test
+  public void itEvaluatesWithoutIn() {
+    assertThat(jinjava.render("{{ 2 in [1, 2] }}", new HashMap<>())).isEqualTo("true");
+    assertThat(jinjava.render("{{ 2 in [1] }}", new HashMap<>())).isEqualTo("false");
+
+    assertThat(jinjava.render("{{ 2 not in [1, 2] }}", new HashMap<>()))
+      .isEqualTo("false");
+    assertThat(jinjava.render("{{ 2 not in [1] }}", new HashMap<>())).isEqualTo("true");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsInExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsInExpTestTest.java
@@ -29,14 +29,4 @@ public class IsInExpTestTest extends BaseJinjavaTest {
     assertThatThrownBy(() -> jinjava.render("{{ 2 is in null }}", new HashMap<>()))
       .hasMessageContaining("1st argument with value 'null' must be iterable");
   }
-
-  @Test
-  public void itEvaluatesWithoutIn() {
-    assertThat(jinjava.render("{{ 2 in [1, 2] }}", new HashMap<>())).isEqualTo("true");
-    assertThat(jinjava.render("{{ 2 in [1] }}", new HashMap<>())).isEqualTo("false");
-
-    assertThat(jinjava.render("{{ 2 not in [1, 2] }}", new HashMap<>()))
-      .isEqualTo("false");
-    assertThat(jinjava.render("{{ 2 not in [1] }}", new HashMap<>())).isEqualTo("true");
-  }
 }


### PR DESCRIPTION
Fixes https://github.com/HubSpot/jinjava/issues/640 and https://github.com/HubSpot/jinjava/issues/705

We currently have support for the `in` operator, which handles collection membership in strings, lists, and maps, but we don't support the negation of this operation yet in jinjava. The negation (`not in`) is supported in Jinja, and the closest we have to this is by using `is not in`. This, however does not support strings as they are not iterable. The bug in 705 is caused by a faulty check that prevents the logic from working on strings.

The approach I went with overrides the `cmp` method, adding logic to the default case where if the current symbol is `not` and the next one is `in`, it uses a new CollectionNonMembershipOperator that returns the opposite of CollectionMembershipOperator.

"not in" is unique in Jinja https://jinja.palletsprojects.com/en/3.0.x/templates/#logic which is why I am handling it with a new operator, rather than doing a generic implementation with `not` before any comparison operator.