### PR TITLE
check for null errors in RenderResult

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/RenderResult.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/RenderResult.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.interpret;
 import com.google.common.collect.ImmutableList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 public class RenderResult {
   private final String output;
@@ -23,7 +24,11 @@ public class RenderResult {
     this.output = "";
     this.context = context;
     this.errors =
-      ImmutableList.<TemplateError>builder().add(fromException).addAll(errors).build();
+      ImmutableList
+        .<TemplateError>builder()
+        .add(fromException)
+        .addAll(Optional.ofNullable(errors).orElse(Collections.emptyList()))
+        .build();
   }
 
   public RenderResult(String result) {


### PR DESCRIPTION
`ImmutableList.builder().addAll()` requires a non-null argument.