### PR TITLE
[Eager Execution] Rerun deferred for loops when variables are modified

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -5,6 +5,7 @@ import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.ForTag;
+import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
@@ -13,6 +14,7 @@ import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -35,6 +37,7 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
     LengthLimitingStringBuilder result = new LengthLimitingStringBuilder(
       interpreter.getConfig().getMaxOutputSize()
     );
+    String prefix = "";
 
     // separate getEagerImage from renderChildren because the token gets evaluated once
     // while the children are evaluated 0...n times.
@@ -67,22 +70,46 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
       false,
       true
     );
-    if (
-      eagerExecutionResult
-        .getSpeculativeBindings()
-        .keySet()
-        .stream()
-        .anyMatch(key -> !(interpreter.getContext().get(key) instanceof DeferredValue))
-    ) {
+    if (!eagerExecutionResult.getSpeculativeBindings().isEmpty()) {
       // Values cannot be modified within a for loop because we don't know many times, if any it will run
-      throw new DeferredValueException(
-        "Modified values in deferred for loop: " +
-        String.join(", ", eagerExecutionResult.getSpeculativeBindings().keySet())
-      );
+      prefix =
+        buildSetTagForDeferredInChildContext(
+          eagerExecutionResult
+            .getSpeculativeBindings()
+            .entrySet()
+            .stream()
+            .collect(
+              Collectors.toMap(
+                Entry::getKey,
+                entry -> PyishObjectMapper.getAsPyishString(entry.getValue())
+              )
+            ),
+          interpreter,
+          true
+        );
+      eagerExecutionResult =
+        executeInChildContext(
+          eagerInterpreter -> {
+            eagerInterpreter.getContext().put("loop", DeferredValue.instance());
+            return EagerExpressionResult.fromString(
+              renderChildren(tagNode, eagerInterpreter)
+            );
+          },
+          interpreter,
+          false,
+          false,
+          true
+        );
+      if (!eagerExecutionResult.getSpeculativeBindings().isEmpty()) {
+        throw new DeferredValueException(
+          "Modified values in deferred for loop: " +
+          String.join(", ", eagerExecutionResult.getSpeculativeBindings().keySet())
+        );
+      }
     }
     result.append(eagerExecutionResult.asTemplateString());
     result.append(reconstructEnd(tagNode));
-    return result.toString();
+    return prefix + result;
   }
 
   @Override

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -99,6 +99,18 @@ public class EagerTest {
   }
 
   @Test
+  public void itDefersNodeWhenModifiedInForLoop() {
+    assertThat(
+        interpreter.render(
+          "{% set bar = 'bar' %}{% set foo = 0 %}{% for i in deferred %}{{ bar ~ foo ~ bar }} {% set foo = foo + 1 %}{% endfor %}"
+        )
+      )
+      .isEqualTo(
+        "{% set foo = 0 %}{% for i in deferred %}{{ 'bar' ~ foo ~ 'bar' }} {% set foo = foo + 1 %}{% endfor %}"
+      );
+  }
+
+  @Test
   public void checkAssumptions() {
     // Just checking assumptions
     String output = interpreter.render("deferred");

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
@@ -9,7 +9,6 @@ import com.hubspot.jinjava.LegacyOverrides;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
-import com.hubspot.jinjava.lib.tag.ForTag;
 import com.hubspot.jinjava.lib.tag.ForTagTest;
 import com.hubspot.jinjava.mode.EagerExecutionMode;
 import com.hubspot.jinjava.tree.parse.TagToken;
@@ -100,19 +99,23 @@ public class EagerForTagTest extends ForTagTest {
 
   @Test
   public void itDoesntAllowChangesInDeferredFor() {
-    interpreter.render(
-      "{% set foo = [0] %}\n" +
-      "{% for i in range(0, deferred) %}\n" +
-      "{{ foo }}\n" +
+    String result = interpreter.render(
+      "{% set foo = [0] -%}\n" +
+      "{%- for i in range(0, deferred) %}\n" +
+      "{{ 'bar' }}{{ foo }}\n" +
       "{% do foo.append(1) %}\n" +
       "{% endfor %}\n" +
       "{{ foo }}"
     );
-    assertThat(interpreter.getContext().getDeferredNodes()).hasSize(1);
-    assertThat(
-        interpreter.getContext().getDeferredNodes().stream().findAny().get().getName()
-      )
-      .isEqualTo(ForTag.TAG_NAME);
+    assertThat(result)
+      .isEqualTo(
+        "{% set foo = [0] %}{% for i in range(0, deferred) %}\n" +
+        "bar{{ foo }}\n" +
+        "{% do foo.append(1) %}\n" +
+        "{% endfor %}\n" +
+        "{{ foo }}"
+      );
+    assertThat(interpreter.getContext().getDeferredNodes()).hasSize(0);
   }
 
   @Test


### PR DESCRIPTION
If, when running a for loop in deferred execution mode, a variable is attempted to be modified, then rerun the for loop with that variable now as a deferred value so that the value of it will correctly change each time the loop is run when executed during a second render.
For example:
```
{% set foo = 0 %}
{% for i in deferred %}
{{ foo }}
{% set foo = foo + 1 %}
{% endfor %}
```
With these changes, the loop will be rerun with `foo` deferred so that `{{ foo }}` will not be prematurely evaluated to just `0`. (That would result in `0` being output every iteration of the loop even when `deferred` gets resolved.