### PR TITLE
[Eager Execution] Store the RevertibleObject in the revertible objects map

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -130,6 +130,7 @@ public class EagerReconstructionUtils {
                   hashCode,
                   PyishObjectMapper.getAsUnquotedPyishString(entry.getValue())
                 );
+              interpreter.getRevertibleObjects().put(entry.getKey(), revertibleObject);
             }
             initiallyResolvedAsStrings.put(
               entry.getKey(),


### PR DESCRIPTION
I had written https://github.com/HubSpot/jinjava/pull/845, but forgot to actually store the revertible object, so we were still computing it every time, which we didn't want to do.