### PR TITLE
Only add originating message if it is different from the default message

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -190,13 +190,13 @@ public class ExpressionResolver {
         final String combinedMessage = String.format(
           "%s%nOriginating Exception:%n%s",
           e.getMessage(),
-          getRootCauseMessage(e)
+          originatingException
         );
         interpreter.addError(
           TemplateError.fromException(
             new TemplateSyntaxException(
               expression,
-              StringUtils.equals(e.getMessage(), originatingException)
+              StringUtils.endsWith(originatingException, e.getMessage())
                 ? e.getMessage()
                 : combinedMessage,
               interpreter.getLineNumber(),

--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -186,7 +186,8 @@ public class ExpressionResolver {
           )
         );
       } else {
-        final String exceptionMessage = String.format(
+        String originatingException = getRootCauseMessage(e);
+        final String combinedMessage = String.format(
           "%s%nOriginating Exception:%n%s",
           e.getMessage(),
           getRootCauseMessage(e)
@@ -194,8 +195,10 @@ public class ExpressionResolver {
         interpreter.addError(
           TemplateError.fromException(
             new TemplateSyntaxException(
-              exceptionMessage,
-              e.getMessage(),
+              expression,
+              StringUtils.equals(e.getMessage(), originatingException)
+                ? e.getMessage()
+                : combinedMessage,
               interpreter.getLineNumber(),
               e
             )


### PR DESCRIPTION
Avoids having a redundant message if there is no originating exception.
Something like this is redundant
```
'Unexpected '=' operator (use {% set %} tag for variable assignment)
Originating Exception:
ELException: Unexpected '=' operator (use {% set %} tag for variable assignment)'
```

Also fixes the exception construction to use `expression` for the `code` parameter rather than the message.