### PR TITLE
[Eager Execution] Replace values on scope when resetting bindings

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
@@ -213,7 +213,7 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
           ) {
             interpreter
               .getContext()
-              .put(
+              .replace(
                 key,
                 ((DeferredValue) interpreter.getContext().get(key)).getOriginalValue()
               );

--- a/src/main/java/com/hubspot/jinjava/util/ScopeMap.java
+++ b/src/main/java/com/hubspot/jinjava/util/ScopeMap.java
@@ -121,6 +121,30 @@ public class ScopeMap<K, V> implements Map<K, V> {
   }
 
   @Override
+  public boolean replace(K key, V oldValue, V newValue) {
+    boolean replaced = scope.replace(key, oldValue, newValue);
+    if (replaced) {
+      return true;
+    }
+    if (parent != null) {
+      return parent.replace(key, oldValue, newValue);
+    }
+    return false;
+  }
+
+  @Override
+  public V replace(K key, V value) {
+    V val = scope.replace(key, value);
+    if (val != null) {
+      return val;
+    }
+    if (parent != null) {
+      return parent.replace(key, value);
+    }
+    return null;
+  }
+
+  @Override
   public V remove(Object key) {
     return scope.remove(key);
   }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1005,4 +1005,9 @@ public class EagerTest {
   public void itRevertsSimple() {
     expectedTemplateInterpreter.assertExpectedOutput("reverts-simple");
   }
+
+  @Test
+  public void itScopesResettingBindings() {
+    expectedTemplateInterpreter.assertExpectedOutput("scopes-resetting-bindings");
+  }
 }

--- a/src/test/resources/eager/scopes-resetting-bindings.expected.jinja
+++ b/src/test/resources/eager/scopes-resetting-bindings.expected.jinja
@@ -1,0 +1,8 @@
+{% set my_list = [0] %}{% for i in deferred %}
+{% for j in deferred %}
+{% if deferred %}
+{% do my_list.append(1) %}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{{ my_list }}

--- a/src/test/resources/eager/scopes-resetting-bindings.jinja
+++ b/src/test/resources/eager/scopes-resetting-bindings.jinja
@@ -1,0 +1,10 @@
+{% set my_list = [] %}
+{% do my_list.append(0) %}
+{% for i in deferred %}
+{% for j in deferred %}
+{% if deferred %}
+{% do my_list.append(1) %}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{{ my_list }}


### PR DESCRIPTION
When resetting bindings after eagerly rendering branches, instead of putting the old values back on the context, we should replace the current values. This is because put will always place the value on the lowest level context. I'm overriding `replace()` so that it will put the value on the same scope that the value is currently on. This fixes how the binding resetting works for values that are modified, but not in the same scope, such as if there are two for loops before the value is modified in a deferred if branch.