### PR TITLE
[Eager Execution] Maintain current_path for relative resolving when deferred

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactory.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactory.java
@@ -13,6 +13,7 @@ import com.hubspot.jinjava.lib.tag.ForTag;
 import com.hubspot.jinjava.lib.tag.FromTag;
 import com.hubspot.jinjava.lib.tag.IfTag;
 import com.hubspot.jinjava.lib.tag.ImportTag;
+import com.hubspot.jinjava.lib.tag.IncludeTag;
 import com.hubspot.jinjava.lib.tag.PrintTag;
 import com.hubspot.jinjava.lib.tag.RawTag;
 import com.hubspot.jinjava.lib.tag.SetTag;
@@ -30,6 +31,7 @@ public class EagerTagFactory {
     .put(PrintTag.class, EagerPrintTag.class)
     .put(FromTag.class, EagerFromTag.class)
     .put(ImportTag.class, EagerImportTag.class)
+    .put(IncludeTag.class, EagerIncludeTag.class)
     .put(ForTag.class, EagerForTag.class)
     .put(CycleTag.class, EagerCycleTag.class)
     .put(IfTag.class, EagerIfTag.class)

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.objects.serialization;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.io.IOException;
 import java.util.Objects;
 
@@ -21,10 +22,14 @@ public class PyishSerializer extends JsonSerializer<Object> {
     jsonGenerator.setPrettyPrinter(PyishPrettyPrinter.INSTANCE);
     jsonGenerator.setCharacterEscapes(PyishCharacterEscapes.INSTANCE);
     String string;
-    if (object instanceof PyishSerializable) {
-      jsonGenerator.writeRawValue(((PyishSerializable) object).toPyishString());
+    Object wrappedObject = JinjavaInterpreter
+      .getCurrentMaybe()
+      .map(interpreter -> interpreter.wrap(object))
+      .orElse(object);
+    if (wrappedObject instanceof PyishSerializable) {
+      jsonGenerator.writeRawValue(((PyishSerializable) wrappedObject).toPyishString());
     } else {
-      string = Objects.toString(object, "");
+      string = Objects.toString(wrappedObject, "");
       try {
         double number = Double.parseDouble(string);
         if (

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -750,7 +750,9 @@ public class EagerTest {
 
   @Test
   public void itHandlesDeferredImportVars() {
-    expectedTemplateInterpreter.assertExpectedOutput("handles-deferred-import-vars");
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
+      "handles-deferred-import-vars"
+    );
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/ExpectedTemplateInterpreter.java
+++ b/src/test/java/com/hubspot/jinjava/ExpectedTemplateInterpreter.java
@@ -33,6 +33,13 @@ public class ExpectedTemplateInterpreter {
     return output;
   }
 
+  public String assertExpectedOutputNonIdempotent(String name) {
+    String template = getFixtureTemplate(name);
+    String output = JinjavaInterpreter.getCurrent().render(template);
+    assertThat(output.trim()).isEqualTo(expected(name).trim());
+    return output;
+  }
+
   public String assertExpectedNonEagerOutput(String name) {
     JinjavaInterpreter preserveInterpreter = new JinjavaInterpreter(
       jinjava,

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -549,7 +549,7 @@ public class EagerImportTagTest extends ImportTagTest {
   public void itDefersWhenPathIsDeferred() {
     String input = "{% import deferred as foo %}";
     String output = interpreter.render(input);
-    assertThat(output).isEqualTo("{% set current_path = null %}" + input);
+    assertThat(output).isEqualTo("{% set current_path = '' %}" + input);
     assertThat(interpreter.getContext().get("foo"))
       .isNotNull()
       .isInstanceOf(DeferredValue.class);

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTagTest.java
@@ -42,7 +42,7 @@ public class EagerIncludeTagTest extends IncludeTagTest {
 
   @Test
   public void itIncludesDeferred() {
-    expectedTemplateInterpreter.assertExpectedOutput("includes-deferred");
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent("includes-deferred");
     assertThat(
         context
           .getEagerTokens()

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactoryTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactoryTest.java
@@ -2,8 +2,7 @@ package com.hubspot.jinjava.lib.tag.eager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hubspot.jinjava.lib.tag.IncludeTag;
-import com.hubspot.jinjava.lib.tag.RawTag;
+import com.hubspot.jinjava.lib.tag.IfchangedTag;
 import com.hubspot.jinjava.lib.tag.Tag;
 import java.util.Objects;
 import java.util.Optional;
@@ -46,10 +45,10 @@ public class EagerTagFactoryTest {
   @Test
   public void itGetsEagerTagDecoratorForNonOverride() {
     Optional<? extends EagerTagDecorator<? extends Tag>> maybeEagerGenericTag = EagerTagFactory.getEagerTagDecorator(
-      new IncludeTag()
+      new IfchangedTag()
     );
     assertThat(maybeEagerGenericTag).isPresent();
     assertThat(maybeEagerGenericTag.get()).isInstanceOf(EagerGenericTag.class);
-    assertThat(maybeEagerGenericTag.get().getTag()).isInstanceOf(IncludeTag.class);
+    assertThat(maybeEagerGenericTag.get().getTag()).isInstanceOf(IfchangedTag.class);
   }
 }

--- a/src/test/resources/eager/handles-deferred-import-vars.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-import-vars.expected.jinja
@@ -4,9 +4,9 @@ Hello {{ myname }}
 
 foo: Hello {{ myname }}
 bar: {{ bar }}
----{% set myname = deferred + 7 %}
+---{% set myname = deferred + 7 %}{% set current_path = 'macro-and-set.jinja' %}
 {% set bar = myname + 19 %}{% set simple = {} %}{% do simple.update({"bar": bar}) %}
 Hello {{ myname }}
-{% do simple.update({'import_resource_path': 'macro-and-set.jinja'}) %}
+{% do simple.update({'import_resource_path': 'macro-and-set.jinja'}) %}{% set current_path = '' %}
 simple.foo: {% set deferred_import_resource_path = 'macro-and-set.jinja' %}{% macro simple.foo() %}Hello {{ myname }}{% endmacro %}{% set deferred_import_resource_path = null %}{{ simple.foo() }}
 simple.bar: {{ simple.bar }}

--- a/src/test/resources/tags/eager/includetag/includes-deferred.expected.jinja
+++ b/src/test/resources/tags/eager/includetag/includes-deferred.expected.jinja
@@ -1,5 +1,5 @@
 Foo begins as: abc
-{% set foo = deferred %}
+{% set current_path = 'tags/eager/includetag/sets-to-deferred.jinja' %}{% set foo = deferred %}
 foo is now {{ deferred }}.
-
+{% set current_path = '' %}
 Foo ends as: {{ foo }}


### PR DESCRIPTION
For when there are deferred tokens after calling an import tag or an include tag.
This requires a decorator for the include tag so that we can reconstruct the new value for current path as well as the initial value using set tags. This is just in case there are deferred tokens that need to do a relative path resolve and they would need the current path at the time they're called. If this happens within an import or include tag, it would be different during a second pass.