### PR TITLE
Limit rendering cycle detection to expression nodes

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -40,6 +40,7 @@ import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.objects.serialization.PyishSerializable;
 import com.hubspot.jinjava.random.ConstantZeroRandomNumberGenerator;
 import com.hubspot.jinjava.random.DeferredRandomNumberGenerator;
+import com.hubspot.jinjava.tree.ExpressionNode;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.TreeParser;
@@ -259,7 +260,7 @@ public class JinjavaInterpreter implements PyishSerializable {
       position = node.getStartPosition();
       String renderStr = node.getMaster().getImage();
       try {
-        if (context.doesRenderStackContain(renderStr)) {
+        if (node instanceof ExpressionNode && context.doesRenderStackContain(renderStr)) {
           // This is a circular rendering. Stop rendering it here.
           addError(
             new TemplateError(

--- a/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
@@ -82,6 +82,16 @@ public class ExpressionNodeTest extends BaseInterpretingTest {
   }
 
   @Test
+  public void itAvoidsInfiniteRecursionWhenVarsAreInIfBlocks() throws Exception {
+    context.put("myvar", "{% if true %}{{ place }}{% endif %}");
+    context.put("place", "{% if true %}{{ myvar }}{% endif %}");
+
+    ExpressionNode node = fixture("simplevar");
+    assertThat(node.render(interpreter).toString())
+      .isEqualTo("{% if true %}{{ myvar }}{% endif %}");
+  }
+
+  @Test
   public void itDoesNotRescursivelyEvaluateExpressionsOfSelf() throws Exception {
     context.put("myvar", "hello {{myvar}}");
 

--- a/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
@@ -73,6 +73,15 @@ public class ExpressionNodeTest extends BaseInterpretingTest {
   }
 
   @Test
+  public void itAllowsRecursionForTagExpressions() throws Exception {
+    context.put("myvar", "{% if true %}{{ place }}{% endif %}");
+    context.put("place", "{% if true %}Hello{% endif %}");
+
+    ExpressionNode node = fixture("simplevar");
+    assertThat(node.render(interpreter).toString()).isEqualTo("Hello");
+  }
+
+  @Test
   public void itDoesNotRescursivelyEvaluateExpressionsOfSelf() throws Exception {
     context.put("myvar", "hello {{myvar}}");
 

--- a/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
@@ -73,7 +73,7 @@ public class ExpressionNodeTest extends BaseInterpretingTest {
   }
 
   @Test
-  public void itAllowsRecursionForTagExpressions() throws Exception {
+  public void itAllowsNestedTagExpressions() throws Exception {
     context.put("myvar", "{% if true %}{{ place }}{% endif %}");
     context.put("place", "{% if true %}Hello{% endif %}");
 


### PR DESCRIPTION
Bug found when this protection was added in https://github.com/HubSpot/jinjava/pull/142

I think this cycle protection should only apply to ExpressionNodes. In my test case I have two nested if loops that will resolve, however since they have the same image this protection is preventing the render from happening.