### PR TITLE
Fixing some flaky tests

### DIFF
--- a/src/test/java/com/hubspot/jinjava/lib/filter/ListFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/ListFilterTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Sets;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -43,6 +44,7 @@ public class ListFilterTest {
   @Test
   public void itConvertsSetsToLists() {
     Set<Integer> ints = Sets.newHashSet(1, 2, 3);
+    ints = new TreeSet<Integer>(ints); // Converting to TreeSet to avoid non-deterministic permutations.
     List<?> o = (List<?>) filter.filter(ints, null);
     assertThat(o).isEqualTo(Lists.newArrayList(1, 2, 3));
   }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/ToJsonFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/ToJsonFilterTest.java
@@ -3,7 +3,7 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import com.hubspot.jinjava.BaseInterpretingTest;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,7 +21,7 @@ public class ToJsonFilterTest extends BaseInterpretingTest {
     int[] testArray = new int[] { 4, 1, 2 };
     assertThat(filter.filter(testArray, interpreter)).isEqualTo("[4,1,2]");
 
-    Map<String, Object> testMap = new HashMap<>();
+    Map<String, Object> testMap = new LinkedHashMap<>();
     testMap.put("testArray", testArray);
     testMap.put("testString", "testString");
     assertThat(filter.filter(testMap, interpreter))

--- a/src/test/java/com/hubspot/jinjava/lib/filter/ToYamlFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/ToYamlFilterTest.java
@@ -3,7 +3,7 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import com.hubspot.jinjava.BaseInterpretingTest;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,7 +22,7 @@ public class ToYamlFilterTest extends BaseInterpretingTest {
     assertThat(filter.filter(testArray, interpreter))
       .isEqualTo("- 4\n" + "- 1\n" + "- 2\n");
 
-    Map<String, Object> testMap = new HashMap<>();
+    Map<String, Object> testMap = new LinkedHashMap<>();
     testMap.put("testArray", testArray);
     testMap.put("testString", "testString");
     assertThat(filter.filter(testMap, interpreter))


### PR DESCRIPTION
**Description**
3 flaky tests are found using Nondex when running commands 
```mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex ``` 
The reasons for test flakiness are that Java Hashmap API do not preserve the order of the key-value pairs, and that Java Set API does not preserve the order of elements. Comparing maps or sets with strings can fail when, for example, the Java version upgrades in the future, or when the code is run in different environments.

**Flaky Tests and Fixes**
Using TreeSet instead of Set, and using LinkedHashMap instead of HashMap to ensure deterministic behavior in tests.