### PR TITLE
Make invalid timezone raise InvalidArgumentException

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -163,7 +163,11 @@ public class Functions {
       try {
         zoneOffset = ZoneId.of(timezone);
       } catch (DateTimeException e) {
-        throw new InvalidDateFormatException(timezone, e);
+        throw new InvalidArgumentException(
+          JinjavaInterpreter.getCurrent(),
+          "datetimeformat",
+          String.format("Invalid timezone: %s", timezone)
+        );
       }
     } else if (var instanceof ZonedDateTime) {
       zoneOffset = ((ZonedDateTime) var).getZone();

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -13,7 +13,6 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.mode.ExecutionMode;
 import com.hubspot.jinjava.objects.Namespace;
-import com.hubspot.jinjava.objects.date.InvalidDateFormatException;
 import com.hubspot.jinjava.objects.date.PyishDate;
 import com.hubspot.jinjava.objects.date.StrftimeFormatter;
 import com.hubspot.jinjava.tree.Node;
@@ -132,7 +131,11 @@ public class Functions {
       try {
         zoneOffset = ZoneId.of(timezone);
       } catch (DateTimeException e) {
-        throw new InvalidDateFormatException(timezone, e);
+        throw new InvalidArgumentException(
+          JinjavaInterpreter.getCurrent(),
+          "today",
+          String.format("Invalid timezone: %s", timezone)
+        );
       }
     }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hubspot.jinjava.BaseInterpretingTest;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.lib.fn.Functions;
 import com.hubspot.jinjava.objects.date.InvalidDateFormatException;
 import com.hubspot.jinjava.objects.date.StrftimeFormatter;
@@ -77,7 +78,7 @@ public class DateTimeFormatFilterTest extends BaseInterpretingTest {
       .isEqualTo("October 12, 2018, at 01:09 AM");
   }
 
-  @Test(expected = InvalidDateFormatException.class)
+  @Test(expected = InvalidArgumentException.class)
   public void itThrowsExceptionOnInvalidTimezone() throws Exception {
     filter.filter(
       1539277785000L,

--- a/src/test/java/com/hubspot/jinjava/lib/fn/TodayFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/TodayFunctionTest.java
@@ -2,19 +2,20 @@ package com.hubspot.jinjava.lib.fn;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValueException;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.mode.EagerExecutionMode;
-import com.hubspot.jinjava.objects.date.InvalidDateFormatException;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import org.junit.Test;
 
-public class TodayFunctionTest {
+public class TodayFunctionTest extends BaseInterpretingTest {
 
   @Test
   public void itDefaultsToUtcTimezone() {
@@ -28,7 +29,7 @@ public class TodayFunctionTest {
     assertThat(zonedDateTime.getZone()).isEqualTo(ZoneId.of("America/New_York"));
   }
 
-  @Test(expected = InvalidDateFormatException.class)
+  @Test(expected = InvalidArgumentException.class)
   public void itThrowsExceptionOnInvalidTimezone() {
     Functions.today("Not a timezone");
   }


### PR DESCRIPTION
Changes the exception raised when an invalid timezone is passed to `datetimeformat` and `today` to `InvalidArgumentException`, which provides less misleading information than the `InvalidDateFormatException` being raised in the existing code.