### PR TITLE
Normalize spacing when reconstructing raw tags

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/RawTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/RawTag.java
@@ -30,19 +30,25 @@ public class RawTag implements Tag {
 
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
+    LengthLimitingStringBuilder result = new LengthLimitingStringBuilder(
+      interpreter.getConfig().getMaxOutputSize()
+    );
     if (
       interpreter.getConfig().getExecutionMode().isPreserveRawTags() &&
       !interpreter.getContext().isUnwrapRawOverride()
     ) {
-      return renderNodeRaw(tagNode);
+      result.append("{% raw %}");
     }
-
-    LengthLimitingStringBuilder result = new LengthLimitingStringBuilder(
-      interpreter.getConfig().getMaxOutputSize()
-    );
 
     for (Node n : tagNode.getChildren()) {
       result.append(renderNodeRaw(n));
+    }
+
+    if (
+      interpreter.getConfig().getExecutionMode().isPreserveRawTags() &&
+      !interpreter.getContext().isUnwrapRawOverride()
+    ) {
+      result.append("{% endraw %}");
     }
 
     return result.toString();

--- a/src/main/java/com/hubspot/jinjava/lib/tag/RawTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/RawTag.java
@@ -37,7 +37,13 @@ public class RawTag implements Tag {
       interpreter.getConfig().getExecutionMode().isPreserveRawTags() &&
       !interpreter.getContext().isUnwrapRawOverride()
     ) {
-      result.append("{% raw %}");
+      result.append(
+        String.format(
+          "%s raw %s",
+          tagNode.getSymbols().getExpressionStartWithTag(),
+          tagNode.getSymbols().getExpressionEndWithTag()
+        )
+      );
     }
 
     for (Node n : tagNode.getChildren()) {
@@ -48,7 +54,13 @@ public class RawTag implements Tag {
       interpreter.getConfig().getExecutionMode().isPreserveRawTags() &&
       !interpreter.getContext().isUnwrapRawOverride()
     ) {
-      result.append("{% endraw %}");
+      result.append(
+        String.format(
+          "%s endraw %s",
+          tagNode.getSymbols().getExpressionStartWithTag(),
+          tagNode.getSymbols().getExpressionEndWithTag()
+        )
+      );
     }
 
     return result.toString();
@@ -64,7 +76,14 @@ public class RawTag implements Tag {
     if (TagNode.class.isAssignableFrom(n.getClass())) {
       TagNode t = (TagNode) n;
       if (StringUtils.isNotBlank(t.getEndName())) {
-        result.append("{% ").append(t.getEndName()).append(" %}");
+        result.append(
+          String.format(
+            "%s %s %s",
+            t.getSymbols().getExpressionStartWithTag(),
+            t.getEndName(),
+            t.getSymbols().getExpressionEndWithTag()
+          )
+        );
       }
     }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/RawTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/RawTagTest.java
@@ -144,6 +144,22 @@ public class RawTagTest extends BaseInterpretingTest {
   }
 
   @Test
+  public void ifFixesSpacingWithRawTagPreservation() {
+    TagNode tagNode = fixture("nospacing");
+    JinjavaInterpreter preserveInterpreter = new JinjavaInterpreter(
+      jinjava,
+      jinjava.getGlobalContextCopy(),
+      JinjavaConfig
+        .newBuilder()
+        .withExecutionMode(PreserveRawExecutionMode.instance())
+        .build()
+    );
+    String result = tag.interpret(tagNode, preserveInterpreter);
+    assertThat(StringUtils.normalizeSpace(result))
+      .isEqualTo("{% raw %} {%print 'foo'%} {% endraw %}");
+  }
+
+  @Test
   public void itPreservesDeferredWhilePreservingRawTags() {
     TagNode tagNode = fixture("deferred");
     JinjavaInterpreter preserveInterpreter = new JinjavaInterpreter(

--- a/src/test/resources/tags/rawtag/nospacing.jinja
+++ b/src/test/resources/tags/rawtag/nospacing.jinja
@@ -1,0 +1,3 @@
+{%raw%}
+{%print 'foo'%}
+{%endraw%}


### PR DESCRIPTION
If a raw tag is used like `{%raw%}`, we want to reconstruct it with the proper spacing so rather than using the `renderNodeRaw()` method, we can explicitly append the starting `{% raw %}` and `{% endraw %}` to the beginning and end of the output, respectively.