### PR TITLE
[Eager Execution] Don't unnecessarily defer for loop

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -113,7 +113,6 @@ public class ForTag implements Tag {
       .stream()
       .filter(n -> !(n instanceof ExpressionNode))
       .count();
-    long numEagerTokensBefore = interpreter.getContext().getEagerTokens().size();
 
     String result = interpretUnchecked(tagNode, interpreter);
     if (
@@ -127,17 +126,6 @@ public class ForTag implements Tag {
     ) {
       throw new DeferredValueException(
         "for loop",
-        interpreter.getLineNumber(),
-        interpreter.getPosition()
-      );
-    }
-
-    if (
-      interpreter.getContext().get("loop") instanceof DeferredValue &&
-      interpreter.getContext().getEagerTokens().size() > numEagerTokensBefore
-    ) {
-      throw new DeferredValueException(
-        "loop variable deferred",
         interpreter.getLineNumber(),
         interpreter.getPosition()
       );
@@ -252,14 +240,27 @@ public class ForTag implements Tag {
               buff.append(node.render(interpreter));
             } catch (OutputTooBigException e) {
               interpreter.addError(TemplateError.fromOutputTooBigException(e));
-              return buff.toString();
+              return checkLoopVariable(interpreter, buff);
             }
           }
         }
       }
-
-      return buff.toString();
+      return checkLoopVariable(interpreter, buff);
     }
+  }
+
+  private String checkLoopVariable(
+    JinjavaInterpreter interpreter,
+    LengthLimitingStringBuilder buff
+  ) {
+    if (interpreter.getContext().get("loop") instanceof DeferredValue) {
+      throw new DeferredValueException(
+        "loop variable deferred",
+        interpreter.getLineNumber(),
+        interpreter.getPosition()
+      );
+    }
+    return buff.toString();
   }
 
   public Pair<List<String>, String> getLoopVarsAndExpression(TagToken tagToken) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -113,6 +113,7 @@ public class ForTag implements Tag {
       .stream()
       .filter(n -> !(n instanceof ExpressionNode))
       .count();
+    long numEagerTokensBefore = interpreter.getContext().getEagerTokens().size();
 
     String result = interpretUnchecked(tagNode, interpreter);
     if (
@@ -131,7 +132,10 @@ public class ForTag implements Tag {
       );
     }
 
-    if (interpreter.getContext().get("loop") instanceof DeferredValue) {
+    if (
+      interpreter.getContext().get("loop") instanceof DeferredValue &&
+      interpreter.getContext().getEagerTokens().size() > numEagerTokensBefore
+    ) {
       throw new DeferredValueException(
         "loop variable deferred",
         interpreter.getLineNumber(),

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -974,4 +974,11 @@ public class EagerTest {
       "handles-same-name-import-var"
     );
   }
+
+  @Test
+  public void itRunsForLoopInsideDeferredForLoop() {
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "runs-for-loop-inside-deferred-for-loop"
+    );
+  }
 }

--- a/src/test/resources/eager/runs-for-loop-inside-deferred-for-loop.expected.jinja
+++ b/src/test/resources/eager/runs-for-loop-inside-deferred-for-loop.expected.jinja
@@ -1,0 +1,4 @@
+{% for i in deferred %}
+0
+1
+{% endfor %}

--- a/src/test/resources/eager/runs-for-loop-inside-deferred-for-loop.jinja
+++ b/src/test/resources/eager/runs-for-loop-inside-deferred-for-loop.jinja
@@ -1,0 +1,5 @@
+{% for i in deferred -%}
+{% for j in [0, 1] %}
+{{ j }}
+{%- endfor %}
+{% endfor %}


### PR DESCRIPTION
Found that we couldn't evaluate for loops that were inside a deferred for loop because we neglected that the parent for loop could be what caused `loop` to be deferred.

The change is to check whether `loop` is deferred while we are still inside the child scope so that we know if it is deferred in the current for loop or if it has been deferred in the parent. If it was only deferred in the parent, then we can evaluate the for loop normally.