### PR TITLE
[Eager Execution] Dont reconstruct meta context variables

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -290,6 +290,7 @@ public class EagerReconstructionUtils {
     if (interpreter.getContext().isDeferredExecutionMode()) {
       return ""; // This will be handled outside of the deferred execution mode.
     }
+    Set<String> metaContextVariables = interpreter.getContext().getMetaContextVariables();
     Map<String, String> deferredMap = new HashMap<>();
     deferredWords
       .stream()
@@ -299,6 +300,7 @@ public class EagerReconstructionUtils {
           interpreter.getContext().containsKey(w) &&
           !(interpreter.getContext().get(w) instanceof DeferredValue)
       )
+      .filter(w -> !metaContextVariables.contains(w))
       .forEach(
         w -> {
           Object value = interpreter.getContext().get(w);

--- a/src/test/java/com/hubspot/jinjava/util/EagerReconstructionUtilsTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerReconstructionUtilsTest.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.OutputTooBigException;
@@ -23,6 +24,7 @@ import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.DefaultTokenScannerSymbols;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -312,6 +314,20 @@ public class EagerReconstructionUtilsTest extends BaseInterpretingTest {
     tagNode = getMockTagNode("endfor");
     assertThat(EagerReconstructionUtils.reconstructEnd(tagNode))
       .isEqualTo("{% endfor %}");
+  }
+
+  @Test
+  public void itIgnoresMetaContextVariables() {
+    interpreter
+      .getContext()
+      .put(Context.IMPORT_RESOURCE_ALIAS_KEY, DeferredValue.instance());
+    assertThat(
+        EagerReconstructionUtils.reconstructFromContextBeforeDeferring(
+          Collections.singleton(Context.IMPORT_RESOURCE_ALIAS_KEY),
+          interpreter
+        )
+      )
+      .isEmpty();
   }
 
   private static MacroFunction getMockMacroFunction(String image) {


### PR DESCRIPTION
If a meta context variable is used for some reason, it shouldn't be reconstructed. This is because these variables are ones that are manipulated outside of just the jinja code, for example, `__macros__`. If they were to be deferred, they should be handled separately, rather than being reconstructed through the template code.