### PR TITLE
[Eager Execution] Check number of deferred tokens at the beginning of TagNode

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
@@ -32,7 +32,6 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
 
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
-    interpreter.getContext().checkNumberOfDeferredTokens();
     try {
       return getTag().interpret(tagNode, interpreter);
     } catch (DeferredValueException | TemplateSyntaxException e) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
@@ -18,7 +18,6 @@ public class EagerIncludeTag extends EagerTagDecorator<IncludeTag> {
 
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
-    interpreter.getContext().checkNumberOfDeferredTokens();
     int numEagerTokensStart = interpreter.getContext().getEagerTokens().size();
     String output = super.interpret(tagNode, interpreter);
     if (interpreter.getContext().getEagerTokens().size() > numEagerTokensStart) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -34,7 +34,6 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
 
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
-    interpreter.getContext().checkNumberOfDeferredTokens();
     try {
       return tag.interpret(tagNode, interpreter);
     } catch (DeferredValueException | TemplateSyntaxException e) {

--- a/src/main/java/com/hubspot/jinjava/tree/TagNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TagNode.java
@@ -52,6 +52,9 @@ public class TagNode extends Node {
     }
 
     try {
+      if (interpreter.getConfig().getExecutionMode().useEagerParser()) {
+        interpreter.getContext().checkNumberOfDeferredTokens();
+      }
       return tag.interpretOutput(this, interpreter);
     } catch (DeferredValueException e) {
       interpreter.getContext().handleDeferredNode(this);


### PR DESCRIPTION
This improves the erroring-out when there are too many deferred tokens. Since there may be eager tag implementations that override `interpret`, this will make it so the check runs before any tag is rendered when using eager execution.