### PR TITLE
Add some visibility in the interpreter when a block is being resolved

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -84,6 +84,7 @@ public class JinjavaInterpreter implements PyishSerializable {
   private int lineNumber = -1;
   private int position = 0;
   private int scopeDepth = 1;
+  private BlockInfo currentBlock;
   private final List<TemplateError> errors = new LinkedList<>();
   private static final int MAX_ERROR_SIZE = 100;
 
@@ -428,6 +429,7 @@ public class JinjavaInterpreter implements PyishSerializable {
             .map(BlockInfo::getNodes)
             .orElse(null);
           context.setSuperBlock(superBlock);
+          currentBlock = block;
 
           OutputList blockValueBuilder = new OutputList(config.getMaxOutputSize());
 
@@ -463,6 +465,7 @@ public class JinjavaInterpreter implements PyishSerializable {
           blockNames.pop();
 
           context.removeSuperBlock();
+          currentBlock = null;
 
           blockPlaceholder.resolve(blockValueBuilder.getValue());
         }
@@ -669,6 +672,10 @@ public class JinjavaInterpreter implements PyishSerializable {
 
   public void setPosition(int position) {
     this.position = position;
+  }
+
+  public BlockInfo getCurrentBlock() {
+    return currentBlock;
   }
 
   public void addError(TemplateError templateError) {


### PR DESCRIPTION
Blocks are strange in that they will get rendered after the rest of the template does, however the output of their rendering may come before the output of non-blocks.

parent.jinja
```
{% block header %}
{% endblock %}
{% set foo =  [1] %}
Parent: {{ foo }}
```
child.jinja
```
{% extends './parent.jinja' %}
{% block header %}
{% do foo.append(2) %}
Child: {{ foo }}
{% endblock %}
```

This will have the result:
```
Child: [1, 2]
Parent: [1]
```

I'm working with a situation where in HubL, we're adding js assets in the order that they are rendered (they're appended to the end of a list), but since the blocks actually render after the initial template, but can appear before that in the HTML output, there is a problem with eager execution where the elements can get added to the js asset list in the wrong order. This can be mitigated by having the knowledge that we are currently resolving a block in the interpreter.