### PR TITLE
[Eager Execution] Put harder limits on revertable objects

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -407,14 +407,14 @@ public class Context extends ScopeMap<String, Object> {
     return eagerTokens;
   }
 
-  public Set<String> getCombinedScopeKeys() {
-    Set<String> scopeKeys = new HashSet<>(getScope().keySet());
+  public Map<String, Object> getCombinedScope() {
+    Map<String, Object> scopeMap = new HashMap<>(getScope());
     Context parent = this.parent;
     while (parent != null && parent.currentPathStack == currentPathStack) {
-      scopeKeys.addAll(parent.getScope().keySet());
+      parent.getScope().forEach(scopeMap::putIfAbsent);
       parent = parent.parent;
     }
-    return scopeKeys;
+    return scopeMap;
   }
 
   public Context getPenultimateParent() {


### PR DESCRIPTION
Speedup for https://github.com/HubSpot/jinjava/pull/842. We may need to further speed this up by caching/storing the string representations of the given hash values so that we don't need to do this calculation on nearly every `executeInChildContext` call.