### PR TITLE
Ensure JinjavInterpreter is popped when running PyishDateTest

### DIFF
--- a/src/test/java/com/hubspot/jinjava/objects/date/PyishDateTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/date/PyishDateTest.java
@@ -72,19 +72,25 @@ public class PyishDateTest {
     PyishDate d1 = new PyishDate(ZonedDateTime.parse("2013-11-12T14:15:16.170+02:00"));
     JinjavaInterpreter interpreter = new Jinjava().newInterpreter();
     JinjavaInterpreter.pushCurrent(interpreter);
-    interpreter
-      .getContext()
-      .put(PyishDate.PYISH_DATE_CUSTOM_DATE_FORMAT_CONTEXT_KEY, "YYYY-MM-dd");
-    assertThat(d1.toString()).isEqualTo("2013-11-12");
-    interpreter
-      .getContext()
-      .put(PyishDate.PYISH_DATE_CUSTOM_DATE_FORMAT_CONTEXT_KEY, "YYYY/MM/dd");
-    assertThat(d1.toString()).isEqualTo("2013/11/12");
-    interpreter
-      .getContext()
-      .put(PyishDate.PYISH_DATE_CUSTOM_DATE_FORMAT_CONTEXT_KEY, "MM/dd/yy");
-    assertThat(d1.toString()).isEqualTo("11/12/13");
-    interpreter.getContext().remove(PyishDate.PYISH_DATE_CUSTOM_DATE_FORMAT_CONTEXT_KEY);
-    assertThat(d1.toString()).isEqualTo("2013-11-12 14:15:16");
+    try {
+      interpreter
+        .getContext()
+        .put(PyishDate.PYISH_DATE_CUSTOM_DATE_FORMAT_CONTEXT_KEY, "YYYY-MM-dd");
+      assertThat(d1.toString()).isEqualTo("2013-11-12");
+      interpreter
+        .getContext()
+        .put(PyishDate.PYISH_DATE_CUSTOM_DATE_FORMAT_CONTEXT_KEY, "YYYY/MM/dd");
+      assertThat(d1.toString()).isEqualTo("2013/11/12");
+      interpreter
+        .getContext()
+        .put(PyishDate.PYISH_DATE_CUSTOM_DATE_FORMAT_CONTEXT_KEY, "MM/dd/yy");
+      assertThat(d1.toString()).isEqualTo("11/12/13");
+      interpreter
+        .getContext()
+        .remove(PyishDate.PYISH_DATE_CUSTOM_DATE_FORMAT_CONTEXT_KEY);
+      assertThat(d1.toString()).isEqualTo("2013-11-12 14:15:16");
+    } finally {
+      JinjavaInterpreter.popCurrent();
+    }
   }
 }


### PR DESCRIPTION
https://github.com/HubSpot/jinjava/pull/812/files made tests fail sporadically due to an interpreter not being popped at the end of the test. This fixes it