### PR TITLE
Override toString() for DeferredValueImpl

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/DeferredValueImpl.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/DeferredValueImpl.java
@@ -1,5 +1,7 @@
 package com.hubspot.jinjava.interpret;
 
+import java.util.Objects;
+
 public class DeferredValueImpl implements DeferredValue {
   private static final DeferredValue INSTANCE = new DeferredValueImpl();
 
@@ -21,5 +23,10 @@ public class DeferredValueImpl implements DeferredValue {
 
   public static DeferredValue instance(Object originalValue) {
     return new DeferredValueImpl(originalValue);
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toString(originalValue);
   }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
@@ -48,6 +48,11 @@ public class DeferredTest {
   }
 
   @Test
+  public void itGetsOriginalValueString() {
+    assertThat(DeferredValue.instance("abc").toString()).isEqualTo("abc");
+  }
+
+  @Test
   public void checkAssumptions() {
     // Just checking assumptions
     String output = interpreter.render("deferred");


### PR DESCRIPTION
Calling `toString()` and getting a result of `com.hubspot.jinjava.interpret.DeferredValueImpl@1234abcd` is not very useful so since this is a delegate of sorts, we can call the `toString()` of the original value instead.