### PR TITLE
Limit infinite evaluation from recursive extends tags

### DIFF
--- a/src/test/java/com/hubspot/jinjava/lib/tag/ExtendsTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ExtendsTagTest.java
@@ -244,6 +244,19 @@ public class ExtendsTagTest extends BaseInterpretingTest {
       .isEqualTo("/errors/error.html");
   }
 
+  @Test
+  public void itLimitsExtendsWithMultipleLevels() throws IOException {
+    // Previously this would run infinitely
+    RenderResult result = jinjava.renderForResult(
+      locator.fixture("rec1.jinja"),
+      new HashMap<>()
+    );
+    assertThat(result.getOutput().trim()).isEqualTo("foo");
+    assertThat(result.getErrors()).hasSize(1);
+    assertThat(result.getErrors().get(0).getMessage())
+      .contains("ExtendsTagCycleException");
+  }
+
   private static class ExtendsTagTestResourceLocator implements ResourceLocator {
     private RelativePathResolver relativePathResolver = new RelativePathResolver();
 

--- a/src/test/resources/tags/extendstag/rec1.jinja
+++ b/src/test/resources/tags/extendstag/rec1.jinja
@@ -1,0 +1,4 @@
+{% extends 'rec2.jinja' %}
+{% block body %}
+foo
+{% endblock %}

--- a/src/test/resources/tags/extendstag/rec2.jinja
+++ b/src/test/resources/tags/extendstag/rec2.jinja
@@ -1,0 +1,4 @@
+{% extends 'rec3.jinja' %}
+{% block body %}
+foobar
+{% endblock %}

--- a/src/test/resources/tags/extendstag/rec3.jinja
+++ b/src/test/resources/tags/extendstag/rec3.jinja
@@ -1,0 +1,4 @@
+{% extends 'rec3.jinja' %}
+{% block body %}
+baz
+{% endblock %}


### PR DESCRIPTION
Prevent infinite levels of extends tags being called when there is an extended child that has a child that extends itself. The basic stack way of detecting extends tag cycles did not catch this case. So this PR adds in a set that remembers the paths that have been extended when processing them and if any ever get encountered more than once, it will break and add an interpreter error.

The test case that I added is a simple demonstration of what caused infinite execution. This PR fixes that case.

cc @kacperadach @hs-lsong @bkrainer 