### PR TITLE
[Eager Execution] Complex Short-Circuit Only

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBinary.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBinary.java
@@ -5,6 +5,7 @@ import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.el.ext.OrOperator;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstBinary;
+import de.odysseus.el.tree.impl.ast.AstIdentifier;
 import de.odysseus.el.tree.impl.ast.AstNode;
 import javax.el.ELContext;
 
@@ -41,12 +42,17 @@ public class EagerAstBinary extends AstBinary implements EvalResultHolder {
       hasEvalResult = true;
       return evalResult;
     } catch (DeferredParsingException e) {
+      // Allow evaluation of identifiers as they won't cause context changes when evaluated.
+      boolean simpleRightSide = right instanceof AstIdentifier;
       String sb =
         EvalResultHolder.reconstructNode(bindings, context, left, e, false) +
         String.format(" %s ", operator.toString()) +
         EvalResultHolder.reconstructNode(
           bindings,
-          (operator instanceof OrOperator || operator == AstBinary.AND)
+          (
+              !simpleRightSide &&
+              (operator instanceof OrOperator || operator == AstBinary.AND)
+            )
             ? DeferredELContext.INSTANCE // short circuit because this may not be evaluated
             : context,
           right,

--- a/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstBinaryTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstBinaryTest.java
@@ -42,14 +42,24 @@ public class EagerAstBinaryTest extends BaseInterpretingTest {
   }
 
   @Test
-  public void itShortCircuitsDeferredAnd() {
-    assertThat(interpreter.resolveELExpression("false && deferred", -1)).isEqualTo(false);
-
+  public void itDoesNotShortCircuitIdentifier() {
     try {
       interpreter.resolveELExpression("foo && deferred && foo", -1);
       fail("Should throw DeferredParsingException");
     } catch (DeferredParsingException e) {
-      assertThat(e.getDeferredEvalResult()).isEqualTo("'bar' && deferred && foo");
+      assertThat(e.getDeferredEvalResult()).isEqualTo("'bar' && deferred && 'bar'");
+    }
+  }
+
+  @Test
+  public void itShortCircuitsDeferredAnd() {
+    assertThat(interpreter.resolveELExpression("false && deferred", -1)).isEqualTo(false);
+
+    try {
+      interpreter.resolveELExpression("foo && deferred && range(1)", -1);
+      fail("Should throw DeferredParsingException");
+    } catch (DeferredParsingException e) {
+      assertThat(e.getDeferredEvalResult()).isEqualTo("'bar' && deferred && range(1)");
     }
   }
 
@@ -57,20 +67,20 @@ public class EagerAstBinaryTest extends BaseInterpretingTest {
   public void itShortCircuitsDeferredOr() {
     assertThat(interpreter.resolveELExpression("foo || deferred", -1)).isEqualTo("bar");
     try {
-      interpreter.resolveELExpression("deferred || foo", -1);
+      interpreter.resolveELExpression("deferred || range(1)", -1);
       fail("Should throw DeferredParsingException");
     } catch (DeferredParsingException e) {
-      assertThat(e.getDeferredEvalResult()).isEqualTo("deferred || foo");
+      assertThat(e.getDeferredEvalResult()).isEqualTo("deferred || range(1)");
     }
   }
 
   @Test
   public void itDoesNotShortCircuitOtherOperators() {
     try {
-      interpreter.resolveELExpression("deferred + foo", -1);
+      interpreter.resolveELExpression("deferred + range(1)", -1);
       fail("Should throw DeferredParsingException");
     } catch (DeferredParsingException e) {
-      assertThat(e.getDeferredEvalResult()).isEqualTo("deferred + 'bar'");
+      assertThat(e.getDeferredEvalResult()).isEqualTo("deferred + [0]");
     }
   }
 }


### PR DESCRIPTION
It is unnecessary to short-circuit evaluation when the right side of the expression is just an identifier. The purpose of short-circuiting is to not run nodes that may cause changes to the context when we are sure if those changes will actually happen. Such as `deferred || list.append(1)`. However, if the right side is just an identifier, we are safe to simply evaluate it without worrying about the context changing so we don't need to short circuit in that case.