### PR TITLE
[Eager Execution] Fix race condition in deferred AstNode evaluation

### DIFF
--- a/src/main/java/com/hubspot/jinjava/Jinjava.java
+++ b/src/main/java/com/hubspot/jinjava/Jinjava.java
@@ -97,7 +97,7 @@ public class Jinjava {
       TreeBuilder.class.getName(),
       EagerExtendedSyntaxBuilder.class.getName()
     );
-    //    eagerExpConfig.setProperty(ExpressionFactoryImpl.PROP_CACHE_SIZE, "0");
+    eagerExpConfig.setProperty(ExpressionFactoryImpl.PROP_CACHE_SIZE, "0");
 
     TypeConverter converter = new TruthyTypeConverter();
     this.expressionFactory = new ExpressionFactoryImpl(expConfig, converter);

--- a/src/main/java/com/hubspot/jinjava/Jinjava.java
+++ b/src/main/java/com/hubspot/jinjava/Jinjava.java
@@ -97,6 +97,7 @@ public class Jinjava {
       TreeBuilder.class.getName(),
       EagerExtendedSyntaxBuilder.class.getName()
     );
+    //    eagerExpConfig.setProperty(ExpressionFactoryImpl.PROP_CACHE_SIZE, "0");
 
     TypeConverter converter = new TruthyTypeConverter();
     this.expressionFactory = new ExpressionFactoryImpl(expConfig, converter);

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBinary.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBinary.java
@@ -83,14 +83,6 @@ public class EagerAstBinary extends AstBinary implements EvalResultHolder {
   }
 
   @Override
-  public void clearEvalResult() {
-    evalResult = null;
-    hasEvalResult = false;
-    left.clearEvalResult();
-    right.clearEvalResult();
-  }
-
-  @Override
   public boolean hasEvalResult() {
     return hasEvalResult;
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBracket.java
@@ -47,16 +47,6 @@ public class EagerAstBracket extends AstBracket implements EvalResultHolder {
   }
 
   @Override
-  public void clearEvalResult() {
-    evalResult = null;
-    hasEvalResult = false;
-    ((EvalResultHolder) prefix).clearEvalResult();
-    if (property != null) {
-      ((EvalResultHolder) property).clearEvalResult();
-    }
-  }
-
-  @Override
   public boolean hasEvalResult() {
     return hasEvalResult;
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoice.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoice.java
@@ -62,15 +62,6 @@ public class EagerAstChoice extends AstChoice implements EvalResultHolder {
   }
 
   @Override
-  public void clearEvalResult() {
-    evalResult = null;
-    hasEvalResult = false;
-    question.clearEvalResult();
-    yes.clearEvalResult();
-    no.clearEvalResult();
-  }
-
-  @Override
   public boolean hasEvalResult() {
     return hasEvalResult;
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDict.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDict.java
@@ -97,23 +97,6 @@ public class EagerAstDict extends AstDict implements EvalResultHolder {
   }
 
   @Override
-  public void clearEvalResult() {
-    evalResult = null;
-    hasEvalResult = false;
-
-    dict.forEach(
-      (key, value) -> {
-        if (key instanceof EvalResultHolder) {
-          ((EvalResultHolder) key).clearEvalResult();
-        }
-        if (value instanceof EvalResultHolder) {
-          ((EvalResultHolder) value).clearEvalResult();
-        }
-      }
-    );
-  }
-
-  @Override
   public boolean hasEvalResult() {
     return hasEvalResult;
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDot.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDot.java
@@ -73,13 +73,6 @@ public class EagerAstDot extends AstDot implements EvalResultHolder {
   }
 
   @Override
-  public void clearEvalResult() {
-    evalResult = null;
-    hasEvalResult = false;
-    base.clearEvalResult();
-  }
-
-  @Override
   public boolean hasEvalResult() {
     return hasEvalResult;
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifier.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifier.java
@@ -34,12 +34,6 @@ public class EagerAstIdentifier extends AstIdentifier implements EvalResultHolde
   }
 
   @Override
-  public void clearEvalResult() {
-    evalResult = null;
-    hasEvalResult = false;
-  }
-
-  @Override
   public boolean hasEvalResult() {
     return hasEvalResult;
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstList.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstList.java
@@ -36,15 +36,6 @@ public class EagerAstList extends AstList implements EvalResultHolder {
   }
 
   @Override
-  public void clearEvalResult() {
-    evalResult = null;
-    hasEvalResult = false;
-    for (int i = 0; i < elements.getCardinality(); i++) {
-      ((EvalResultHolder) elements.getChild(i)).clearEvalResult();
-    }
-  }
-
-  @Override
   public boolean hasEvalResult() {
     return hasEvalResult;
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
@@ -91,16 +91,6 @@ public class EagerAstMacroFunction extends AstMacroFunction implements EvalResul
   }
 
   @Override
-  public void clearEvalResult() {
-    evalResult = null;
-    hasEvalResult = false;
-    params.clearEvalResult();
-    for (int i = 0; i < ((AstParameters) params).getCardinality(); i++) {
-      ((EvalResultHolder) ((AstParameters) params).getChild(i)).clearEvalResult();
-    }
-  }
-
-  @Override
   public boolean hasEvalResult() {
     return hasEvalResult;
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
@@ -60,14 +60,6 @@ public class EagerAstMethod extends AstMethod implements EvalResultHolder {
   }
 
   @Override
-  public void clearEvalResult() {
-    evalResult = null;
-    hasEvalResult = false;
-    property.clearEvalResult();
-    params.clearEvalResult();
-  }
-
-  @Override
   public boolean hasEvalResult() {
     return hasEvalResult;
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNamedParameter.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNamedParameter.java
@@ -66,13 +66,6 @@ public class EagerAstNamedParameter
   }
 
   @Override
-  public void clearEvalResult() {
-    evalResult = null;
-    hasEvalResult = false;
-    value.clearEvalResult();
-  }
-
-  @Override
   public boolean hasEvalResult() {
     return hasEvalResult;
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNested.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNested.java
@@ -52,13 +52,6 @@ public class EagerAstNested extends AstRightValue implements EvalResultHolder {
   }
 
   @Override
-  public void clearEvalResult() {
-    evalResult = null;
-    hasEvalResult = false;
-    ((EvalResultHolder) child).clearEvalResult();
-  }
-
-  @Override
   public boolean hasEvalResult() {
     return hasEvalResult;
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNodeDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNodeDecorator.java
@@ -44,12 +44,6 @@ public class EagerAstNodeDecorator extends AstNode implements EvalResultHolder {
   }
 
   @Override
-  public void clearEvalResult() {
-    evalResult = null;
-    hasEvalResult = false;
-  }
-
-  @Override
   public boolean hasEvalResult() {
     return hasEvalResult;
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstParameters.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstParameters.java
@@ -77,13 +77,6 @@ public class EagerAstParameters extends AstParameters implements EvalResultHolde
   }
 
   @Override
-  public void clearEvalResult() {
-    evalResult = null;
-    hasEvalResult = false;
-    nodes.forEach(node -> ((EvalResultHolder) node).clearEvalResult());
-  }
-
-  @Override
   public boolean hasEvalResult() {
     return hasEvalResult;
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstRangeBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstRangeBracket.java
@@ -84,21 +84,6 @@ public class EagerAstRangeBracket extends AstRangeBracket implements EvalResultH
   }
 
   @Override
-  public void clearEvalResult() {
-    evalResult = null;
-    hasEvalResult = false;
-    if (prefix != null) {
-      ((EvalResultHolder) prefix).clearEvalResult();
-    }
-    if (property != null) {
-      ((EvalResultHolder) property).clearEvalResult();
-    }
-    if (rangeMax != null) {
-      ((EvalResultHolder) rangeMax).clearEvalResult();
-    }
-  }
-
-  @Override
   public boolean hasEvalResult() {
     return hasEvalResult;
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstRoot.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstRoot.java
@@ -21,13 +21,7 @@ public class EagerAstRoot extends AstNode {
 
   @Override
   public Object eval(Bindings bindings, ELContext context) {
-    try {
-      return rootNode.eval(bindings, context);
-    } finally {
-      if (rootNode instanceof EvalResultHolder) {
-        ((EvalResultHolder) rootNode).clearEvalResult();
-      }
-    }
+    return rootNode.eval(bindings, context);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstTuple.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstTuple.java
@@ -58,15 +58,6 @@ public class EagerAstTuple extends AstTuple implements EvalResultHolder {
   }
 
   @Override
-  public void clearEvalResult() {
-    evalResult = null;
-    hasEvalResult = false;
-    for (int i = 0; i < elements.getCardinality(); i++) {
-      ((EvalResultHolder) elements.getChild(i)).clearEvalResult();
-    }
-  }
-
-  @Override
   public boolean hasEvalResult() {
     return hasEvalResult;
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstUnary.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstUnary.java
@@ -62,13 +62,6 @@ public class EagerAstUnary extends AstUnary implements EvalResultHolder {
   }
 
   @Override
-  public void clearEvalResult() {
-    evalResult = null;
-    hasEvalResult = false;
-    child.clearEvalResult();
-  }
-
-  @Override
   public boolean hasEvalResult() {
     return hasEvalResult;
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
@@ -17,8 +17,6 @@ public interface EvalResultHolder {
 
   void setEvalResult(Object evalResult);
 
-  void clearEvalResult();
-
   boolean hasEvalResult();
 
   default Object eval(


### PR DESCRIPTION
There is a race condition that can happen in an AstNode that is evaluated with Eager Execution. If multiple threads share the same `ExpressionFactoryImpl`, then if a ValueExpression is pulled from the `TreeStore` cache before its evaluation (and subsequent `clearEvalResult()` call and it is used in another thread then it is possible that the stored `evalResult` from the first thread could be used in the second thread when encountering a DeferredValueException.

This is proven with the unit test `itIsThreadSafe()` that fails before the change I made by setting the cache size to 0 for eager execution's ExpressionFactory.

Here, is where it was possible to use the value stored from the other thread https://github.com/HubSpot/jinjava/blob/e144dcb387700ad98e95ad6f0b404f79d8204353/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java#L68-L71.
It could also happen here, but that's not easily reproducible in a unit test https://github.com/HubSpot/jinjava/blob/e144dcb387700ad98e95ad6f0b404f79d8204353/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java#L30-L31