### PR TITLE
Adjust divide/multiply for backwards compatability

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/DivideFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DivideFilter.java
@@ -67,20 +67,16 @@ public class DivideFilter implements AdvancedFilter {
     Object toMul = args[0];
     Number num;
     if (toMul != null) {
-      if (toMul instanceof Number) {
-        num = (Number) toMul;
-      } else {
-        try {
-          num = new BigDecimal(toMul.toString());
-        } catch (NumberFormatException e) {
-          throw new InvalidArgumentException(
-            interpreter,
-            this,
-            InvalidReason.NUMBER_FORMAT,
-            0,
-            toMul
-          );
-        }
+      try {
+        num = new BigDecimal(toMul.toString());
+      } catch (NumberFormatException e) {
+        throw new InvalidArgumentException(
+          interpreter,
+          this,
+          InvalidReason.NUMBER_FORMAT,
+          0,
+          toMul
+        );
       }
     } else {
       return var;

--- a/src/main/java/com/hubspot/jinjava/lib/filter/MultiplyFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/MultiplyFilter.java
@@ -65,20 +65,16 @@ public class MultiplyFilter implements AdvancedFilter {
     Object toMul = args[0];
     Number num;
     if (toMul != null) {
-      if (toMul instanceof Number) {
-        num = (Number) toMul;
-      } else {
-        try {
-          num = new BigDecimal(toMul.toString());
-        } catch (NumberFormatException e) {
-          throw new InvalidArgumentException(
-            interpreter,
-            this,
-            InvalidReason.NUMBER_FORMAT,
-            0,
-            toMul
-          );
-        }
+      try {
+        num = new BigDecimal(toMul.toString());
+      } catch (NumberFormatException e) {
+        throw new InvalidArgumentException(
+          interpreter,
+          this,
+          InvalidReason.NUMBER_FORMAT,
+          0,
+          toMul
+        );
       }
     } else {
       return var;

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DivideFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DivideFilterTest.java
@@ -16,7 +16,7 @@ public class DivideFilterTest extends BaseJinjavaTest {
           ImmutableMap.of("numerator", 10, "denominator", 2)
         )
       )
-      .isEqualTo("5.0");
+      .isEqualTo("5");
     assertThat(
         jinjava.render(
           "{{ numerator // denominator }}",
@@ -41,6 +41,6 @@ public class DivideFilterTest extends BaseJinjavaTest {
           ImmutableMap.of("numerator", 9, "denominator", 10)
         )
       )
-      .isEqualTo("0.9 0.9");
+      .isEqualTo("1 0.9");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/MultiplyFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/MultiplyFilterTest.java
@@ -20,13 +20,13 @@ public class MultiplyFilterTest extends BaseJinjavaTest {
   public void itMultipliesDecimalNumbers() {
     Map<String, Object> vars = ImmutableMap.of("test", 10);
     RenderResult renderResult = jinjava.renderForResult("{{ test|multiply(.25) }}", vars);
-    assertThat(renderResult.getOutput()).isEqualTo("2.5");
+    assertThat(renderResult.getOutput()).isEqualTo("2.50");
   }
 
   @Test
   public void itCoercesStringsToNumbers() {
     Map<String, Object> vars = ImmutableMap.of("test", "10");
     RenderResult renderResult = jinjava.renderForResult("{{ test|multiply(.25) }}", vars);
-    assertThat(renderResult.getOutput()).isEqualTo("2.5");
+    assertThat(renderResult.getOutput()).isEqualTo("2.50");
   }
 }


### PR DESCRIPTION
https://github.com/HubSpot/jinjava/pull/766 has some issues with backwards compatibility.

We have a bunch of customer code:
```
{{ content.post_body|wordcount|divide(300) }}
```
and the coercion to decimal makes the previous change unreadable.