### PR TITLE
[Eager Execution] Use new DeferredMacroValueImpl when reconstructing macro functions

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/DeferredMacroValueImpl.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/DeferredMacroValueImpl.java
@@ -1,0 +1,16 @@
+package com.hubspot.jinjava.interpret;
+
+public class DeferredMacroValueImpl implements DeferredValue {
+  private static final DeferredValue INSTANCE = new DeferredMacroValueImpl();
+
+  private DeferredMacroValueImpl() {}
+
+  @Override
+  public Object getOriginalValue() {
+    return null;
+  }
+
+  public static DeferredValue instance() {
+    return INSTANCE;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -1,7 +1,7 @@
 package com.hubspot.jinjava.lib.expression;
 
 import com.hubspot.jinjava.JinjavaConfig;
-import com.hubspot.jinjava.interpret.DeferredValue;
+import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.filter.EscapeFilter;
 import com.hubspot.jinjava.lib.tag.RawTag;
@@ -102,7 +102,8 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
             .getDeferredWords()
             .stream()
             .filter(
-              word -> !(interpreter.getContext().get(word) instanceof DeferredValue)
+              word ->
+                !(interpreter.getContext().get(word) instanceof DeferredMacroValueImpl)
             )
             .collect(Collectors.toSet())
         )

--- a/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.el.ext.AbstractCallableMethod;
 import com.hubspot.jinjava.el.ext.AstMacroFunction;
 import com.hubspot.jinjava.interpret.Context;
-import com.hubspot.jinjava.interpret.DeferredValue;
+import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
@@ -146,7 +146,7 @@ public class EagerMacroFunction extends AbstractCallableMethod {
           macroFunction
             .getArguments()
             .stream()
-            .map(arg -> DeferredValue.instance())
+            .map(arg -> DeferredMacroValueImpl.instance())
             .toArray()
         );
         result = (getStartTag(interpreter) + evaluation + getEndTag(interpreter));

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InterpretException;
@@ -161,7 +162,8 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
             .getDeferredWords()
             .stream()
             .filter(
-              word -> !(interpreter.getContext().get(word) instanceof DeferredValue)
+              word ->
+                !(interpreter.getContext().get(word) instanceof DeferredMacroValueImpl)
             )
             .collect(Collectors.toSet()),
           new HashSet<>(loopVars)

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
@@ -1,6 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
-import com.hubspot.jinjava.interpret.DeferredValue;
+import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.SetTag;
@@ -101,7 +101,8 @@ public class EagerInlineSetTagStrategy extends EagerSetTagStrategy {
             .getDeferredWords()
             .stream()
             .filter(
-              word -> !(interpreter.getContext().get(word) instanceof DeferredValue)
+              word ->
+                !(interpreter.getContext().get(word) instanceof DeferredMacroValueImpl)
             )
             .collect(Collectors.toSet()),
           Arrays.stream(variables).map(String::trim).collect(Collectors.toSet())

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
@@ -1,6 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
-import com.hubspot.jinjava.interpret.DeferredValue;
+import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.tag.PrintTag;
@@ -110,7 +110,8 @@ public class EagerPrintTag extends EagerStateChangingTag<PrintTag> {
             .getDeferredWords()
             .stream()
             .filter(
-              word -> !(interpreter.getContext().get(word) instanceof DeferredValue)
+              word ->
+                !(interpreter.getContext().get(word) instanceof DeferredMacroValueImpl)
             )
             .collect(Collectors.toSet())
         )

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -490,7 +490,7 @@ public class EagerTest {
           .flatMap(eagerToken -> eagerToken.getUsedDeferredWords().stream())
           .collect(Collectors.toSet())
       )
-      .isEmpty();
+      .contains("deferred");
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
@@ -60,7 +60,7 @@ public class EagerForTagTest extends ForTagTest {
     assertThat(maybeEagerToken).isPresent();
     assertThat(maybeEagerToken.get().getSetDeferredWords())
       .containsExactlyInAnyOrder("item");
-    assertThat(maybeEagerToken.get().getUsedDeferredWords()).isEmpty();
+    assertThat(maybeEagerToken.get().getUsedDeferredWords()).contains("deferred");
   }
 
   @Test
@@ -75,7 +75,7 @@ public class EagerForTagTest extends ForTagTest {
     assertThat(maybeEagerToken).isPresent();
     assertThat(maybeEagerToken.get().getSetDeferredWords())
       .containsExactlyInAnyOrder("item", "item2");
-    assertThat(maybeEagerToken.get().getUsedDeferredWords()).isEmpty();
+    assertThat(maybeEagerToken.get().getUsedDeferredWords()).contains("deferred");
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTagTest.java
@@ -84,7 +84,7 @@ public class EagerIncludeTagTest extends IncludeTagTest {
           .flatMap(eagerToken -> eagerToken.getUsedDeferredWords().stream())
           .collect(Collectors.toSet())
       )
-      .isEmpty();
+      .containsExactlyInAnyOrder("foo", "deferred");
     assertThat(
         context
           .getEagerTokens()

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagTest.java
@@ -76,7 +76,7 @@ public class EagerSetTagTest extends SetTagTest {
     assertThat(maybeEagerToken.get().getSetDeferredWords())
       .containsExactlyInAnyOrder("foo");
     assertThat(maybeEagerToken.get().getUsedDeferredWords())
-      .containsExactlyInAnyOrder("range");
+      .containsExactlyInAnyOrder("deferred", "range");
   }
 
   @Test
@@ -94,7 +94,7 @@ public class EagerSetTagTest extends SetTagTest {
     assertThat(maybeEagerToken.get().getSetDeferredWords())
       .containsExactlyInAnyOrder("foo", "foobar");
     assertThat(maybeEagerToken.get().getUsedDeferredWords())
-      .containsExactlyInAnyOrder("range");
+      .containsExactlyInAnyOrder("deferred", "range");
   }
 
   @Test
@@ -131,7 +131,7 @@ public class EagerSetTagTest extends SetTagTest {
           .flatMap(eagerToken -> eagerToken.getUsedDeferredWords().stream())
           .collect(Collectors.toSet())
       )
-      .isEmpty();
+      .containsExactlyInAnyOrder("foo", "deferred");
   }
 
   @Test
@@ -158,7 +158,7 @@ public class EagerSetTagTest extends SetTagTest {
           .flatMap(eagerToken -> eagerToken.getUsedDeferredWords().stream())
           .collect(Collectors.toSet())
       )
-      .containsExactly("add.filter");
+      .containsExactlyInAnyOrder("deferred", "foo", "add.filter");
   }
 
   @Test
@@ -210,7 +210,7 @@ public class EagerSetTagTest extends SetTagTest {
           .flatMap(eagerToken -> eagerToken.getUsedDeferredWords().stream())
           .collect(Collectors.toSet())
       )
-      .containsExactlyInAnyOrder("add.filter");
+      .containsExactlyInAnyOrder("deferred", "foo", "add.filter");
     context.remove("foo");
     context.put("deferred", 2);
     context.setDeferredExecutionMode(false);


### PR DESCRIPTION
In https://github.com/HubSpot/jinjava/pull/689, I changed how `usedDeferredWords` were calculated, and made it so that any word that was already deferred would not be included in this set. This is suboptimal because it is good to know that the words were used even if they've already been deferred. Since the use-case for adding this check was to deal with the artificially deferred values when deferring macro functions and preventing name clashing resulting in variables getting deferred that didn't need to be, I am instead adding a new class `DeferredMacroValueImpl` which will only be used when providing the placeholders for macro functions. This allows us to bring back the older functionality where `usedDeferredWords` worked better.