### PR TITLE
[Eager Execution] Handle null values in EvalResultHolder as empty strings

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
@@ -52,6 +52,9 @@ public interface EvalResultHolder {
     DeferredParsingException exception,
     boolean preserveIdentifier
   ) {
+    if (astNode == null) {
+      return "";
+    }
     if (
       preserveIdentifier &&
       !astNode.hasEvalResult() &&

--- a/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstRangeBracketTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstRangeBracketTest.java
@@ -1,0 +1,44 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hubspot.jinjava.BaseInterpretingTest;
+import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.LegacyOverrides;
+import com.hubspot.jinjava.interpret.Context;
+import com.hubspot.jinjava.interpret.DeferredValue;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.mode.EagerExecutionMode;
+import com.hubspot.jinjava.random.RandomNumberGeneratorStrategy;
+import org.junit.Before;
+import org.junit.Test;
+
+public class EagerAstRangeBracketTest extends BaseInterpretingTest {
+  @Before
+  public void setup() {
+    JinjavaConfig config = JinjavaConfig
+      .newBuilder()
+      .withRandomNumberGeneratorStrategy(RandomNumberGeneratorStrategy.DEFERRED)
+      .withExecutionMode(EagerExecutionMode.instance())
+      .withNestedInterpretationEnabled(true)
+      .withLegacyOverrides(
+        LegacyOverrides.newBuilder().withUsePyishObjectMapper(true).build()
+      )
+      .withMaxMacroRecursionDepth(5)
+      .withEnableRecursiveMacroCalls(true)
+      .build();
+    JinjavaInterpreter parentInterpreter = new JinjavaInterpreter(
+      jinjava,
+      new Context(),
+      config
+    );
+    interpreter = new JinjavaInterpreter(parentInterpreter);
+
+    interpreter.getContext().put("deferred", DeferredValue.instance());
+  }
+
+  @Test
+  public void itHandlesNullRangePrefix() {
+    assertThat(interpreter.render("{{ deferred[:100] }}")).isEqualTo("{{ deferred[:100] }}");
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstRangeBracketTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstRangeBracketTest.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class EagerAstRangeBracketTest extends BaseInterpretingTest {
+
   @Before
   public void setup() {
     JinjavaConfig config = JinjavaConfig
@@ -39,6 +40,7 @@ public class EagerAstRangeBracketTest extends BaseInterpretingTest {
 
   @Test
   public void itHandlesNullRangePrefix() {
-    assertThat(interpreter.render("{{ deferred[:100] }}")).isEqualTo("{{ deferred[:100] }}");
+    assertThat(interpreter.render("{{ deferred[:100] }}"))
+      .isEqualTo("{{ deferred[:100] }}");
   }
 }


### PR DESCRIPTION
In order to prevent a NPE, we will first check if `astNode` is null. If it is, we will reconstruct it as an empty string.
This prevents the NPE if a deferred value has a range bracket applied with a null start value like `{{ deferred[:100] }}`