### PR TITLE
Add Base 64 encode and decode filters

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -196,7 +196,10 @@ public class ExpressionResolver {
           TemplateError.fromException(
             new TemplateSyntaxException(
               expression,
-              StringUtils.endsWith(originatingException, e.getMessage())
+              (
+                  e.getCause() == null ||
+                  StringUtils.endsWith(originatingException, e.getCause().getMessage())
+                )
                 ? e.getMessage()
                 : combinedMessage,
               interpreter.getLineNumber(),

--- a/src/main/java/com/hubspot/jinjava/lib/filter/Base64DecodeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/Base64DecodeFilter.java
@@ -1,0 +1,43 @@
+package com.hubspot.jinjava.lib.filter;
+
+import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
+import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import java.nio.charset.Charset;
+import java.util.Base64;
+
+@JinjavaDoc(
+  value = "Decode a base 64 input into a string.",
+  input = @JinjavaParam(
+    value = "input",
+    type = "string",
+    desc = "The base 64 input to decode.",
+    required = true
+  ),
+  params = {
+    @JinjavaParam(
+      value = "encoding",
+      type = "string",
+      desc = "The string encoding charset to use.",
+      defaultValue = "UTF-8"
+    )
+  },
+  snippets = {
+    @JinjavaSnippet(code = "{% set my_number = -53 %}\n" + "{{ my_number|abs }}")
+  }
+)
+public class Base64DecodeFilter implements Filter {
+  public static final String NAME = "b64decode";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+    Charset charset = Base64EncodeFilter.checkCharset(interpreter, this, args);
+    return new String(Base64.getDecoder().decode((var.toString()).getBytes()), charset);
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/lib/filter/Base64DecodeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/Base64DecodeFilter.java
@@ -3,8 +3,11 @@ package com.hubspot.jinjava.lib.filter;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
+import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 @JinjavaDoc(
@@ -37,7 +40,13 @@ public class Base64DecodeFilter implements Filter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+    if (!(var instanceof String)) {
+      throw new InvalidArgumentException(interpreter, this, InvalidReason.STRING, 0, var);
+    }
     Charset charset = Base64EncodeFilter.checkCharset(interpreter, this, args);
-    return new String(Base64.getDecoder().decode((var.toString()).getBytes()), charset);
+    return new String(
+      Base64.getDecoder().decode((var.toString()).getBytes(StandardCharsets.US_ASCII)),
+      charset
+    );
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/Base64EncodeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/Base64EncodeFilter.java
@@ -1,0 +1,91 @@
+package com.hubspot.jinjava.lib.filter;
+
+import com.google.common.base.Joiner;
+import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
+import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
+import com.hubspot.jinjava.interpret.InvalidReason;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.lib.Importable;
+import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
+import java.util.Base64;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.net.util.Charsets;
+
+@JinjavaDoc(
+  value = "Encode the string input into base 64.",
+  input = @JinjavaParam(
+    value = "input",
+    type = "string",
+    desc = "The string input to encode into base 64.",
+    required = true
+  ),
+  params = {
+    @JinjavaParam(
+      value = "encoding",
+      type = "string",
+      desc = "The string encoding charset to use.",
+      defaultValue = "UTF-8"
+    )
+  },
+  snippets = {
+    @JinjavaSnippet(code = "{% set my_number = -53 %}\n" + "{{ my_number|abs }}")
+  }
+)
+public class Base64EncodeFilter implements Filter {
+  public static final String NAME = "b64encode";
+  public static final String AVAILABLE_CHARSETS = Joiner
+    .on(", ")
+    .join(
+      StandardCharsets.US_ASCII.name(),
+      StandardCharsets.ISO_8859_1.name(),
+      StandardCharsets.UTF_8.name(),
+      StandardCharsets.UTF_16BE.name(),
+      StandardCharsets.UTF_16LE.name(),
+      StandardCharsets.UTF_16.name()
+    );
+
+  static Charset checkCharset(
+    JinjavaInterpreter interpreter,
+    Importable filter,
+    String... args
+  ) {
+    Charset charset = StandardCharsets.UTF_8;
+    if (args.length > 0) {
+      try {
+        charset = Charsets.toCharset(StringUtils.upperCase(args[0]));
+      } catch (UnsupportedCharsetException e) {
+        throw new InvalidArgumentException(
+          interpreter,
+          filter,
+          InvalidReason.ENUM,
+          1,
+          args[0],
+          AVAILABLE_CHARSETS
+        );
+      }
+    }
+    return charset;
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+    Charset charset = Base64EncodeFilter.checkCharset(interpreter, this, args);
+    byte[] bytes;
+    if (var instanceof byte[]) {
+      bytes = (byte[]) var;
+    } else {
+      bytes = PyishObjectMapper.getAsUnquotedPyishString(var).getBytes(charset);
+    }
+    return Base64.getEncoder().encodeToString(bytes);
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FilterLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FilterLibrary.java
@@ -112,7 +112,9 @@ public class FilterLibrary extends SimpleLibrary<Filter> {
       FromJsonFilter.class,
       ToYamlFilter.class,
       FromYamlFilter.class,
-      RenderFilter.class
+      RenderFilter.class,
+      Base64EncodeFilter.class,
+      Base64DecodeFilter.class
     );
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/Base64FilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/Base64FilterTest.java
@@ -1,0 +1,60 @@
+package com.hubspot.jinjava.lib.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hubspot.jinjava.BaseJinjavaTest;
+import java.util.Collections;
+import org.junit.Test;
+
+public class Base64FilterTest extends BaseJinjavaTest {
+
+  @Test
+  public void itEncodesWithDefaultCharset() {
+    assertThat(jinjava.render("{{ 'ß'|b64encode }}", Collections.emptyMap()))
+      .isEqualTo("w58=");
+  }
+
+  @Test
+  public void itEncodesWithUtf16Le() {
+    assertThat(
+        jinjava.render("{{ 'ß'|b64encode(encoding='utf-16le') }}", Collections.emptyMap())
+      )
+      .isEqualTo("3wA=");
+  }
+
+  @Test
+  public void itDecodesWithUtf16Le() {
+    assertThat(
+        jinjava.render(
+          "{{ '3wA='|b64decode(encoding='utf-16le') }}",
+          Collections.emptyMap()
+        )
+      )
+      .isEqualTo("ß");
+  }
+
+  @Test
+  public void itEncodesAndDecodesDefaultCharset() {
+    assertThat(
+        jinjava.render("{{ 123456789|b64encode|b64decode }}", Collections.emptyMap())
+      )
+      .isEqualTo("123456789");
+  }
+
+  @Test
+  public void itEncodesAndDecodesUtf16Le() {
+    assertThat(
+        jinjava.render(
+          "{{ 123456789|b64encode(encoding='utf-16le')|b64decode(encoding='utf-16le') }}",
+          Collections.emptyMap()
+        )
+      )
+      .isEqualTo("123456789");
+  }
+
+  @Test
+  public void itEncodesObject() {
+    assertThat(jinjava.render("{{ {'foo': ['bar']}|b64encode }}", Collections.emptyMap()))
+      .isEqualTo("eydmb28nOiBbJ2JhciddfQ==");
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/lib/filter/Base64FilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/Base64FilterTest.java
@@ -3,6 +3,9 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hubspot.jinjava.BaseJinjavaTest;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
+import com.hubspot.jinjava.interpret.RenderResult;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import java.util.Collections;
 import org.junit.Test;
 
@@ -56,5 +59,27 @@ public class Base64FilterTest extends BaseJinjavaTest {
   public void itEncodesObject() {
     assertThat(jinjava.render("{{ {'foo': ['bar']}|b64encode }}", Collections.emptyMap()))
       .isEqualTo("eydmb28nOiBbJ2JhciddfQ==");
+  }
+
+  @Test
+  public void itHandlesInvalidDecode() {
+    RenderResult renderResult = jinjava.renderForResult(
+      "{{ 'ß'|b64decode }}",
+      Collections.emptyMap()
+    );
+    assertThat(renderResult.getErrors()).hasSize(1);
+    assertThat(renderResult.getErrors().get(0).getException())
+      .isInstanceOf(TemplateSyntaxException.class);
+  }
+
+  @Test
+  public void itThrowsErrorForNonStringDecode() {
+    RenderResult renderResult = jinjava.renderForResult(
+      "{{ 123|b64decode }}",
+      Collections.emptyMap()
+    );
+    assertThat(renderResult.getErrors()).hasSize(1);
+    assertThat(renderResult.getErrors().get(0).getException())
+      .isInstanceOf(InvalidArgumentException.class);
   }
 }


### PR DESCRIPTION
Adds 2 new filters:

- `b64encode`
- `b64decode`

Each of them default to using UTF-8, but you can specify the charset as one of:
```
US_ASCII
ISO_8859_1
UTF_8
UTF_16BE
UTF_16LE
UTF_16
```
(If running on a machine that supports more charsets, you can use one of those too).
These filters are both supported in ansible

For https://github.com/HubSpot/jinjava/issues/743