### PR TITLE
Prevent NPE for ZoneId.of

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -161,11 +161,11 @@ public class Functions {
   public static String dateTimeFormat(Object var, String... format) {
     ZoneId zoneOffset = ZoneOffset.UTC;
 
-    if (format.length > 1) {
+    if (format.length > 1 && format[1] != null) {
       String timezone = format[1];
       try {
         zoneOffset = ZoneId.of(timezone);
-      } catch (DateTimeException | NullPointerException e) {
+      } catch (DateTimeException e) {
         throw new InvalidArgumentException(
           JinjavaInterpreter.getCurrent(),
           "datetimeformat",

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -165,7 +165,7 @@ public class Functions {
       String timezone = format[1];
       try {
         zoneOffset = ZoneId.of(timezone);
-      } catch (DateTimeException e) {
+      } catch (DateTimeException | NullPointerException e) {
         throw new InvalidArgumentException(
           JinjavaInterpreter.getCurrent(),
           "datetimeformat",

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
@@ -112,4 +112,16 @@ public class DateTimeFormatFilterTest extends BaseInterpretingTest {
       )
       .isEqualTo(Functions.dateTimeFormat(d, "%A, %e %B", "UTC", "America/Los_Angeles"));
   }
+
+  @Test
+  public void itDefaultsToUtcForNullTimezone() {
+    interpreter.getContext().put("d", d);
+
+    assertThat(
+        interpreter.renderFlat(
+          "{{ d|datetimeformat('%A, %e %B, %I:%M %p', null, 'sv') }}"
+        )
+      )
+      .isEqualTo("onsdag, 6 november, 02:22 em");
+  }
 }


### PR DESCRIPTION
If dateTimeFormat is called with a `null` timezone, it can lead to a NullPointerException when calling `ZoneId.of(null)`. This resorts to using UTC if the parameter is `null`.