### PR TITLE
Use number operations for multiply and divide filters

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/DivideFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DivideFilter.java
@@ -20,13 +20,11 @@ import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.el.TruthyTypeConverter;
 import com.hubspot.jinjava.interpret.InvalidArgumentException;
-import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import de.odysseus.el.misc.NumberOperations;
 import java.math.BigDecimal;
-import java.math.BigInteger;
 
 @JinjavaDoc(
   value = "Divides the current value by a divisor",

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DivideFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DivideFilter.java
@@ -18,11 +18,13 @@ package com.hubspot.jinjava.lib.filter;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.el.TruthyTypeConverter;
 import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
+import de.odysseus.el.misc.NumberOperations;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
@@ -47,6 +49,7 @@ import java.math.BigInteger;
   }
 )
 public class DivideFilter implements Filter {
+  private static final TruthyTypeConverter TYPE_CONVERTER = new TruthyTypeConverter();
 
   @Override
   public Object filter(Object object, JinjavaInterpreter interpreter, String... arg) {
@@ -74,53 +77,8 @@ public class DivideFilter implements Filter {
     } else {
       return object;
     }
-    try {
-      if (object instanceof Integer) {
-        return (Integer) object / num.intValue();
-      }
-      if (object instanceof Float) {
-        return (Float) object / num.floatValue();
-      }
-      if (object instanceof Long) {
-        return (Long) object / num.longValue();
-      }
-      if (object instanceof Short) {
-        return (Short) object / num.shortValue();
-      }
-      if (object instanceof Double) {
-        return (Double) object / num.doubleValue();
-      }
-      if (object instanceof BigDecimal) {
-        return ((BigDecimal) object).divide(BigDecimal.valueOf(num.doubleValue()));
-      }
-      if (object instanceof BigInteger) {
-        return ((BigInteger) object).divide(BigInteger.valueOf(num.longValue()));
-      }
-      if (object instanceof Byte) {
-        return (Byte) object / num.byteValue();
-      }
-      if (object instanceof String) {
-        try {
-          return Double.valueOf((String) object) / num.doubleValue();
-        } catch (NumberFormatException e) {
-          throw new InvalidInputException(
-            interpreter,
-            this,
-            InvalidReason.NUMBER_FORMAT,
-            object.toString()
-          );
-        }
-      }
-    } catch (ArithmeticException e) {
-      throw new InvalidInputException(
-        interpreter,
-        this,
-        InvalidReason.NON_ZERO_NUMBER,
-        0,
-        num.toString()
-      );
-    }
-    return object;
+
+    return NumberOperations.div(TYPE_CONVERTER, object, num);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/MultiplyFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/MultiplyFilter.java
@@ -18,11 +18,13 @@ package com.hubspot.jinjava.lib.filter;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.el.TruthyTypeConverter;
 import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
+import de.odysseus.el.misc.NumberOperations;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
@@ -45,6 +47,7 @@ import java.math.BigInteger;
   snippets = { @JinjavaSnippet(code = "{% set n = 20 %}\n" + "{{ n|multiply(3) }}") }
 )
 public class MultiplyFilter implements Filter {
+  private static final TruthyTypeConverter TYPE_CONVERTER = new TruthyTypeConverter();
 
   @Override
   public Object filter(Object object, JinjavaInterpreter interpreter, String... arg) {
@@ -69,43 +72,7 @@ public class MultiplyFilter implements Filter {
       );
     }
 
-    if (object instanceof Integer) {
-      return num.intValue() * (Integer) object;
-    }
-    if (object instanceof Float) {
-      return 0D + num.floatValue() * (Float) object;
-    }
-    if (object instanceof Long) {
-      return num.longValue() * (Long) object;
-    }
-    if (object instanceof Short) {
-      return num.shortValue() * (Short) object;
-    }
-    if (object instanceof Double) {
-      return num.doubleValue() * (Double) object;
-    }
-    if (object instanceof BigDecimal) {
-      return ((BigDecimal) object).multiply(BigDecimal.valueOf(num.doubleValue()));
-    }
-    if (object instanceof BigInteger) {
-      return ((BigInteger) object).multiply(BigInteger.valueOf(num.longValue()));
-    }
-    if (object instanceof Byte) {
-      return num.byteValue() * (Byte) object;
-    }
-    if (object instanceof String) {
-      try {
-        return num.doubleValue() * Double.parseDouble((String) object);
-      } catch (NumberFormatException e) {
-        throw new InvalidInputException(
-          interpreter,
-          this,
-          InvalidReason.NUMBER_FORMAT,
-          object.toString()
-        );
-      }
-    }
-    return object;
+    return NumberOperations.mul(TYPE_CONVERTER, object, num);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/MultiplyFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/MultiplyFilter.java
@@ -20,13 +20,11 @@ import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.el.TruthyTypeConverter;
 import com.hubspot.jinjava.interpret.InvalidArgumentException;
-import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import de.odysseus.el.misc.NumberOperations;
 import java.math.BigDecimal;
-import java.math.BigInteger;
 
 @JinjavaDoc(
   value = "Multiplies the current object with the given multiplier",

--- a/src/test/java/com/hubspot/jinjava/lib/filter/MultiplyFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/MultiplyFilterTest.java
@@ -1,0 +1,33 @@
+package com.hubspot.jinjava.lib.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.hubspot.jinjava.BaseJinjavaTest;
+import com.hubspot.jinjava.interpret.RenderResult;
+import java.util.Map;
+import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MultiplyFilterTest extends BaseJinjavaTest {
+
+  @Before
+  public void setup() {
+    jinjava.getGlobalContext().registerClasses(MultiplyFilter.class);
+  }
+
+  @Test
+  public void itMultipliesDecimalNumbers() {
+    Map<String, Object> vars = ImmutableMap.of("test", 10);
+    RenderResult renderResult = jinjava.renderForResult("{{ test|multiply(.25) }}", vars);
+    assertThat(renderResult.getOutput()).isEqualTo("2.50");
+  }
+
+  @Test
+  public void itCoercesStringsToNumbers() {
+    Map<String, Object> vars = ImmutableMap.of("test", "10");
+    RenderResult renderResult = jinjava.renderForResult("{{ test|multiply(.25) }}", vars);
+    assertThat(renderResult.getOutput()).isEqualTo("2.50");
+  }
+}


### PR DESCRIPTION
There are differences between the in-built `*` and `/` operations and the `multiply` and `divide` filters. This unifies the behavior by reusing the `*/` operation methods to reduce confusion and simplify the code base.