### PR TITLE
[Eager Execution] Maintain deferred values when executing macro functions

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -407,6 +407,16 @@ public class Context extends ScopeMap<String, Object> {
     return eagerTokens;
   }
 
+  public Context getPenultimateParent() {
+    Context secondToLastContext = this;
+    if (parent != null) {
+      while (secondToLastContext.parent.parent != null) {
+        secondToLastContext = secondToLastContext.parent;
+      }
+    }
+    return secondToLastContext;
+  }
+
   public List<? extends Node> getSuperBlock() {
     if (superBlock != null) {
       return superBlock;

--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.lib.fn;
 import com.hubspot.jinjava.el.ext.AbstractCallableMethod;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.Context.TemporaryValueClosable;
+import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
@@ -126,7 +127,11 @@ public class MacroFunction extends AbstractCallableMethod {
       if (scopeEntry.getValue() instanceof MacroFunction) {
         interpreter.getContext().addGlobalMacro((MacroFunction) scopeEntry.getValue());
       } else {
-        interpreter.getContext().put(scopeEntry.getKey(), scopeEntry.getValue());
+        if (
+          !(interpreter.getContext().get(scopeEntry.getKey()) instanceof DeferredValue)
+        ) {
+          interpreter.getContext().put(scopeEntry.getKey(), scopeEntry.getValue());
+        }
       }
     }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -647,6 +647,20 @@ public class EagerImportTagTest extends ImportTagTest {
       .isEqualTo("a\n" + "\n" + "b\n" + "c['aresolved', 'bresolved']");
   }
 
+  @Test
+  public void itPutsDeferredInOtherSpotValuesOnContext() {
+    setupResourceLocator();
+    String result = interpreter.render(
+      "{% import 'import-macro-applies-val.jinja' -%}\n" +
+      "{% set val = deferred -%}\n" +
+      "{{ apply('foo') }}\n" +
+      "{{ val }}"
+    );
+    assertThat(result.trim()).isEqualTo("{% set val = deferred %}\n5foo\n{{ val }}");
+    context.put("deferred", "resolved");
+    assertThat(interpreter.render(result).trim()).isEqualTo("5foo\nresolved");
+  }
+
   private static JinjavaInterpreter getChildInterpreter(
     JinjavaInterpreter interpreter,
     String alias

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -625,6 +625,28 @@ public class EagerImportTagTest extends ImportTagTest {
     assertThat(interpreter.getContext().getDeferredNodes()).hasSize(1);
   }
 
+  @Test
+  public void itHandlesVarFromImportedMacro() {
+    setupResourceLocator();
+    String result = interpreter.render(
+      "{% import 'import-macro-and-var.jinja' -%}\n" +
+      "{{ adjust('a') }}\n" +
+      "{{ adjust('b') }}\n" +
+      "c{{ var }}"
+    );
+    assertThat(result.trim())
+      .isEqualTo(
+        "{% set var = [] %}{% do var.append('a' ~ deferred) %}\n" +
+        "a\n" +
+        "{% do var.append('b' ~ deferred) %}\n" +
+        "b\n" +
+        "c{{ var }}"
+      );
+    context.put("deferred", "resolved");
+    assertThat(interpreter.render(result).trim())
+      .isEqualTo("a\n" + "\n" + "b\n" + "c['aresolved', 'bresolved']");
+  }
+
   private static JinjavaInterpreter getChildInterpreter(
     JinjavaInterpreter interpreter,
     String alias

--- a/src/test/resources/tags/eager/importtag/import-macro-and-var.jinja
+++ b/src/test/resources/tags/eager/importtag/import-macro-and-var.jinja
@@ -1,0 +1,5 @@
+{% set var = [] -%}
+{% macro adjust(val) -%}
+{% do var.append(val ~ deferred) -%}
+{{ val }}
+{%- endmacro %}

--- a/src/test/resources/tags/eager/importtag/import-macro-applies-val.jinja
+++ b/src/test/resources/tags/eager/importtag/import-macro-applies-val.jinja
@@ -1,0 +1,4 @@
+{% set val = 5 -%}
+{% macro apply(param) -%}
+{{ val ~ param }}
+{%- endmacro %}


### PR DESCRIPTION
There is a situation where a value (e.g. `my_list`) that is declared within an imported macro function is getting modified depending on a deferred value and `my_list` needs to be deferred. `my_list` is used outside of the import context and the macro function that modifies it is called multiple times. Before this change, each time the macro function got called, it would override the deferred value of the `my_list` like `{% set my_list = [] %}` so the modifications from previous macro function calls would get discarded. The tests cover this but think a situation where there's a macro function `append` that appends values to `my_list` and part of the operation also results in `my_list` getting deferred.
If you call:
```
{{ append(1) }}
{{ append(2) }}
{{ my_list }}
```
You wouldn't want to see a reconstructed output like:
```
{% set my_list = [] %}
{% do my_list.append(1) %}
{% set my_list = [] %}
{% do my_list.append(2) %}
{{ my_list }}
```
This change makes it so that `my_list` will stay deferred if it got deferred within the local context scope of the macro function (we check the import file to see where the eager token was created).