### PR TITLE
[Eager Execution] Include the size of a map or list when determining the hashcode

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -206,7 +206,9 @@ public class EagerReconstructionUtils {
       ) {
         return o; // Can't run hashcode as it will have infinite recursion and cause a stack overflow
       }
-      return o.hashCode();
+      return (
+        o.hashCode() + (o instanceof PyList ? ((PyList) o).size() : ((PyMap) o).size())
+      );
     }
     return o;
   }

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -199,16 +199,11 @@ public class EagerReconstructionUtils {
   }
 
   private static Object getObjectOrHashCode(Object o) {
-    if (o instanceof PyList || o instanceof PyMap) {
-      if (
-        (o instanceof PyList && ((PyList) o).toList().contains(o)) ||
-        (o instanceof PyMap && ((PyMap) o).toMap().containsValue(o))
-      ) {
-        return o; // Can't run hashcode as it will have infinite recursion and cause a stack overflow
-      }
-      return (
-        o.hashCode() + (o instanceof PyList ? ((PyList) o).size() : ((PyMap) o).size())
-      );
+    if (o instanceof PyList && !((PyList) o).toList().contains(o)) {
+      return o.hashCode();
+    }
+    if (o instanceof PyMap && !((PyMap) o).toMap().containsValue(o)) {
+      return o.hashCode() + ((PyMap) o).keySet().hashCode();
     }
     return o;
   }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
@@ -122,18 +122,20 @@ public class EagerForTagTest extends ForTagTest {
   public void itDoesntAllowChangesInDeferredForWithSameHashCode() {
     // Map with {'1':'1'} has the same hashcode as {} so we must differentiate
     String result = interpreter.render(
-      "{% set foo = {} -%}\n" +
+      "{% set foo = {'a': 'a'} -%}\n" +
       "{%- for i in range(0, deferred) %}\n" +
       "{{ 'bar' }}{{ foo }}\n" +
-      "{% do foo.update({'1': '1'}) %}\n" +
+      "{% do foo.clear() %}\n" +
+      "{% do foo.update({'b': 'b'}) %}\n" +
       "{% endfor %}\n" +
       "{{ foo }}"
     );
     assertThat(result)
       .isEqualTo(
-        "{% set foo = {} %}{% for i in range(0, deferred) %}\n" +
+        "{% set foo = {'a': 'a'} %}{% for i in range(0, deferred) %}\n" +
         "bar{{ foo }}\n" +
-        "{% do foo.update({'1': 1}) %}\n" +
+        "{% do foo.clear() %}\n" +
+        "{% do foo.update({'b': 'b'}) %}\n" +
         "{% endfor %}\n" +
         "{{ foo }}"
       );

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
@@ -120,7 +120,7 @@ public class EagerForTagTest extends ForTagTest {
 
   @Test
   public void itDoesntAllowChangesInDeferredForWithSameHashCode() {
-    // Map with {'1':'1'} has the same hashcode as {} so we must differentiate
+    // Map with {'a':'a'} has the same hashcode as {'b':'b'} so we must differentiate
     String result = interpreter.render(
       "{% set foo = {'a': 'a'} -%}\n" +
       "{%- for i in range(0, deferred) %}\n" +

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
@@ -119,6 +119,28 @@ public class EagerForTagTest extends ForTagTest {
   }
 
   @Test
+  public void itDoesntAllowChangesInDeferredForWithSameHashCode() {
+    // Map with {'1':'1'} has the same hashcode as {} so we must differentiate
+    String result = interpreter.render(
+      "{% set foo = {} -%}\n" +
+      "{%- for i in range(0, deferred) %}\n" +
+      "{{ 'bar' }}{{ foo }}\n" +
+      "{% do foo.update({'1': '1'}) %}\n" +
+      "{% endfor %}\n" +
+      "{{ foo }}"
+    );
+    assertThat(result)
+      .isEqualTo(
+        "{% set foo = {} %}{% for i in range(0, deferred) %}\n" +
+        "bar{{ foo }}\n" +
+        "{% do foo.update({'1': 1}) %}\n" +
+        "{% endfor %}\n" +
+        "{{ foo }}"
+      );
+    assertThat(interpreter.getContext().getDeferredNodes()).hasSize(0);
+  }
+
+  @Test
   public void itAllowsChangesInDeferredForToken() {
     String output = interpreter.render(
       "{% set foo = [0] %}\n" +


### PR DESCRIPTION
Hash map gets its hashcode by adding together the hashcode of its entries. An entry gets its hashcode by xor-ing the hashcode of the key and value. If the key and value are the same, then the hashcode of the entry will be 0. Therefore maps with only entries with equal key-value will have a hashcode of 0. We should be able to distinguish these at least somewhat by just including the size of the map as well as we are just trying to use the hashcode to tell if the map has changed.