### PR TITLE
[Eager Execution] Use strtodate to pyish serialize dates to be deserialized as dates

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.objects.date;
 
 import com.hubspot.jinjava.objects.PyWrapper;
+import com.hubspot.jinjava.objects.serialization.PyishSerializable;
 import java.io.Serializable;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -17,9 +18,12 @@ import org.apache.commons.lang3.math.NumberUtils;
  * @author jstehler
  *
  */
-public final class PyishDate extends Date implements Serializable, PyWrapper {
+public final class PyishDate
+  extends Date
+  implements Serializable, PyWrapper, PyishSerializable {
   private static final long serialVersionUID = 1L;
   public static final String PYISH_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
+  public static final String FULL_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 
   private final ZonedDateTime date;
 
@@ -121,5 +125,14 @@ public final class PyishDate extends Date implements Serializable, PyWrapper {
     }
     PyishDate that = (PyishDate) obj;
     return Objects.equals(toDateTime(), that.toDateTime());
+  }
+
+  @Override
+  public String toPyishString() {
+    return String.format(
+      "%s|strtodate(%s)",
+      strftime(FULL_DATE_FORMAT),
+      FULL_DATE_FORMAT
+    );
   }
 }

--- a/src/test/java/com/hubspot/jinjava/objects/date/PyishDateTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/date/PyishDateTest.java
@@ -2,6 +2,8 @@ package com.hubspot.jinjava.objects.date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Date;
@@ -54,5 +56,13 @@ public class PyishDateTest {
   @Test(expected = NullPointerException.class)
   public void testNullStringNotAllowed() {
     new PyishDate((String) null);
+  }
+
+  @Test
+  public void itPyishSerializes() {
+    PyishDate d1 = new PyishDate(ZonedDateTime.parse("2013-11-12T14:15:16.170+02:00"));
+    JinjavaInterpreter interpreter = new Jinjava().newInterpreter();
+    interpreter.render("{% set foo = " + d1.toPyishString() + "%}");
+    assertThat(d1).isNotEqualTo(interpreter.getContext().get("foo"));
   }
 }


### PR DESCRIPTION
This PR makes it so that when a PyishDate value needs to be rewritten on the context for later use, it will be written out such that it will be resolved as a PyishDate, rather than a string. This allows it to be properly used in functions such as the `|between_times` filter.