### PR TITLE
Revert "Update jsoup to fix CVE-2021-37714"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
       <dependency>
         <groupId>org.jsoup</groupId>
         <artifactId>jsoup</artifactId>
-        <version>1.14.2</version>
+        <version>1.10.3</version>
       </dependency>
       <dependency>
         <groupId>de.odysseus.juel</groupId>


### PR DESCRIPTION
Reverts HubSpot/jinjava#738
Reverting for now as the jsoup bump changes how `&nbsp;` is parsed and breaks the StripTagsFilter functionality