### PR TITLE
[Eager Execution] Fix string reconstruction for number-like or boolean-like values

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
@@ -28,6 +28,12 @@ public class PyishSerializer extends JsonSerializer<Object> {
       .orElse(object);
     if (wrappedObject instanceof PyishSerializable) {
       jsonGenerator.writeRawValue(((PyishSerializable) wrappedObject).toPyishString());
+    } else if (wrappedObject instanceof Boolean) {
+      jsonGenerator.writeBoolean((Boolean) wrappedObject);
+    } else if (wrappedObject instanceof Number) {
+      jsonGenerator.writeNumber(wrappedObject.toString());
+    } else if (wrappedObject instanceof String) {
+      jsonGenerator.writeString((String) wrappedObject);
     } else {
       string = Objects.toString(wrappedObject, "");
       try {

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -974,4 +974,9 @@ public class EagerTest {
       "handles-same-name-import-var"
     );
   }
+
+  @Test
+  public void itReconstructsTypesProperly() {
+    expectedTemplateInterpreter.assertExpectedOutput("reconstructs-types-properly");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagTest.java
@@ -136,7 +136,8 @@ public class EagerSetTagTest extends SetTagTest {
 
   @Test
   public void itDefersBlockWithFilter() {
-    String template = "{% set foo | add(deferred) %}{{ 1 + 1 }}{% endset %}{{ foo }}";
+    String template =
+      "{% set foo | int |add(deferred) %}{{ 1 + 1 }}{% endset %}{{ foo }}";
     final String result = interpreter.render(template);
 
     assertThat(result)

--- a/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
@@ -388,7 +388,7 @@ public class EagerExpressionResolverTest {
     EagerExpressionResult eagerExpressionResult = eagerResolveExpression(
       "date|datetimeformat('%Y')"
     );
-    assertThat(eagerExpressionResult.toString()).isEqualTo("1970");
+    assertThat(eagerExpressionResult.toString()).isEqualTo("'1970'");
   }
 
   @Test

--- a/src/test/resources/eager/defers-changes-within-deferred-set-block.expected.jinja
+++ b/src/test/resources/eager/defers-changes-within-deferred-set-block.expected.jinja
@@ -1,5 +1,5 @@
 1
-{% set bar,foo = [1],1 %}{% if deferred %}
+{% set bar,foo = [1],'1' %}{% if deferred %}
 {% set foo %}2{% set bar = [1, 2] %}{% endset %}
 {% endif %}
 Bar: {{ bar }}

--- a/src/test/resources/eager/handles-cycle-in-deferred-for.expected.jinja
+++ b/src/test/resources/eager/handles-cycle-in-deferred-for.expected.jinja
@@ -1,3 +1,3 @@
 {% for item in deferred %}
-{% cycle 1,2,3 %}
-{% cycle 1,2,3 %}{% endfor %}
+{% cycle '1','2','3' %}
+{% cycle '1','2','3' %}{% endfor %}

--- a/src/test/resources/eager/reconstructs-types-properly.expected.jinja
+++ b/src/test/resources/eager/reconstructs-types-properly.expected.jinja
@@ -1,0 +1,1 @@
+{{ {'bool': 'true', 'num': '1'} ~ deferred }}

--- a/src/test/resources/eager/reconstructs-types-properly.jinja
+++ b/src/test/resources/eager/reconstructs-types-properly.jinja
@@ -1,0 +1,2 @@
+{% set foo = {'bool': 'true', 'num': '1'} %}
+{{ foo ~ deferred }}


### PR DESCRIPTION
I realised that this functionality and the tests for it were actually a bit off.
If you have an object that has string values, such as a map of `{'foo': 'true'}` it should be output with `'true'` and not `true`. Similarly for number-like strings, we should not inherently cast them to numbers as there are filters for performing that for both numbers and booleans.