### PR TITLE
Fix spacing for prettier-java

### DIFF
--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -979,7 +979,7 @@ public class EagerTest {
   public void itReconstructsTypesProperly() {
     expectedTemplateInterpreter.assertExpectedOutput("reconstructs-types-properly");
   }
-  
+
   @Test
   public void itRunsForLoopInsideDeferredForLoop() {
     expectedTemplateInterpreter.assertExpectedOutput(


### PR DESCRIPTION
Seems that an extra space ended up here after handling merge conflicts using the github UI. This is causing our build of jinjava to fail due to issues with prettier.