### PR TITLE
update PyishDate and test files for cos-email task

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.objects.date;
 
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.objects.PyWrapper;
 import com.hubspot.jinjava.objects.serialization.PyishSerializable;
 import java.io.Serializable;
@@ -24,6 +25,8 @@ public final class PyishDate
   private static final long serialVersionUID = 1L;
   public static final String PYISH_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
   public static final String FULL_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+  public static final String PYISH_DATE_CUSTOM_DATE_FORMAT_CONTEXT_KEY =
+    "Jinjava_PyishDate_Custom_Format_Key";
 
   private final ZonedDateTime date;
 
@@ -107,6 +110,22 @@ public final class PyishDate
 
   @Override
   public String toString() {
+    if (
+      JinjavaInterpreter.getCurrent() != null &&
+      JinjavaInterpreter
+        .getCurrent()
+        .getContext()
+        .containsKey(PYISH_DATE_CUSTOM_DATE_FORMAT_CONTEXT_KEY)
+    ) {
+      return strftime(
+        JinjavaInterpreter
+          .getCurrent()
+          .getContext()
+          .get(PYISH_DATE_CUSTOM_DATE_FORMAT_CONTEXT_KEY)
+          .toString()
+      );
+    }
+
     return strftime(PYISH_DATE_FORMAT);
   }
 

--- a/src/test/java/com/hubspot/jinjava/objects/date/PyishDateTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/date/PyishDateTest.java
@@ -66,4 +66,25 @@ public class PyishDateTest {
     interpreter.render("{% set foo = " + PyishObjectMapper.getAsPyishString(d1) + "%}");
     assertThat(d1).isEqualTo(interpreter.getContext().get("foo"));
   }
+
+  @Test
+  public void testPyishDateToStringWithCustomDateFormatter() {
+    PyishDate d1 = new PyishDate(ZonedDateTime.parse("2013-11-12T14:15:16.170+02:00"));
+    JinjavaInterpreter interpreter = new Jinjava().newInterpreter();
+    JinjavaInterpreter.pushCurrent(interpreter);
+    interpreter
+      .getContext()
+      .put(PyishDate.PYISH_DATE_CUSTOM_DATE_FORMAT_CONTEXT_KEY, "YYYY-MM-dd");
+    assertThat(d1.toString()).isEqualTo("2013-11-12");
+    interpreter
+      .getContext()
+      .put(PyishDate.PYISH_DATE_CUSTOM_DATE_FORMAT_CONTEXT_KEY, "YYYY/MM/dd");
+    assertThat(d1.toString()).isEqualTo("2013/11/12");
+    interpreter
+      .getContext()
+      .put(PyishDate.PYISH_DATE_CUSTOM_DATE_FORMAT_CONTEXT_KEY, "MM/dd/yy");
+    assertThat(d1.toString()).isEqualTo("11/12/13");
+    interpreter.getContext().remove(PyishDate.PYISH_DATE_CUSTOM_DATE_FORMAT_CONTEXT_KEY);
+    assertThat(d1.toString()).isEqualTo("2013-11-12 14:15:16");
+  }
 }


### PR DESCRIPTION
- Refactored the `toString()` method for `PyishDate` to provide more flexibilities on the output format. 
- Updated unit test to verify the above behaviour. 