### PR TITLE
[Eager Execution] Make renderChildren not static

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Sets;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.SetTag;
+import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
@@ -31,12 +32,12 @@ public class EagerBlockSetTagStrategy extends EagerSetTagStrategy {
     int numEagerTokens = interpreter.getContext().getEagerTokens().size();
     return EagerTagDecorator.executeInChildContext(
       eagerInterpreter -> {
-        String renderedChildren = EagerTagDecorator.renderChildren(
-          tagNode,
-          eagerInterpreter
-        );
+        StringBuilder sb = new StringBuilder();
+        for (Node child : tagNode.getChildren()) {
+          sb.append(child.render(eagerInterpreter).getValue());
+        }
         return EagerExpressionResult.fromString(
-          renderedChildren,
+          sb.toString(),
           numEagerTokens ==
             eagerInterpreter.getContext().getParent().getEagerTokens().size()
             ? ResolutionState.FULL

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -162,7 +162,7 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
    * @param interpreter The JinjavaInterpreter.
    * @return the string output of this tag node's children.
    */
-  public static String renderChildren(TagNode tagNode, JinjavaInterpreter interpreter) {
+  public String renderChildren(TagNode tagNode, JinjavaInterpreter interpreter) {
     StringBuilder sb = new StringBuilder();
     for (Node child : tagNode.getChildren()) {
       sb.append(child.render(interpreter).getValue());


### PR DESCRIPTION
This method should not be static. I changed it to be so in https://github.com/HubSpot/jinjava/pull/699, but am changing it back to non-static now.