### PR TITLE
[Eager Execution] Stop processing after reaching max number of deferred tokens

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -30,6 +30,7 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
     ExpressionToken master,
     JinjavaInterpreter interpreter
   ) {
+    interpreter.getContext().checkNumberOfDeferredTokens();
     EagerExecutionResult eagerExecutionResult;
     eagerExecutionResult =
       EagerReconstructionUtils.executeInChildContext(

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
@@ -29,6 +29,7 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
 
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
+    interpreter.getContext().checkNumberOfDeferredTokens();
     try {
       return getTag().interpret(tagNode, interpreter);
     } catch (DeferredValueException | TemplateSyntaxException e) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
@@ -18,6 +18,7 @@ public class EagerIncludeTag extends EagerTagDecorator<IncludeTag> {
 
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
+    interpreter.getContext().checkNumberOfDeferredTokens();
     int numEagerTokensStart = interpreter.getContext().getEagerTokens().size();
     String output = super.interpret(tagNode, interpreter);
     if (interpreter.getContext().getEagerTokens().size() > numEagerTokensStart) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -34,6 +34,7 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
 
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
+    interpreter.getContext().checkNumberOfDeferredTokens();
     try {
       return tag.interpret(tagNode, interpreter);
     } catch (DeferredValueException | TemplateSyntaxException e) {


### PR DESCRIPTION
Stop processing with eager execution after reaching the max number of deferred tokens. I reworked this to be faster so that rather than breaking each time after the processing happens, we'll preemptively start breaking before doing any more eager execution logic.