### PR TITLE
[Eager Execution] Don't update map with self

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -211,6 +211,9 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
     for (Map.Entry<String, Object> entry : (
       (Map<String, Object>) ((DeferredValue) currentAliasMap).getOriginalValue()
     ).entrySet()) {
+      if (entry.getKey().equals(currentImportAlias)) {
+        continue;
+      }
       if (entry.getValue() instanceof DeferredValue) {
         keyValueJoiner.add(String.format("'%s': %s", entry.getKey(), entry.getKey()));
       } else if (!(entry.getValue() instanceof MacroFunction)) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
@@ -1,6 +1,5 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.SetTag;
@@ -147,16 +146,12 @@ public abstract class EagerSetTagStrategy {
       String currentImportAlias = maybeFullImportAlias
         .get()
         .substring(maybeFullImportAlias.get().lastIndexOf(".") + 1);
-      String updateString = getUpdateString(variables);
-      if (variables.equals(currentImportAlias)) {
-        suffixToPreserveState.append(
-          EagerReconstructionUtils.buildSetTag(
-            ImmutableMap.of(variables, updateString),
-            interpreter,
-            false
-          )
-        );
-      } else {
+      String filteredVariables = Arrays
+        .stream(variables.split(","))
+        .filter(var -> !var.equals(currentImportAlias))
+        .collect(Collectors.joining(","));
+      if (!filteredVariables.isEmpty()) {
+        String updateString = getUpdateString(filteredVariables);
         suffixToPreserveState.append(
           interpreter.render(
             EagerReconstructionUtils.buildDoUpdateTag(

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.SetTag;
@@ -147,15 +148,25 @@ public abstract class EagerSetTagStrategy {
         .get()
         .substring(maybeFullImportAlias.get().lastIndexOf(".") + 1);
       String updateString = getUpdateString(variables);
-      suffixToPreserveState.append(
-        interpreter.render(
-          EagerReconstructionUtils.buildDoUpdateTag(
-            currentImportAlias,
-            updateString,
-            interpreter
+      if (variables.equals(currentImportAlias)) {
+        suffixToPreserveState.append(
+          EagerReconstructionUtils.buildSetTag(
+            ImmutableMap.of(variables, updateString),
+            interpreter,
+            false
           )
-        )
-      );
+        );
+      } else {
+        suffixToPreserveState.append(
+          interpreter.render(
+            EagerReconstructionUtils.buildDoUpdateTag(
+              currentImportAlias,
+              updateString,
+              interpreter
+            )
+          )
+        );
+      }
     }
     return suffixToPreserveState.toString();
   }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -967,4 +967,11 @@ public class EagerTest {
       "handles-double-import-modification.expected"
     );
   }
+
+  @Test
+  public void itHandlesSameNameImportVar() {
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
+      "handles-same-name-import-var"
+    );
+  }
 }

--- a/src/test/resources/eager/handles-same-name-import-var.expected.jinja
+++ b/src/test/resources/eager/handles-same-name-import-var.expected.jinja
@@ -1,3 +1,10 @@
-{% import '../settag/set-var-and-deferred.jinja' as dict %}
-{{ dict }}
-
+{% if deferred %}
+{% set __ignored__ %}{% set current_path = '../settag/set-var-and-deferred.jinja' %}{% set current_path,value = null,null %}{% set my_var = {} %}{% set my_var = {} %}{% if deferred %}
+{% set __ignored__ %}{% set current_path = '../settag/set-var-and-deferred.jinja' %}{% do my_var.update({"current_path": current_path}) %}{% set value = null %}{% do my_var.update({"value": value}) %}{% set my_var = {} %}{% set my_var = {'foo': 'bar'} %}{% set my_var = {'my_var': {'foo': 'bar'}} %}
+{% set value = deferred %}{% do my_var.update({"value": value}) %}{% do my_var.update({"value": value}) %}
+{% do my_var.update({"import_resource_path": "../settag/set-var-and-deferred.jinja", "value": value}) %}{% set current_path = '' %}{% do my_var.update({"current_path": current_path}) %}{% endset %}{% do my_var.update({"__ignored__": __ignored__}) %}
+{{ my_var }}
+{% endif %}
+{% do my_var.update({'current_path': current_path,'import_resource_path': '../settag/set-var-and-deferred.jinja','value': value}) %}{% set current_path = '' %}{% endset %}
+{{ my_var }}
+{% endif %}

--- a/src/test/resources/eager/handles-same-name-import-var.expected.jinja
+++ b/src/test/resources/eager/handles-same-name-import-var.expected.jinja
@@ -1,0 +1,3 @@
+{% import '../settag/set-var-and-deferred.jinja' as dict %}
+{{ dict }}
+

--- a/src/test/resources/eager/handles-same-name-import-var.jinja
+++ b/src/test/resources/eager/handles-same-name-import-var.jinja
@@ -1,0 +1,4 @@
+{% if deferred %}
+{% import '../settag/set-var-and-deferred.jinja' as my_var %}
+{{ my_var }}
+{% endif %}

--- a/src/test/resources/tags/settag/set-var-and-deferred.jinja
+++ b/src/test/resources/tags/settag/set-var-and-deferred.jinja
@@ -1,0 +1,6 @@
+{% if deferred %}
+{% set __ignored__ %}{% set current_path = '../settag/set-var-and-deferred.jinja' %}{% set value = null %}{% set my_var = {} %}{% set my_var = {'foo': 'bar'} %}{% set my_var = {'my_var': my_var} %}
+{% set value = deferred %}{% do my_var.update({"value": value}) %}
+{% do my_var.update({'import_resource_path': '../settag/set-var-and-deferred.jinja','value': value}) %}{% set current_path = '' %}{% endset %}
+{{ my_var }}
+{% endif %}


### PR DESCRIPTION
This PR avoids the situation that could result in a StackOverflowError being thrown when evaluating reconstructed code if a file is imported with an alias that matches one of the variables declared in that file.
We avoid reconstructing something like `{% do env.update({'env': env}) %}`