### PR TITLE
ignore nulls when extending pylist

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
@@ -41,7 +41,7 @@ public class PyList extends ForwardingList<Object> implements PyWrapper {
   }
 
   public boolean extend(PyList e) {
-    return addAll(e.list);
+    return e != null && addAll(e.list);
   }
 
   public Object pop() {

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
@@ -34,6 +34,17 @@ public class PyListTest extends BaseJinjavaTest {
   }
 
   @Test
+  public void itSupportsExtendOperationWithNullList() {
+    assertThat(
+        jinjava.render(
+          "{% set test = [1, 2, 3] %}" + "{% do test.extend(null) %}" + "{{ test }}",
+          Collections.emptyMap()
+        )
+      )
+      .isEqualTo("[1, 2, 3]");
+  }
+
+  @Test
   public void itSupportsInsertOperation() {
     assertThat(
         jinjava.render(


### PR DESCRIPTION
if extend was passed a null, it would throw an NPE.