### PR TITLE
Do not rebuild collections when shuffling using CONSTANT_ZERO RandomNumberStrategy

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/RandomFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RandomFilter.java
@@ -19,7 +19,6 @@ import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.random.RandomNumberGeneratorStrategy;
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -51,10 +50,6 @@ public class RandomFilter implements Filter {
       return null;
     }
 
-    boolean isConstantRandom =
-      interpreter.getConfig().getRandomNumberGeneratorStrategy() ==
-      RandomNumberGeneratorStrategy.CONSTANT_ZERO;
-
     // collection
     if (object instanceof Collection) {
       Collection<?> clt = (Collection<?>) object;
@@ -63,9 +58,6 @@ public class RandomFilter implements Filter {
         return null;
       }
       Iterator<?> it = clt.iterator();
-      if (isConstantRandom) {
-        return it.next();
-      }
       int index = interpreter.getRandom().nextInt(size);
       while (index-- > 0) {
         it.next();
@@ -78,9 +70,6 @@ public class RandomFilter implements Filter {
       if (size == 0) {
         return null;
       }
-      if (isConstantRandom) {
-        return Array.get(object, 0);
-      }
       int index = interpreter.getRandom().nextInt(size);
       return Array.get(object, index);
     }
@@ -92,9 +81,6 @@ public class RandomFilter implements Filter {
         return null;
       }
       Iterator<?> it = map.values().iterator();
-      if (isConstantRandom) {
-        return it.next();
-      }
       int index = interpreter.getRandom().nextInt(size);
       while (index-- > 0) {
         it.next();
@@ -103,16 +89,10 @@ public class RandomFilter implements Filter {
     }
     // number
     if (object instanceof Number) {
-      if (isConstantRandom) {
-        return 0;
-      }
       return interpreter.getRandom().nextInt(((Number) object).intValue());
     }
     // string
     if (object instanceof String) {
-      if (isConstantRandom) {
-        return 0;
-      }
       try {
         return interpreter
           .getRandom()

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RandomFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RandomFilter.java
@@ -19,6 +19,7 @@ import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.random.RandomNumberGeneratorStrategy;
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -49,13 +50,21 @@ public class RandomFilter implements Filter {
     if (object == null) {
       return null;
     }
+
+    boolean isConstantRandom =
+      interpreter.getConfig().getRandomNumberGeneratorStrategy() ==
+      RandomNumberGeneratorStrategy.CONSTANT_ZERO;
+
     // collection
     if (object instanceof Collection) {
       Collection<?> clt = (Collection<?>) object;
-      Iterator<?> it = clt.iterator();
       int size = clt.size();
       if (size == 0) {
         return null;
+      }
+      Iterator<?> it = clt.iterator();
+      if (isConstantRandom) {
+        return it.next();
       }
       int index = interpreter.getRandom().nextInt(size);
       while (index-- > 0) {
@@ -69,16 +78,22 @@ public class RandomFilter implements Filter {
       if (size == 0) {
         return null;
       }
+      if (isConstantRandom) {
+        return Array.get(object, 0);
+      }
       int index = interpreter.getRandom().nextInt(size);
       return Array.get(object, index);
     }
     // map
     if (object instanceof Map) {
       Map<?, ?> map = (Map<?, ?>) object;
-      Iterator<?> it = map.values().iterator();
       int size = map.size();
       if (size == 0) {
         return null;
+      }
+      Iterator<?> it = map.values().iterator();
+      if (isConstantRandom) {
+        return it.next();
       }
       int index = interpreter.getRandom().nextInt(size);
       while (index-- > 0) {
@@ -88,10 +103,16 @@ public class RandomFilter implements Filter {
     }
     // number
     if (object instanceof Number) {
+      if (isConstantRandom) {
+        return 0;
+      }
       return interpreter.getRandom().nextInt(((Number) object).intValue());
     }
     // string
     if (object instanceof String) {
+      if (isConstantRandom) {
+        return 0;
+      }
       try {
         return interpreter
           .getRandom()

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ShuffleFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ShuffleFilter.java
@@ -4,6 +4,7 @@ import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.random.RandomNumberGeneratorStrategy;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -19,7 +20,7 @@ import java.util.List;
   ),
   snippets = {
     @JinjavaSnippet(
-      desc = "The example below is a standard blog loop that's order is randomized on page load",
+      desc = "The example below is a standard blog loop whose order is randomized on page load",
       code = "{% for content in contents|shuffle %}\n" +
       "    <div class=\"post-item\">Markup of each post</div>\n" +
       "{% endfor %}"
@@ -36,6 +37,13 @@ public class ShuffleFilter implements Filter {
   @SuppressWarnings("unchecked")
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+    if (
+      interpreter.getConfig().getRandomNumberGeneratorStrategy() ==
+      RandomNumberGeneratorStrategy.CONSTANT_ZERO
+    ) {
+      return var;
+    }
+
     if (var instanceof Collection) {
       List<?> list = new ArrayList<>((Collection<Object>) var);
       Collections.shuffle(list, interpreter.getRandom());

--- a/src/main/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyMap.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyMap.java
@@ -38,6 +38,9 @@ public class SizeLimitingPyMap extends PyMap implements PyWrapper {
 
   @Override
   public void putAll(Map<? extends String, ?> m) {
+    if (m == null) {
+      return;
+    }
     HashSet<String> keys = new HashSet<>(delegate().keySet());
     checkSize(
       (int) m.keySet().stream().filter(k -> !keys.contains(k)).count() + delegate().size()

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RandomFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RandomFilterTest.java
@@ -1,0 +1,135 @@
+package com.hubspot.jinjava.lib.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.random.ConstantZeroRandomNumberGenerator;
+import com.hubspot.jinjava.random.RandomNumberGeneratorStrategy;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RandomFilterTest {
+  RandomFilter filter = new RandomFilter();
+
+  JinjavaInterpreter interpreter = mock(JinjavaInterpreter.class);
+  JinjavaConfig config = mock(JinjavaConfig.class);
+
+  @Before
+  public void setUp() throws Exception {
+    when(interpreter.getRandom()).thenReturn(ThreadLocalRandom.current());
+    when(interpreter.getConfig()).thenReturn(config);
+    when(config.getRandomNumberGeneratorStrategy())
+      .thenReturn(RandomNumberGeneratorStrategy.THREAD_LOCAL);
+  }
+
+  @Test
+  public void itReturnsNullWithNullObject() {
+    assertThat(filter.filter(null, interpreter)).isNull();
+  }
+
+  @Test
+  public void itTakesRandomElementFromList() {
+    Collection<Integer> ints = Arrays.asList(1, 2);
+    Object random = filter.filter(ints, interpreter);
+    assertThat((Integer) random).isBetween(1, 2);
+  }
+
+  @Test
+  public void itReturnsNullFromEmptyList() {
+    assertThat(filter.filter(Collections.emptyList(), interpreter)).isNull();
+  }
+
+  @Test
+  public void itAlwaysUsesFirstListValueWhenUsingConstantRandom() {
+    setUpConstantRandom();
+
+    Collection<Integer> ints = Arrays.asList(1, 2);
+    assertThat((Integer) filter.filter(ints, interpreter)).isEqualTo(1);
+  }
+
+  @Test
+  public void itTakesRandomElementFromArray() {
+    assertThat((Integer) filter.filter(new Integer[] { 1, 2 }, interpreter))
+      .isBetween(1, 2);
+  }
+
+  @Test
+  public void itReturnsNullFromEmptyArray() {
+    assertThat(filter.filter(new Integer[] {}, interpreter)).isNull();
+  }
+
+  @Test
+  public void itAlwaysUsesFirstArrayValueWhenUsingConstantRandom() {
+    setUpConstantRandom();
+    assertThat((Integer) filter.filter(new Integer[] { 1, 2 }, interpreter)).isEqualTo(1);
+  }
+
+  private void setUpConstantRandom() {
+    when(interpreter.getRandom()).thenReturn(new ConstantZeroRandomNumberGenerator());
+    when(interpreter.getConfig()).thenReturn(config);
+    when(config.getRandomNumberGeneratorStrategy())
+      .thenReturn(RandomNumberGeneratorStrategy.CONSTANT_ZERO);
+  }
+
+  @Test
+  public void itTakesRandomElementFromMap() {
+    LinkedHashMap<Integer, Integer> map = new LinkedHashMap<>();
+    map.put(1, 3);
+    map.put(2, 4);
+    assertThat((Integer) filter.filter(map, interpreter)).isBetween(3, 4);
+  }
+
+  @Test
+  public void itReturnsNullFromEmptyMap() {
+    assertThat(filter.filter(Collections.emptyMap(), interpreter)).isNull();
+  }
+
+  @Test
+  public void itAlwaysUsesFirstMapValueWhenUsingConstantRandom() {
+    setUpConstantRandom();
+    LinkedHashMap<Integer, Integer> map = new LinkedHashMap<>();
+    map.put(1, 3);
+    map.put(2, 4);
+    assertThat((Integer) filter.filter(map, interpreter)).isEqualTo(3);
+  }
+
+  @Test
+  public void itGeneratesRandomNumberInRange() {
+    assertThat((Integer) filter.filter(2, interpreter)).isBetween(0, 2);
+  }
+
+  @Test
+  public void itAlwaysReturnsRangeWhenUsingConstantRandom() {
+    setUpConstantRandom();
+    assertThat((Integer) filter.filter(3, interpreter)).isEqualTo(0);
+  }
+
+  @Test
+  public void itGeneratesRandomNumberWithStringRange() {
+    assertThat((Integer) filter.filter("2.0", interpreter)).isBetween(0, 2);
+  }
+
+  @Test
+  public void itReturnsZeroWithBadStringRange() {
+    assertThat((Integer) filter.filter("what", interpreter)).isEqualTo(0);
+  }
+
+  @Test
+  public void itAlwaysReturnsZeroWhenUsingConstantRandom() {
+    setUpConstantRandom();
+    assertThat((Integer) filter.filter("whut", interpreter)).isEqualTo(0);
+  }
+
+  @Test
+  public void itReturnsOriginalObjectForOtherClasses() {
+    assertThat((JinjavaInterpreter) filter.filter(interpreter, interpreter))
+      .isEqualTo(interpreter);
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyMapTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyMapTest.java
@@ -56,10 +56,16 @@ public class SizeLimitingPyMapTest extends BaseInterpretingTest {
   }
 
   @Test
-  public void itLimitsOnAddAll() {
+  public void itLimitsOnPutAll() {
     SizeLimitingPyMap objects = new SizeLimitingPyMap(new HashMap<>(), 2);
     assertThatThrownBy(() -> objects.putAll(createMap(3)))
       .isInstanceOf(CollectionTooBigException.class);
+  }
+
+  @Test
+  public void itHandlesNullOnPutAll() {
+    SizeLimitingPyMap objects = new SizeLimitingPyMap(new HashMap<>(), 10);
+    objects.putAll(null);
   }
 
   @Test


### PR DESCRIPTION
Even when using the CONSTANT_ZERO `RandomNumberStrategy`, values could change for collections since the collection is rebuilt.

This fixes that and also adds test coverage for the random filter.