### PR TITLE
[Eager Execution] Don't mark dictionary keys as deferred words if key evaluation is off

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
@@ -56,6 +56,7 @@ public class EagerExpressionResolver {
   private static final Pattern NAMED_PARAMETER_KEY_PATTERN = Pattern.compile(
     "[\\w.]+=([^=]|$)"
   );
+  private static final Pattern DICTIONARY_KEY_PATTERN = Pattern.compile("[\\w]: ");
 
   /**
    * Resolve the expression while handling deferred values.
@@ -160,10 +161,15 @@ public class EagerExpressionResolver {
     int end,
     JinjavaInterpreter interpreter
   ) {
+    partiallyResolved = partiallyResolved.substring(start, end);
+    if (!interpreter.getConfig().getLegacyOverrides().isEvaluateMapKeys()) {
+      partiallyResolved =
+        DICTIONARY_KEY_PATTERN.matcher(partiallyResolved).replaceAll("");
+    }
     return Arrays
       .stream(
         NAMED_PARAMETER_KEY_PATTERN
-          .matcher(partiallyResolved.substring(start, end))
+          .matcher(partiallyResolved)
           .replaceAll("$1")
           .split("[^\\w.]")
       )

--- a/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
@@ -697,6 +697,27 @@ public class EagerExpressionResolverTest {
     assertThat(result.getDeferredWords()).containsExactlyInAnyOrder("range", "deferred");
   }
 
+  @Test
+  public void itDoesntMarkDictionaryKeysAsDeferredWords() {
+    context.put("a", "a val");
+    EagerExpressionResult result = eagerResolveExpression("{a: a, b:deferred}");
+    assertThat(result.toString()).isEqualTo("{a: 'a val', b: deferred}");
+    assertThat(result.getDeferredWords()).doesNotContain("a", "b");
+  }
+
+  @Test
+  public void itMarksDictionaryKeysAsDeferredWordsIfEvaluated() throws Exception {
+    JinjavaInterpreter.pushCurrent(getInterpreter(true));
+    try {
+      context.put("a", "a val");
+      EagerExpressionResult result = eagerResolveExpression("{deferred: a}");
+      assertThat(result.toString()).isEqualTo("{deferred: 'a val'}");
+      assertThat(result.getDeferredWords()).containsExactly("deferred");
+    } finally {
+      JinjavaInterpreter.popCurrent();
+    }
+  }
+
   public static void voidFunction(int nothing) {}
 
   public static boolean isNull(Object foo, Object bar) {


### PR DESCRIPTION
To properly support the legacy functionality for `withEvaluateMapKeys(false)`, if there are dictionary keys that are not surrounded with quotes, they should not be marked as deferred words. This PR uses regex to remove dictionary keys from the possible words that are searched when determining which words couldn't be resolved (only when the legacy override is false).

Note, that because the partially resolved EL expression gets "normalized" in terms of whitespace, we don't need to look for extra/missing spaces within the `DICTIONARY_KEY_PATTERN`.