### PR TITLE
[Eager Execution] Revert non-deferred values as well if context reverting is enabled

### DIFF
--- a/src/test/resources/eager/doesnt-double-append-in-deferred-if-tag.expected.jinja
+++ b/src/test/resources/eager/doesnt-double-append-in-deferred-if-tag.expected.jinja
@@ -1,5 +1,8 @@
 {% set foo = [0, 1] %}{% if deferred == true %}
 [0, 1]
 {% set foo = [0, 1, 2] %}
+{% else %}
+[0, 1]
+{% set foo = [0, 1, 3] %}
 {% endif %}
 {{ foo }}

--- a/src/test/resources/eager/doesnt-double-append-in-deferred-if-tag.jinja
+++ b/src/test/resources/eager/doesnt-double-append-in-deferred-if-tag.jinja
@@ -2,5 +2,8 @@
 {% if deferred == foo.append(1) %}
 {{ foo }}
 {% do foo.append(2) %}
+{% else %}
+{{ foo }}
+{% do foo.append(3) %}
 {% endif %}
 {{ foo }}


### PR DESCRIPTION
Otherwise throw a DeferredValueException.
This better handles reverting the values to what they were before the if statement so that the later branches will have the original values. This can only be done when eager context reverting is enabled so that we have the original values to revert to. If not we will throw a DeferredValueException because we can't get back to where we were before.

Whereas previously, this only handled values that were changed via `{% set %}`, this also handles values that are changed via update with something like `{% do x.append %}`