### PR TITLE
Track Current Processed Node In The Context

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -735,7 +735,7 @@ public class Context extends ScopeMap<String, Object> {
   }
 
   public Node getCurrentNode() {
-    return this.currentNode;
+    return currentNode;
   }
 
   public void setCurrentNode(final Node currentNode) {

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -111,6 +111,7 @@ public class Context extends ScopeMap<String, Object> {
   private boolean unwrapRawOverride = false;
   private DynamicVariableResolver dynamicVariableResolver = null;
   private final Set<String> metaContextVariables; // These variable names aren't tracked in eager execution
+  private Node currentProcessedNode;
 
   public Context() {
     this(null, null, null, true);
@@ -731,5 +732,13 @@ public class Context extends ScopeMap<String, Object> {
     public void close() {
       resetValueConsumer.accept(previousValue);
     }
+  }
+
+  public Node getCurrentProcessedNode() {
+    return this.currentProcessedNode;
+  }
+
+  public void setCurrentProcessedNode(final Node currentProcessedNode) {
+    this.currentProcessedNode = currentProcessedNode;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -111,7 +111,7 @@ public class Context extends ScopeMap<String, Object> {
   private boolean unwrapRawOverride = false;
   private DynamicVariableResolver dynamicVariableResolver = null;
   private final Set<String> metaContextVariables; // These variable names aren't tracked in eager execution
-  private Node currentProcessedNode;
+  private Node currentNode;
 
   public Context() {
     this(null, null, null, true);
@@ -734,11 +734,11 @@ public class Context extends ScopeMap<String, Object> {
     }
   }
 
-  public Node getCurrentProcessedNode() {
-    return this.currentProcessedNode;
+  public Node getCurrentNode() {
+    return this.currentNode;
   }
 
-  public void setCurrentProcessedNode(final Node currentProcessedNode) {
-    this.currentProcessedNode = currentProcessedNode;
+  public void setCurrentNode(final Node currentNode) {
+    this.currentNode = currentNode;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -43,7 +43,7 @@ public class ExpressionNode extends Node {
 
   @Override
   public OutputNode render(JinjavaInterpreter interpreter) {
-    interpreter.getContext().setCurrentProcessedNode(this);
+    interpreter.getContext().setCurrentNode(this);
     try {
       return expressionStrategy.interpretOutput(master, interpreter);
     } catch (DeferredValueException e) {

--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -43,6 +43,7 @@ public class ExpressionNode extends Node {
 
   @Override
   public OutputNode render(JinjavaInterpreter interpreter) {
+    interpreter.getContext().setCurrentProcessedNode(this);
     try {
       return expressionStrategy.interpretOutput(master, interpreter);
     } catch (DeferredValueException e) {

--- a/src/main/java/com/hubspot/jinjava/tree/TagNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TagNode.java
@@ -44,7 +44,7 @@ public class TagNode extends Node {
 
   @Override
   public OutputNode render(JinjavaInterpreter interpreter) {
-    interpreter.getContext().setCurrentProcessedNode(this);
+    interpreter.getContext().setCurrentNode(this);
     if (
       interpreter.getContext().isValidationMode() && !tag.isRenderedInValidationMode()
     ) {

--- a/src/main/java/com/hubspot/jinjava/tree/TagNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TagNode.java
@@ -44,6 +44,7 @@ public class TagNode extends Node {
 
   @Override
   public OutputNode render(JinjavaInterpreter interpreter) {
+    interpreter.getContext().setCurrentProcessedNode(this);
     if (
       interpreter.getContext().isValidationMode() && !tag.isRenderedInValidationMode()
     ) {

--- a/src/main/java/com/hubspot/jinjava/tree/TextNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TextNode.java
@@ -32,7 +32,7 @@ public class TextNode extends Node {
 
   @Override
   public OutputNode render(JinjavaInterpreter interpreter) {
-    interpreter.getContext().setCurrentProcessedNode(this);
+    interpreter.getContext().setCurrentNode(this);
     return new RenderedOutputNode(
       interpreter.getContext().isValidationMode() ? "" : master.output()
     );

--- a/src/main/java/com/hubspot/jinjava/tree/TextNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TextNode.java
@@ -32,6 +32,7 @@ public class TextNode extends Node {
 
   @Override
   public OutputNode render(JinjavaInterpreter interpreter) {
+    interpreter.getContext().setCurrentProcessedNode(this);
     return new RenderedOutputNode(
       interpreter.getContext().isValidationMode() ? "" : master.output()
     );


### PR DESCRIPTION
Hi there,

I'd like to provide more detail when an exception is fired as a result of processing a macro block. The use case is something like the following:

I have a main template file that has the following snippet:
```
     {% import 'com/<companyName>/macros/translate.jinja' as macro %}

     {{macro.translateWord("hello", "de")}}  
     {{macro.translateWord("world", "es")}}
```

the macro has something like the following:
```
{%- macro translateWord(word, languageIso) %}
       {% set supportedIsoLanguages = ["en", "de", "fr"] %}
       {{ assert:contains(languageIso, supportedIsoLanguages) }}
       {{ util:translateString(word, languageIso) }}
{% endmacro -%}
```

So the first item renders as expected...in the second case it fails because it is not a supported language because of the `assert:contains`...however the error I’d like to report back is something like the following:

```
Expression `{{macro.translateWord("world", "es")}}` found at line 4 
failed because of expression `{{ assert:contains(languageIso, supportedLanguages) }}` at line 2.
```

I can get the current line via the interpreter (that would give me line 2 of the macro function) but I’d like to include more detail namely the original expression that dispatched to the macro function if at all possible. This is particularly useful if `macro.translateWord` is initiated often for example.