### PR TITLE
[Eager Execution] Import path deferred

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -219,6 +219,13 @@ public class ImportTag implements Tag {
     JinjavaInterpreter interpreter
   ) {
     String path = StringUtils.trimToEmpty(helper.get(0));
+    String templateFile = interpreter.resolveString(
+      path,
+      tagToken.getLineNumber(),
+      tagToken.getStartPosition()
+    );
+    templateFile = interpreter.resolveResourceLocation(templateFile);
+    interpreter.getContext().addDependency("coded_files", templateFile);
     try {
       interpreter
         .getContext()
@@ -241,14 +248,6 @@ public class ImportTag implements Tag {
       );
       return Optional.empty();
     }
-
-    String templateFile = interpreter.resolveString(
-      path,
-      tagToken.getLineNumber(),
-      tagToken.getStartPosition()
-    );
-    templateFile = interpreter.resolveResourceLocation(templateFile);
-    interpreter.getContext().addDependency("coded_files", templateFile);
     return Optional.of(templateFile);
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTag.java
@@ -1,11 +1,13 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
 import com.hubspot.jinjava.lib.tag.FromTag;
+import com.hubspot.jinjava.loader.RelativePathResolver;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import java.io.IOException;
@@ -51,7 +53,21 @@ public class EagerFromTag extends EagerStateChangingTag<FromTag> {
             interpreter.getContext().addGlobalMacro(deferredMacro);
           }
         );
-      return tagToken.getImage();
+      return (
+        buildSetTagForDeferredInChildContext(
+          ImmutableMap.of(
+            RelativePathResolver.CURRENT_PATH_CONTEXT_KEY,
+            '\'' +
+            (String) interpreter
+              .getContext()
+              .get(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY) +
+            '\''
+          ),
+          interpreter,
+          false
+        ) +
+        tagToken.getImage()
+      );
     }
     if (!maybeTemplateFile.isPresent()) {
       return "";

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTag.java
@@ -8,6 +8,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
 import com.hubspot.jinjava.lib.tag.FromTag;
 import com.hubspot.jinjava.loader.RelativePathResolver;
+import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import java.io.IOException;
@@ -57,11 +58,9 @@ public class EagerFromTag extends EagerStateChangingTag<FromTag> {
         buildSetTagForDeferredInChildContext(
           ImmutableMap.of(
             RelativePathResolver.CURRENT_PATH_CONTEXT_KEY,
-            '\'' +
-            (String) interpreter
-              .getContext()
-              .get(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY) +
-            '\''
+            PyishObjectMapper.getAsPyishString(
+              interpreter.getContext().get(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY)
+            )
           ),
           interpreter,
           false

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.lib.tag.eager;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
@@ -9,6 +10,7 @@ import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
 import com.hubspot.jinjava.lib.tag.ImportTag;
+import com.hubspot.jinjava.loader.RelativePathResolver;
 import com.hubspot.jinjava.objects.collections.PyMap;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.tree.Node;
@@ -46,7 +48,21 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
         throw e;
       }
       interpreter.getContext().put(currentImportAlias, DeferredValue.instance());
-      return tagToken.getImage();
+      return (
+        buildSetTagForDeferredInChildContext(
+          ImmutableMap.of(
+            RelativePathResolver.CURRENT_PATH_CONTEXT_KEY,
+            '\'' +
+            (String) interpreter
+              .getContext()
+              .get(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY) +
+            '\''
+          ),
+          interpreter,
+          false
+        ) +
+        tagToken.getImage()
+      );
     }
     if (!maybeTemplateFile.isPresent()) {
       return "";

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -38,11 +38,16 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
 
     String currentImportAlias = ImportTag.getContextVar(helper);
 
-    Optional<String> maybeTemplateFile = ImportTag.getTemplateFile(
-      helper,
-      tagToken,
-      interpreter
-    );
+    Optional<String> maybeTemplateFile;
+    try {
+      maybeTemplateFile = ImportTag.getTemplateFile(helper, tagToken, interpreter);
+    } catch (DeferredValueException e) {
+      if (currentImportAlias.isEmpty()) {
+        throw e;
+      }
+      interpreter.getContext().put(currentImportAlias, DeferredValue.instance());
+      return tagToken.getImage();
+    }
     if (!maybeTemplateFile.isPresent()) {
       return "";
     }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -52,11 +52,9 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
         buildSetTagForDeferredInChildContext(
           ImmutableMap.of(
             RelativePathResolver.CURRENT_PATH_CONTEXT_KEY,
-            '\'' +
-            (String) interpreter
-              .getContext()
-              .get(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY) +
-            '\''
+            PyishObjectMapper.getAsPyishString(
+              interpreter.getContext().get(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY)
+            )
           ),
           interpreter,
           false

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTagTest.java
@@ -76,7 +76,7 @@ public class EagerFromTagTest extends FromTagTest {
   public void itDefersWhenPathIsDeferred() {
     String input = "{% from deferred import foo %}";
     String output = interpreter.render(input);
-    assertThat(output).isEqualTo(input);
+    assertThat(output).isEqualTo("{% set current_path = null %}" + input);
     assertThat(interpreter.getContext().getGlobalMacro("foo")).isNotNull();
     assertThat(interpreter.getContext().getGlobalMacro("foo").isDeferred()).isTrue();
   }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTagTest.java
@@ -1,5 +1,7 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.common.io.Resources;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.DeferredValue;
@@ -68,6 +70,15 @@ public class EagerFromTagTest extends FromTagTest {
   @After
   public void teardown() {
     JinjavaInterpreter.popCurrent();
+  }
+
+  @Test
+  public void itDefersWhenPathIsDeferred() {
+    String input = "{% from deferred import foo %}";
+    String output = interpreter.render(input);
+    assertThat(output).isEqualTo(input);
+    assertThat(interpreter.getContext().getGlobalMacro("foo")).isNotNull();
+    assertThat(interpreter.getContext().getGlobalMacro("foo").isDeferred()).isTrue();
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTagTest.java
@@ -82,6 +82,17 @@ public class EagerFromTagTest extends FromTagTest {
   }
 
   @Test
+  public void itReconstructsCurrentPath() {
+    interpreter.getContext().put(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY, "bar");
+
+    String input = "{% from deferred import foo %}";
+    String output = interpreter.render(input);
+    assertThat(output).isEqualTo("{% set current_path = 'bar' %}" + input);
+    assertThat(interpreter.getContext().getGlobalMacro("foo")).isNotNull();
+    assertThat(interpreter.getContext().getGlobalMacro("foo").isDeferred()).isTrue();
+  }
+
+  @Test
   @Ignore
   @Override
   public void itDefersImport() {}

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -556,6 +556,17 @@ public class EagerImportTagTest extends ImportTagTest {
   }
 
   @Test
+  public void itReconstructsCurrentPath() {
+    interpreter.getContext().put(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY, "bar");
+    String input = "{% import deferred as foo %}";
+    String output = interpreter.render(input);
+    assertThat(output).isEqualTo("{% set current_path = 'bar' %}" + input);
+    assertThat(interpreter.getContext().get("foo"))
+      .isNotNull()
+      .isInstanceOf(DeferredValue.class);
+  }
+
+  @Test
   public void itDefersNodeWhenNoImportAlias() {
     String input = "{% import deferred %}";
     String output = interpreter.render(input);

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -549,7 +549,7 @@ public class EagerImportTagTest extends ImportTagTest {
   public void itDefersWhenPathIsDeferred() {
     String input = "{% import deferred as foo %}";
     String output = interpreter.render(input);
-    assertThat(output).isEqualTo(input);
+    assertThat(output).isEqualTo("{% set current_path = null %}" + input);
     assertThat(interpreter.getContext().get("foo"))
       .isNotNull()
       .isInstanceOf(DeferredValue.class);

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -545,6 +545,24 @@ public class EagerImportTagTest extends ImportTagTest {
     assertThat(interpreter.render(result)).isEqualTo("A_resolved_A-B_resolved_B");
   }
 
+  @Test
+  public void itDefersWhenPathIsDeferred() {
+    String input = "{% import deferred as foo %}";
+    String output = interpreter.render(input);
+    assertThat(output).isEqualTo(input);
+    assertThat(interpreter.getContext().get("foo"))
+      .isNotNull()
+      .isInstanceOf(DeferredValue.class);
+  }
+
+  @Test
+  public void itDefersNodeWhenNoImportAlias() {
+    String input = "{% import deferred %}";
+    String output = interpreter.render(input);
+    assertThat(output).isEqualTo(input);
+    assertThat(interpreter.getContext().getDeferredNodes()).hasSize(1);
+  }
+
   private static JinjavaInterpreter getChildInterpreter(
     JinjavaInterpreter interpreter,
     String alias


### PR DESCRIPTION
This PR handles the case where the path for either a From or an Import tag can not be resolved due to it being a deferred value. Rather than always deferring the node, it will only defer the values which in the case of a From tag, will be the macro functions. In the case of an Import tag, it will be the import alias, if it exists. It also reconstructs the current path in case relative import will be used during a second rendering to resolve the path.