### PR TITLE
[Eager Execution] Prevent double curly braces from being reconstructed

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -26,11 +26,15 @@ public class PyishObjectMapper {
 
   public static String getAsPyishString(Object val) {
     try {
-      return PYISH_OBJECT_WRITER
+      String string = PYISH_OBJECT_WRITER
         .writeValueAsString(val)
         .replace("'", "\\'")
         // Replace double-quotes with single quote as they are preferred in Jinja
         .replaceAll("(?<!\\\\)(\\\\\\\\)*(?:\")", "$1'");
+      if (!string.contains("{{")) {
+        return string.replaceAll("}}(,|$)", "} }$1");
+      }
+      return string;
     } catch (JsonProcessingException e) {
       return Objects.toString(val, "");
     }

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -32,7 +32,7 @@ public class PyishObjectMapper {
         // Replace double-quotes with single quote as they are preferred in Jinja
         .replaceAll("(?<!\\\\)(\\\\\\\\)*(?:\")", "$1'");
       if (!string.contains("{{")) {
-        return string.replaceAll("}}(,|$)", "} }$1");
+        return String.join("} ", string.split("}(?=})"));
       }
       return string;
     } catch (JsonProcessingException e) {

--- a/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
@@ -158,6 +158,26 @@ public class EagerExpressionStrategyTest extends ExpressionNodeTest {
     assertExpectedOutput("{{ deferred ~ foo }}", "{{ deferred ~ {'foo': {} } }}");
   }
 
+  @Test
+  public void itDoesNotReconstructWithNestedDoubleCurlyBraces() {
+    interpreter
+      .getContext()
+      .put("foo", ImmutableMap.of("foo", ImmutableMap.of("bar", ImmutableMap.of())));
+    assertExpectedOutput(
+      "{{ deferred ~ foo }}",
+      "{{ deferred ~ {'foo': {'bar': {} } } }}"
+    );
+  }
+
+  @Test
+  public void itReconstructsWithNestedInterpretation() {
+    interpreter.getContext().put("foo", "{{ print 'bar' }}");
+    assertExpectedOutput(
+      "{{ deferred ~ foo }}",
+      "{{ deferred ~ '{{ print \\'bar\\' }}' }}"
+    );
+  }
+
   private void assertExpectedOutput(String inputTemplate, String expectedOutput) {
     assertThat(interpreter.render(inputTemplate)).isEqualTo(expectedOutput);
   }

--- a/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.lib.expression;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.LegacyOverrides;
 import com.hubspot.jinjava.interpret.DeferredValue;
@@ -149,6 +150,12 @@ public class EagerExpressionStrategyTest extends ExpressionNodeTest {
   @Test
   public void itDoesNotNestedInterpretIfThereAreFakeNotes() {
     assertExpectedOutput("{{ '{#something_to_{{keep}}' }}", "{#something_to_{{keep}}");
+  }
+
+  @Test
+  public void itDoesNotReconstructWithDoubleCurlyBraces() {
+    interpreter.getContext().put("foo", ImmutableMap.of("foo", ImmutableMap.of()));
+    assertExpectedOutput("{{ deferred ~ foo }}", "{{ deferred ~ {'foo': {} } }}");
   }
 
   private void assertExpectedOutput(String inputTemplate, String expectedOutput) {

--- a/src/test/resources/eager/handles-same-name-import-var.expected.jinja
+++ b/src/test/resources/eager/handles-same-name-import-var.expected.jinja
@@ -1,6 +1,6 @@
 {% if deferred %}
 {% set __ignored__ %}{% set current_path = '../settag/set-var-and-deferred.jinja' %}{% set current_path,value = null,null %}{% set my_var = {} %}{% set my_var = {} %}{% if deferred %}
-{% set __ignored__ %}{% set current_path = '../settag/set-var-and-deferred.jinja' %}{% do my_var.update({"current_path": current_path}) %}{% set value = null %}{% do my_var.update({"value": value}) %}{% set my_var = {} %}{% set my_var = {'foo': 'bar'} %}{% set my_var = {'my_var': {'foo': 'bar'}} %}
+{% set __ignored__ %}{% set current_path = '../settag/set-var-and-deferred.jinja' %}{% do my_var.update({"current_path": current_path}) %}{% set value = null %}{% do my_var.update({"value": value}) %}{% set my_var = {} %}{% set my_var = {'foo': 'bar'} %}{% set my_var = {'my_var': {'foo': 'bar'} } %}
 {% set value = deferred %}{% do my_var.update({"value": value}) %}{% do my_var.update({"value": value}) %}
 {% do my_var.update({"import_resource_path": "../settag/set-var-and-deferred.jinja", "value": value}) %}{% set current_path = '' %}{% do my_var.update({"current_path": current_path}) %}{% endset %}{% do my_var.update({"__ignored__": __ignored__}) %}
 {{ my_var }}


### PR DESCRIPTION
This would cause expression token parsing to break in a second rendering pass because the `}}` would be interpreted as the end of an expression node. We can add an extra space there as that it is still valid json.