### PR TITLE
[Eager Execution] Handle modification in double imported file

### DIFF
--- a/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
+++ b/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
@@ -55,7 +55,9 @@ public class LegacyOverrides {
         .withEvaluateMapKeys(legacyOverrides.evaluateMapKeys)
         .withIterateOverMapKeys(legacyOverrides.iterateOverMapKeys)
         .withUsePyishObjectMapper(legacyOverrides.usePyishObjectMapper)
-        .withWhitespaceRequiredWithinTokens(legacyOverrides.whitespaceRequiredWithinTokens);
+        .withWhitespaceRequiredWithinTokens(
+          legacyOverrides.whitespaceRequiredWithinTokens
+        );
     }
 
     public Builder withEvaluateMapKeys(boolean evaluateMapKeys) {
@@ -73,8 +75,10 @@ public class LegacyOverrides {
       return this;
     }
 
-    public Builder withWhitespaceRequiredWithinTokens(boolean useWhitespace) {
-      this.whitespaceRequiredWithinTokens = useWhitespace;
+    public Builder withWhitespaceRequiredWithinTokens(
+      boolean whitespaceRequiredWithinTokens
+    ) {
+      this.whitespaceRequiredWithinTokens = whitespaceRequiredWithinTokens;
       return this;
     }
   }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -952,4 +952,22 @@ public class EagerTest {
       "handles-value-modified-in-macro"
     );
   }
+
+  @Test
+  public void itHandlesDoubleImportModification() {
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
+      "handles-double-import-modification"
+    );
+  }
+
+  @Test
+  public void itHandlesDoubleImportModificationSecondPass() {
+    interpreter.getContext().put("deferred", false);
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "handles-double-import-modification.expected"
+    );
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
+      "handles-double-import-modification.expected"
+    );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -457,7 +457,7 @@ public class EagerImportTagTest extends ImportTagTest {
     );
     assertThat(result)
       .isEqualTo(
-        "{% if deferred %}{% set current_path = 'import-tree-b.jinja' %}{% set b = {} %}{% set current_path = 'import-tree-a.jinja' %}{% set a = {} %}{% set something = 'somn' %}{% do a.update({\"something\": something}) %}\n" +
+        "{% if deferred %}{% set current_path = 'import-tree-b.jinja' %}{% set a,foo_b = {'foo_a': 'a', 'import_resource_path': 'import-tree-a.jinja', 'something': 'somn'},null %}{% set b = {} %}{% set current_path = 'import-tree-a.jinja' %}{% set a = {} %}{% set something = 'somn' %}{% do a.update({\"something\": something}) %}\n" +
         "{% set foo_a = 'a' %}{% do a.update({\"foo_a\": foo_a}) %}\n" +
         "{% do a.update({'foo_a': 'a','import_resource_path': 'import-tree-a.jinja','something': 'somn'}) %}{% set current_path = 'import-tree-b.jinja' %}\n" +
         "{% set foo_b = 'b' + a.foo_a %}{% do b.update({\"foo_b\": foo_b}) %}\n" +

--- a/src/test/resources/eager/handles-double-import-modification.expected.expected.jinja
+++ b/src/test/resources/eager/handles-double-import-modification.expected.expected.jinja
@@ -4,5 +4,5 @@
 
 
 ---
-{'foo': 'b', 'import_resource_path': 'deferred-modification.jinja'}
-{'foo': 'b', 'import_resource_path': 'deferred-modification.jinja'}
+b
+b

--- a/src/test/resources/eager/handles-double-import-modification.expected.expected.jinja
+++ b/src/test/resources/eager/handles-double-import-modification.expected.expected.jinja
@@ -1,0 +1,8 @@
+---
+
+
+
+
+---
+{'foo': 'b', 'import_resource_path': 'deferred-modification.jinja'}
+{'foo': 'b', 'import_resource_path': 'deferred-modification.jinja'}

--- a/src/test/resources/eager/handles-double-import-modification.expected.jinja
+++ b/src/test/resources/eager/handles-double-import-modification.expected.jinja
@@ -1,0 +1,20 @@
+{% set current_path = 'deferred-modification.jinja' %}{% set foo = null %}{% set bar1 = {} %}{% set bar1 = {} %}{% if deferred %}
+
+{% set foo = 'a' %}{% do bar1.update({"foo": foo}) %}
+
+{% endif %}
+
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar1.update({"foo": foo}) %}
+{% do bar1.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}
+---
+{% set current_path = 'deferred-modification.jinja' %}{% set foo = null %}{% set bar2 = {} %}{% set bar2 = {} %}{% if deferred %}
+
+{% set foo = 'a' %}{% do bar2.update({"foo": foo}) %}
+
+{% endif %}
+
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar2.update({"foo": foo}) %}
+{% do bar2.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}
+---
+{{ bar1 }}
+{{ bar2 }}

--- a/src/test/resources/eager/handles-double-import-modification.expected.jinja
+++ b/src/test/resources/eager/handles-double-import-modification.expected.jinja
@@ -16,5 +16,5 @@
 {% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar2.update({"foo": foo}) %}
 {% do bar2.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}
 ---
-{{ bar1 }}
-{{ bar2 }}
+{{ bar1.foo }}
+{{ bar2.foo }}

--- a/src/test/resources/eager/handles-double-import-modification.jinja
+++ b/src/test/resources/eager/handles-double-import-modification.jinja
@@ -1,0 +1,6 @@
+{% import "deferred-modification.jinja" as bar1 %}
+---
+{% import "deferred-modification.jinja" as bar2 %}
+---
+{{ bar1 }}
+{{ bar2 }}

--- a/src/test/resources/eager/handles-double-import-modification.jinja
+++ b/src/test/resources/eager/handles-double-import-modification.jinja
@@ -2,5 +2,5 @@
 ---
 {% import "deferred-modification.jinja" as bar2 %}
 ---
-{{ bar1 }}
-{{ bar2 }}
+{{ bar1.foo }}
+{{ bar2.foo }}

--- a/src/test/resources/tags/macrotag/deferred-modification.jinja
+++ b/src/test/resources/tags/macrotag/deferred-modification.jinja
@@ -1,0 +1,7 @@
+{% if deferred %}
+
+{% set foo = [foo, 'a']|join('') %}
+
+{% endif %}
+
+{% set foo = [foo, 'b']|join('') %}


### PR DESCRIPTION
When importing a file multiple times that has to defer the value of some of its exported variables, you could run into a certain case that occurs because we weren't reconstructing a set tag for deferring child bindings.
The simple test case that I created for this has an import file `deferred-modification.jinja`:
```
{% if deferred %}
{% set foo = foo ~'a' %}
{% endif %}
{% set foo = foo ~ 'b' %}
```
When importing as `bar`, this will end up "resolving" like:
```
{% set bar = {} %}{% if deferred %}
{% set foo = 'a' %}{% do bar.update({"foo": foo}) %}
{% endif %}
{% set foo = foo ~ 'b' %}{% do bar.update({"foo": foo}) %}
```
The problem ends up in that last line because we have `foo ~ 'b'`. This is fine if you are only importing this file once because  `foo` will still be `null` at this point, which is what we expect. However, if you import this twice like:
```
{% import 'deferred-modification.jinja' as bar1 %}
{% import 'deferred-modification.jinja' as bar2 %}
```
You will have some code that has a couple notable things:
```
...
{% set foo = foo ~ 'b' %}{% do bar1.update({"foo": foo}) %}
...
{% set foo = foo ~ 'b' %}{% do bar2.update({"foo": foo}) %}
...
```
And you can see that the second time we call `foo ~ 'b'`, foo will already have a value so you would end up with `bar1.foo == 'b'` and `bar2.foo == 'bb'`.
We can solve this by reconstructing set tags for these values (like `foo`) that get deferred while executing the import tag.
So we prepend the output with `{% set foo = null %}` so we end up with something more like:
```
{% set foo = null %}
...
{% set foo = foo ~ 'b' %}{% do bar1.update({"foo": foo}) %}
...
{% set foo = null %}
...
{% set foo = foo ~ 'b' %}{% do bar2.update({"foo": foo}) %}
...
```
This resets those values when beginning to read the reconstructed code from the import tags each time so that we get the expected result of `bar1.foo == 'b'` and `bar2.foo == 'b'`