### PR TITLE
Preserve spacing in <br> in striptags

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java
@@ -36,7 +36,6 @@ public class StripTagsFilter implements Filter {
 
     String val = interpreter.renderFlat((String) object);
     val = val.replaceAll("<br>", "\n");
-    //String cleanedVal = Jsoup.parse(val).text();
     String cleanedVal = Jsoup.clean(val, Whitelist.none());
 
     String normalizedVal = WHITESPACE.matcher(cleanedVal).replaceAll(" ");

--- a/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java
@@ -35,6 +35,8 @@ public class StripTagsFilter implements Filter {
     }
 
     String val = interpreter.renderFlat((String) object);
+    val = val.replaceAll("<br>", "\n");
+    //String cleanedVal = Jsoup.parse(val).text();
     String cleanedVal = Jsoup.clean(val, Whitelist.none());
 
     String normalizedVal = WHITESPACE.matcher(cleanedVal).replaceAll(" ");

--- a/src/test/java/com/hubspot/jinjava/lib/filter/StripTagsFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/StripTagsFilterTest.java
@@ -63,4 +63,16 @@ public class StripTagsFilterTest {
     assertThat(filter.filter("&lt;div&gt;test&lt;/test&gt;", interpreter))
       .isEqualTo("&lt;div&gt;test&lt;/test&gt;");
   }
+
+  @Test
+  public void itPreservesBreaks() throws Exception {
+    assertThat(filter.filter("<p>Test!<br><br>Space</p>", interpreter))
+      .isEqualTo("Test! Space");
+  }
+
+  @Test
+  public void itConvertsNewlinesToSpaces() throws Exception {
+    assertThat(filter.filter("<p>Test!\n\nSpace</p>", interpreter))
+      .isEqualTo("Test! Space");
+  }
 }


### PR DESCRIPTION
Another subtle difference between Jsoup parse and clean. Parse converts `<br>` tags to new lines and clean just removes them leading to some output HTML diffs.