### PR TITLE
Fix striptags to clean HTML instead of parsing

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java
@@ -6,10 +6,6 @@ import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.util.regex.Pattern;
 import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Document.OutputSettings;
-import org.jsoup.nodes.Entities.EscapeMode;
-import org.jsoup.parser.Parser;
 import org.jsoup.safety.Whitelist;
 
 /**

--- a/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java
@@ -6,6 +6,11 @@ import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.util.regex.Pattern;
 import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Document.OutputSettings;
+import org.jsoup.nodes.Entities.EscapeMode;
+import org.jsoup.parser.Parser;
+import org.jsoup.safety.Whitelist;
 
 /**
  * striptags(value) Strip SGML/XML tags and replace adjacent whitespace by one space.
@@ -34,8 +39,9 @@ public class StripTagsFilter implements Filter {
     }
 
     String val = interpreter.renderFlat((String) object);
-    String strippedVal = Jsoup.parseBodyFragment(val).text();
-    String normalizedVal = WHITESPACE.matcher(strippedVal).replaceAll(" ");
+    String cleanedVal = Jsoup.clean(val, Whitelist.none());
+
+    String normalizedVal = WHITESPACE.matcher(cleanedVal).replaceAll(" ");
 
     return normalizedVal;
   }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/StripTagsFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/StripTagsFilterTest.java
@@ -37,7 +37,7 @@ public class StripTagsFilterTest {
   @Test
   public void itWorksWithNonHtmlStrings() throws Exception {
     assertThat(filter.filter("foo", interpreter)).isEqualTo("foo");
-    assertThat(filter.filter("foo < bar", interpreter)).isEqualTo("foo < bar");
+    assertThat(filter.filter("foo < bar", interpreter)).isEqualTo("foo &lt; bar");
   }
 
   @Test
@@ -50,5 +50,17 @@ public class StripTagsFilterTest {
   public void itStripsTagsFromHtml() throws Exception {
     assertThat(filter.filter("foo <b>bar</b> other", interpreter))
       .isEqualTo("foo bar other");
+  }
+
+  @Test
+  public void itStripsTagsFromNestedHtml() throws Exception {
+    assertThat(filter.filter("<div><strong>test</strong></div>", interpreter))
+      .isEqualTo("test");
+  }
+
+  @Test
+  public void itStripsTagsFromEscapedHtml() throws Exception {
+    assertThat(filter.filter("&lt;div&gt;test&lt;/test&gt;", interpreter))
+      .isEqualTo("&lt;div&gt;test&lt;/test&gt;");
   }
 }


### PR DESCRIPTION
Jsoup parse has a problem. If you input escaped HTML text `&lt;div&gt;test&lt;/test&gt;` it will not recognize the escaped HTML tags, parse to HTML text, and then output the unescaped version `<div>test</div>` allowing for XSS. This utilizes the Jsoup clean method which just strips all tags from the input and escapes any HTML entities. 