### PR TITLE
[Eager Execution] Set position before evaluating any if's or elif's

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -578,6 +578,19 @@ public class JinjavaInterpreter implements PyishSerializable {
   }
 
   /**
+   * Resolve expression against current context. Also set the interpreter's position,
+   * useful for nodes that resolve multiple expressions such as a node using an IfTag and ElseTags.
+   * @param expression Jinja expression.
+   * @param lineNumber Line number of expression.
+   * @param position Start position of expression.
+   * @return Value of expression.
+   */
+  public Object resolveELExpression(String expression, int lineNumber, int position) {
+    this.position = position;
+    return resolveELExpression(expression, lineNumber);
+  }
+
+  /**
    * Resolve property of bean.
    *
    * @param object

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IfTag.java
@@ -133,7 +133,11 @@ public class IfTag implements Tag {
     JinjavaInterpreter interpreter
   ) {
     return ObjectTruthValue.evaluate(
-      interpreter.resolveELExpression(tagNode.getHelpers(), tagNode.getLineNumber())
+      interpreter.resolveELExpression(
+        tagNode.getHelpers(),
+        tagNode.getLineNumber(),
+        tagNode.getStartPosition()
+      )
     );
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
@@ -239,7 +239,8 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
       return !ObjectTruthValue.evaluate(
         eagerInterpreter.resolveELExpression(
           tagNode.getHelpers(),
-          tagNode.getLineNumber()
+          tagNode.getLineNumber(),
+          tagNode.getStartPosition()
         )
       );
     } catch (DeferredValueException e) {
@@ -259,7 +260,8 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
       return ObjectTruthValue.evaluate(
         eagerInterpreter.resolveELExpression(
           tagNode.getHelpers(),
-          tagNode.getLineNumber()
+          tagNode.getLineNumber(),
+          tagNode.getStartPosition()
         )
       );
     } catch (DeferredValueException e) {

--- a/src/test/resources/eager/doesnt-overwrite-elif.expected.jinja
+++ b/src/test/resources/eager/doesnt-overwrite-elif.expected.jinja
@@ -1,2 +1,2 @@
-{% set foo = [0] %}{% if deferred && foo.append(1) %}1{% elif deferred && foo.append(2) %}2{% endif %}
+{% set foo = [0] %}{% if false %}{% elif deferred && foo.append(1) %}1{% elif deferred && foo.append(2) %}2{% endif %}
 {{ foo }}

--- a/src/test/resources/eager/doesnt-overwrite-elif.jinja
+++ b/src/test/resources/eager/doesnt-overwrite-elif.jinja
@@ -1,3 +1,3 @@
 {% set foo = [0] %}
-{% if deferred && foo.append(1) %}1{% elif deferred && foo.append(2) %}2{% endif %}
+{% if foo == [9] %}9{% elif deferred && foo.append(1) %}1{% elif deferred && foo.append(2) %}2{% endif %}
 {{ foo }}


### PR DESCRIPTION
The position should be set before the expression for the if statement or the elif statements are read so that we can properly determine which one was last resolved by the interpreter.
Adds to the test to be able to catch this.
Follow up on https://github.com/HubSpot/jinjava/pull/721