### PR TITLE
Fix StringIndexOutOfBoundsException in truncate filter

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -437,6 +437,7 @@ public class Functions {
         if (!killwords) {
           length = movePointerToJustBeforeLastWord(length, string);
         }
+        length = Math.max(length, 0);
 
         return string.substring(0, length) + ends;
       } else {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/TruncateFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/TruncateFilterTest.java
@@ -50,4 +50,9 @@ public class TruncateFilterTest {
     assertThat(filter.filter("foo bar", interpreter, "5", "True", "!"))
       .isEqualTo("foo b!");
   }
+
+  @Test
+  public void itTruncatesGivenNegativeLength() throws Exception {
+    assertThat(filter.filter("foo bar", interpreter, "-1", "True")).isEqualTo("...");
+  }
 }


### PR DESCRIPTION
If truncate is used with length < 0 and killwords true, it could attempt to call string.substring with a negative length, which leads to a `StringIndexOutOfBoundsException`. This fixes it by forcing the length to be at least `0`.