### PR TITLE
Handle nested import file paths

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -180,19 +180,8 @@ public class MacroFunction extends AbstractCallableMethod {
       return false;
     }
     MacroFunction that = (MacroFunction) o;
-    if (this.deferred && that.deferred) {
-      return (
-        caller == that.caller &&
-        content.equals(that.content) &&
-        Objects.equals(
-          localContextScope.get(Context.IMPORT_RESOURCE_PATH_KEY),
-          that.localContextScope.get(Context.IMPORT_RESOURCE_PATH_KEY)
-        )
-      );
-    }
     return (
       caller == that.caller &&
-      content.equals(that.content) &&
       Objects.equals(getName(), that.getName()) &&
       Objects.equals(
         localContextScope.get(Context.IMPORT_RESOURCE_PATH_KEY),
@@ -206,7 +195,6 @@ public class MacroFunction extends AbstractCallableMethod {
     return Objects.hash(
       getName(),
       localContextScope.get(Context.IMPORT_RESOURCE_PATH_KEY),
-      content,
       caller
     );
   }

--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -180,16 +180,34 @@ public class MacroFunction extends AbstractCallableMethod {
       return false;
     }
     MacroFunction that = (MacroFunction) o;
+    if (this.deferred && that.deferred) {
+      return (
+        caller == that.caller &&
+        content.equals(that.content) &&
+        Objects.equals(
+          localContextScope.get(Context.IMPORT_RESOURCE_PATH_KEY),
+          that.localContextScope.get(Context.IMPORT_RESOURCE_PATH_KEY)
+        )
+      );
+    }
     return (
       caller == that.caller &&
-      definitionLineNumber == that.definitionLineNumber &&
-      definitionStartPosition == that.definitionStartPosition &&
-      content.equals(that.content)
+      content.equals(that.content) &&
+      Objects.equals(getName(), that.getName()) &&
+      Objects.equals(
+        localContextScope.get(Context.IMPORT_RESOURCE_PATH_KEY),
+        that.localContextScope.get(Context.IMPORT_RESOURCE_PATH_KEY)
+      )
     );
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(content, caller, definitionLineNumber, definitionStartPosition);
+    return Objects.hash(
+      getName(),
+      localContextScope.get(Context.IMPORT_RESOURCE_PATH_KEY),
+      content,
+      caller
+    );
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
@@ -107,11 +107,11 @@ public class EagerMacroFunction extends AbstractCallableMethod {
     String prefix = "";
     String suffix = "";
     Optional<String> importFile = macroFunction.getImportFile(interpreter);
+    Object currentDeferredImportResource = null;
     if (importFile.isPresent()) {
       interpreter.getContext().getCurrentPathStack().pop();
-      Object currentDeferredImportResource = interpreter
-        .getContext()
-        .get(Context.DEFERRED_IMPORT_RESOURCE_PATH_KEY);
+      currentDeferredImportResource =
+        interpreter.getContext().get(Context.DEFERRED_IMPORT_RESOURCE_PATH_KEY);
       if (currentDeferredImportResource instanceof DeferredValue) {
         currentDeferredImportResource =
           ((DeferredValue) currentDeferredImportResource).getOriginalValue();
@@ -158,6 +158,10 @@ public class EagerMacroFunction extends AbstractCallableMethod {
             .map(arg -> DeferredMacroValueImpl.instance())
             .toArray()
         );
+
+        interpreter
+          .getContext()
+          .put(Context.DEFERRED_IMPORT_RESOURCE_PATH_KEY, currentDeferredImportResource);
         if (interpreter.getContext().getEagerTokens().size() > numEagerTokensStart) {
           evaluation =
             (String) evaluate(

--- a/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
@@ -5,6 +5,7 @@ import com.hubspot.jinjava.el.ext.AbstractCallableMethod;
 import com.hubspot.jinjava.el.ext.AstMacroFunction;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
+import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
@@ -108,9 +109,13 @@ public class EagerMacroFunction extends AbstractCallableMethod {
     Optional<String> importFile = macroFunction.getImportFile(interpreter);
     if (importFile.isPresent()) {
       interpreter.getContext().getCurrentPathStack().pop();
-      String currentDeferredImportResource = (String) interpreter
+      Object currentDeferredImportResource = interpreter
         .getContext()
         .get(Context.DEFERRED_IMPORT_RESOURCE_PATH_KEY);
+      if (currentDeferredImportResource instanceof DeferredValue) {
+        currentDeferredImportResource =
+          ((DeferredValue) currentDeferredImportResource).getOriginalValue();
+      }
       prefix =
         EagerReconstructionUtils.buildSetTag(
           ImmutableMap.of(
@@ -120,6 +125,9 @@ public class EagerMacroFunction extends AbstractCallableMethod {
           interpreter,
           false
         );
+      interpreter
+        .getContext()
+        .put(Context.DEFERRED_IMPORT_RESOURCE_PATH_KEY, importFile.get());
       suffix =
         EagerReconstructionUtils.buildSetTag(
           ImmutableMap.of(

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -25,7 +25,9 @@ import com.hubspot.jinjava.util.HelperStringTokenizer;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -151,7 +153,9 @@ public class ImportTag implements Tag {
         parent.getContext().addGlobalMacro(macro);
       }
       childBindings.remove(Context.GLOBAL_MACROS_SCOPE_KEY);
-      parent.getContext().putAll(childBindings);
+      parent
+        .getContext()
+        .putAll(getChildBindingsWithoutImportResourcePath(childBindings));
     } else {
       for (Map.Entry<String, MacroFunction> macro : child
         .getContext()
@@ -162,6 +166,17 @@ public class ImportTag implements Tag {
       childBindings.remove(Context.GLOBAL_MACROS_SCOPE_KEY);
       parent.getContext().put(contextVar, childBindings);
     }
+  }
+
+  public static Map<String, Object> getChildBindingsWithoutImportResourcePath(
+    Map<String, Object> childBindings
+  ) {
+    // Don't remove them from childBindings, because it is needed in a macro function's localContextScope
+    return childBindings
+      .entrySet()
+      .stream()
+      .filter(entry -> !entry.getKey().equals(Context.IMPORT_RESOURCE_PATH_KEY))
+      .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
   }
 
   public static void handleDeferredNodesDuringImport(

--- a/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
@@ -156,9 +156,7 @@ public class MacroTag implements Tag {
             (Map<String, Object>) interpreter
               .getContext()
               .getOrDefault(parentName, new HashMap<>());
-          if (!isLocalMacroFunctionAlreadyDeferred(macro.getName(), macroOfParent)) {
-            macroOfParent.put(macro.getName(), macro);
-          }
+          macroOfParent.put(macro.getName(), macro);
           if (!interpreter.getContext().containsKey(parentName)) {
             interpreter.getContext().put(parentName, macroOfParent);
           }
@@ -166,14 +164,7 @@ public class MacroTag implements Tag {
           Object originalValue =
             ((DeferredValue) interpreter.getContext().get(parentName)).getOriginalValue();
           if (originalValue instanceof Map) {
-            if (
-              !isLocalMacroFunctionAlreadyDeferred(
-                macro.getName(),
-                (Map<String, Object>) originalValue
-              )
-            ) {
-              ((Map<String, Object>) originalValue).put(macro.getName(), macro);
-            }
+            ((Map<String, Object>) originalValue).put(macro.getName(), macro);
           } else {
             macroOfParent = new HashMap<>();
             macroOfParent.put(macro.getName(), macro);
@@ -191,11 +182,7 @@ public class MacroTag implements Tag {
         );
       }
     } else {
-      if (
-        !isGlobalMacroFunctionAlreadyDeferred(macro.getName(), interpreter.getContext())
-      ) {
-        interpreter.getContext().addGlobalMacro(macro);
-      }
+      interpreter.getContext().addGlobalMacro(macro);
     }
 
     if (deferred) {
@@ -207,22 +194,6 @@ public class MacroTag implements Tag {
     }
 
     return "";
-  }
-
-  private boolean isLocalMacroFunctionAlreadyDeferred(
-    String name,
-    Map<String, Object> macroOfParent
-  ) {
-    return (
-      (macroOfParent.get(name) instanceof MacroFunction) &&
-      ((MacroFunction) macroOfParent.get(name)).isDeferred()
-    );
-  }
-
-  private boolean isGlobalMacroFunctionAlreadyDeferred(String name, Context context) {
-    return (
-      context.getGlobalMacro(name) != null && context.getGlobalMacro(name).isDeferred()
-    );
   }
 
   public static boolean populateArgNames(

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -338,7 +338,9 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
       }
       childBindings.remove(Context.GLOBAL_MACROS_SCOPE_KEY);
       childBindings.remove(Context.IMPORT_RESOURCE_ALIAS_KEY);
-      parent.getContext().putAll(childBindings);
+      parent
+        .getContext()
+        .putAll(ImportTag.getChildBindingsWithoutImportResourcePath(childBindings));
     } else {
       Map<String, MacroFunction> globalMacros = child.getContext().getGlobalMacros();
       for (Map.Entry<String, MacroFunction> macro : globalMacros.entrySet()) {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
@@ -11,6 +11,7 @@ import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
+import com.hubspot.jinjava.lib.tag.eager.EagerImportTagTest.PrintPathFilter;
 import com.hubspot.jinjava.loader.LocationResolver;
 import com.hubspot.jinjava.loader.RelativePathResolver;
 import com.hubspot.jinjava.loader.ResourceLocator;
@@ -39,6 +40,7 @@ public class ImportTagTest extends BaseInterpretingTest {
     );
 
     context.put("padding", 42);
+    context.registerFilter(new PrintPathFilter());
   }
 
   @Test
@@ -350,6 +352,17 @@ public class ImportTagTest extends BaseInterpretingTest {
     assertThat(result.getErrors().get(0).getSourceTemplate().isPresent());
     assertThat(result.getErrors().get(0).getSourceTemplate().get())
       .isEqualTo("tags/importtag/errors/macro-with-error.jinja");
+  }
+
+  @Test
+  public void itCorrectlySetsNestedPaths() {
+    context.put("foo", "foo");
+    assertThat(
+        interpreter.render(
+          "{% import 'double-import-macro.jinja' %}{{ print_path_macro2(foo) }}"
+        )
+      )
+      .isEqualTo("double-import-macro.jinja\n\nimport-macro.jinja\nfoo\n");
   }
 
   private String fixture(String name) {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -544,15 +544,16 @@ public class EagerImportTagTest extends ImportTagTest {
     );
     assertThat(firstPassResult)
       .isEqualTo(
-        "{% set deferred_import_resource_path = 'double-import-macro.jinja' %}{% macro print_path_macro2(var) %}{{ filter:print_path.filter(foo, ____int3rpr3t3r____) }}\n" +
+        "{% set deferred_import_resource_path = 'double-import-macro.jinja' %}{% macro print_path_macro2(var) %}{{ filter:print_path.filter(var, ____int3rpr3t3r____) }}\n" +
         "{% set deferred_import_resource_path = 'import-macro.jinja' %}{% macro print_path_macro(var) %}\n" +
         "{{ filter:print_path.filter(var, ____int3rpr3t3r____) }}\n" +
         "{{ var }}\n" +
-        "{% endmacro %}{% set deferred_import_resource_path = 'double-import-macro.jinja' %}{{ print_path_macro(foo) }}{% endmacro %}{% set deferred_import_resource_path = null %}{{ print_path_macro2(foo) }}"
+        "{% endmacro %}{% set deferred_import_resource_path = null %}{{ print_path_macro(var) }}{% endmacro %}{% set deferred_import_resource_path = null %}{{ print_path_macro2(foo) }}"
       );
     context.put("foo", "foo");
+    context.put(Context.GLOBAL_MACROS_SCOPE_KEY, null);
     assertThat(interpreter.render(firstPassResult).trim())
-      .isEqualTo("double-import-macro.jinja\nimport-macro.jinja\nfoo");
+      .isEqualTo("double-import-macro.jinja\n\nimport-macro.jinja\nfoo");
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -536,6 +536,26 @@ public class EagerImportTagTest extends ImportTagTest {
   }
 
   @Test
+  public void itCorrectlySetsNestedPathsForSecondPass() {
+    setupResourceLocator();
+    context.put("foo", DeferredValue.instance());
+    String firstPassResult = interpreter.render(
+      "{% import 'double-import-macro.jinja' %}{{ print_path_macro2(foo) }}"
+    );
+    assertThat(firstPassResult)
+      .isEqualTo(
+        "{% set deferred_import_resource_path = 'double-import-macro.jinja' %}{% macro print_path_macro2(var) %}{{ filter:print_path.filter(foo, ____int3rpr3t3r____) }}\n" +
+        "{% set deferred_import_resource_path = 'import-macro.jinja' %}{% macro print_path_macro(var) %}\n" +
+        "{{ filter:print_path.filter(var, ____int3rpr3t3r____) }}\n" +
+        "{{ var }}\n" +
+        "{% endmacro %}{% set deferred_import_resource_path = 'double-import-macro.jinja' %}{{ print_path_macro(foo) }}{% endmacro %}{% set deferred_import_resource_path = null %}{{ print_path_macro2(foo) }}"
+      );
+    context.put("foo", "foo");
+    assertThat(interpreter.render(firstPassResult).trim())
+      .isEqualTo("double-import-macro.jinja\nimport-macro.jinja\nfoo");
+  }
+
+  @Test
   public void itImportsDoublyNamed() {
     setupResourceLocator();
     String result = interpreter.render(

--- a/src/test/resources/tags/eager/importtag/double-import-macro.jinja
+++ b/src/test/resources/tags/eager/importtag/double-import-macro.jinja
@@ -1,0 +1,5 @@
+{% import 'import-macro.jinja' -%}
+{% macro print_path_macro2(var) -%}
+{{ foo|print_path }}
+{{ print_path_macro(foo) }}
+{%- endmacro %}

--- a/src/test/resources/tags/eager/importtag/double-import-macro.jinja
+++ b/src/test/resources/tags/eager/importtag/double-import-macro.jinja
@@ -1,5 +1,5 @@
 {% import 'import-macro.jinja' -%}
 {% macro print_path_macro2(var) -%}
-{{ foo|print_path }}
-{{ print_path_macro(foo) }}
+{{ var|print_path }}
+{{ print_path_macro(var) }}
 {%- endmacro %}

--- a/src/test/resources/tags/macrotag/double-import-macro.jinja
+++ b/src/test/resources/tags/macrotag/double-import-macro.jinja
@@ -1,0 +1,5 @@
+{% import 'import-macro.jinja' -%}
+{% macro print_path_macro2(var) -%}
+{{ foo|print_path }}
+{{ print_path_macro(foo) }}
+{%- endmacro %}

--- a/src/test/resources/tags/macrotag/double-import-macro.jinja
+++ b/src/test/resources/tags/macrotag/double-import-macro.jinja
@@ -1,5 +1,5 @@
 {% import 'import-macro.jinja' -%}
 {% macro print_path_macro2(var) -%}
-{{ foo|print_path }}
-{{ print_path_macro(foo) }}
+{{ var|print_path }}
+{{ print_path_macro(var) }}
 {%- endmacro %}

--- a/src/test/resources/tags/macrotag/import-macro.jinja
+++ b/src/test/resources/tags/macrotag/import-macro.jinja
@@ -1,0 +1,4 @@
+{% macro print_path_macro(var) %}
+{{ var|print_path }}
+{{ var }}
+{% endmacro %}


### PR DESCRIPTION
There is a bug in Jinjava that affects the `import_resource_path` when there is a file that gets imported that has a macro, but that file also imports another file. The `import_resource_path` of the second file is put onto the context for the first file.

I created a test but it works like:
`double-import-macro.jinja`
```
{% import 'import-macro.jinja' -%}
{% macro print_path_macro2(var) -%}
{{ var|print_path }}
{{ print_path_macro(var) }}
{%- endmacro %}
```
`import-macro.jinja`
```
{% macro print_path_macro(var) %}
{{ var|print_path }}
{{ var }}
{% endmacro %}
```
Calling:
```
{% import 'double-import-macro.jinja' %}
{{ print_path_macro2('foo') }}
```
Should print
```
double-import-macro.jinja
import-macro.jinja
foo
```
But the bug had it outputting
```
import-macro.jinja
import-macro.jinja
foo
```
This PR fixes it for default and eager execution and also fixes the hashcode for macro functions to work better in eager execution. (Includes the `import_resource_path` of the macro in the hashcode.