### PR TITLE
[Eager Execution] StripTagsFilter should throw DeferredValueException when necessary

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.lib.filter;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.util.regex.Pattern;
 import org.jsoup.Jsoup;
@@ -33,8 +34,12 @@ public class StripTagsFilter implements Filter {
     if (!(object instanceof String)) {
       return object;
     }
+    int numEagerTokensStart = interpreter.getContext().getEagerTokens().size();
 
     String val = interpreter.renderFlat((String) object);
+    if (interpreter.getContext().getEagerTokens().size() > numEagerTokensStart) {
+      throw new DeferredValueException("Deferred in StripTagsFilter");
+    }
 
     String cleanedVal = Jsoup.parse(val).text();
     cleanedVal = Jsoup.clean(cleanedVal, Whitelist.none());

--- a/src/test/java/com/hubspot/jinjava/lib/filter/StripTagsFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/StripTagsFilterTest.java
@@ -1,13 +1,21 @@
 package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
+import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.lib.tag.eager.EagerToken;
+import com.hubspot.jinjava.tree.parse.DefaultTokenScannerSymbols;
+import com.hubspot.jinjava.tree.parse.ExpressionToken;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.internal.stubbing.answers.ReturnsArgumentAt;
@@ -15,7 +23,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StripTagsFilterTest {
-  @Mock
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   JinjavaInterpreter interpreter;
 
   @InjectMocks
@@ -23,6 +31,7 @@ public class StripTagsFilterTest {
 
   @Before
   public void setup() {
+    when(interpreter.getContext().getEagerTokens()).thenReturn(Collections.emptySet());
     when(interpreter.renderFlat(anyString())).thenAnswer(new ReturnsArgumentAt(0));
   }
 
@@ -85,5 +94,29 @@ public class StripTagsFilterTest {
   public void itAddsWhitespaceBetweenParagraphTags() {
     assertThat(filter.filter("<p>Test</p><p>Value</p>", interpreter))
       .isEqualTo("Test Value");
+  }
+
+  @Test
+  public void itThrowsDeferredValueExceptionWhenEagerTokensAreLeft() {
+    AtomicInteger counter = new AtomicInteger();
+    when(interpreter.getContext().getEagerTokens())
+      .thenAnswer(
+        i ->
+          counter.getAndIncrement() == 0
+            ? Collections.emptySet()
+            : Collections.singleton(
+              new EagerToken(
+                new ExpressionToken(
+                  "{{ deferred && other }}",
+                  0,
+                  0,
+                  new DefaultTokenScannerSymbols()
+                ),
+                Collections.emptySet()
+              )
+            )
+      );
+    assertThatThrownBy(() -> filter.filter("{{ deferred && other }}", interpreter))
+      .isInstanceOf(DeferredValueException.class);
   }
 }


### PR DESCRIPTION
Because `interpreter.renderFlat()` is being called, we should handle the situation when more deferred tokens were added during the execution. If this is the case, then we should throw a `DeferredValueException` because they may contain characters necessary for their execution that would get modified by the Jsoup cleaning.