### PR TITLE
[Eager Execution] Store computed pyish representations of context keys

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -56,6 +56,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -73,6 +74,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 public class JinjavaInterpreter implements PyishSerializable {
   private final Multimap<String, BlockInfo> blocks = ArrayListMultimap.create();
   private final LinkedList<Node> extendParentRoots = new LinkedList<>();
+  private final Map<String, RevertibleObject> revertibleObjects = new HashMap<>();
 
   private Context context;
   private final JinjavaConfig config;
@@ -184,6 +186,10 @@ public class JinjavaInterpreter implements PyishSerializable {
 
   public boolean isValidationMode() {
     return config.isValidationMode();
+  }
+
+  public Map<String, RevertibleObject> getRevertibleObjects() {
+    return revertibleObjects;
   }
 
   public class InterpreterScopeClosable implements AutoCloseable {

--- a/src/main/java/com/hubspot/jinjava/interpret/RevertibleObject.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/RevertibleObject.java
@@ -1,0 +1,19 @@
+package com.hubspot.jinjava.interpret;
+
+public class RevertibleObject {
+  private final Object hashCode;
+  private final String pyishString;
+
+  public RevertibleObject(Object hashCode, String pyishString) {
+    this.hashCode = hashCode;
+    this.pyishString = pyishString;
+  }
+
+  public Object getHashCode() {
+    return hashCode;
+  }
+
+  public String getPyishString() {
+    return pyishString;
+  }
+}


### PR DESCRIPTION
https://github.com/HubSpot/jinjava/pull/843 is still not fast enough. So, let's try storing the computed pyish representations so that we don't have to compute them every time. That is an expensive operation, so this should provide a speed increase when there are many context keys and many operations requiring a check for context changes.