### PR TITLE
Allow configuration option for more precise divide filter

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -65,6 +65,7 @@ public class JinjavaConfig {
   private final ELResolver elResolver;
   private final ExecutionMode executionMode;
   private final LegacyOverrides legacyOverrides;
+  private final boolean enablePreciseDivideFilter;
 
   public static Builder newBuilder() {
     return new Builder();
@@ -118,6 +119,7 @@ public class JinjavaConfig {
     elResolver = builder.elResolver;
     executionMode = builder.executionMode;
     legacyOverrides = builder.legacyOverrides;
+    enablePreciseDivideFilter = builder.enablePreciseDivideFilter;
   }
 
   public Charset getCharset() {
@@ -228,6 +230,10 @@ public class JinjavaConfig {
     return legacyOverrides;
   }
 
+  public boolean getEnablePreciseDivideFilter() {
+    return enablePreciseDivideFilter;
+  }
+
   public static class Builder {
     private Charset charset = StandardCharsets.UTF_8;
     private Locale locale = Locale.ENGLISH;
@@ -256,6 +262,7 @@ public class JinjavaConfig {
     private int maxMapSize = Integer.MAX_VALUE;
     private ExecutionMode executionMode = DefaultExecutionMode.instance();
     private LegacyOverrides legacyOverrides = LegacyOverrides.NONE;
+    private boolean enablePreciseDivideFilter = false;
 
     private Builder() {}
 
@@ -399,6 +406,11 @@ public class JinjavaConfig {
 
     public Builder withLegacyOverrides(LegacyOverrides legacyOverrides) {
       this.legacyOverrides = legacyOverrides;
+      return this;
+    }
+
+    public Builder withEnablePreciseDivideFilter(boolean enablePreciseDivideFilter) {
+      this.enablePreciseDivideFilter = enablePreciseDivideFilter;
       return this;
     }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DivideFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DivideFilter.java
@@ -67,16 +67,22 @@ public class DivideFilter implements AdvancedFilter {
     Object toMul = args[0];
     Number num;
     if (toMul != null) {
-      try {
-        num = new BigDecimal(toMul.toString());
-      } catch (NumberFormatException e) {
-        throw new InvalidArgumentException(
-          interpreter,
-          this,
-          InvalidReason.NUMBER_FORMAT,
-          0,
-          toMul
-        );
+      if (
+        interpreter.getConfig().getEnablePreciseDivideFilter() && toMul instanceof Number
+      ) {
+        num = (Number) toMul;
+      } else {
+        try {
+          num = new BigDecimal(toMul.toString());
+        } catch (NumberFormatException e) {
+          throw new InvalidArgumentException(
+            interpreter,
+            this,
+            InvalidReason.NUMBER_FORMAT,
+            0,
+            toMul
+          );
+        }
       }
     } else {
       return var;

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DivideFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DivideFilterTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.BaseJinjavaTest;
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.LegacyOverrides;
 import org.junit.Test;
 
 public class DivideFilterTest extends BaseJinjavaTest {
@@ -42,5 +45,34 @@ public class DivideFilterTest extends BaseJinjavaTest {
         )
       )
       .isEqualTo("1 0.9");
+  }
+
+  @Test
+  public void itRendersWithMorePrecisionWithConfigOption() {
+    Jinjava customJinjava = new Jinjava(
+      JinjavaConfig
+        .newBuilder()
+        .withLegacyOverrides(
+          LegacyOverrides.newBuilder().withUsePyishObjectMapper(true).build()
+        )
+        .withEnablePreciseDivideFilter(true)
+        .build()
+    );
+
+    assertThat(
+        jinjava.render(
+          "{{ numerator|divide(denominator) }}",
+          ImmutableMap.of("numerator", 2, "denominator", 100)
+        )
+      )
+      .isEqualTo("0");
+
+    assertThat(
+        customJinjava.render(
+          "{{ numerator|divide(denominator) }}",
+          ImmutableMap.of("numerator", 2, "denominator", 100)
+        )
+      )
+      .isEqualTo("0.02");
   }
 }


### PR DESCRIPTION
I tried turning this on previously https://github.com/HubSpot/jinjava/pull/766 however this breaks many existing templates. Instead I introduce a configuration option to enable it instead.