### PR TITLE
Make ObjectMapper configurable via JinjavaConfig

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,10 @@
       <artifactId>jackson-dataformat-yaml</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
       <groupId>ch.obermuhlner</groupId>
       <artifactId>big-math</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,14 @@
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-guava</artifactId>
+    </dependency>
+    <dependency>
       <groupId>ch.obermuhlner</groupId>
       <artifactId>big-math</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -123,18 +123,6 @@
       <artifactId>jackson-dataformat-yaml</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jdk8</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>ch.obermuhlner</groupId>
       <artifactId>big-math</artifactId>
     </dependency>

--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -17,6 +17,7 @@ package com.hubspot.jinjava;
 
 import static com.hubspot.jinjava.lib.fn.Functions.DEFAULT_RANGE_LIMIT;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.jinjava.el.JinjavaInterpreterResolver;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.Context.Library;
@@ -66,6 +67,7 @@ public class JinjavaConfig {
   private final ExecutionMode executionMode;
   private final LegacyOverrides legacyOverrides;
   private final boolean enablePreciseDivideFilter;
+  private final ObjectMapper objectMapper;
 
   public static Builder newBuilder() {
     return new Builder();
@@ -120,6 +122,7 @@ public class JinjavaConfig {
     executionMode = builder.executionMode;
     legacyOverrides = builder.legacyOverrides;
     enablePreciseDivideFilter = builder.enablePreciseDivideFilter;
+    objectMapper = builder.objectMapper;
   }
 
   public Charset getCharset() {
@@ -214,6 +217,10 @@ public class JinjavaConfig {
     return elResolver;
   }
 
+  public ObjectMapper getObjectMapper() {
+    return objectMapper;
+  }
+
   /**
    * @deprecated  Replaced by {@link LegacyOverrides#isIterateOverMapKeys()}
    */
@@ -263,6 +270,7 @@ public class JinjavaConfig {
     private ExecutionMode executionMode = DefaultExecutionMode.instance();
     private LegacyOverrides legacyOverrides = LegacyOverrides.NONE;
     private boolean enablePreciseDivideFilter = false;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private Builder() {}
 
@@ -392,8 +400,8 @@ public class JinjavaConfig {
     @Deprecated
     public Builder withIterateOverMapKeys(boolean iterateOverMapKeys) {
       return withLegacyOverrides(
-        LegacyOverrides
-          .Builder.from(legacyOverrides)
+        LegacyOverrides.Builder
+          .from(legacyOverrides)
           .withIterateOverMapKeys(iterateOverMapKeys)
           .build()
       );
@@ -411,6 +419,11 @@ public class JinjavaConfig {
 
     public Builder withEnablePreciseDivideFilter(boolean enablePreciseDivideFilter) {
       this.enablePreciseDivideFilter = enablePreciseDivideFilter;
+      return this;
+    }
+
+    public Builder withObjectMapper(ObjectMapper objectMapper) {
+      this.objectMapper = objectMapper;
       return this;
     }
 

--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -400,8 +400,8 @@ public class JinjavaConfig {
     @Deprecated
     public Builder withIterateOverMapKeys(boolean iterateOverMapKeys) {
       return withLegacyOverrides(
-        LegacyOverrides.Builder
-          .from(legacyOverrides)
+        LegacyOverrides
+          .Builder.from(legacyOverrides)
           .withIterateOverMapKeys(iterateOverMapKeys)
           .build()
       );

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ToJsonFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ToJsonFilter.java
@@ -1,10 +1,6 @@
 package com.hubspot.jinjava.lib.filter;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
@@ -22,15 +18,11 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
   snippets = { @JinjavaSnippet(code = "{{object|tojson}}") }
 )
 public class ToJsonFilter implements Filter {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-    .registerModule(new Jdk8Module())
-    .registerModule(new GuavaModule())
-    .registerModule(new JavaTimeModule());
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
     try {
-      return OBJECT_MAPPER.writeValueAsString(var);
+      return interpreter.getConfig().getObjectMapper().writeValueAsString(var);
     } catch (JsonProcessingException e) {
       throw new InvalidInputException(interpreter, this, InvalidReason.JSON_WRITE);
     }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ToJsonFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ToJsonFilter.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.lib.filter;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
@@ -19,7 +20,8 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
   snippets = { @JinjavaSnippet(code = "{{object|tojson}}") }
 )
 public class ToJsonFilter implements Filter {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+  .registerModule(new JavaTimeModule());
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ToJsonFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ToJsonFilter.java
@@ -2,6 +2,8 @@ package com.hubspot.jinjava.lib.filter;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
@@ -21,7 +23,9 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 )
 public class ToJsonFilter implements Filter {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-  .registerModule(new JavaTimeModule());
+    .registerModule(new Jdk8Module())
+    .registerModule(new GuavaModule())
+    .registerModule(new JavaTimeModule());
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {


### PR DESCRIPTION
The ObjectMapper used by `tojson` is just a plain `new ObjectMapper()` which can cause serialization issues like:

```
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Java 8 date/time type `java.time.ZonedDateTime` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling
```

This makes `ObjectMapper` configurable via `JinjavaConfig` for more control / consistency.