### PR TITLE
[Eager Execution] Handle serialization of null keys as empty string in maps

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -1,21 +1,34 @@
 package com.hubspot.jinjava.objects.serialization;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.hubspot.jinjava.util.WhitespaceUtils;
+import java.io.IOException;
 import java.util.Objects;
 
 public class PyishObjectMapper {
-  public static final ObjectWriter PYISH_OBJECT_WRITER = new ObjectMapper()
-    .registerModule(
-      new SimpleModule()
-        .setSerializerModifier(PyishBeanSerializerModifier.INSTANCE)
-        .addSerializer(PyishSerializable.class, PyishSerializer.INSTANCE)
-    )
-    .writer(PyishPrettyPrinter.INSTANCE)
-    .with(PyishCharacterEscapes.INSTANCE);
+  public static final ObjectWriter PYISH_OBJECT_WRITER;
+
+  static {
+    ObjectMapper mapper = new ObjectMapper()
+      .registerModule(
+        new SimpleModule()
+          .setSerializerModifier(PyishBeanSerializerModifier.INSTANCE)
+          .addSerializer(PyishSerializable.class, PyishSerializer.INSTANCE)
+      )
+      .configure(SerializationFeature.WRITE_NULL_MAP_VALUES, false)
+      .setSerializationInclusion(Include.NON_NULL);
+    mapper.getSerializerProvider().setNullKeySerializer(new NullKeySerializer());
+    PYISH_OBJECT_WRITER =
+      mapper.writer(PyishPrettyPrinter.INSTANCE).with(PyishCharacterEscapes.INSTANCE);
+  }
 
   public static String getAsUnquotedPyishString(Object val) {
     if (val != null) {
@@ -37,6 +50,19 @@ public class PyishObjectMapper {
       return string;
     } catch (JsonProcessingException e) {
       return Objects.toString(val, "");
+    }
+  }
+
+  public static class NullKeySerializer extends JsonSerializer<Object> {
+
+    @Override
+    public void serialize(
+      Object o,
+      JsonGenerator jsonGenerator,
+      SerializerProvider serializerProvider
+    )
+      throws IOException {
+      jsonGenerator.writeFieldName("");
     }
   }
 }

--- a/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
@@ -1,0 +1,20 @@
+package com.hubspot.jinjava.objects.serialization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hubspot.jinjava.objects.collections.SizeLimitingPyMap;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class PyishObjectMapperTest {
+
+  @Test
+  public void itSerializesMapWithNullKeysAsEmptyString() {
+    Map<String, Object> map = new SizeLimitingPyMap(new HashMap<>(), 10);
+    map.put("foo", "bar");
+    map.put(null, "null");
+    assertThat(PyishObjectMapper.getAsPyishString(map))
+      .isEqualTo("{'': 'null', 'foo': 'bar'}");
+  }
+}


### PR DESCRIPTION
Null keys are not valid JSON. There is no way to deserialize null keys in JSON. Trying to serialize them with jackson will throw a JsonParseException by default. If trying to serialize in PyishObjectMapper, it will default to using the java string representation if this happens.
In this circumstance, we could instead just serialize null keys to empty strings, which is better than using java's string representation.