### PR TITLE
[Eager Execution] Minor bug fixes

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBracket.java
@@ -58,7 +58,9 @@ public class EagerAstBracket extends AstBracket implements EvalResultHolder {
       throw new DeferredParsingException(this, sb);
     } finally {
       ((EvalResultHolder) prefix).getAndClearEvalResult();
-      ((EvalResultHolder) property).getAndClearEvalResult();
+      if (property != null) {
+        ((EvalResultHolder) property).getAndClearEvalResult();
+      }
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -381,7 +381,7 @@ public class JinjavaInterpreter implements PyishSerializable {
           SetTag.IGNORED_VARIABLE_NAME,
           ignoredOutput.toString(),
           this,
-          true
+          false
         ) +
         output.getValue()
       );

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -201,8 +201,8 @@ public class EagerReconstructionUtils {
   private static Object getObjectOrHashCode(Object o) {
     if (o instanceof PyList || o instanceof PyMap) {
       if (
-        (o instanceof PyList && ((PyList) o).contains(o)) ||
-        (o instanceof PyMap && ((PyMap) o).containsValue(o))
+        (o instanceof PyList && ((PyList) o).toList().contains(o)) ||
+        (o instanceof PyMap && ((PyMap) o).toMap().containsValue(o))
       ) {
         return o; // Can't run hashcode as it will have infinite recursion and cause a stack overflow
       }

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -200,6 +200,12 @@ public class EagerReconstructionUtils {
 
   private static Object getObjectOrHashCode(Object o) {
     if (o instanceof PyList || o instanceof PyMap) {
+      if (
+        (o instanceof PyList && ((PyList) o).contains(o)) ||
+        (o instanceof PyMap && ((PyMap) o).containsValue(o))
+      ) {
+        return o; // Can't run hashcode as it will have infinite recursion and cause a stack overflow
+      }
       return o.hashCode();
     }
     return o;


### PR DESCRIPTION
Fixes a couple of small bugs:
- DeferredValueException being thrown due to trying to register a deferred token for the ignored output from processing extends roots if the max number of deferred tokens has already been reached. This exception is not caught like all the others are supposed to and it is fixed by not trying to register the deferred token in this location
- Avoid NPE that could happen if an EagerAstBracket's `property` was null by first adding a null check before calling its method
- Avoid Stack Overflow that occurs when calling hashcode on a list or map that contains a reference to itself.