### PR TITLE
[Eager Execution] Support deferring meta variables

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.collect.Sets;
 import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
@@ -17,6 +18,7 @@ import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -147,7 +149,13 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
       eagerExpressionResult.getDeferredWords(),
       interpreter
     );
-
+    Set<String> metaLoopVars = Sets
+      .intersection(
+        interpreter.getContext().getMetaContextVariables(),
+        Sets.newHashSet(loopVars)
+      )
+      .immutableCopy();
+    interpreter.getContext().getMetaContextVariables().removeAll(metaLoopVars);
     interpreter
       .getContext()
       .handleEagerToken(

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.collect.Sets;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.SetTag;
 import com.hubspot.jinjava.tree.TagNode;
@@ -7,6 +8,7 @@ import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Triple;
@@ -34,6 +36,14 @@ public abstract class EagerSetTagStrategy {
       variables = new String[] { var };
       expression = tagNode.getHelpers();
     }
+
+    Set<String> metaLoopVars = Sets
+      .intersection(
+        interpreter.getContext().getMetaContextVariables(),
+        Arrays.stream(variables).map(String::trim).collect(Collectors.toSet())
+      )
+      .immutableCopy();
+    interpreter.getContext().getMetaContextVariables().removeAll(metaLoopVars);
 
     EagerExecutionResult eagerExecutionResult = getEagerExecutionResult(
       tagNode,

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -936,4 +936,13 @@ public class EagerTest {
       "handles-import-in-deferred-if"
     );
   }
+
+  @Test
+  public void itAllowsMetaContextVarOverriding() {
+    interpreter.getContext().getMetaContextVariables().add("meta");
+    interpreter.getContext().put("meta", "META");
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "allows-meta-context-var-overriding"
+    );
+  }
 }

--- a/src/test/resources/eager/allows-meta-context-var-overriding.expected.jinja
+++ b/src/test/resources/eager/allows-meta-context-var-overriding.expected.jinja
@@ -1,0 +1,9 @@
+0
+META
+{% for meta in deferred %}
+{{ meta }}{% endfor %}
+{{ meta }}
+{% set meta = [] %}{% if deferred %}
+{% set meta = [1] %}
+{% endif %}
+{{ meta }}

--- a/src/test/resources/eager/allows-meta-context-var-overriding.jinja
+++ b/src/test/resources/eager/allows-meta-context-var-overriding.jinja
@@ -1,0 +1,13 @@
+{% for meta in [0] %}
+{{ meta }}
+{%- endfor %}
+{{ meta }}
+{% for meta in deferred %}
+{{ meta }}
+{%- endfor %}
+{{ meta }}
+{%- set meta = [] %}
+{% if deferred %}
+{% do meta.append(1) %}
+{% endif %}
+{{ meta }}


### PR DESCRIPTION
If meta context variables are overwritten, they should be deferrable.
For example, in HubL we add `content` to the meta context variables because it is something whose value is set outside of the template. However, if someone wants to name a variable `content`, they can do that and we would then treat it normally (so remove it from the `metaContextVariables` set).