### PR TITLE
[Eager Execution] Always run deferred for loop twice and add test for it

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -86,10 +86,9 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
           interpreter,
           true
         );
-
-      // Run for loop again now that the necessary values have been deferred
-      eagerExecutionResult = runLoopOnce(tagNode, interpreter);
     }
+    // Run for loop again now that the necessary values have been deferred
+    eagerExecutionResult = runLoopOnce(tagNode, interpreter);
     if (!eagerExecutionResult.getSpeculativeBindings().isEmpty()) {
       throw new DeferredValueException(
         "Modified values in deferred for loop: " +

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
@@ -119,6 +119,24 @@ public class EagerForTagTest extends ForTagTest {
   }
 
   @Test
+  public void itDefersVariablesThatLaterGetDeferred() {
+    String result = interpreter.render(
+      "{%- for i in range(0, deferred) %}\n" +
+      "{{ foo ~ (1 + 2) }}\n" +
+      "{% set foo = i %}\n" +
+      "{% endfor %}"
+    );
+    assertThat(result)
+      .isEqualTo(
+        "{% for i in range(0, deferred) %}\n" +
+        "{{ foo ~ 3 }}\n" +
+        "{% set foo = i %}\n" +
+        "{% endfor %}"
+      );
+    assertThat(interpreter.getContext().getDeferredNodes()).hasSize(0);
+  }
+
+  @Test
   public void itDoesntAllowChangesInDeferredForWithSameHashCode() {
     // Map with {'a':'a'} has the same hashcode as {'b':'b'} so we must differentiate
     String result = interpreter.render(


### PR DESCRIPTION
In [this commit](https://github.com/HubSpot/jinjava/commit/34cfcb2a6067af016cbc54bf000aea958017347c), I moved it so that we only ran the for loop again if there were speculative bindings. Unfortunately, I didn't have a test case for this so I didn't realise that there was a problem.
So this PR adds a specific test case that covers why we need to always run it twice (in case we defer a value later in the loop so that we don't accidentally resolve its value when it ends up changing.