### PR TITLE
Parse first then clean in striptags

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java
@@ -35,8 +35,12 @@ public class StripTagsFilter implements Filter {
     }
 
     String val = interpreter.renderFlat((String) object);
-    val = val.replaceAll("<br>", "\n");
-    String cleanedVal = Jsoup.clean(val, Whitelist.none());
+
+    String cleanedVal = Jsoup.parse(val).text();
+    cleanedVal = Jsoup.clean(cleanedVal, Whitelist.none());
+
+    // backwards compatibility with Jsoup.parse
+    cleanedVal = cleanedVal.replaceAll("&nbsp;", " ");
 
     String normalizedVal = WHITESPACE.matcher(cleanedVal).replaceAll(" ");
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/StripTagsFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/StripTagsFilterTest.java
@@ -61,7 +61,7 @@ public class StripTagsFilterTest {
   @Test
   public void itStripsTagsFromEscapedHtml() throws Exception {
     assertThat(filter.filter("&lt;div&gt;test&lt;/test&gt;", interpreter))
-      .isEqualTo("&lt;div&gt;test&lt;/test&gt;");
+      .isEqualTo("test");
   }
 
   @Test
@@ -74,5 +74,16 @@ public class StripTagsFilterTest {
   public void itConvertsNewlinesToSpaces() throws Exception {
     assertThat(filter.filter("<p>Test!\n\nSpace</p>", interpreter))
       .isEqualTo("Test! Space");
+  }
+
+  @Test
+  public void itHandlesNonBreakSpaces() {
+    assertThat(filter.filter("Test&nbsp;Value", interpreter)).isEqualTo("Test Value");
+  }
+
+  @Test
+  public void itAddsWhitespaceBetweenParagraphTags() {
+    assertThat(filter.filter("<p>Test</p><p>Value</p>", interpreter))
+      .isEqualTo("Test Value");
   }
 }


### PR DESCRIPTION
Seeing whitespace issues moving from Jsoup parse to clean. Jsoup parse is smarter than just removing tags as it will do things such as add whitespace between `<p>` tags. I moved back to using Jsoup parse for the superior whitespace handling but also added a "clean" to handle XSS-attack possible via parse.

I tested on a large HTML sample and the two methods are similar at least on my HTML sample.