### PR TITLE
Set propertyResolved after evaluating the AbstractCallableMethod

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
@@ -91,10 +91,11 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
     try {
       Object methodProperty = getValue(context, base, method, false);
       if (methodProperty instanceof AbstractCallableMethod) {
-        context.setPropertyResolved(true);
-        return interpreter.getContext().isValidationMode()
+        Object result = interpreter.getContext().isValidationMode()
           ? ""
           : ((AbstractCallableMethod) methodProperty).evaluate(params);
+        context.setPropertyResolved(true);
+        return result;
       }
     } catch (IllegalArgumentException e) {
       // failed to access property, continue with method calls


### PR DESCRIPTION
This is more in line with the other delegates for resolving properties. Currently, when this is called first, if there are any unresolved properties within the method, (since the ELContext is shared), then we'll think that the method could not be resolved, even if it was. By setting `propertyResolved` to `true` after the operation takes place, we ensure that the boolean value represents whether the current method was resolved, rather than some nested property being resolved.