### PR TITLE
Fix NPE with null timezone passed to today function

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -127,7 +127,7 @@ public class Functions {
   )
   public static ZonedDateTime today(String... var) {
     ZoneId zoneOffset = ZoneOffset.UTC;
-    if (var.length > 0) {
+    if (var.length > 0 && var[0] != null) {
       String timezone = var[0];
       try {
         zoneOffset = ZoneId.of(timezone);

--- a/src/test/java/com/hubspot/jinjava/lib/fn/TodayFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/TodayFunctionTest.java
@@ -33,6 +33,7 @@ public class TodayFunctionTest {
     Functions.today("Not a timezone");
   }
 
+  @Test
   public void itIgnoresNullTimezone() {
     assertThat(Functions.today((String) null).getZone()).isEqualTo(ZoneOffset.UTC);
   }

--- a/src/test/java/com/hubspot/jinjava/lib/fn/TodayFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/TodayFunctionTest.java
@@ -30,7 +30,11 @@ public class TodayFunctionTest {
 
   @Test(expected = InvalidDateFormatException.class)
   public void itThrowsExceptionOnInvalidTimezone() {
-    ZonedDateTime zonedDateTime = Functions.today("Not a timezone");
+    Functions.today("Not a timezone");
+  }
+
+  public void itIgnoresNullTimezone() {
+    assertThat(Functions.today((String) null).getZone()).isEqualTo(ZoneOffset.UTC);
   }
 
   @Test(expected = DeferredValueException.class)

--- a/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
@@ -26,7 +26,9 @@ public class UnixTimestampFunctionTest {
     assertThat(Functions.unixtimestamp(d)).isEqualTo(epochMilliseconds);
     assertThat(
         Math.abs(
-          Functions.unixtimestamp(null) - ZonedDateTime.now().toEpochSecond() * 1000
+          Functions.unixtimestamp((Object) null) -
+          ZonedDateTime.now().toEpochSecond() *
+          1000
         )
       )
       .isLessThan(1000);
@@ -45,7 +47,7 @@ public class UnixTimestampFunctionTest {
       )
     );
     try {
-      Functions.unixtimestamp(null);
+      Functions.unixtimestamp((Object) null);
     } finally {
       JinjavaInterpreter.popCurrent();
     }


### PR DESCRIPTION
errors looked like this

```
java.lang.NullPointerException: zoneId
	at java.base/java.util.Objects.requireNonNull(Objects.java:246)
	at java.base/java.time.ZoneId.of(ZoneId.java:400)
	at java.base/java.time.ZoneId.of(ZoneId.java:356)
	at com.hubspot.jinjava.lib.fn.Functions.today(Functions.java:133)
```