### PR TITLE
Make unixtimestamp behave the same as System.currentTimeMillis()

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -252,7 +252,7 @@ public class Functions {
       return 0;
     }
 
-    return d.toEpochSecond() * 1000 + Math.round(d.getNano() / 1_000_000.0);
+    return d.toEpochSecond() * 1000 + (int) Math.floor(d.getNano() / 1_000_000.0);
   }
 
   @JinjavaDoc(

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -252,7 +252,7 @@ public class Functions {
       return 0;
     }
 
-    return d.toEpochSecond() * 1000 + (int) Math.floor(d.getNano() / 1_000_000.0);
+    return d.toEpochSecond() * 1000 + d.getNano() / 1_000_000;
   }
 
   @JinjavaDoc(


### PR DESCRIPTION
We are using Math.round() to determine the number of milliseconds to add to the epoch second in `unixtimestamp`, but System.currentTimeMillis() uses floor division, not rounding. This can lead to rare instances where the value of `unixtimestamp()` is greater than the value of `System.currentTimeMillis()`.

By removing the rounding and just using integer division, we should avoid that situation.