### PR TITLE
[Eager Execution] Track deferred exception start position too

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -46,7 +46,12 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
           eagerInterpreter ->
             EagerExpressionResult.fromString(
               getEagerImage(
-                buildToken(tagNode, e, interpreter.getLineNumber()),
+                buildToken(
+                  tagNode,
+                  e,
+                  interpreter.getLineNumber(),
+                  interpreter.getPosition()
+                ),
                 eagerInterpreter
               )
             ),

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
@@ -90,6 +90,7 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
   ) {
     // line number of the last attempted resolveELExpression
     final int deferredLineNumber = interpreter.getLineNumber();
+    final int deferredPosition = interpreter.getPosition();
     // If the branch is impossible, it should be removed.
     boolean definitelyDrop = shouldDropBranch(tagNode, interpreter, deferredLineNumber);
     // If an ("elseif") branch would definitely get executed,
@@ -98,7 +99,12 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
     // the first branch.
     boolean definitelyExecuted = false;
     StringBuilder sb = new StringBuilder();
-    sb.append(getEagerImage(buildToken(tagNode, e, deferredLineNumber), interpreter));
+    sb.append(
+      getEagerImage(
+        buildToken(tagNode, e, deferredLineNumber, deferredPosition),
+        interpreter
+      )
+    );
     int branchStart = 0;
     int childrenSize = tagNode.getChildren().size();
     while (branchStart < childrenSize) {
@@ -139,7 +145,10 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
           );
         } else {
           sb.append(
-            getEagerImage(buildToken(caseNode, e, deferredLineNumber), interpreter)
+            getEagerImage(
+              buildToken(caseNode, e, deferredLineNumber, deferredPosition),
+              interpreter
+            )
           );
         }
       }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTag.java
@@ -27,7 +27,7 @@ public class EagerSetTag extends EagerStateChangingTag<SetTag> implements Flexib
       return EagerInlineSetTagStrategy.INSTANCE.run(
         new TagNode(
           getTag(),
-          buildToken(tagNode, e, interpreter.getLineNumber()),
+          buildToken(tagNode, e, interpreter.getLineNumber(), interpreter.getPosition()),
           tagNode.getSymbols()
         ),
         interpreter

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
@@ -27,7 +27,10 @@ public class EagerStateChangingTag<T extends Tag> extends EagerTagDecorator<T> {
     InterpretException e
   ) {
     StringBuilder result = new StringBuilder(
-      getEagerImage(buildToken(tagNode, e, interpreter.getLineNumber()), interpreter)
+      getEagerImage(
+        buildToken(tagNode, e, interpreter.getLineNumber(), interpreter.getPosition()),
+        interpreter
+      )
     );
 
     if (!tagNode.getChildren().isEmpty()) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -111,7 +111,12 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
           eagerInterpreter ->
             EagerExpressionResult.fromString(
               getEagerImage(
-                buildToken(tagNode, e, interpreter.getLineNumber()),
+                buildToken(
+                  tagNode,
+                  e,
+                  interpreter.getLineNumber(),
+                  interpreter.getPosition()
+                ),
                 eagerInterpreter
               ) +
               renderChildren(tagNode, eagerInterpreter)
@@ -134,11 +139,13 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
   public TagToken buildToken(
     TagNode tagNode,
     InterpretException e,
-    int deferredLineNumber
+    int deferredLineNumber,
+    int deferredPosition
   ) {
     if (
       e instanceof DeferredParsingException &&
-      deferredLineNumber == tagNode.getLineNumber()
+      deferredLineNumber == tagNode.getLineNumber() &&
+      deferredPosition == tagNode.getStartPosition()
     ) {
       return new TagToken(
         String.format(

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -891,4 +891,9 @@ public class EagerTest {
       "handles-block-set-in-deferred-if.expected"
     );
   }
+
+  @Test
+  public void itDoesntOverwriteElif() {
+    expectedTemplateInterpreter.assertExpectedOutput("doesnt-overwrite-elif");
+  }
 }

--- a/src/test/resources/eager/doesnt-overwrite-elif.expected.jinja
+++ b/src/test/resources/eager/doesnt-overwrite-elif.expected.jinja
@@ -1,0 +1,2 @@
+{% set foo = [0] %}{% if deferred && foo.append(1) %}1{% elif deferred && foo.append(2) %}2{% endif %}
+{{ foo }}

--- a/src/test/resources/eager/doesnt-overwrite-elif.jinja
+++ b/src/test/resources/eager/doesnt-overwrite-elif.jinja
@@ -1,0 +1,3 @@
+{% set foo = [0] %}
+{% if deferred && foo.append(1) %}1{% elif deferred && foo.append(2) %}2{% endif %}
+{{ foo }}


### PR DESCRIPTION
Before this, we only looked at the line number to tell which token through the DeferredParsingException. However, if there is an `{% if %}` and `{% elif %}` on the same line, then that would consider the exception as thrown from both of them so one or more conditions would be overridden. This updates it to also look for the position of the token within the line to determine which token the exception was thrown in.