### PR TITLE
[Eager Execution] Fix regex and improve tests

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
@@ -56,7 +56,7 @@ public class EagerExpressionResolver {
   private static final Pattern NAMED_PARAMETER_KEY_PATTERN = Pattern.compile(
     "[\\w.]+=([^=]|$)"
   );
-  private static final Pattern DICTIONARY_KEY_PATTERN = Pattern.compile("[\\w]: ");
+  private static final Pattern DICTIONARY_KEY_PATTERN = Pattern.compile("[\\w]+: ");
 
   /**
    * Resolve the expression while handling deferred values.
@@ -164,7 +164,7 @@ public class EagerExpressionResolver {
     partiallyResolved = partiallyResolved.substring(start, end);
     if (!interpreter.getConfig().getLegacyOverrides().isEvaluateMapKeys()) {
       partiallyResolved =
-        DICTIONARY_KEY_PATTERN.matcher(partiallyResolved).replaceAll("");
+        DICTIONARY_KEY_PATTERN.matcher(partiallyResolved).replaceAll(" ");
     }
     return Arrays
       .stream(

--- a/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
@@ -699,19 +699,19 @@ public class EagerExpressionResolverTest {
 
   @Test
   public void itDoesntMarkDictionaryKeysAsDeferredWords() {
-    context.put("a", "a val");
-    EagerExpressionResult result = eagerResolveExpression("{a: a, b:deferred}");
-    assertThat(result.toString()).isEqualTo("{a: 'a val', b: deferred}");
-    assertThat(result.getDeferredWords()).doesNotContain("a", "b");
+    context.put("foo", "foo val");
+    EagerExpressionResult result = eagerResolveExpression("{foo: foo, bar:deferred}");
+    assertThat(result.toString()).isEqualTo("{foo: 'foo val', bar: deferred}");
+    assertThat(result.getDeferredWords()).doesNotContain("foo", "bar");
   }
 
   @Test
   public void itMarksDictionaryKeysAsDeferredWordsIfEvaluated() throws Exception {
     JinjavaInterpreter.pushCurrent(getInterpreter(true));
     try {
-      context.put("a", "a val");
-      EagerExpressionResult result = eagerResolveExpression("{deferred: a}");
-      assertThat(result.toString()).isEqualTo("{deferred: 'a val'}");
+      context.put("foo", "foo val");
+      EagerExpressionResult result = eagerResolveExpression("{deferred: foo}");
+      assertThat(result.toString()).isEqualTo("{deferred: 'foo val'}");
       assertThat(result.getDeferredWords()).containsExactly("deferred");
     } finally {
       JinjavaInterpreter.popCurrent();


### PR DESCRIPTION
This is what I get for writing my test cases without using the trusty `foo` and `bar` in https://github.com/HubSpot/jinjava/pull/729

The regular expression only looked for a single character rather than one or more characters and I didn't catch that in the tests. So this PR fixes the regex and uses better naming in the test cases.