### PR TITLE
Throw a template error when attempting to divide by zero

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/DivideFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DivideFilter.java
@@ -74,41 +74,51 @@ public class DivideFilter implements Filter {
     } else {
       return object;
     }
-    if (object instanceof Integer) {
-      return (Integer) object / num.intValue();
-    }
-    if (object instanceof Float) {
-      return (Float) object / num.floatValue();
-    }
-    if (object instanceof Long) {
-      return (Long) object / num.longValue();
-    }
-    if (object instanceof Short) {
-      return (Short) object / num.shortValue();
-    }
-    if (object instanceof Double) {
-      return (Double) object / num.doubleValue();
-    }
-    if (object instanceof BigDecimal) {
-      return ((BigDecimal) object).divide(BigDecimal.valueOf(num.doubleValue()));
-    }
-    if (object instanceof BigInteger) {
-      return ((BigInteger) object).divide(BigInteger.valueOf(num.longValue()));
-    }
-    if (object instanceof Byte) {
-      return (Byte) object / num.byteValue();
-    }
-    if (object instanceof String) {
-      try {
-        return Double.valueOf((String) object) / num.doubleValue();
-      } catch (NumberFormatException e) {
-        throw new InvalidInputException(
-          interpreter,
-          this,
-          InvalidReason.NUMBER_FORMAT,
-          object.toString()
-        );
+    try {
+      if (object instanceof Integer) {
+        return (Integer) object / num.intValue();
       }
+      if (object instanceof Float) {
+        return (Float) object / num.floatValue();
+      }
+      if (object instanceof Long) {
+        return (Long) object / num.longValue();
+      }
+      if (object instanceof Short) {
+        return (Short) object / num.shortValue();
+      }
+      if (object instanceof Double) {
+        return (Double) object / num.doubleValue();
+      }
+      if (object instanceof BigDecimal) {
+        return ((BigDecimal) object).divide(BigDecimal.valueOf(num.doubleValue()));
+      }
+      if (object instanceof BigInteger) {
+        return ((BigInteger) object).divide(BigInteger.valueOf(num.longValue()));
+      }
+      if (object instanceof Byte) {
+        return (Byte) object / num.byteValue();
+      }
+      if (object instanceof String) {
+        try {
+          return Double.valueOf((String) object) / num.doubleValue();
+        } catch (NumberFormatException e) {
+          throw new InvalidInputException(
+            interpreter,
+            this,
+            InvalidReason.NUMBER_FORMAT,
+            object.toString()
+          );
+        }
+      }
+    } catch (ArithmeticException e) {
+      throw new InvalidInputException(
+        interpreter,
+        this,
+        InvalidReason.NON_ZERO_NUMBER,
+        0,
+        num.toString()
+      );
     }
     return object;
   }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DivideFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DivideFilterTest.java
@@ -1,0 +1,50 @@
+package com.hubspot.jinjava.lib.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.google.common.collect.ImmutableMap;
+import com.hubspot.jinjava.BaseJinjavaTest;
+import com.hubspot.jinjava.interpret.FatalTemplateErrorsException;
+import org.junit.Test;
+
+public class DivideFilterTest extends BaseJinjavaTest {
+
+  @Test
+  public void itDivides() {
+    assertThat(
+        jinjava.render(
+          "{{ numerator|divide(denominator) }}",
+          ImmutableMap.of("numerator", 10, "denominator", 2)
+        )
+      )
+      .isEqualTo("5");
+    assertThat(
+        jinjava.render(
+          "{{ numerator // denominator }}",
+          ImmutableMap.of("numerator", 10, "denominator", 2)
+        )
+      )
+      .isEqualTo("5");
+    assertThat(
+        jinjava.render(
+          "{{ numerator / denominator }}",
+          ImmutableMap.of("numerator", 10, "denominator", 2)
+        )
+      )
+      .isEqualTo("5.0");
+  }
+
+  @Test
+  public void itThrowsAnExceptionOnDivideByZero() {
+    assertThatExceptionOfType(FatalTemplateErrorsException.class)
+      .isThrownBy(
+        () -> {
+          jinjava.render(
+            "{{ numerator|divide(denominator) }}",
+            ImmutableMap.of("numerator", 10, "denominator", 0)
+          );
+        }
+      );
+  }
+}


### PR DESCRIPTION
Rather than throwing an uncaught ArithmeticException, this makes Jinjava throw a template error which can be handled like all other Jinjava template errors.