### PR TITLE
[Eager Execution] Get original value of deferred_import_resource_path if it's a deferred value

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
@@ -119,12 +119,16 @@ public class MacroTag implements Tag {
       argNamesWithDefaults
     );
     MacroFunction macro;
-    String contextImportResourcePath = (String) interpreter
+    Object contextImportResourcePath = interpreter
       .getContext()
-      .get(Context.DEFERRED_IMPORT_RESOURCE_PATH_KEY, "");
+      .get(Context.DEFERRED_IMPORT_RESOURCE_PATH_KEY);
+    if (contextImportResourcePath instanceof DeferredValue) {
+      contextImportResourcePath =
+        ((DeferredValue) contextImportResourcePath).getOriginalValue();
+    }
     boolean scopeEntered = false;
     try {
-      if (StringUtils.isNotEmpty(contextImportResourcePath)) {
+      if (StringUtils.isNotEmpty((String) contextImportResourcePath)) {
         scopeEntered = true;
         interpreter.enterScope();
         interpreter


### PR DESCRIPTION
This change was made to the EagerMacroFunction in https://github.com/HubSpot/jinjava/pull/820 to prevent a class cast exception from DeferredValueImpl to String. It is also needed in MacroTag.java