### PR TITLE
fix exception with trailing percent in strftimeformatter

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
@@ -67,7 +67,7 @@ public class StrftimeFormatter {
 
     for (int i = 0; i < strftime.length(); i++) {
       char c = strftime.charAt(i);
-      if (c == '%') {
+      if (c == '%' && strftime.length() > i + 1) {
         c = strftime.charAt(++i);
         boolean stripLeadingZero = false;
         String[] conversions = CONVERSIONS;

--- a/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
@@ -38,6 +38,11 @@ public class StrftimeFormatterTest {
   }
 
   @Test
+  public void testFormatWithTrailingPercent() {
+    assertThat(StrftimeFormatter.format(d, "%B %-d, %")).isEqualTo("November 6, %");
+  }
+
+  @Test
   public void testWithNoPcts() {
     assertThat(StrftimeFormatter.format(d, "MMMM yyyy")).isEqualTo("November 2013");
   }


### PR DESCRIPTION
If a format string ended with %, we would throw at `StringIndexOutOfBoundsException`