### PR TITLE
Use regex to match whitespace for locating the "in" in a for loop

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -45,6 +45,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.apache.commons.lang3.tuple.Pair;
 
 /**
@@ -93,6 +95,7 @@ public class ForTag implements Tag {
 
   private static final long serialVersionUID = 6175143875754966497L;
   private static final String LOOP = "loop";
+  private static final Pattern IN_PATTERN = Pattern.compile("\\sin\\s");
 
   @Override
   public boolean isRenderedInValidationMode() {
@@ -246,9 +249,9 @@ public class ForTag implements Tag {
   }
 
   private Optional<String> getLoopExpression(String helpers) {
-    int inIndex = helpers.indexOf(" in ");
-    if (inIndex > 0) {
-      return Optional.of(helpers.substring(inIndex + 4).trim());
+    Matcher matcher = IN_PATTERN.matcher(helpers);
+    if (matcher.find()) {
+      return Optional.of(helpers.substring(matcher.end()).trim());
     }
     return Optional.empty();
   }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
@@ -290,6 +290,14 @@ public class ForTagTest extends BaseInterpretingTest {
     assertThat(rendered).isEqualTo("foo?\nbar?\n");
   }
 
+  @Test
+  public void itHandlesUnconventionalSpacing() {
+    String template = "{% for item\nin \t[0,1] %}" + "{{ item }}\n" + "{% endfor %}";
+
+    String rendered = jinjava.render(template, context);
+    assertThat(rendered).isEqualTo("0\n1\n");
+  }
+
   private Node fixture(String name) {
     try {
       return new TreeParser(


### PR DESCRIPTION
Since other characters can be used to separate the "in" in a for loop, such as a newline, let's use regex to match to find the location of the "in".
Follow up on https://github.com/HubSpot/jinjava/pull/706