### PR TITLE
Add basic toString method to ForLoop class

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/ForLoop.java
+++ b/src/main/java/com/hubspot/jinjava/util/ForLoop.java
@@ -142,4 +142,9 @@ public class ForLoop implements Iterator<Object> {
   public void remove() {
     throw new UnsupportedOperationException();
   }
+
+  @Override
+  public String toString() {
+    return "<ForLoop: " + length + ">";
+  }
 }


### PR DESCRIPTION
The default toString implementation shows the hashcode, meaning that we get diffs if ForLoops are included in the output. This PR would minimize diffs.