### PR TITLE
Don't throw exceptions on bad date arithmetic

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/PlusTimeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/PlusTimeFilter.java
@@ -4,8 +4,13 @@ import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateError;
+import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
+import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
+import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import com.hubspot.jinjava.lib.fn.Functions;
 import com.hubspot.jinjava.objects.date.PyishDate;
+import java.time.DateTimeException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -43,18 +48,32 @@ public class PlusTimeFilter extends BaseDateFilter {
     long diff = parseDiffAmount(interpreter, args);
     ChronoUnit chronoUnit = parseChronoUnit(interpreter, args);
 
-    if (var instanceof ZonedDateTime) {
-      ZonedDateTime dateTime = (ZonedDateTime) var;
-      return new PyishDate(dateTime.plus(diff, chronoUnit));
-    } else if (var instanceof PyishDate) {
-      PyishDate pyishDate = (PyishDate) var;
-      return new PyishDate(pyishDate.toDateTime().plus(diff, chronoUnit));
-    } else if (var instanceof Number) {
-      Number timestamp = (Number) var;
-      ZonedDateTime zonedDateTime = Functions.getDateTimeArg(timestamp, ZoneOffset.UTC);
-      return new PyishDate(zonedDateTime.plus(diff, chronoUnit));
+    try {
+      if (var instanceof ZonedDateTime) {
+        ZonedDateTime dateTime = (ZonedDateTime) var;
+        return new PyishDate(dateTime.plus(diff, chronoUnit));
+      } else if (var instanceof PyishDate) {
+        PyishDate pyishDate = (PyishDate) var;
+        return new PyishDate(pyishDate.toDateTime().plus(diff, chronoUnit));
+      } else if (var instanceof Number) {
+        Number timestamp = (Number) var;
+        ZonedDateTime zonedDateTime = Functions.getDateTimeArg(timestamp, ZoneOffset.UTC);
+        return new PyishDate(zonedDateTime.plus(diff, chronoUnit));
+      }
+    } catch (DateTimeException e) {
+      interpreter.addError(
+        new TemplateError(
+          ErrorType.WARNING,
+          ErrorReason.OTHER,
+          ErrorItem.FILTER,
+          e.getMessage(),
+          null,
+          interpreter.getLineNumber(),
+          interpreter.getPosition(),
+          e
+        )
+      );
     }
-
     return var;
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/MinusTimeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/MinusTimeFilterTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.BaseJinjavaTest;
+import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.objects.date.PyishDate;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -56,5 +57,18 @@ public class MinusTimeFilterTest extends BaseJinjavaTest {
     vars = ImmutableMap.of("test", timestamp);
     assertThat(jinjava.render("{{ test|minus_time(1, 'days')|unixtimestamp }}", vars))
       .isEqualTo(String.valueOf(oneDay));
+  }
+
+  @Test
+  public void itWarnsOnDateTimeException() {
+    long timestamp = 1543352736000L;
+
+    Map<String, Object> vars = ImmutableMap.of("test", timestamp);
+    RenderResult renderResult = jinjava.renderForResult(
+      "{{ test|minus_time(9999999999, 'years')|unixtimestamp }}",
+      vars
+    );
+    assertThat(renderResult.getOutput()).isEqualTo(String.valueOf(timestamp));
+    assertThat(renderResult.getErrors()).hasSize(1);
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/PlusTimeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/PlusTimeFilterTest.java
@@ -98,4 +98,17 @@ public class PlusTimeFilterTest extends BaseJinjavaTest {
     );
     assertThat(renderResult.getErrors()).hasSize(1);
   }
+
+  @Test
+  public void itWarnsOnDateTimeException() {
+    long timestamp = 1543352736000L;
+
+    Map<String, Object> vars = ImmutableMap.of("test", timestamp);
+    RenderResult renderResult = jinjava.renderForResult(
+      "{{ test|plus_time(9999999999, 'years')|unixtimestamp }}",
+      vars
+    );
+    assertThat(renderResult.getOutput()).isEqualTo(String.valueOf(timestamp));
+    assertThat(renderResult.getErrors()).hasSize(1);
+  }
 }


### PR DESCRIPTION
Catches bad plus_time and minus_time calls and warns, but doesn't raise an exception.