### PR TITLE
[Eager Execution] Resolve the path when reconstructing EagerIncludes paths

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
@@ -27,6 +27,7 @@ public class EagerIncludeTag extends EagerTagDecorator<IncludeTag> {
         tagNode.getLineNumber(),
         tagNode.getStartPosition()
       );
+      templateFile = interpreter.resolveResourceLocation(templateFile);
       final String initialPathSetter = EagerImportTag.getSetTagForCurrentPath(
         interpreter
       );

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTagTest.java
@@ -2,13 +2,20 @@ package com.hubspot.jinjava.lib.tag.eager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.io.Resources;
 import com.hubspot.jinjava.ExpectedTemplateInterpreter;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.IncludeTagTest;
+import com.hubspot.jinjava.loader.LocationResolver;
+import com.hubspot.jinjava.loader.RelativePathResolver;
+import com.hubspot.jinjava.loader.ResourceLocator;
 import com.hubspot.jinjava.mode.EagerExecutionMode;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Before;
@@ -35,6 +42,32 @@ public class EagerIncludeTagTest extends IncludeTagTest {
     JinjavaInterpreter.pushCurrent(interpreter);
   }
 
+  private void setupResourceLocator() {
+    jinjava.setResourceLocator(
+      new ResourceLocator() {
+        private RelativePathResolver relativePathResolver = new RelativePathResolver();
+
+        @Override
+        public String getString(
+          String fullName,
+          Charset encoding,
+          JinjavaInterpreter interpreter
+        )
+          throws IOException {
+          return Resources.toString(
+            Resources.getResource(String.format("tags/eager/includetag/%s", fullName)),
+            StandardCharsets.UTF_8
+          );
+        }
+
+        @Override
+        public Optional<LocationResolver> getLocationResolver() {
+          return Optional.of(relativePathResolver);
+        }
+      }
+    );
+  }
+
   @After
   public void teardown() {
     JinjavaInterpreter.popCurrent();
@@ -42,6 +75,7 @@ public class EagerIncludeTagTest extends IncludeTagTest {
 
   @Test
   public void itIncludesDeferred() {
+    setupResourceLocator();
     expectedTemplateInterpreter.assertExpectedOutputNonIdempotent("includes-deferred");
     assertThat(
         context

--- a/src/test/resources/tags/eager/includetag/includes-deferred.expected.jinja
+++ b/src/test/resources/tags/eager/includetag/includes-deferred.expected.jinja
@@ -1,5 +1,5 @@
 Foo begins as: abc
-{% set current_path = 'tags/eager/includetag/sets-to-deferred.jinja' %}{% set foo = deferred %}
+{% set current_path = 'sets-to-deferred.jinja' %}{% set foo = deferred %}
 foo is now {{ deferred }}.
 {% set current_path = '' %}
 Foo ends as: {{ foo }}

--- a/src/test/resources/tags/eager/includetag/includes-deferred.jinja
+++ b/src/test/resources/tags/eager/includetag/includes-deferred.jinja
@@ -1,4 +1,4 @@
 {%- set foo = 'abc' -%}
 Foo begins as: {{ foo }}
-{% include "tags/eager/includetag/sets-to-deferred.jinja" %}
+{% include "./sets-to-deferred.jinja" %}
 Foo ends as: {{ foo }}


### PR DESCRIPTION
Call `interpreter.resolveResourceLocation(templateFile)` to resolve the template file before reconstructing. Especially important if the original `templateFile` uses a relative path.