### PR TITLE
[Eager Execution] Handle case where object is not resolvable as a string

### DIFF
--- a/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethodTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethodTest.java
@@ -7,6 +7,7 @@ import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.LegacyOverrides;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.el.ext.eager.EagerAstDotTest.Foo;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -197,6 +198,18 @@ public class EagerAstMethodTest extends BaseInterpretingTest {
       // It's not smart enough to know that it is safe to reduce this to just `foo_list.append(deferred)`
       assertThat(e.getDeferredEvalResult())
         .isEqualTo("(foo_list, 'bar')[0].append(deferred)");
+    }
+  }
+
+  @Test
+  public void itPreservesUnresolvable() {
+    interpreter.getContext().put("foo_object", new Foo());
+    try {
+      interpreter.resolveELExpression("foo_object.deferred|upper", -1);
+      fail("Should throw DeferredParsingException");
+    } catch (DeferredParsingException e) {
+      assertThat(e.getDeferredEvalResult())
+        .isEqualTo("filter:upper.filter(foo_object.deferred, ____int3rpr3t3r____)");
     }
   }
 }


### PR DESCRIPTION
Since `getValueAsJinjavaStringSafe` can throw a DeferredValueException (when a value cannot be resolved as a string), we need to be able to handle that and do so by subsequently setting `preserveIdentifier` to true. This will make us resolve less of the expression, which is what we need if the final object cannot be resolved to a string value.

In the test example, `foo_object.deferred` throws a DeferredParsingException, and since `foo_object` is not resolvable to a string, we preserve the identifier, which is `foo_object` in that case.