### PR TITLE
[EagerExecution] Parse the result to check for unclosed comments

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -48,26 +48,26 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
     }
     if (eagerExecutionResult.getResult().isFullyResolved()) {
       String result = eagerExecutionResult.getResult().toString(true);
-      if (!StringUtils.equals(result, master.getImage())) {
-        long errorSizeStart = getUnclosedCommentErrorsCount(interpreter);
-        interpreter.parse(result);
-        if (
-          getUnclosedCommentErrorsCount(interpreter) == errorSizeStart &&
-          (
-            StringUtils.contains(result, master.getSymbols().getExpressionStart()) ||
-            StringUtils.contains(result, master.getSymbols().getExpressionStartWithTag())
-          )
-        ) {
-          if (interpreter.getConfig().isNestedInterpretationEnabled()) {
+      if (
+        !StringUtils.equals(result, master.getImage()) &&
+        (
+          StringUtils.contains(result, master.getSymbols().getExpressionStart()) ||
+          StringUtils.contains(result, master.getSymbols().getExpressionStartWithTag())
+        )
+      ) {
+        if (interpreter.getConfig().isNestedInterpretationEnabled()) {
+          long errorSizeStart = getUnclosedCommentErrorsCount(interpreter);
+          interpreter.parse(result);
+          if (getUnclosedCommentErrorsCount(interpreter) == errorSizeStart) {
             try {
               result = interpreter.renderFlat(result);
             } catch (Exception e) {
               Logging.ENGINE_LOG.warn("Error rendering variable node result", e);
             }
-          } else {
-            // Possible macro/set tag in front of this one. Includes result
-            result = wrapInRawOrExpressionIfNeeded(result, interpreter);
           }
+        } else {
+          // Possible macro/set tag in front of this one. Includes result
+          result = wrapInRawOrExpressionIfNeeded(result, interpreter);
         }
       }
 

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -754,7 +754,6 @@ public class EagerTest {
     try {
       new ExpectedTemplateInterpreter(jinjava, noNestedInterpreter, "eager")
       .assertExpectedOutput("wraps-certain-output-in-raw");
-      assertThat(noNestedInterpreter.getErrors()).isEmpty();
     } finally {
       JinjavaInterpreter.popCurrent();
     }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -754,6 +754,7 @@ public class EagerTest {
     try {
       new ExpectedTemplateInterpreter(jinjava, noNestedInterpreter, "eager")
       .assertExpectedOutput("wraps-certain-output-in-raw");
+      assertThat(noNestedInterpreter.getErrors()).isEmpty();
     } finally {
       JinjavaInterpreter.popCurrent();
     }


### PR DESCRIPTION
Uses a more robust method by parsing the expression result to check if there are unclosed comments, as there may be some within `{% raw %}` tags that we needn't worry about. We don't want to do nested interpretation if there are unclosed comments as they may in fact be minified css that look like note tags, and should not cause all the proceeding text to be removed.