### PR TITLE
[Eager Execution] Fix eager cycle tag handling of null resolutions

### DIFF
--- a/src/test/java/com/hubspot/jinjava/lib/tag/CycleTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/CycleTagTest.java
@@ -2,7 +2,6 @@ package com.hubspot.jinjava.lib.tag;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.Maps;
 import com.hubspot.jinjava.BaseInterpretingTest;
 import org.junit.Test;
 
@@ -11,6 +10,6 @@ public class CycleTagTest extends BaseInterpretingTest {
   @Test
   public void itDefaultsNullToImage() {
     String template = "{% for item in [0,1] %}{% cycle {{item}} %}{% endfor %}";
-    assertThat(jinjava.render(template, Maps.newHashMap())).isEqualTo("{{item}}{{item}}");
+    assertThat(interpreter.render(template)).isEqualTo("{{item}}{{item}}");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/CycleTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/CycleTagTest.java
@@ -12,4 +12,24 @@ public class CycleTagTest extends BaseInterpretingTest {
     String template = "{% for item in [0,1] %}{% cycle {{item}} %}{% endfor %}";
     assertThat(interpreter.render(template)).isEqualTo("{{item}}{{item}}");
   }
+
+  @Test
+  public void itDefaultsMultipleNullToImage() {
+    String template = "{% for item in [0,1] %}{% cycle {{foo}},{{bar}} %}{% endfor %}";
+    assertThat(interpreter.render(template)).isEqualTo("{{foo}}{{bar}}");
+  }
+
+  @Test
+  public void itDefaultsNullToImageUsingAs() {
+    String template =
+      "{% for item in [0,1] %}{% cycle {{item}} as var %}{% cycle var %}{% endfor %}";
+    assertThat(interpreter.render(template)).isEqualTo("{{item}}{{item}}");
+  }
+
+  @Test
+  public void itDefaultsMultipleNullToImageUsingAs() {
+    String template =
+      "{% for item in [0,1] %}{% cycle {{foo}},{{bar}} as var %}{% cycle var %}{% endfor %}";
+    assertThat(interpreter.render(template)).isEqualTo("{{foo}}{{bar}}");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTagTest.java
@@ -32,6 +32,7 @@ public class EagerCycleTagTest extends CycleTagTest {
     tag = new EagerCycleTag();
     context.registerTag(tag);
     context.registerTag(new EagerForTag());
+    JinjavaInterpreter.pushCurrent(interpreter);
   }
 
   @After


### PR DESCRIPTION
The unit test here provided a false sense of security because it was actually not running with the correct interpreter. It was running with the default interpreter so it wasn't actually testing the EagerCycleTag logic because I missed a `pushCurrent(interpreter)` call...

The problem was that because the cycle tag defaults to the input if the resolved string is `null` (such is the case when trying to do `{% cycle {{item}} %}` because `${{{item}}}` is invalid EL syntax), we were properly setting the `resolvedExpression`, but we weren't setting `resolvedValues`, and were still trying to retrieve it from the EL result (which was null), this lead to the output being empty, rather than just being `{{item}}` each cycle.

This is easily fixed by setting the `resolvedValues` to the comma-split input string after its been normalized to mirror the default cycle tag functionality.