### PR TITLE
Refactor static methods in EagerTagDecorator into separate class

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -6,11 +6,11 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.filter.EscapeFilter;
 import com.hubspot.jinjava.lib.tag.RawTag;
 import com.hubspot.jinjava.lib.tag.eager.EagerExecutionResult;
-import com.hubspot.jinjava.lib.tag.eager.EagerTagDecorator;
 import com.hubspot.jinjava.lib.tag.eager.EagerToken;
 import com.hubspot.jinjava.tree.output.RenderedOutputNode;
 import com.hubspot.jinjava.tree.parse.ExpressionToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
+import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.Logging;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -32,7 +32,7 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
   ) {
     EagerExecutionResult eagerExecutionResult;
     eagerExecutionResult =
-      EagerTagDecorator.executeInChildContext(
+      EagerReconstructionUtils.executeInChildContext(
         eagerInterpreter ->
           EagerExpressionResolver.resolveExpression(master.getExpr(), interpreter),
         interpreter,
@@ -77,7 +77,7 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
       return prefixToPreserveState.toString() + result;
     }
     prefixToPreserveState.append(
-      EagerTagDecorator.reconstructFromContextBeforeDeferring(
+      EagerReconstructionUtils.reconstructFromContextBeforeDeferring(
         eagerExecutionResult.getResult().getDeferredWords(),
         interpreter
       )
@@ -107,7 +107,7 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
         )
       );
     // There is only a preserving prefix because it couldn't be entirely evaluated.
-    return EagerTagDecorator.wrapInAutoEscapeIfNeeded(
+    return EagerReconstructionUtils.wrapInAutoEscapeIfNeeded(
       prefixToPreserveState.toString() + helpers,
       interpreter
     );
@@ -134,7 +134,7 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
         output.contains(config.getTokenScannerSymbols().getExpressionStartWithTag())
       )
     ) {
-      return EagerTagDecorator.wrapInTag(output, RawTag.TAG_NAME, interpreter);
+      return EagerReconstructionUtils.wrapInTag(output, RawTag.TAG_NAME, interpreter);
     }
     return output;
   }

--- a/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
@@ -112,7 +112,7 @@ public class EagerMacroFunction extends AbstractCallableMethod {
         .getContext()
         .get(Context.DEFERRED_IMPORT_RESOURCE_PATH_KEY);
       prefix =
-        EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
+        EagerReconstructionUtils.buildSetTag(
           ImmutableMap.of(
             Context.DEFERRED_IMPORT_RESOURCE_PATH_KEY,
             PyishObjectMapper.getAsPyishString(importFile.get())
@@ -121,7 +121,7 @@ public class EagerMacroFunction extends AbstractCallableMethod {
           false
         );
       suffix =
-        EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
+        EagerReconstructionUtils.buildSetTag(
           ImmutableMap.of(
             Context.DEFERRED_IMPORT_RESOURCE_PATH_KEY,
             PyishObjectMapper.getAsPyishString(currentDeferredImportResource)

--- a/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
@@ -10,8 +10,8 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
 import com.hubspot.jinjava.lib.tag.MacroTag;
-import com.hubspot.jinjava.lib.tag.eager.EagerTagDecorator;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
+import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -112,7 +112,7 @@ public class EagerMacroFunction extends AbstractCallableMethod {
         .getContext()
         .get(Context.DEFERRED_IMPORT_RESOURCE_PATH_KEY);
       prefix =
-        EagerTagDecorator.buildSetTagForDeferredInChildContext(
+        EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
           ImmutableMap.of(
             Context.DEFERRED_IMPORT_RESOURCE_PATH_KEY,
             PyishObjectMapper.getAsPyishString(importFile.get())
@@ -121,7 +121,7 @@ public class EagerMacroFunction extends AbstractCallableMethod {
           false
         );
       suffix =
-        EagerTagDecorator.buildSetTagForDeferredInChildContext(
+        EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
           ImmutableMap.of(
             Context.DEFERRED_IMPORT_RESOURCE_PATH_KEY,
             PyishObjectMapper.getAsPyishString(currentDeferredImportResource)

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
@@ -9,6 +9,7 @@ import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult.ResolutionState;
+import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
 import java.util.Collections;
 import java.util.Optional;
@@ -30,7 +31,7 @@ public class EagerBlockSetTagStrategy extends EagerSetTagStrategy {
     JinjavaInterpreter interpreter
   ) {
     int numEagerTokens = interpreter.getContext().getEagerTokens().size();
-    return EagerTagDecorator.executeInChildContext(
+    return EagerReconstructionUtils.executeInChildContext(
       eagerInterpreter -> {
         StringBuilder sb = new StringBuilder();
         for (Node child : tagNode.getChildren()) {
@@ -178,11 +179,11 @@ public class EagerBlockSetTagStrategy extends EagerSetTagStrategy {
       filterSetPostfix = runInlineStrategy(tagNode, variables, filterResult, interpreter);
     }
 
-    return EagerTagDecorator.wrapInAutoEscapeIfNeeded(
+    return EagerReconstructionUtils.wrapInAutoEscapeIfNeeded(
       triple.getLeft() +
       triple.getMiddle() +
       eagerExecutionResult.getResult().toString(true) +
-      EagerTagDecorator.reconstructEnd(tagNode) +
+      EagerReconstructionUtils.reconstructEnd(tagNode) +
       filterSetPostfix +
       triple.getRight(),
       interpreter

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
@@ -146,7 +146,7 @@ public class EagerCycleTag extends EagerStateChangingTag<CycleTag> {
   ) {
     String var = helper.get(2);
     if (!fullyResolved) {
-      return EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
+      return EagerReconstructionUtils.buildSetTag(
         ImmutableMap.of(
           var,
           String.format("[%s]", resolvedExpression.replace(",", ", "))

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
@@ -7,6 +7,7 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.tag.CycleTag;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
+import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.HelperStringTokenizer;
 import com.hubspot.jinjava.util.WhitespaceUtils;
 import java.util.ArrayList;
@@ -41,7 +42,7 @@ public class EagerCycleTag extends EagerStateChangingTag<CycleTag> {
       helper.add(sb.toString());
     }
     String expression = '[' + helper.get(0) + ']';
-    EagerExecutionResult eagerExecutionResult = executeInChildContext(
+    EagerExecutionResult eagerExecutionResult = EagerReconstructionUtils.executeInChildContext(
       eagerInterpreter ->
         EagerExpressionResolver.resolveExpression(expression, interpreter),
       interpreter,
@@ -78,7 +79,7 @@ public class EagerCycleTag extends EagerStateChangingTag<CycleTag> {
       resolvedValues =
         new HelperStringTokenizer(resolvedExpression).splitComma(true).allTokens();
       prefixToPreserveState.append(
-        reconstructFromContextBeforeDeferring(
+        EagerReconstructionUtils.reconstructFromContextBeforeDeferring(
           eagerExecutionResult.getResult().getDeferredWords(),
           interpreter
         )
@@ -145,7 +146,7 @@ public class EagerCycleTag extends EagerStateChangingTag<CycleTag> {
   ) {
     String var = helper.get(2);
     if (!fullyResolved) {
-      return EagerTagDecorator.buildSetTagForDeferredInChildContext(
+      return EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
         ImmutableMap.of(
           var,
           String.format("[%s]", resolvedExpression.replace(",", ", "))

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerExecutionResult.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerExecutionResult.java
@@ -1,6 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
-import static com.hubspot.jinjava.lib.tag.eager.EagerTagDecorator.buildSetTagForDeferredInChildContext;
+import static com.hubspot.jinjava.util.EagerReconstructionUtils.buildSetTagForDeferredInChildContext;
 
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.objects.Namespace;

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerExecutionResult.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerExecutionResult.java
@@ -1,6 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
-import static com.hubspot.jinjava.util.EagerReconstructionUtils.buildSetTagForDeferredInChildContext;
+import static com.hubspot.jinjava.util.EagerReconstructionUtils.buildSetTag;
 
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.objects.Namespace;
@@ -41,7 +41,7 @@ public class EagerExecutionResult {
       return prefixToPreserveState;
     }
     prefixToPreserveState =
-      buildSetTagForDeferredInChildContext(
+      buildSetTag(
         speculativeBindings
           .entrySet()
           .stream()

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -69,7 +69,7 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
     if (!eagerExecutionResult.getSpeculativeBindings().isEmpty()) {
       // Defer any variables that we tried to modify during the loop
       prefix =
-        EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
+        EagerReconstructionUtils.buildSetTag(
           eagerExecutionResult
             .getSpeculativeBindings()
             .entrySet()

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -10,6 +10,7 @@ import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
+import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
 import java.util.HashSet;
@@ -42,7 +43,8 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
     // separate getEagerImage from renderChildren because the token gets evaluated once
     // while the children are evaluated 0...n times.
     result.append(
-      executeInChildContext(
+      EagerReconstructionUtils
+        .executeInChildContext(
           eagerInterpreter ->
             EagerExpressionResult.fromString(
               getEagerImage(
@@ -67,7 +69,7 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
     if (!eagerExecutionResult.getSpeculativeBindings().isEmpty()) {
       // Defer any variables that we tried to modify during the loop
       prefix =
-        buildSetTagForDeferredInChildContext(
+        EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
           eagerExecutionResult
             .getSpeculativeBindings()
             .entrySet()
@@ -92,7 +94,7 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
     }
 
     result.append(eagerExecutionResult.asTemplateString());
-    result.append(reconstructEnd(tagNode));
+    result.append(EagerReconstructionUtils.reconstructEnd(tagNode));
     return prefix + result;
   }
 
@@ -100,7 +102,7 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
     TagNode tagNode,
     JinjavaInterpreter interpreter
   ) {
-    return executeInChildContext(
+    return EagerReconstructionUtils.executeInChildContext(
       eagerInterpreter -> {
         if (!(eagerInterpreter.getContext().get("loop") instanceof DeferredValue)) {
           eagerInterpreter.getContext().put("loop", DeferredValue.instance());
@@ -140,7 +142,7 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
       .add("in")
       .add(eagerExpressionResult.toString())
       .add(tagToken.getSymbols().getExpressionEndWithTag());
-    String newlyDeferredFunctionImages = reconstructFromContextBeforeDeferring(
+    String newlyDeferredFunctionImages = EagerReconstructionUtils.reconstructFromContextBeforeDeferring(
       eagerExpressionResult.getDeferredWords(),
       interpreter
     );

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTag.java
@@ -11,6 +11,7 @@ import com.hubspot.jinjava.loader.RelativePathResolver;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.parse.TagToken;
+import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
@@ -55,7 +56,7 @@ public class EagerFromTag extends EagerStateChangingTag<FromTag> {
           }
         );
       return (
-        buildSetTagForDeferredInChildContext(
+        EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
           ImmutableMap.of(
             RelativePathResolver.CURRENT_PATH_CONTEXT_KEY,
             PyishObjectMapper.getAsPyishString(
@@ -114,7 +115,11 @@ public class EagerFromTag extends EagerStateChangingTag<FromTag> {
           // Set after output
           output =
             output +
-            buildSetTagForDeferredInChildContext(newToOldImportNames, interpreter, true);
+            EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
+              newToOldImportNames,
+              interpreter,
+              true
+            );
         }
         return output;
       } catch (IOException e) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTag.java
@@ -56,7 +56,7 @@ public class EagerFromTag extends EagerStateChangingTag<FromTag> {
           }
         );
       return (
-        EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
+        EagerReconstructionUtils.buildSetTag(
           ImmutableMap.of(
             RelativePathResolver.CURRENT_PATH_CONTEXT_KEY,
             PyishObjectMapper.getAsPyishString(
@@ -115,11 +115,7 @@ public class EagerFromTag extends EagerStateChangingTag<FromTag> {
           // Set after output
           output =
             output +
-            EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
-              newToOldImportNames,
-              interpreter,
-              true
-            );
+            EagerReconstructionUtils.buildSetTag(newToOldImportNames, interpreter, true);
         }
         return output;
       } catch (IOException e) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
@@ -13,6 +13,7 @@ import com.hubspot.jinjava.lib.tag.IfTag;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
+import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import org.apache.commons.lang3.StringUtils;
 
@@ -32,7 +33,7 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
       return getTag().interpret(tagNode, interpreter);
     } catch (DeferredValueException | TemplateSyntaxException e) {
       try {
-        return wrapInAutoEscapeIfNeeded(
+        return EagerReconstructionUtils.wrapInAutoEscapeIfNeeded(
           eagerInterpret(tagNode, interpreter, e),
           interpreter
         );
@@ -64,7 +65,8 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
     );
 
     result.append(
-      executeInChildContext(
+      EagerReconstructionUtils
+        .executeInChildContext(
           eagerInterpreter ->
             EagerExpressionResult.fromString(
               eagerRenderBranches(tagNode, eagerInterpreter, e)
@@ -77,7 +79,7 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
         .asTemplateString()
     );
     tagNode.getMaster().setRightTrimAfterEnd(false);
-    result.append(reconstructEnd(tagNode));
+    result.append(EagerReconstructionUtils.reconstructEnd(tagNode));
 
     return result.toString();
   }
@@ -115,7 +117,7 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
       int branchEnd = findNextElseToken(tagNode, branchStart);
       if (!definitelyDrop) {
         int finalBranchStart = branchStart;
-        EagerExecutionResult result = executeInChildContext(
+        EagerExecutionResult result = EagerReconstructionUtils.executeInChildContext(
           eagerInterpreter ->
             EagerExpressionResult.fromString(
               evaluateBranch(tagNode, finalBranchStart, branchEnd, interpreter)

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -15,6 +15,7 @@ import com.hubspot.jinjava.objects.collections.PyMap;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.parse.TagToken;
+import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -120,7 +121,7 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
   }
 
   public static String getSetTagForCurrentPath(JinjavaInterpreter interpreter) {
-    return buildSetTagForDeferredInChildContext(
+    return EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
       ImmutableMap.of(
         RelativePathResolver.CURRENT_PATH_CONTEXT_KEY,
         PyishObjectMapper.getAsPyishString(
@@ -175,7 +176,7 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
       }
     }
     if (keyValueJoiner.length() > 0) {
-      return buildDoUpdateTag(
+      return EagerReconstructionUtils.buildDoUpdateTag(
         currentImportAlias,
         "{" + keyValueJoiner.toString() + "}",
         interpreter

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -121,7 +121,7 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
   }
 
   public static String getSetTagForCurrentPath(JinjavaInterpreter interpreter) {
-    return EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
+    return EagerReconstructionUtils.buildSetTag(
       ImmutableMap.of(
         RelativePathResolver.CURRENT_PATH_CONTEXT_KEY,
         PyishObjectMapper.getAsPyishString(

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
@@ -32,7 +32,7 @@ public class EagerIncludeTag extends EagerTagDecorator<IncludeTag> {
       final String initialPathSetter = EagerImportTag.getSetTagForCurrentPath(
         interpreter
       );
-      final String newPathSetter = EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
+      final String newPathSetter = EagerReconstructionUtils.buildSetTag(
         ImmutableMap.of(
           RelativePathResolver.CURRENT_PATH_CONTEXT_KEY,
           PyishObjectMapper.getAsPyishString(templateFile)

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
@@ -6,6 +6,7 @@ import com.hubspot.jinjava.lib.tag.IncludeTag;
 import com.hubspot.jinjava.loader.RelativePathResolver;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.tree.TagNode;
+import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.HelperStringTokenizer;
 import org.apache.commons.lang3.StringUtils;
 
@@ -31,7 +32,7 @@ public class EagerIncludeTag extends EagerTagDecorator<IncludeTag> {
       final String initialPathSetter = EagerImportTag.getSetTagForCurrentPath(
         interpreter
       );
-      final String newPathSetter = buildSetTagForDeferredInChildContext(
+      final String newPathSetter = EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
         ImmutableMap.of(
           RelativePathResolver.CURRENT_PATH_CONTEXT_KEY,
           PyishObjectMapper.getAsPyishString(templateFile)

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
@@ -7,6 +7,7 @@ import com.hubspot.jinjava.lib.tag.SetTag;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
+import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
 import com.hubspot.jinjava.util.WhitespaceUtils;
 import java.util.Arrays;
@@ -29,7 +30,7 @@ public class EagerInlineSetTagStrategy extends EagerSetTagStrategy {
     String expression,
     JinjavaInterpreter interpreter
   ) {
-    return EagerTagDecorator.executeInChildContext(
+    return EagerReconstructionUtils.executeInChildContext(
       eagerInterpreter ->
         EagerExpressionResolver.resolveExpression('[' + expression + ']', interpreter),
       interpreter,
@@ -131,7 +132,7 @@ public class EagerInlineSetTagStrategy extends EagerSetTagStrategy {
     Triple<String, String, String> triple,
     JinjavaInterpreter interpreter
   ) {
-    return EagerTagDecorator.wrapInAutoEscapeIfNeeded(
+    return EagerReconstructionUtils.wrapInAutoEscapeIfNeeded(
       triple.getLeft() + triple.getMiddle() + triple.getRight(),
       interpreter
     );

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
@@ -6,6 +6,7 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.tag.PrintTag;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
+import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -51,7 +52,7 @@ public class EagerPrintTag extends EagerStateChangingTag<PrintTag> {
     JinjavaInterpreter interpreter,
     boolean includeExpressionResult
   ) {
-    EagerExecutionResult eagerExecutionResult = executeInChildContext(
+    EagerExecutionResult eagerExecutionResult = EagerReconstructionUtils.executeInChildContext(
       eagerInterpreter -> EagerExpressionResolver.resolveExpression(expr, interpreter),
       interpreter,
       true,
@@ -70,7 +71,7 @@ public class EagerPrintTag extends EagerStateChangingTag<PrintTag> {
         prefixToPreserveState.toString() +
         (
           includeExpressionResult
-            ? wrapInRawIfNeeded(
+            ? EagerReconstructionUtils.wrapInRawIfNeeded(
               eagerExecutionResult.getResult().toString(true),
               interpreter
             )
@@ -79,7 +80,7 @@ public class EagerPrintTag extends EagerStateChangingTag<PrintTag> {
       );
     }
     prefixToPreserveState.append(
-      reconstructFromContextBeforeDeferring(
+      EagerReconstructionUtils.reconstructFromContextBeforeDeferring(
         eagerExecutionResult.getResult().getDeferredWords(),
         interpreter
       )
@@ -115,7 +116,7 @@ public class EagerPrintTag extends EagerStateChangingTag<PrintTag> {
         )
       );
     // Possible set tag in front of this one.
-    return wrapInAutoEscapeIfNeeded(
+    return EagerReconstructionUtils.wrapInAutoEscapeIfNeeded(
       prefixToPreserveState.toString() + joiner.toString(),
       interpreter
     );

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.lib.tag.eager;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.SetTag;
 import com.hubspot.jinjava.tree.TagNode;
+import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -114,7 +115,7 @@ public abstract class EagerSetTagStrategy {
       interpreter.getContext().putAll(eagerExecutionResult.getSpeculativeBindings());
     }
     prefixToPreserveState.append(
-      EagerTagDecorator.reconstructFromContextBeforeDeferring(
+      EagerReconstructionUtils.reconstructFromContextBeforeDeferring(
         eagerExecutionResult.getResult().getDeferredWords(),
         interpreter
       )
@@ -137,7 +138,7 @@ public abstract class EagerSetTagStrategy {
       String updateString = getUpdateString(variables);
       suffixToPreserveState.append(
         interpreter.render(
-          EagerTagDecorator.buildDoUpdateTag(
+          EagerReconstructionUtils.buildDoUpdateTag(
             currentImportAlias,
             updateString,
             interpreter

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
@@ -7,6 +7,7 @@ import com.hubspot.jinjava.lib.tag.Tag;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
+import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 public class EagerStateChangingTag<T extends Tag> extends EagerTagDecorator<T> {
@@ -35,7 +36,7 @@ public class EagerStateChangingTag<T extends Tag> extends EagerTagDecorator<T> {
 
     if (!tagNode.getChildren().isEmpty()) {
       result.append(
-        executeInChildContext(
+        EagerReconstructionUtils.executeInChildContext(
           eagerInterpreter ->
             EagerExpressionResult.fromString(renderChildren(tagNode, eagerInterpreter)),
           interpreter,
@@ -53,7 +54,7 @@ public class EagerStateChangingTag<T extends Tag> extends EagerTagDecorator<T> {
         ((FlexibleTag) getTag()).hasEndTag((TagToken) tagNode.getMaster())
       )
     ) {
-      result.append(reconstructEnd(tagNode));
+      result.append(EagerReconstructionUtils.reconstructEnd(tagNode));
     }
 
     return result.toString();

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -1,46 +1,23 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
-import com.hubspot.jinjava.el.ext.AbstractCallableMethod;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
-import com.hubspot.jinjava.interpret.Context.Library;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
-import com.hubspot.jinjava.interpret.DisabledException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
 import com.hubspot.jinjava.interpret.OutputTooBigException;
 import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
-import com.hubspot.jinjava.lib.fn.MacroFunction;
-import com.hubspot.jinjava.lib.fn.eager.EagerMacroFunction;
-import com.hubspot.jinjava.lib.tag.AutoEscapeTag;
-import com.hubspot.jinjava.lib.tag.DoTag;
-import com.hubspot.jinjava.lib.tag.MacroTag;
-import com.hubspot.jinjava.lib.tag.RawTag;
-import com.hubspot.jinjava.lib.tag.SetTag;
 import com.hubspot.jinjava.lib.tag.Tag;
-import com.hubspot.jinjava.objects.Namespace;
-import com.hubspot.jinjava.objects.collections.PyList;
-import com.hubspot.jinjava.objects.collections.PyMap;
-import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.tree.parse.Token;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
+import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Set;
-import java.util.StringJoiner;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
@@ -61,7 +38,7 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
       return tag.interpret(tagNode, interpreter);
     } catch (DeferredValueException | TemplateSyntaxException e) {
       try {
-        return wrapInAutoEscapeIfNeeded(
+        return EagerReconstructionUtils.wrapInAutoEscapeIfNeeded(
           eagerInterpret(tagNode, interpreter, e),
           interpreter
         );
@@ -107,7 +84,8 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
       interpreter.getConfig().getMaxOutputSize()
     );
     result.append(
-      executeInChildContext(
+      EagerReconstructionUtils
+        .executeInChildContext(
           eagerInterpreter ->
             EagerExpressionResult.fromString(
               getEagerImage(
@@ -130,7 +108,7 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
     );
 
     if (StringUtils.isNotBlank(tagNode.getEndName())) {
-      result.append(reconstructEnd(tagNode));
+      result.append(EagerReconstructionUtils.reconstructEnd(tagNode));
     }
 
     return result.toString();
@@ -178,368 +156,6 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
   }
 
   /**
-   * Execute the specified functions within a protected context.
-   * Additionally, if the execution causes existing values on the context to become
-   *   deferred, then their previous values will wrapped in a <code>set</code>
-   *   tag that gets prepended to the returned result.
-   * The <code>function</code> is run in deferredExecutionMode=true, where the context needs to
-   *   be protected from having values updated or set,
-   *   such as when evaluating both the positive and negative nodes in an if statement.
-   * @param function Function to run within a "protected" child context
-   * @param interpreter JinjavaInterpreter to create a child from.
-   * @param takeNewValue If a value is updated (not replaced) either take the new value or
-   *                     take the previous value and put it into the
-   *                     <code>EagerExecutionResult.prefixToPreserveState</code>.
-   * @param partialMacroEvaluation Allow macro functions to be partially evaluated rather than
-   *                               needing an explicit result during this render.
-   * @param checkForContextChanges Set this to be true if executing <code>function</code> could
-   *                               cause changes to the context. Otherwise, a false value will
-   *                               speed up execution.
-   * @return An <code>EagerExecutionResult</code> where:
-   *  <code>result</code> is the string result of <code>function</code>.
-   *  <code>prefixToPreserveState</code> is either blank or a <code>set</code> tag
-   *    that preserves the state within the output for a second rendering pass.
-   */
-  public static EagerExecutionResult executeInChildContext(
-    Function<JinjavaInterpreter, EagerExpressionResult> function,
-    JinjavaInterpreter interpreter,
-    boolean takeNewValue,
-    boolean partialMacroEvaluation,
-    boolean checkForContextChanges
-  ) {
-    EagerExpressionResult result;
-    Set<String> metaContextVariables = interpreter.getContext().getMetaContextVariables();
-    final Map<String, Object> initiallyResolvedHashes;
-    final Map<String, String> initiallyResolvedAsStrings;
-    if (checkForContextChanges) {
-      initiallyResolvedHashes =
-        interpreter
-          .getContext()
-          .entrySet()
-          .stream()
-          .filter(e -> !metaContextVariables.contains(e.getKey()))
-          .filter(
-            entry ->
-              !(entry.getValue() instanceof DeferredValue) && entry.getValue() != null
-          )
-          .collect(
-            Collectors.toMap(
-              Entry::getKey,
-              entry -> getObjectOrHashCode(entry.getValue())
-            )
-          );
-      initiallyResolvedAsStrings = new HashMap<>();
-      // This creates a stringified snapshot of the context
-      // so it can be disabled via the config because it may cause performance issues.
-      if (interpreter.getConfig().getExecutionMode().useEagerContextReverting()) {
-        initiallyResolvedHashes
-          .keySet()
-          .stream()
-          .filter(
-            key ->
-              EagerExpressionResolver.isResolvableObject(
-                interpreter.getContext().get(key)
-              )
-          )
-          .forEach(
-            key -> {
-              try {
-                initiallyResolvedAsStrings.put(
-                  key,
-                  PyishObjectMapper.getAsUnquotedPyishString(
-                    interpreter.getContext().get(key)
-                  )
-                );
-              } catch (Exception ignored) {}
-            }
-          );
-      }
-    } else {
-      initiallyResolvedHashes = Collections.emptyMap();
-      initiallyResolvedAsStrings = Collections.emptyMap();
-    }
-
-    // Don't create new call stacks to prevent hitting max recursion with this silent new scope
-    Map<String, Object> sessionBindings;
-    try (InterpreterScopeClosable c = interpreter.enterNonStackingScope()) {
-      if (checkForContextChanges) {
-        interpreter.getContext().setDeferredExecutionMode(true);
-      }
-      interpreter.getContext().setPartialMacroEvaluation(partialMacroEvaluation);
-      result = function.apply(interpreter);
-      sessionBindings = interpreter.getContext().getSessionBindings();
-    }
-    sessionBindings =
-      sessionBindings
-        .entrySet()
-        .stream()
-        .filter(
-          entry ->
-            entry.getValue() != null &&
-            !entry.getValue().equals(interpreter.getContext().get(entry.getKey()))
-        )
-        .filter(
-          entry ->
-            !(interpreter.getContext().get(entry.getKey()) instanceof DeferredValue)
-        )
-        .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-    if (checkForContextChanges) {
-      sessionBindings.putAll(
-        interpreter
-          .getContext()
-          .entrySet()
-          .stream()
-          .filter(e -> initiallyResolvedHashes.containsKey(e.getKey()))
-          .filter(
-            e ->
-              !initiallyResolvedHashes
-                .get(e.getKey())
-                .equals(getObjectOrHashCode(e.getValue()))
-          )
-          .collect(
-            Collectors.toMap(
-              Entry::getKey,
-              e -> {
-                if (e.getValue() instanceof DeferredValue) {
-                  return ((DeferredValue) e.getValue()).getOriginalValue();
-                }
-                if (takeNewValue) {
-                  return e.getValue();
-                }
-
-                // This is necessary if a state-changing function, such as .update()
-                // or .append() is run against a variable in the context.
-                // It will revert the effects when takeNewValue is false.
-                if (initiallyResolvedAsStrings.containsKey(e.getKey())) {
-                  // convert to new list or map
-                  return interpreter.resolveELExpression(
-                    initiallyResolvedAsStrings.get(e.getKey()),
-                    interpreter.getLineNumber()
-                  );
-                }
-
-                // Previous value could not be mapped to a string
-                throw new DeferredValueException(e.getKey());
-              }
-            )
-          )
-      );
-    }
-    sessionBindings =
-      sessionBindings
-        .entrySet()
-        .stream()
-        .filter(entry -> !metaContextVariables.contains(entry.getKey()))
-        .filter(
-          entry ->
-            !(entry.getValue() instanceof DeferredValue) && entry.getValue() != null
-        ) // these are already set recursively
-        .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-
-    return new EagerExecutionResult(result, sessionBindings);
-  }
-
-  private static Object getObjectOrHashCode(Object o) {
-    if (o instanceof PyList || o instanceof PyMap) {
-      return o.hashCode();
-    }
-    return o;
-  }
-
-  /**
-   * Reconstruct the macro functions and variables from the context before they
-   * get deferred.
-   * Those macro functions and variables found within {@code deferredWords} are
-   * reconstructed with {@link MacroTag}(s) and a {@link SetTag}, respectively to
-   * preserve the context within the Jinjava template itself.
-   * @param deferredWords set of words that will need to be deferred based on the
-   *                      previously performed operation.
-   * @param interpreter the Jinjava interpreter.
-   * @return a Jinjava-syntax string of 0 or more macro tags and 0 or 1 set tags.
-   */
-  public static String reconstructFromContextBeforeDeferring(
-    Set<String> deferredWords,
-    JinjavaInterpreter interpreter
-  ) {
-    return (
-      reconstructMacroFunctionsBeforeDeferring(deferredWords, interpreter) +
-      reconstructVariablesBeforeDeferring(deferredWords, interpreter)
-    );
-  }
-
-  /**
-   * Build macro tag images for any macro functions that are included in deferredWords
-   * and remove those macro functions from the deferredWords set.
-   * These macro functions are either global or local macro functions, with local
-   * meaning they've been imported under an alias such as "simple.multiply()".
-   * @param deferredWords Set of words that were encountered and their evaluation has
-   *                      to be deferred for a later render.
-   * @param interpreter The Jinjava interpreter.
-   * @return A jinjava-syntax string that is the images of any macro functions that must
-   *  be evaluated at a later time.
-   */
-  private static String reconstructMacroFunctionsBeforeDeferring(
-    Set<String> deferredWords,
-    JinjavaInterpreter interpreter
-  ) {
-    Set<String> toRemove = new HashSet<>();
-    Map<String, MacroFunction> macroFunctions = deferredWords
-      .stream()
-      .filter(w -> !interpreter.getContext().containsKey(w))
-      .map(w -> interpreter.getContext().getGlobalMacro(w))
-      .filter(Objects::nonNull)
-      .collect(Collectors.toMap(AbstractCallableMethod::getName, Function.identity()));
-    for (String word : deferredWords) {
-      if (word.contains(".")) {
-        interpreter
-          .getContext()
-          .getLocalMacro(word)
-          .ifPresent(macroFunction -> macroFunctions.put(word, macroFunction));
-      }
-    }
-
-    String result = macroFunctions
-      .entrySet()
-      .stream()
-      .peek(entry -> toRemove.add(entry.getKey()))
-      .peek(entry -> entry.getValue().setDeferred(true))
-      .map(
-        entry ->
-          executeInChildContext(
-            eagerInterpreter ->
-              EagerExpressionResult.fromString(
-                new EagerMacroFunction(entry.getKey(), entry.getValue(), interpreter)
-                .reconstructImage()
-              ),
-            interpreter,
-            false,
-            false,
-            true
-          )
-      )
-      .map(EagerExecutionResult::asTemplateString)
-      .collect(Collectors.joining());
-    // Remove macro functions from the set because they've been fully processed now.
-    deferredWords.removeAll(toRemove);
-    return result;
-  }
-
-  private static String reconstructVariablesBeforeDeferring(
-    Set<String> deferredWords,
-    JinjavaInterpreter interpreter
-  ) {
-    if (interpreter.getContext().isDeferredExecutionMode()) {
-      return ""; // This will be handled outside of the deferred execution mode.
-    }
-    Map<String, String> deferredMap = new HashMap<>();
-    deferredWords
-      .stream()
-      .map(w -> w.split("\\.", 2)[0]) // get base prop
-      .filter(
-        w ->
-          interpreter.getContext().containsKey(w) &&
-          !(interpreter.getContext().get(w) instanceof DeferredValue)
-      )
-      .forEach(
-        w -> {
-          Object value = interpreter.getContext().get(w);
-          deferredMap.put(
-            w,
-            String.format(
-              value instanceof Namespace ? "namespace(%s)" : "%s",
-              PyishObjectMapper.getAsPyishString(value)
-            )
-          );
-        }
-      );
-    return buildSetTagForDeferredInChildContext(deferredMap, interpreter, true);
-  }
-
-  /**
-   * Build the image for a {@link SetTag} which preserves the values of objects on the context
-   * for a later rendering pass. The set tag will set the keys to the values within
-   * the {@code deferredValuesToSet} Map.
-   * @param deferredValuesToSet Map that specifies what the context objects should be set
-   *                            to in the returned image.
-   * @param interpreter The Jinjava interpreter.
-   * @param registerEagerToken Whether or not to register the returned {@link SetTag}
-   *                           image as an {@link EagerToken}.
-   * @return A jinjava-syntax string that is the image of a set tag that will
-   *  be executed at a later time.
-   */
-  public static String buildSetTagForDeferredInChildContext(
-    Map<String, String> deferredValuesToSet,
-    JinjavaInterpreter interpreter,
-    boolean registerEagerToken
-  ) {
-    if (deferredValuesToSet.isEmpty()) {
-      return "";
-    }
-    Map<Library, Set<String>> disabled = interpreter.getConfig().getDisabled();
-    if (
-      disabled != null &&
-      disabled.containsKey(Library.TAG) &&
-      disabled.get(Library.TAG).contains(SetTag.TAG_NAME)
-    ) {
-      throw new DisabledException("set tag disabled");
-    }
-
-    StringJoiner vars = new StringJoiner(",");
-    StringJoiner values = new StringJoiner(",");
-    deferredValuesToSet.forEach(
-      (key, value) -> {
-        // This ensures they are properly aligned to each other.
-        vars.add(key);
-        values.add(value);
-      }
-    );
-    LengthLimitingStringJoiner result = new LengthLimitingStringJoiner(
-      interpreter.getConfig().getMaxOutputSize(),
-      " "
-    );
-    result
-      .add(interpreter.getConfig().getTokenScannerSymbols().getExpressionStartWithTag())
-      .add(SetTag.TAG_NAME)
-      .add(vars.toString())
-      .add("=")
-      .add(values.toString())
-      .add(interpreter.getConfig().getTokenScannerSymbols().getExpressionEndWithTag());
-    String image = result.toString();
-    // Don't defer if we're sticking with the new value
-    if (registerEagerToken) {
-      interpreter
-        .getContext()
-        .handleEagerToken(
-          new EagerToken(
-            new TagToken(
-              image,
-              // TODO this line number won't be accurate, currently doesn't matter.
-              interpreter.getLineNumber(),
-              interpreter.getPosition(),
-              interpreter.getConfig().getTokenScannerSymbols()
-            ),
-            Collections.emptySet(),
-            deferredValuesToSet.keySet()
-          )
-        );
-    }
-    return image;
-  }
-
-  public static String buildDoUpdateTag(
-    String currentImportAlias,
-    String updateString,
-    JinjavaInterpreter interpreter
-  ) {
-    return new LengthLimitingStringJoiner(interpreter.getConfig().getMaxOutputSize(), " ")
-      .add(interpreter.getConfig().getTokenScannerSymbols().getExpressionStartWithTag())
-      .add(DoTag.TAG_NAME)
-      .add(String.format("%s.update(%s)", currentImportAlias, updateString))
-      .add(interpreter.getConfig().getTokenScannerSymbols().getExpressionEndWithTag())
-      .toString();
-  }
-
-  /**
    * Casts token to TagToken if possible to get the eager image of the token.
    * @see #getEagerTagImage(TagToken, JinjavaInterpreter)
    * @param token Token to cast.
@@ -584,7 +200,7 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
       joiner.add(resolvedString);
     }
     joiner.add(tagToken.getSymbols().getExpressionEndWithTag());
-    String reconstructedFromContext = reconstructFromContextBeforeDeferring(
+    String reconstructedFromContext = EagerReconstructionUtils.reconstructFromContextBeforeDeferring(
       eagerExpressionResult.getDeferredWords(),
       interpreter
     );
@@ -610,71 +226,5 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
       );
 
     return (reconstructedFromContext + joiner.toString());
-  }
-
-  public static String reconstructEnd(TagNode tagNode) {
-    return String.format(
-      "%s %s %s",
-      tagNode.getSymbols().getExpressionStartWithTag(),
-      tagNode.getEndName(),
-      tagNode.getSymbols().getExpressionEndWithTag()
-    );
-  }
-
-  public static String wrapInRawIfNeeded(String output, JinjavaInterpreter interpreter) {
-    if (
-      interpreter.getConfig().getExecutionMode().isPreserveRawTags() &&
-      !interpreter.getContext().isUnwrapRawOverride()
-    ) {
-      if (
-        output.contains(
-          interpreter.getConfig().getTokenScannerSymbols().getExpressionStart()
-        ) ||
-        output.contains(
-          interpreter.getConfig().getTokenScannerSymbols().getExpressionStartWithTag()
-        )
-      ) {
-        output = wrapInTag(output, RawTag.TAG_NAME, interpreter);
-      }
-    }
-    return output;
-  }
-
-  public static String wrapInAutoEscapeIfNeeded(
-    String output,
-    JinjavaInterpreter interpreter
-  ) {
-    if (
-      interpreter.getContext().isAutoEscape() &&
-      (
-        interpreter.getContext().getParent() == null ||
-        !interpreter.getContext().getParent().isAutoEscape()
-      )
-    ) {
-      output = wrapInTag(output, AutoEscapeTag.TAG_NAME, interpreter);
-    }
-    return output;
-  }
-
-  public static String wrapInTag(
-    String s,
-    String tagNameToWrap,
-    JinjavaInterpreter interpreter
-  ) {
-    return (
-      String.format(
-        "%s %s %s",
-        interpreter.getConfig().getTokenScannerSymbols().getExpressionStartWithTag(),
-        tagNameToWrap,
-        interpreter.getConfig().getTokenScannerSymbols().getExpressionEndWithTag()
-      ) +
-      s +
-      String.format(
-        "%s end%s %s",
-        interpreter.getConfig().getTokenScannerSymbols().getExpressionStartWithTag(),
-        tagNameToWrap,
-        interpreter.getConfig().getTokenScannerSymbols().getExpressionEndWithTag()
-      )
-    );
   }
 }

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -1,0 +1,466 @@
+package com.hubspot.jinjava.util;
+
+import com.hubspot.jinjava.el.ext.AbstractCallableMethod;
+import com.hubspot.jinjava.interpret.Context.Library;
+import com.hubspot.jinjava.interpret.DeferredValue;
+import com.hubspot.jinjava.interpret.DeferredValueException;
+import com.hubspot.jinjava.interpret.DisabledException;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
+import com.hubspot.jinjava.lib.fn.MacroFunction;
+import com.hubspot.jinjava.lib.fn.eager.EagerMacroFunction;
+import com.hubspot.jinjava.lib.tag.AutoEscapeTag;
+import com.hubspot.jinjava.lib.tag.DoTag;
+import com.hubspot.jinjava.lib.tag.MacroTag;
+import com.hubspot.jinjava.lib.tag.RawTag;
+import com.hubspot.jinjava.lib.tag.SetTag;
+import com.hubspot.jinjava.lib.tag.eager.EagerExecutionResult;
+import com.hubspot.jinjava.lib.tag.eager.EagerToken;
+import com.hubspot.jinjava.objects.Namespace;
+import com.hubspot.jinjava.objects.collections.PyList;
+import com.hubspot.jinjava.objects.collections.PyMap;
+import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
+import com.hubspot.jinjava.tree.TagNode;
+import com.hubspot.jinjava.tree.parse.TagToken;
+import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class EagerReconstructionUtils {
+
+  /**
+   * Execute the specified functions within a protected context.
+   * Additionally, if the execution causes existing values on the context to become
+   *   deferred, then their previous values will wrapped in a <code>set</code>
+   *   tag that gets prepended to the returned result.
+   * The <code>function</code> is run in deferredExecutionMode=true, where the context needs to
+   *   be protected from having values updated or set,
+   *   such as when evaluating both the positive and negative nodes in an if statement.
+   * @param function Function to run within a "protected" child context
+   * @param interpreter JinjavaInterpreter to create a child from.
+   * @param takeNewValue If a value is updated (not replaced) either take the new value or
+   *                     take the previous value and put it into the
+   *                     <code>EagerExecutionResult.prefixToPreserveState</code>.
+   * @param partialMacroEvaluation Allow macro functions to be partially evaluated rather than
+   *                               needing an explicit result during this render.
+   * @param checkForContextChanges Set this to be true if executing <code>function</code> could
+   *                               cause changes to the context. Otherwise, a false value will
+   *                               speed up execution.
+   * @return An <code>EagerExecutionResult</code> where:
+   *  <code>result</code> is the string result of <code>function</code>.
+   *  <code>prefixToPreserveState</code> is either blank or a <code>set</code> tag
+   *    that preserves the state within the output for a second rendering pass.
+   */
+  public static EagerExecutionResult executeInChildContext(
+    Function<JinjavaInterpreter, EagerExpressionResult> function,
+    JinjavaInterpreter interpreter,
+    boolean takeNewValue,
+    boolean partialMacroEvaluation,
+    boolean checkForContextChanges
+  ) {
+    EagerExpressionResult result;
+    Set<String> metaContextVariables = interpreter.getContext().getMetaContextVariables();
+    final Map<String, Object> initiallyResolvedHashes;
+    final Map<String, String> initiallyResolvedAsStrings;
+    if (checkForContextChanges) {
+      initiallyResolvedHashes =
+        interpreter
+          .getContext()
+          .entrySet()
+          .stream()
+          .filter(e -> !metaContextVariables.contains(e.getKey()))
+          .filter(
+            entry ->
+              !(entry.getValue() instanceof DeferredValue) && entry.getValue() != null
+          )
+          .collect(
+            Collectors.toMap(
+              Entry::getKey,
+              entry -> getObjectOrHashCode(entry.getValue())
+            )
+          );
+      initiallyResolvedAsStrings = new HashMap<>();
+      // This creates a stringified snapshot of the context
+      // so it can be disabled via the config because it may cause performance issues.
+      if (interpreter.getConfig().getExecutionMode().useEagerContextReverting()) {
+        initiallyResolvedHashes
+          .keySet()
+          .stream()
+          .filter(
+            key ->
+              EagerExpressionResolver.isResolvableObject(
+                interpreter.getContext().get(key)
+              )
+          )
+          .forEach(
+            key -> {
+              try {
+                initiallyResolvedAsStrings.put(
+                  key,
+                  PyishObjectMapper.getAsUnquotedPyishString(
+                    interpreter.getContext().get(key)
+                  )
+                );
+              } catch (Exception ignored) {}
+            }
+          );
+      }
+    } else {
+      initiallyResolvedHashes = Collections.emptyMap();
+      initiallyResolvedAsStrings = Collections.emptyMap();
+    }
+
+    // Don't create new call stacks to prevent hitting max recursion with this silent new scope
+    Map<String, Object> sessionBindings;
+    try (InterpreterScopeClosable c = interpreter.enterNonStackingScope()) {
+      if (checkForContextChanges) {
+        interpreter.getContext().setDeferredExecutionMode(true);
+      }
+      interpreter.getContext().setPartialMacroEvaluation(partialMacroEvaluation);
+      result = function.apply(interpreter);
+      sessionBindings = interpreter.getContext().getSessionBindings();
+    }
+    sessionBindings =
+      sessionBindings
+        .entrySet()
+        .stream()
+        .filter(
+          entry ->
+            entry.getValue() != null &&
+            !entry.getValue().equals(interpreter.getContext().get(entry.getKey()))
+        )
+        .filter(
+          entry ->
+            !(interpreter.getContext().get(entry.getKey()) instanceof DeferredValue)
+        )
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+    if (checkForContextChanges) {
+      sessionBindings.putAll(
+        interpreter
+          .getContext()
+          .entrySet()
+          .stream()
+          .filter(e -> initiallyResolvedHashes.containsKey(e.getKey()))
+          .filter(
+            e ->
+              !initiallyResolvedHashes
+                .get(e.getKey())
+                .equals(getObjectOrHashCode(e.getValue()))
+          )
+          .collect(
+            Collectors.toMap(
+              Entry::getKey,
+              e -> {
+                if (e.getValue() instanceof DeferredValue) {
+                  return ((DeferredValue) e.getValue()).getOriginalValue();
+                }
+                if (takeNewValue) {
+                  return e.getValue();
+                }
+
+                // This is necessary if a state-changing function, such as .update()
+                // or .append() is run against a variable in the context.
+                // It will revert the effects when takeNewValue is false.
+                if (initiallyResolvedAsStrings.containsKey(e.getKey())) {
+                  // convert to new list or map
+                  return interpreter.resolveELExpression(
+                    initiallyResolvedAsStrings.get(e.getKey()),
+                    interpreter.getLineNumber()
+                  );
+                }
+
+                // Previous value could not be mapped to a string
+                throw new DeferredValueException(e.getKey());
+              }
+            )
+          )
+      );
+    }
+    sessionBindings =
+      sessionBindings
+        .entrySet()
+        .stream()
+        .filter(entry -> !metaContextVariables.contains(entry.getKey()))
+        .filter(
+          entry ->
+            !(entry.getValue() instanceof DeferredValue) && entry.getValue() != null
+        ) // these are already set recursively
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+    return new EagerExecutionResult(result, sessionBindings);
+  }
+
+  private static Object getObjectOrHashCode(Object o) {
+    if (o instanceof PyList || o instanceof PyMap) {
+      return o.hashCode();
+    }
+    return o;
+  }
+
+  /**
+   * Reconstruct the macro functions and variables from the context before they
+   * get deferred.
+   * Those macro functions and variables found within {@code deferredWords} are
+   * reconstructed with {@link MacroTag}(s) and a {@link SetTag}, respectively to
+   * preserve the context within the Jinjava template itself.
+   * @param deferredWords set of words that will need to be deferred based on the
+   *                      previously performed operation.
+   * @param interpreter the Jinjava interpreter.
+   * @return a Jinjava-syntax string of 0 or more macro tags and 0 or 1 set tags.
+   */
+  public static String reconstructFromContextBeforeDeferring(
+    Set<String> deferredWords,
+    JinjavaInterpreter interpreter
+  ) {
+    return (
+      reconstructMacroFunctionsBeforeDeferring(deferredWords, interpreter) +
+      reconstructVariablesBeforeDeferring(deferredWords, interpreter)
+    );
+  }
+
+  /**
+   * Build macro tag images for any macro functions that are included in deferredWords
+   * and remove those macro functions from the deferredWords set.
+   * These macro functions are either global or local macro functions, with local
+   * meaning they've been imported under an alias such as "simple.multiply()".
+   * @param deferredWords Set of words that were encountered and their evaluation has
+   *                      to be deferred for a later render.
+   * @param interpreter The Jinjava interpreter.
+   * @return A jinjava-syntax string that is the images of any macro functions that must
+   *  be evaluated at a later time.
+   */
+  private static String reconstructMacroFunctionsBeforeDeferring(
+    Set<String> deferredWords,
+    JinjavaInterpreter interpreter
+  ) {
+    Set<String> toRemove = new HashSet<>();
+    Map<String, MacroFunction> macroFunctions = deferredWords
+      .stream()
+      .filter(w -> !interpreter.getContext().containsKey(w))
+      .map(w -> interpreter.getContext().getGlobalMacro(w))
+      .filter(Objects::nonNull)
+      .collect(Collectors.toMap(AbstractCallableMethod::getName, Function.identity()));
+    for (String word : deferredWords) {
+      if (word.contains(".")) {
+        interpreter
+          .getContext()
+          .getLocalMacro(word)
+          .ifPresent(macroFunction -> macroFunctions.put(word, macroFunction));
+      }
+    }
+
+    String result = macroFunctions
+      .entrySet()
+      .stream()
+      .peek(entry -> toRemove.add(entry.getKey()))
+      .peek(entry -> entry.getValue().setDeferred(true))
+      .map(
+        entry ->
+          executeInChildContext(
+            eagerInterpreter ->
+              EagerExpressionResult.fromString(
+                new EagerMacroFunction(entry.getKey(), entry.getValue(), interpreter)
+                .reconstructImage()
+              ),
+            interpreter,
+            false,
+            false,
+            true
+          )
+      )
+      .map(EagerExecutionResult::asTemplateString)
+      .collect(Collectors.joining());
+    // Remove macro functions from the set because they've been fully processed now.
+    deferredWords.removeAll(toRemove);
+    return result;
+  }
+
+  private static String reconstructVariablesBeforeDeferring(
+    Set<String> deferredWords,
+    JinjavaInterpreter interpreter
+  ) {
+    if (interpreter.getContext().isDeferredExecutionMode()) {
+      return ""; // This will be handled outside of the deferred execution mode.
+    }
+    Map<String, String> deferredMap = new HashMap<>();
+    deferredWords
+      .stream()
+      .map(w -> w.split("\\.", 2)[0]) // get base prop
+      .filter(
+        w ->
+          interpreter.getContext().containsKey(w) &&
+          !(interpreter.getContext().get(w) instanceof DeferredValue)
+      )
+      .forEach(
+        w -> {
+          Object value = interpreter.getContext().get(w);
+          deferredMap.put(
+            w,
+            String.format(
+              value instanceof Namespace ? "namespace(%s)" : "%s",
+              PyishObjectMapper.getAsPyishString(value)
+            )
+          );
+        }
+      );
+    return buildSetTagForDeferredInChildContext(deferredMap, interpreter, true);
+  }
+
+  /**
+   * Build the image for a {@link SetTag} which preserves the values of objects on the context
+   * for a later rendering pass. The set tag will set the keys to the values within
+   * the {@code deferredValuesToSet} Map.
+   * @param deferredValuesToSet Map that specifies what the context objects should be set
+   *                            to in the returned image.
+   * @param interpreter The Jinjava interpreter.
+   * @param registerEagerToken Whether or not to register the returned {@link SetTag}
+   *                           image as an {@link EagerToken}.
+   * @return A jinjava-syntax string that is the image of a set tag that will
+   *  be executed at a later time.
+   */
+  public static String buildSetTagForDeferredInChildContext(
+    Map<String, String> deferredValuesToSet,
+    JinjavaInterpreter interpreter,
+    boolean registerEagerToken
+  ) {
+    if (deferredValuesToSet.isEmpty()) {
+      return "";
+    }
+    Map<Library, Set<String>> disabled = interpreter.getConfig().getDisabled();
+    if (
+      disabled != null &&
+      disabled.containsKey(Library.TAG) &&
+      disabled.get(Library.TAG).contains(SetTag.TAG_NAME)
+    ) {
+      throw new DisabledException("set tag disabled");
+    }
+
+    StringJoiner vars = new StringJoiner(",");
+    StringJoiner values = new StringJoiner(",");
+    deferredValuesToSet.forEach(
+      (key, value) -> {
+        // This ensures they are properly aligned to each other.
+        vars.add(key);
+        values.add(value);
+      }
+    );
+    LengthLimitingStringJoiner result = new LengthLimitingStringJoiner(
+      interpreter.getConfig().getMaxOutputSize(),
+      " "
+    );
+    result
+      .add(interpreter.getConfig().getTokenScannerSymbols().getExpressionStartWithTag())
+      .add(SetTag.TAG_NAME)
+      .add(vars.toString())
+      .add("=")
+      .add(values.toString())
+      .add(interpreter.getConfig().getTokenScannerSymbols().getExpressionEndWithTag());
+    String image = result.toString();
+    // Don't defer if we're sticking with the new value
+    if (registerEagerToken) {
+      interpreter
+        .getContext()
+        .handleEagerToken(
+          new EagerToken(
+            new TagToken(
+              image,
+              // TODO this line number won't be accurate, currently doesn't matter.
+              interpreter.getLineNumber(),
+              interpreter.getPosition(),
+              interpreter.getConfig().getTokenScannerSymbols()
+            ),
+            Collections.emptySet(),
+            deferredValuesToSet.keySet()
+          )
+        );
+    }
+    return image;
+  }
+
+  public static String buildDoUpdateTag(
+    String currentImportAlias,
+    String updateString,
+    JinjavaInterpreter interpreter
+  ) {
+    return new LengthLimitingStringJoiner(interpreter.getConfig().getMaxOutputSize(), " ")
+      .add(interpreter.getConfig().getTokenScannerSymbols().getExpressionStartWithTag())
+      .add(DoTag.TAG_NAME)
+      .add(String.format("%s.update(%s)", currentImportAlias, updateString))
+      .add(interpreter.getConfig().getTokenScannerSymbols().getExpressionEndWithTag())
+      .toString();
+  }
+
+  public static String reconstructEnd(TagNode tagNode) {
+    return String.format(
+      "%s %s %s",
+      tagNode.getSymbols().getExpressionStartWithTag(),
+      tagNode.getEndName(),
+      tagNode.getSymbols().getExpressionEndWithTag()
+    );
+  }
+
+  public static String wrapInRawIfNeeded(String output, JinjavaInterpreter interpreter) {
+    if (
+      interpreter.getConfig().getExecutionMode().isPreserveRawTags() &&
+      !interpreter.getContext().isUnwrapRawOverride()
+    ) {
+      if (
+        output.contains(
+          interpreter.getConfig().getTokenScannerSymbols().getExpressionStart()
+        ) ||
+        output.contains(
+          interpreter.getConfig().getTokenScannerSymbols().getExpressionStartWithTag()
+        )
+      ) {
+        output = wrapInTag(output, RawTag.TAG_NAME, interpreter);
+      }
+    }
+    return output;
+  }
+
+  public static String wrapInAutoEscapeIfNeeded(
+    String output,
+    JinjavaInterpreter interpreter
+  ) {
+    if (
+      interpreter.getContext().isAutoEscape() &&
+      (
+        interpreter.getContext().getParent() == null ||
+        !interpreter.getContext().getParent().isAutoEscape()
+      )
+    ) {
+      output = wrapInTag(output, AutoEscapeTag.TAG_NAME, interpreter);
+    }
+    return output;
+  }
+
+  public static String wrapInTag(
+    String s,
+    String tagNameToWrap,
+    JinjavaInterpreter interpreter
+  ) {
+    return (
+      String.format(
+        "%s %s %s",
+        interpreter.getConfig().getTokenScannerSymbols().getExpressionStartWithTag(),
+        tagNameToWrap,
+        interpreter.getConfig().getTokenScannerSymbols().getExpressionEndWithTag()
+      ) +
+      s +
+      String.format(
+        "%s end%s %s",
+        interpreter.getConfig().getTokenScannerSymbols().getExpressionStartWithTag(),
+        tagNameToWrap,
+        interpreter.getConfig().getTokenScannerSymbols().getExpressionEndWithTag()
+      )
+    );
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -311,7 +311,7 @@ public class EagerReconstructionUtils {
           );
         }
       );
-    return buildSetTagForDeferredInChildContext(deferredMap, interpreter, true);
+    return buildSetTag(deferredMap, interpreter, true);
   }
 
   /**
@@ -326,7 +326,7 @@ public class EagerReconstructionUtils {
    * @return A jinjava-syntax string that is the image of a set tag that will
    *  be executed at a later time.
    */
-  public static String buildSetTagForDeferredInChildContext(
+  public static String buildSetTag(
     Map<String, String> deferredValuesToSet,
     JinjavaInterpreter interpreter,
     boolean registerEagerToken

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
@@ -4,8 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.DeferredValue;
@@ -14,31 +12,18 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.OutputTooBigException;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.lib.fn.ELFunctionDefinition;
-import com.hubspot.jinjava.lib.fn.MacroFunction;
 import com.hubspot.jinjava.lib.tag.Tag;
-import com.hubspot.jinjava.mode.DefaultExecutionMode;
 import com.hubspot.jinjava.mode.EagerExecutionMode;
-import com.hubspot.jinjava.mode.PreserveRawExecutionMode;
-import com.hubspot.jinjava.objects.collections.PyList;
-import com.hubspot.jinjava.objects.collections.PyMap;
 import com.hubspot.jinjava.tree.TagNode;
-import com.hubspot.jinjava.tree.parse.DefaultTokenScannerSymbols;
 import com.hubspot.jinjava.tree.parse.TagToken;
-import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
-/**
- * Test for the static methods in the EagerTagDecorator.
- */
 @RunWith(MockitoJUnitRunner.class)
 public class EagerTagDecoratorTest extends BaseInterpretingTest {
   private static final long MAX_OUTPUT_SIZE = 50L;
@@ -85,266 +70,6 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
   @After
   public void teardown() {
     JinjavaInterpreter.popCurrent();
-  }
-
-  @Test
-  public void itExecutesInChildContextAndTakesNewValue() {
-    context.put("foo", new PyList(new ArrayList<>()));
-    EagerExecutionResult result = EagerTagDecorator.executeInChildContext(
-      (
-        interpreter1 -> {
-          ((List<Integer>) interpreter1.getContext().get("foo")).add(1);
-          return EagerExpressionResult.fromString("function return");
-        }
-      ),
-      interpreter,
-      true,
-      false,
-      true
-    );
-
-    assertThat(context.get("foo")).isEqualTo(ImmutableList.of(1));
-    assertThat(context.getEagerTokens()).isEmpty();
-    assertThat(result.getResult().toString()).isEqualTo("function return");
-    // This will add an eager token because we normally don't call this method
-    // unless we're in deferred execution mode.
-    assertThat(result.getPrefixToPreserveState()).isEqualTo("{% set foo = [1] %}");
-  }
-
-  @Test
-  public void itExecutesInChildContextAndDefersNewValue() {
-    context.put("foo", new ArrayList<Integer>());
-    EagerExecutionResult result = EagerTagDecorator.executeInChildContext(
-      (
-        interpreter1 -> {
-          context.put(
-            "foo",
-            DeferredValue.instance(interpreter1.getContext().get("foo"))
-          );
-          return EagerExpressionResult.fromString("function return");
-        }
-      ),
-      interpreter,
-      false,
-      false,
-      true
-    );
-    assertThat(result.getResult().toString()).isEqualTo("function return");
-    assertThat(result.getPrefixToPreserveState()).isEqualTo("{% set foo = [] %}");
-    assertThat(context.get("foo")).isInstanceOf(DeferredValue.class);
-  }
-
-  @Test
-  public void itReconstructsMacroFunctionsFromGlobal() {
-    Set<String> deferredWords = new HashSet<>();
-    deferredWords.add("foo");
-    String image = "{% macro foo(bar) %}something{% endmacro %}";
-    MacroFunction mockMacroFunction = getMockMacroFunction(image);
-    context.addGlobalMacro(mockMacroFunction);
-    String result = EagerTagDecorator.reconstructFromContextBeforeDeferring(
-      deferredWords,
-      interpreter
-    );
-    assertThat(result).isEqualTo(image);
-    assertThat(deferredWords).isEmpty();
-  }
-
-  @Test
-  public void itReconstructsMacroFunctionsFromLocal() {
-    Set<String> deferredWords = new HashSet<>();
-    deferredWords.add("local.foo");
-    String image = "{% macro foo(bar) %}something{% endmacro %}";
-    MacroFunction mockMacroFunction = getMockMacroFunction(image);
-    Map<String, Object> localAlias = new PyMap(ImmutableMap.of("foo", mockMacroFunction));
-    context.put("local", localAlias);
-    String result = EagerTagDecorator.reconstructFromContextBeforeDeferring(
-      deferredWords,
-      interpreter
-    );
-    assertThat(result).isEqualTo("{% macro local.foo(bar) %}something{% endmacro %}");
-    assertThat(deferredWords).isEmpty();
-  }
-
-  @Test
-  public void itReconstructsVariables() {
-    Set<String> deferredWords = new HashSet<>();
-    deferredWords.add("foo.append");
-    context.put("foo", new PyList(new ArrayList<>()));
-    String result = EagerTagDecorator.reconstructFromContextBeforeDeferring(
-      deferredWords,
-      interpreter
-    );
-    assertThat(result).isEqualTo("{% set foo = [] %}");
-  }
-
-  @Test
-  public void itDoesntReconstructVariablesInDeferredExecutionMode() {
-    Set<String> deferredWords = new HashSet<>();
-    deferredWords.add("foo.append");
-    context.put("foo", new PyList(new ArrayList<>()));
-    context.setDeferredExecutionMode(true);
-    String result = EagerTagDecorator.reconstructFromContextBeforeDeferring(
-      deferredWords,
-      interpreter
-    );
-    assertThat(result).isEqualTo("");
-  }
-
-  @Test
-  public void itReconstructsVariablesAndMacroFunctions() {
-    Set<String> deferredWords = new HashSet<>();
-    deferredWords.add("bar.append");
-    deferredWords.add("foo");
-    String image = "{% macro foo(bar) %}something{% endmacro %}";
-    MacroFunction mockMacroFunction = getMockMacroFunction(image);
-    context.addGlobalMacro(mockMacroFunction);
-    context.put("bar", new PyList(new ArrayList<>()));
-    String result = EagerTagDecorator.reconstructFromContextBeforeDeferring(
-      deferredWords,
-      interpreter
-    );
-    assertThat(result)
-      .isEqualTo("{% macro foo(bar) %}something{% endmacro %}{% set bar = [] %}");
-  }
-
-  @Test
-  public void itBuildsSetTagForDeferredAndRegisters() {
-    Map<String, String> deferredValuesToSet = ImmutableMap.of("foo", "'bar'");
-    String result = EagerTagDecorator.buildSetTagForDeferredInChildContext(
-      deferredValuesToSet,
-      interpreter,
-      true
-    );
-    assertThat(result).isEqualTo("{% set foo = 'bar' %}");
-    assertThat(context.getEagerTokens()).hasSize(1);
-    EagerToken eagerToken = context
-      .getEagerTokens()
-      .stream()
-      .findAny()
-      .orElseThrow(RuntimeException::new);
-    assertThat(eagerToken.getSetDeferredWords()).containsExactly("foo");
-    assertThat(eagerToken.getUsedDeferredWords()).isEmpty();
-  }
-
-  @Test
-  public void itBuildsSetTagForDeferredAndDoesntRegister() {
-    Map<String, String> deferredValuesToSet = ImmutableMap.of("foo", "'bar'");
-    String result = EagerTagDecorator.buildSetTagForDeferredInChildContext(
-      deferredValuesToSet,
-      interpreter,
-      false
-    );
-    assertThat(result).isEqualTo("{% set foo = 'bar' %}");
-    assertThat(context.getEagerTokens()).isEmpty();
-  }
-
-  @Test
-  public void itBuildsSetTagForMultipleDeferred() {
-    Map<String, String> deferredValuesToSet = ImmutableMap.of("foo", "'bar'", "baz", "2");
-    String result = EagerTagDecorator.buildSetTagForDeferredInChildContext(
-      deferredValuesToSet,
-      interpreter,
-      true
-    );
-    assertThat(result).isEqualTo("{% set foo,baz = 'bar',2 %}");
-    assertThat(context.getEagerTokens()).hasSize(1);
-    EagerToken eagerToken = context
-      .getEagerTokens()
-      .stream()
-      .findAny()
-      .orElseThrow(RuntimeException::new);
-    assertThat(eagerToken.getSetDeferredWords()).containsExactlyInAnyOrder("foo", "baz");
-    assertThat(eagerToken.getUsedDeferredWords()).isEmpty();
-  }
-
-  @Test
-  public void itLimitsSetTagConstruction() {
-    StringBuilder tooLong = new StringBuilder();
-    for (int i = 0; i < MAX_OUTPUT_SIZE; i++) {
-      tooLong.append(i);
-    }
-    Map<String, String> deferredValuesToSet = ImmutableMap.of("foo", tooLong.toString());
-    assertThatThrownBy(
-        () ->
-          EagerTagDecorator.buildSetTagForDeferredInChildContext(
-            deferredValuesToSet,
-            interpreter,
-            true
-          )
-      )
-      .isInstanceOf(OutputTooBigException.class);
-  }
-
-  @Test
-  public void itWrapsInRawTag() {
-    String toWrap = "{{ foo }}";
-    JinjavaConfig preserveRawConfig = JinjavaConfig
-      .newBuilder()
-      .withExecutionMode(PreserveRawExecutionMode.instance())
-      .build();
-    assertThat(
-        EagerTagDecorator.wrapInRawIfNeeded(
-          toWrap,
-          new JinjavaInterpreter(jinjava, context, preserveRawConfig)
-        )
-      )
-      .isEqualTo(String.format("{%% raw %%}%s{%% endraw %%}", toWrap));
-  }
-
-  @Test
-  public void itDoesntWrapInRawTagUnnecessarily() {
-    String toWrap = "foo";
-    JinjavaConfig preserveRawConfig = JinjavaConfig
-      .newBuilder()
-      .withExecutionMode(PreserveRawExecutionMode.instance())
-      .build();
-    assertThat(
-        EagerTagDecorator.wrapInRawIfNeeded(
-          toWrap,
-          new JinjavaInterpreter(jinjava, context, preserveRawConfig)
-        )
-      )
-      .isEqualTo(toWrap);
-  }
-
-  @Test
-  public void itDoesntWrapInRawTagForDefaultConfig() {
-    JinjavaConfig defaultConfig = JinjavaConfig
-      .newBuilder()
-      .withExecutionMode(DefaultExecutionMode.instance())
-      .build();
-    String toWrap = "{{ foo }}";
-    assertThat(
-        EagerTagDecorator.wrapInRawIfNeeded(
-          toWrap,
-          new JinjavaInterpreter(jinjava, context, defaultConfig)
-        )
-      )
-      .isEqualTo(toWrap);
-  }
-
-  @Test
-  public void itWrapsInAutoEscapeTag() {
-    String toWrap = "<div>{{deferred}}</div>";
-    interpreter.getContext().setAutoEscape(true);
-    assertThat(EagerTagDecorator.wrapInAutoEscapeIfNeeded(toWrap, interpreter))
-      .isEqualTo(String.format("{%% autoescape %%}%s{%% endautoescape %%}", toWrap));
-  }
-
-  @Test
-  public void itDoesntWrapInAutoEscapeWhenFalse() {
-    String toWrap = "<div>{{deferred}}</div>";
-    interpreter.getContext().setAutoEscape(false);
-    assertThat(EagerTagDecorator.wrapInAutoEscapeIfNeeded(toWrap, interpreter))
-      .isEqualTo(toWrap);
-  }
-
-  @Test
-  public void itReconstructsTheEndOfATagNode() {
-    TagNode tagNode = getMockTagNode("endif");
-    assertThat(EagerTagDecorator.reconstructEnd(tagNode)).isEqualTo("{% endif %}");
-    tagNode = getMockTagNode("endfor");
-    assertThat(EagerTagDecorator.reconstructEnd(tagNode)).isEqualTo("{% endfor %}");
   }
 
   @Test
@@ -425,22 +150,6 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
         interpreter.render("{{ modify_context('foo', 'bar') ~ deferred }}{{ foo }}")
       )
       .isEqualTo("{{ null ~ deferred }}[bar]");
-  }
-
-  private static MacroFunction getMockMacroFunction(String image) {
-    MacroFunction mockMacroFunction = mock(MacroFunction.class);
-    when(mockMacroFunction.getName()).thenReturn("foo");
-    when(mockMacroFunction.getArguments()).thenReturn(ImmutableList.of("bar"));
-    when(mockMacroFunction.getEvaluationResult(anyMap(), anyMap(), anyList(), any()))
-      .thenReturn(image.substring(image.indexOf("%}") + 2, image.lastIndexOf("{%")));
-    return mockMacroFunction;
-  }
-
-  private static TagNode getMockTagNode(String endName) {
-    TagNode mockTagNode = mock(TagNode.class);
-    when(mockTagNode.getSymbols()).thenReturn(new DefaultTokenScannerSymbols());
-    when(mockTagNode.getEndName()).thenReturn(endName);
-    return mockTagNode;
   }
 
   public static void addToContext(String key, Object value) {

--- a/src/test/java/com/hubspot/jinjava/util/EagerReconstructionUtilsTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerReconstructionUtilsTest.java
@@ -1,0 +1,337 @@
+package com.hubspot.jinjava.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.hubspot.jinjava.BaseInterpretingTest;
+import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.interpret.DeferredValue;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.OutputTooBigException;
+import com.hubspot.jinjava.lib.fn.MacroFunction;
+import com.hubspot.jinjava.lib.tag.eager.EagerExecutionResult;
+import com.hubspot.jinjava.lib.tag.eager.EagerToken;
+import com.hubspot.jinjava.mode.DefaultExecutionMode;
+import com.hubspot.jinjava.mode.EagerExecutionMode;
+import com.hubspot.jinjava.mode.PreserveRawExecutionMode;
+import com.hubspot.jinjava.objects.collections.PyList;
+import com.hubspot.jinjava.objects.collections.PyMap;
+import com.hubspot.jinjava.tree.TagNode;
+import com.hubspot.jinjava.tree.parse.DefaultTokenScannerSymbols;
+import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EagerReconstructionUtilsTest extends BaseInterpretingTest {
+  private static final long MAX_OUTPUT_SIZE = 50L;
+
+  @Before
+  public void eagerSetup() throws Exception {
+    interpreter =
+      new JinjavaInterpreter(
+        jinjava,
+        context,
+        JinjavaConfig
+          .newBuilder()
+          .withMaxOutputSize(MAX_OUTPUT_SIZE)
+          .withExecutionMode(EagerExecutionMode.instance())
+          .build()
+      );
+
+    JinjavaInterpreter.pushCurrent(interpreter);
+  }
+
+  @After
+  public void teardown() {
+    JinjavaInterpreter.popCurrent();
+  }
+
+  @Test
+  public void itExecutesInChildContextAndTakesNewValue() {
+    context.put("foo", new PyList(new ArrayList<>()));
+    EagerExecutionResult result = EagerReconstructionUtils.executeInChildContext(
+      (
+        interpreter1 -> {
+          ((List<Integer>) interpreter1.getContext().get("foo")).add(1);
+          return EagerExpressionResult.fromString("function return");
+        }
+      ),
+      interpreter,
+      true,
+      false,
+      true
+    );
+
+    assertThat(context.get("foo")).isEqualTo(ImmutableList.of(1));
+    assertThat(context.getEagerTokens()).isEmpty();
+    assertThat(result.getResult().toString()).isEqualTo("function return");
+    // This will add an eager token because we normally don't call this method
+    // unless we're in deferred execution mode.
+    assertThat(result.getPrefixToPreserveState()).isEqualTo("{% set foo = [1] %}");
+  }
+
+  @Test
+  public void itExecutesInChildContextAndDefersNewValue() {
+    context.put("foo", new ArrayList<Integer>());
+    EagerExecutionResult result = EagerReconstructionUtils.executeInChildContext(
+      (
+        interpreter1 -> {
+          context.put(
+            "foo",
+            DeferredValue.instance(interpreter1.getContext().get("foo"))
+          );
+          return EagerExpressionResult.fromString("function return");
+        }
+      ),
+      interpreter,
+      false,
+      false,
+      true
+    );
+    assertThat(result.getResult().toString()).isEqualTo("function return");
+    assertThat(result.getPrefixToPreserveState()).isEqualTo("{% set foo = [] %}");
+    assertThat(context.get("foo")).isInstanceOf(DeferredValue.class);
+  }
+
+  @Test
+  public void itReconstructsMacroFunctionsFromGlobal() {
+    Set<String> deferredWords = new HashSet<>();
+    deferredWords.add("foo");
+    String image = "{% macro foo(bar) %}something{% endmacro %}";
+    MacroFunction mockMacroFunction = getMockMacroFunction(image);
+    context.addGlobalMacro(mockMacroFunction);
+    String result = EagerReconstructionUtils.reconstructFromContextBeforeDeferring(
+      deferredWords,
+      interpreter
+    );
+    assertThat(result).isEqualTo(image);
+    assertThat(deferredWords).isEmpty();
+  }
+
+  @Test
+  public void itReconstructsMacroFunctionsFromLocal() {
+    Set<String> deferredWords = new HashSet<>();
+    deferredWords.add("local.foo");
+    String image = "{% macro foo(bar) %}something{% endmacro %}";
+    MacroFunction mockMacroFunction = getMockMacroFunction(image);
+    Map<String, Object> localAlias = new PyMap(ImmutableMap.of("foo", mockMacroFunction));
+    context.put("local", localAlias);
+    String result = EagerReconstructionUtils.reconstructFromContextBeforeDeferring(
+      deferredWords,
+      interpreter
+    );
+    assertThat(result).isEqualTo("{% macro local.foo(bar) %}something{% endmacro %}");
+    assertThat(deferredWords).isEmpty();
+  }
+
+  @Test
+  public void itReconstructsVariables() {
+    Set<String> deferredWords = new HashSet<>();
+    deferredWords.add("foo.append");
+    context.put("foo", new PyList(new ArrayList<>()));
+    String result = EagerReconstructionUtils.reconstructFromContextBeforeDeferring(
+      deferredWords,
+      interpreter
+    );
+    assertThat(result).isEqualTo("{% set foo = [] %}");
+  }
+
+  @Test
+  public void itDoesntReconstructVariablesInDeferredExecutionMode() {
+    Set<String> deferredWords = new HashSet<>();
+    deferredWords.add("foo.append");
+    context.put("foo", new PyList(new ArrayList<>()));
+    context.setDeferredExecutionMode(true);
+    String result = EagerReconstructionUtils.reconstructFromContextBeforeDeferring(
+      deferredWords,
+      interpreter
+    );
+    assertThat(result).isEqualTo("");
+  }
+
+  @Test
+  public void itReconstructsVariablesAndMacroFunctions() {
+    Set<String> deferredWords = new HashSet<>();
+    deferredWords.add("bar.append");
+    deferredWords.add("foo");
+    String image = "{% macro foo(bar) %}something{% endmacro %}";
+    MacroFunction mockMacroFunction = getMockMacroFunction(image);
+    context.addGlobalMacro(mockMacroFunction);
+    context.put("bar", new PyList(new ArrayList<>()));
+    String result = EagerReconstructionUtils.reconstructFromContextBeforeDeferring(
+      deferredWords,
+      interpreter
+    );
+    assertThat(result)
+      .isEqualTo("{% macro foo(bar) %}something{% endmacro %}{% set bar = [] %}");
+  }
+
+  @Test
+  public void itBuildsSetTagForDeferredAndRegisters() {
+    Map<String, String> deferredValuesToSet = ImmutableMap.of("foo", "'bar'");
+    String result = EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
+      deferredValuesToSet,
+      interpreter,
+      true
+    );
+    assertThat(result).isEqualTo("{% set foo = 'bar' %}");
+    assertThat(context.getEagerTokens()).hasSize(1);
+    EagerToken eagerToken = context
+      .getEagerTokens()
+      .stream()
+      .findAny()
+      .orElseThrow(RuntimeException::new);
+    assertThat(eagerToken.getSetDeferredWords()).containsExactly("foo");
+    assertThat(eagerToken.getUsedDeferredWords()).isEmpty();
+  }
+
+  @Test
+  public void itBuildsSetTagForDeferredAndDoesntRegister() {
+    Map<String, String> deferredValuesToSet = ImmutableMap.of("foo", "'bar'");
+    String result = EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
+      deferredValuesToSet,
+      interpreter,
+      false
+    );
+    assertThat(result).isEqualTo("{% set foo = 'bar' %}");
+    assertThat(context.getEagerTokens()).isEmpty();
+  }
+
+  @Test
+  public void itBuildsSetTagForMultipleDeferred() {
+    Map<String, String> deferredValuesToSet = ImmutableMap.of("foo", "'bar'", "baz", "2");
+    String result = EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
+      deferredValuesToSet,
+      interpreter,
+      true
+    );
+    assertThat(result).isEqualTo("{% set foo,baz = 'bar',2 %}");
+    assertThat(context.getEagerTokens()).hasSize(1);
+    EagerToken eagerToken = context
+      .getEagerTokens()
+      .stream()
+      .findAny()
+      .orElseThrow(RuntimeException::new);
+    assertThat(eagerToken.getSetDeferredWords()).containsExactlyInAnyOrder("foo", "baz");
+    assertThat(eagerToken.getUsedDeferredWords()).isEmpty();
+  }
+
+  @Test
+  public void itLimitsSetTagConstruction() {
+    StringBuilder tooLong = new StringBuilder();
+    for (int i = 0; i < MAX_OUTPUT_SIZE; i++) {
+      tooLong.append(i);
+    }
+    Map<String, String> deferredValuesToSet = ImmutableMap.of("foo", tooLong.toString());
+    assertThatThrownBy(
+        () ->
+          EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
+            deferredValuesToSet,
+            interpreter,
+            true
+          )
+      )
+      .isInstanceOf(OutputTooBigException.class);
+  }
+
+  @Test
+  public void itWrapsInRawTag() {
+    String toWrap = "{{ foo }}";
+    JinjavaConfig preserveRawConfig = JinjavaConfig
+      .newBuilder()
+      .withExecutionMode(PreserveRawExecutionMode.instance())
+      .build();
+    assertThat(
+        EagerReconstructionUtils.wrapInRawIfNeeded(
+          toWrap,
+          new JinjavaInterpreter(jinjava, context, preserveRawConfig)
+        )
+      )
+      .isEqualTo(String.format("{%% raw %%}%s{%% endraw %%}", toWrap));
+  }
+
+  @Test
+  public void itDoesntWrapInRawTagUnnecessarily() {
+    String toWrap = "foo";
+    JinjavaConfig preserveRawConfig = JinjavaConfig
+      .newBuilder()
+      .withExecutionMode(PreserveRawExecutionMode.instance())
+      .build();
+    assertThat(
+        EagerReconstructionUtils.wrapInRawIfNeeded(
+          toWrap,
+          new JinjavaInterpreter(jinjava, context, preserveRawConfig)
+        )
+      )
+      .isEqualTo(toWrap);
+  }
+
+  @Test
+  public void itDoesntWrapInRawTagForDefaultConfig() {
+    JinjavaConfig defaultConfig = JinjavaConfig
+      .newBuilder()
+      .withExecutionMode(DefaultExecutionMode.instance())
+      .build();
+    String toWrap = "{{ foo }}";
+    assertThat(
+        EagerReconstructionUtils.wrapInRawIfNeeded(
+          toWrap,
+          new JinjavaInterpreter(jinjava, context, defaultConfig)
+        )
+      )
+      .isEqualTo(toWrap);
+  }
+
+  @Test
+  public void itWrapsInAutoEscapeTag() {
+    String toWrap = "<div>{{deferred}}</div>";
+    interpreter.getContext().setAutoEscape(true);
+    assertThat(EagerReconstructionUtils.wrapInAutoEscapeIfNeeded(toWrap, interpreter))
+      .isEqualTo(String.format("{%% autoescape %%}%s{%% endautoescape %%}", toWrap));
+  }
+
+  @Test
+  public void itDoesntWrapInAutoEscapeWhenFalse() {
+    String toWrap = "<div>{{deferred}}</div>";
+    interpreter.getContext().setAutoEscape(false);
+    assertThat(EagerReconstructionUtils.wrapInAutoEscapeIfNeeded(toWrap, interpreter))
+      .isEqualTo(toWrap);
+  }
+
+  @Test
+  public void itReconstructsTheEndOfATagNode() {
+    TagNode tagNode = getMockTagNode("endif");
+    assertThat(EagerReconstructionUtils.reconstructEnd(tagNode)).isEqualTo("{% endif %}");
+    tagNode = getMockTagNode("endfor");
+    assertThat(EagerReconstructionUtils.reconstructEnd(tagNode))
+      .isEqualTo("{% endfor %}");
+  }
+
+  private static MacroFunction getMockMacroFunction(String image) {
+    MacroFunction mockMacroFunction = mock(MacroFunction.class);
+    when(mockMacroFunction.getName()).thenReturn("foo");
+    when(mockMacroFunction.getArguments()).thenReturn(ImmutableList.of("bar"));
+    when(mockMacroFunction.getEvaluationResult(anyMap(), anyMap(), anyList(), any()))
+      .thenReturn(image.substring(image.indexOf("%}") + 2, image.lastIndexOf("{%")));
+    return mockMacroFunction;
+  }
+
+  private static TagNode getMockTagNode(String endName) {
+    TagNode mockTagNode = mock(TagNode.class);
+    when(mockTagNode.getSymbols()).thenReturn(new DefaultTokenScannerSymbols());
+    when(mockTagNode.getEndName()).thenReturn(endName);
+    return mockTagNode;
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/util/EagerReconstructionUtilsTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerReconstructionUtilsTest.java
@@ -181,7 +181,7 @@ public class EagerReconstructionUtilsTest extends BaseInterpretingTest {
   @Test
   public void itBuildsSetTagForDeferredAndRegisters() {
     Map<String, String> deferredValuesToSet = ImmutableMap.of("foo", "'bar'");
-    String result = EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
+    String result = EagerReconstructionUtils.buildSetTag(
       deferredValuesToSet,
       interpreter,
       true
@@ -200,7 +200,7 @@ public class EagerReconstructionUtilsTest extends BaseInterpretingTest {
   @Test
   public void itBuildsSetTagForDeferredAndDoesntRegister() {
     Map<String, String> deferredValuesToSet = ImmutableMap.of("foo", "'bar'");
-    String result = EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
+    String result = EagerReconstructionUtils.buildSetTag(
       deferredValuesToSet,
       interpreter,
       false
@@ -212,7 +212,7 @@ public class EagerReconstructionUtilsTest extends BaseInterpretingTest {
   @Test
   public void itBuildsSetTagForMultipleDeferred() {
     Map<String, String> deferredValuesToSet = ImmutableMap.of("foo", "'bar'", "baz", "2");
-    String result = EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
+    String result = EagerReconstructionUtils.buildSetTag(
       deferredValuesToSet,
       interpreter,
       true
@@ -236,12 +236,7 @@ public class EagerReconstructionUtilsTest extends BaseInterpretingTest {
     }
     Map<String, String> deferredValuesToSet = ImmutableMap.of("foo", tooLong.toString());
     assertThatThrownBy(
-        () ->
-          EagerReconstructionUtils.buildSetTagForDeferredInChildContext(
-            deferredValuesToSet,
-            interpreter,
-            true
-          )
+        () -> EagerReconstructionUtils.buildSetTag(deferredValuesToSet, interpreter, true)
       )
       .isInstanceOf(OutputTooBigException.class);
   }


### PR DESCRIPTION
Since the EagerTagDecorator had developed essentially 2 purposes:
- Being an abstract class for the default eager functionality
- Handle reconstruction logic for various components of eager execution

I decided to refactor it to break the static reconstruction methods into a separate class called `EagerReconstructionUtils`.