### PR TITLE
[Eager Execution] Don't do nested interpretation on unclosed note tags

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -30,6 +30,7 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
     ExpressionToken master,
     JinjavaInterpreter interpreter
   ) {
+    int numEagerTokensStart = interpreter.getContext().getEagerTokens().size();
     EagerExecutionResult eagerExecutionResult;
     eagerExecutionResult =
       EagerTagDecorator.executeInChildContext(
@@ -46,7 +47,10 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
     } else {
       interpreter.getContext().putAll(eagerExecutionResult.getSpeculativeBindings());
     }
-    if (eagerExecutionResult.getResult().isFullyResolved()) {
+    if (
+      eagerExecutionResult.getResult().isFullyResolved() &&
+      interpreter.getContext().getEagerTokens().size() == numEagerTokensStart
+    ) {
       String result = eagerExecutionResult.getResult().toString(true);
       if (
         !StringUtils.equals(result, master.getImage()) &&

--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -30,7 +30,6 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
     ExpressionToken master,
     JinjavaInterpreter interpreter
   ) {
-    int numEagerTokensStart = interpreter.getContext().getEagerTokens().size();
     EagerExecutionResult eagerExecutionResult;
     eagerExecutionResult =
       EagerTagDecorator.executeInChildContext(
@@ -47,13 +46,20 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
     } else {
       interpreter.getContext().putAll(eagerExecutionResult.getSpeculativeBindings());
     }
-    if (
-      eagerExecutionResult.getResult().isFullyResolved() &&
-      interpreter.getContext().getEagerTokens().size() == numEagerTokensStart
-    ) {
+    if (eagerExecutionResult.getResult().isFullyResolved()) {
       String result = eagerExecutionResult.getResult().toString(true);
+      boolean containsIncompleteComment =
+        StringUtils.contains(
+          result,
+          "" + master.getSymbols().getPrefixChar() + master.getSymbols().getNoteChar()
+        ) &&
+        !StringUtils.contains(
+          result,
+          "" + master.getSymbols().getNoteChar() + master.getSymbols().getPostfixChar()
+        );
       if (
         !StringUtils.equals(result, master.getImage()) &&
+        !containsIncompleteComment &&
         (
           StringUtils.contains(result, master.getSymbols().getExpressionStart()) ||
           StringUtils.contains(result, master.getSymbols().getExpressionStartWithTag())

--- a/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
@@ -146,6 +146,11 @@ public class EagerExpressionStrategyTest extends ExpressionNodeTest {
     assertExpectedOutput("{{ is_deferred_execution_mode() }}", "true");
   }
 
+  @Test
+  public void itDoesNotNestedInterpretIfThereAreFakeNotes() {
+    assertExpectedOutput("{{ '{#something_to_{{keep}}' }}", "{#something_to_{{keep}}");
+  }
+
   private void assertExpectedOutput(String inputTemplate, String expectedOutput) {
     assertThat(interpreter.render(inputTemplate)).isEqualTo(expectedOutput);
   }


### PR DESCRIPTION
If there are incomplete hubl notes, don't do nested interpretation as it will remove data from the output that should instead be there.