### PR TITLE
Revert 821 revert 820 handle nested import file paths

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -182,14 +182,20 @@ public class MacroFunction extends AbstractCallableMethod {
     MacroFunction that = (MacroFunction) o;
     return (
       caller == that.caller &&
-      definitionLineNumber == that.definitionLineNumber &&
-      definitionStartPosition == that.definitionStartPosition &&
-      content.equals(that.content)
+      Objects.equals(getName(), that.getName()) &&
+      Objects.equals(
+        localContextScope.get(Context.IMPORT_RESOURCE_PATH_KEY),
+        that.localContextScope.get(Context.IMPORT_RESOURCE_PATH_KEY)
+      )
     );
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(content, caller, definitionLineNumber, definitionStartPosition);
+    return Objects.hash(
+      getName(),
+      localContextScope.get(Context.IMPORT_RESOURCE_PATH_KEY),
+      caller
+    );
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -23,11 +23,10 @@ import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.HelperStringTokenizer;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -157,9 +156,7 @@ public class ImportTag implements Tag {
         .getContext()
         .putAll(getChildBindingsWithoutImportResourcePath(childBindings));
     } else {
-      childBindings.putAll(child
-        .getContext()
-        .getGlobalMacros());
+      childBindings.putAll(child.getContext().getGlobalMacros());
       childBindings.remove(Context.GLOBAL_MACROS_SCOPE_KEY);
       parent.getContext().put(contextVar, childBindings);
     }
@@ -168,12 +165,14 @@ public class ImportTag implements Tag {
   public static Map<String, Object> getChildBindingsWithoutImportResourcePath(
     Map<String, Object> childBindings
   ) {
+    Map<String, Object> filteredMap = new HashMap<>();
     // Don't remove them from childBindings, because it is needed in a macro function's localContextScope
-    return childBindings
+    childBindings
       .entrySet()
       .stream()
       .filter(entry -> !entry.getKey().equals(Context.IMPORT_RESOURCE_PATH_KEY))
-      .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+      .forEach(entry -> filteredMap.put(entry.getKey(), entry.getValue()));
+    return filteredMap;
   }
 
   public static void handleDeferredNodesDuringImport(

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -157,12 +157,9 @@ public class ImportTag implements Tag {
         .getContext()
         .putAll(getChildBindingsWithoutImportResourcePath(childBindings));
     } else {
-      for (Map.Entry<String, MacroFunction> macro : child
+      childBindings.putAll(child
         .getContext()
-        .getGlobalMacros()
-        .entrySet()) {
-        childBindings.put(macro.getKey(), macro.getValue());
-      }
+        .getGlobalMacros());
       childBindings.remove(Context.GLOBAL_MACROS_SCOPE_KEY);
       parent.getContext().put(contextVar, childBindings);
     }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -25,7 +25,9 @@ import com.hubspot.jinjava.util.HelperStringTokenizer;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -151,7 +153,9 @@ public class ImportTag implements Tag {
         parent.getContext().addGlobalMacro(macro);
       }
       childBindings.remove(Context.GLOBAL_MACROS_SCOPE_KEY);
-      parent.getContext().putAll(childBindings);
+      parent
+        .getContext()
+        .putAll(getChildBindingsWithoutImportResourcePath(childBindings));
     } else {
       for (Map.Entry<String, MacroFunction> macro : child
         .getContext()
@@ -162,6 +166,17 @@ public class ImportTag implements Tag {
       childBindings.remove(Context.GLOBAL_MACROS_SCOPE_KEY);
       parent.getContext().put(contextVar, childBindings);
     }
+  }
+
+  public static Map<String, Object> getChildBindingsWithoutImportResourcePath(
+    Map<String, Object> childBindings
+  ) {
+    // Don't remove them from childBindings, because it is needed in a macro function's localContextScope
+    return childBindings
+      .entrySet()
+      .stream()
+      .filter(entry -> !entry.getKey().equals(Context.IMPORT_RESOURCE_PATH_KEY))
+      .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
   }
 
   public static void handleDeferredNodesDuringImport(

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -342,10 +342,7 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
         .getContext()
         .putAll(ImportTag.getChildBindingsWithoutImportResourcePath(childBindings));
     } else {
-      Map<String, MacroFunction> globalMacros = child.getContext().getGlobalMacros();
-      for (Map.Entry<String, MacroFunction> macro : globalMacros.entrySet()) {
-        childBindings.put(macro.getKey(), macro.getValue());
-      }
+      childBindings.putAll(child.getContext().getGlobalMacros());
       Map<String, Object> mapForCurrentContextAlias = getMapForCurrentContextAlias(
         currentImportAlias,
         child

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -338,7 +338,9 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
       }
       childBindings.remove(Context.GLOBAL_MACROS_SCOPE_KEY);
       childBindings.remove(Context.IMPORT_RESOURCE_ALIAS_KEY);
-      parent.getContext().putAll(childBindings);
+      parent
+        .getContext()
+        .putAll(ImportTag.getChildBindingsWithoutImportResourcePath(childBindings));
     } else {
       Map<String, MacroFunction> globalMacros = child.getContext().getGlobalMacros();
       for (Map.Entry<String, MacroFunction> macro : globalMacros.entrySet()) {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
@@ -11,6 +11,7 @@ import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
+import com.hubspot.jinjava.lib.tag.eager.EagerImportTagTest.PrintPathFilter;
 import com.hubspot.jinjava.loader.LocationResolver;
 import com.hubspot.jinjava.loader.RelativePathResolver;
 import com.hubspot.jinjava.loader.ResourceLocator;
@@ -39,6 +40,7 @@ public class ImportTagTest extends BaseInterpretingTest {
     );
 
     context.put("padding", 42);
+    context.registerFilter(new PrintPathFilter());
   }
 
   @Test
@@ -350,6 +352,17 @@ public class ImportTagTest extends BaseInterpretingTest {
     assertThat(result.getErrors().get(0).getSourceTemplate().isPresent());
     assertThat(result.getErrors().get(0).getSourceTemplate().get())
       .isEqualTo("tags/importtag/errors/macro-with-error.jinja");
+  }
+
+  @Test
+  public void itCorrectlySetsNestedPaths() {
+    context.put("foo", "foo");
+    assertThat(
+        interpreter.render(
+          "{% import 'double-import-macro.jinja' %}{{ print_path_macro2(foo) }}"
+        )
+      )
+      .isEqualTo("double-import-macro.jinja\n\nimport-macro.jinja\nfoo\n");
   }
 
   private String fixture(String name) {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
@@ -79,6 +79,21 @@ public class ImportTagTest extends BaseInterpretingTest {
   }
 
   @Test
+  public void itHandlesNullImportedValues() throws IOException {
+    Jinjava jinjava = new Jinjava();
+    interpreter = new JinjavaInterpreter(jinjava, context, jinjava.getGlobalConfig());
+
+    interpreter.render(
+      Resources.toString(
+        Resources.getResource("tags/importtag/imports-null.jinja"),
+        StandardCharsets.UTF_8
+      )
+    );
+    assertThat(context.get("foo")).isEqualTo("foo");
+    assertThat(context.get("bar")).isEqualTo(null);
+  }
+
+  @Test
   public void importedContextExposesVars() {
     assertThat(fixture("import"))
       .contains("wrap-padding: padding-left:42px;padding-right:42px");

--- a/src/test/resources/tags/eager/importtag/double-import-macro.jinja
+++ b/src/test/resources/tags/eager/importtag/double-import-macro.jinja
@@ -1,0 +1,5 @@
+{% import 'import-macro.jinja' -%}
+{% macro print_path_macro2(var) -%}
+{{ var|print_path }}
+{{ print_path_macro(var) }}
+{%- endmacro %}

--- a/src/test/resources/tags/importtag/imports-null.jinja
+++ b/src/test/resources/tags/importtag/imports-null.jinja
@@ -1,0 +1,4 @@
+{% set bar = 'bar' %}
+{% import 'tags/importtag/null-value.jinja' %}
+{{ foo }}
+{{ bar }}

--- a/src/test/resources/tags/importtag/null-value.jinja
+++ b/src/test/resources/tags/importtag/null-value.jinja
@@ -1,0 +1,2 @@
+{% set foo = 'foo' %}
+{% set bar = null %}

--- a/src/test/resources/tags/macrotag/double-import-macro.jinja
+++ b/src/test/resources/tags/macrotag/double-import-macro.jinja
@@ -1,0 +1,5 @@
+{% import 'import-macro.jinja' -%}
+{% macro print_path_macro2(var) -%}
+{{ var|print_path }}
+{{ print_path_macro(var) }}
+{%- endmacro %}

--- a/src/test/resources/tags/macrotag/import-macro.jinja
+++ b/src/test/resources/tags/macrotag/import-macro.jinja
@@ -1,0 +1,4 @@
+{% macro print_path_macro(var) %}
+{{ var|print_path }}
+{{ var }}
+{% endmacro %}


### PR DESCRIPTION
This fixes the NPE in https://github.com/HubSpot/jinjava/pull/820
via https://github.com/HubSpot/jinjava/commit/13e92544df5ae75225071c4759d96f963c7acf60
It uses `HashMap.put()` instead of collecting with `Collectors.toMap()` to be able to handle entries with null values.