### PR TITLE
[Eager Execution] Multiple loop variable reconstruction

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -28,6 +28,7 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -95,8 +96,20 @@ public class Functions {
   )
   public static Namespace createNamespace(Object... parameters) {
     Namespace namespace = parameters.length > 0 && parameters[0] instanceof Map
-      ? new Namespace((Map<String, Object>) parameters[0])
-      : new Namespace();
+      ? new Namespace(
+        (Map<String, Object>) parameters[0],
+        JinjavaInterpreter
+          .getCurrentMaybe()
+          .map(interpreter -> interpreter.getConfig().getMaxMapSize())
+          .orElse(Integer.MAX_VALUE)
+      )
+      : new Namespace(
+        new HashMap<>(),
+        JinjavaInterpreter
+          .getCurrentMaybe()
+          .map(interpreter -> interpreter.getConfig().getMaxMapSize())
+          .orElse(Integer.MAX_VALUE)
+      );
     namespace.putAll(
       Arrays
         .stream(parameters)

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerExecutionResult.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerExecutionResult.java
@@ -3,7 +3,6 @@ package com.hubspot.jinjava.lib.tag.eager;
 import static com.hubspot.jinjava.util.EagerReconstructionUtils.buildSetTag;
 
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.objects.Namespace;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
 import java.util.Map;
@@ -48,11 +47,7 @@ public class EagerExecutionResult {
           .collect(
             Collectors.toMap(
               Entry::getKey,
-              entry ->
-                String.format(
-                  entry.getValue() instanceof Namespace ? "namespace(%s)" : "%s",
-                  PyishObjectMapper.getAsPyishString(entry.getValue())
-                )
+              entry -> PyishObjectMapper.getAsPyishString(entry.getValue())
             )
           ),
         JinjavaInterpreter.getCurrent(),

--- a/src/main/java/com/hubspot/jinjava/objects/Namespace.java
+++ b/src/main/java/com/hubspot/jinjava/objects/Namespace.java
@@ -1,13 +1,26 @@
 package com.hubspot.jinjava.objects;
 
+import com.hubspot.jinjava.objects.collections.SizeLimitingPyMap;
+import com.hubspot.jinjava.objects.serialization.PyishSerializable;
 import java.util.HashMap;
 import java.util.Map;
 
-public class Namespace extends HashMap<String, Object> {
+public class Namespace extends SizeLimitingPyMap implements PyishSerializable {
 
-  public Namespace() {}
+  public Namespace() {
+    this(new HashMap<>());
+  }
 
   public Namespace(Map<String, Object> map) {
-    super(map);
+    this(map, Integer.MAX_VALUE);
+  }
+
+  public Namespace(Map<String, Object> map, int maxSize) {
+    super(map, maxSize);
+  }
+
+  @Override
+  public String toPyishString() {
+    return String.format("namespace(%s)", PyishSerializable.super.toPyishString());
   }
 }

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -17,7 +17,6 @@ import com.hubspot.jinjava.lib.tag.RawTag;
 import com.hubspot.jinjava.lib.tag.SetTag;
 import com.hubspot.jinjava.lib.tag.eager.EagerExecutionResult;
 import com.hubspot.jinjava.lib.tag.eager.EagerToken;
-import com.hubspot.jinjava.objects.Namespace;
 import com.hubspot.jinjava.objects.collections.PyList;
 import com.hubspot.jinjava.objects.collections.PyMap;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
@@ -336,13 +335,7 @@ public class EagerReconstructionUtils {
       .forEach(
         w -> {
           Object value = interpreter.getContext().get(w);
-          deferredMap.put(
-            w,
-            String.format(
-              value instanceof Namespace ? "namespace(%s)" : "%s",
-              PyishObjectMapper.getAsPyishString(value)
-            )
-          );
+          deferredMap.put(w, PyishObjectMapper.getAsPyishString(value));
         }
       );
     return buildSetTag(deferredMap, interpreter, true);

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -128,7 +128,7 @@ public class EagerReconstructionUtils {
               revertibleObject =
                 new RevertibleObject(
                   hashCode,
-                  PyishObjectMapper.getAsUnquotedPyishString(entry.getValue())
+                  PyishObjectMapper.getAsPyishString(entry.getValue())
                 );
               interpreter.getRevertibleObjects().put(entry.getKey(), revertibleObject);
             }
@@ -185,10 +185,10 @@ public class EagerReconstructionUtils {
             Collectors.toMap(
               Entry::getKey,
               e -> {
-                if (e.getValue() instanceof DeferredValue) {
-                  return ((DeferredValue) e.getValue()).getOriginalValue();
-                }
                 if (takeNewValue) {
+                  if (e.getValue() instanceof DeferredValue) {
+                    return ((DeferredValue) e.getValue()).getOriginalValue();
+                  }
                   return e.getValue();
                 }
 
@@ -201,6 +201,9 @@ public class EagerReconstructionUtils {
                     initiallyResolvedAsStrings.get(e.getKey()),
                     interpreter.getLineNumber()
                   );
+                }
+                if (e.getValue() instanceof DeferredValue) {
+                  return ((DeferredValue) e.getValue()).getOriginalValue();
                 }
 
                 // Previous value could not be mapped to a string

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1010,4 +1010,9 @@ public class EagerTest {
   public void itScopesResettingBindings() {
     expectedTemplateInterpreter.assertExpectedOutput("scopes-resetting-bindings");
   }
+
+  @Test
+  public void itReconstructsWithMultipleLoops() {
+    expectedTemplateInterpreter.assertExpectedOutput("reconstructs-with-multiple-loops");
+  }
 }

--- a/src/test/resources/eager/reconstructs-with-multiple-loops.expected.jinja
+++ b/src/test/resources/eager/reconstructs-with-multiple-loops.expected.jinja
@@ -1,0 +1,14 @@
+{% set my_list = [] %}{% for i in deferred %}
+  {% if deferred %}
+    {% for j in deferred %}
+      {% if deferred %}
+        {% do my_list.append(1) %}
+      {% else %}
+        {% do my_list.append(2) %}
+      {% endif %}
+    {% endfor %}
+  {% else %}
+    {% do my_list.append(3) %}
+  {% endif %}
+{% endfor %}
+{{ my_list }}

--- a/src/test/resources/eager/reconstructs-with-multiple-loops.expected.jinja
+++ b/src/test/resources/eager/reconstructs-with-multiple-loops.expected.jinja
@@ -1,14 +1,23 @@
-{% set my_list = [] %}{% for i in deferred %}
+[][]
+[0][0]
+{% set alpha,beta = [0],[0] %}{% for i in deferred %}
   {% if deferred %}
     {% for j in deferred %}
       {% if deferred %}
-        {% do my_list.append(1) %}
+        {% do alpha.append(1) %}
       {% else %}
-        {% do my_list.append(2) %}
+        {% do alpha.append(2) %}
       {% endif %}
     {% endfor %}
   {% else %}
-    {% do my_list.append(3) %}
+    {% for j in deferred %}
+      {% do beta.append(1) %}
+      {% if deferred %}
+        {% do alpha.append(3) %}
+      {% else %}
+        {% do alpha.append(4) %}
+      {% endif %}
+    {% endfor %}
   {% endif %}
 {% endfor %}
-{{ my_list }}
+{{ alpha ~ beta }}

--- a/src/test/resources/eager/reconstructs-with-multiple-loops.jinja
+++ b/src/test/resources/eager/reconstructs-with-multiple-loops.jinja
@@ -1,0 +1,15 @@
+{% set my_list = [] %}
+{% for i in deferred %}
+  {% if deferred %}
+    {% for j in deferred %}
+      {% if deferred %}
+        {% do my_list.append(1) %}
+      {% else %}
+        {% do my_list.append(2) %}
+      {% endif %}
+    {% endfor %}
+  {% else %}
+    {% do my_list.append(3) %}
+  {% endif %}
+{% endfor %}
+{{ my_list }}

--- a/src/test/resources/eager/reconstructs-with-multiple-loops.jinja
+++ b/src/test/resources/eager/reconstructs-with-multiple-loops.jinja
@@ -1,15 +1,26 @@
-{% set my_list = [] %}
+{% set alpha, beta = [], [] %}
+{{ alpha ~ beta }}
+{%- do alpha.append(0) %}
+{%- do beta.append(0) %}
+{{ alpha ~ beta }}
 {% for i in deferred %}
   {% if deferred %}
     {% for j in deferred %}
       {% if deferred %}
-        {% do my_list.append(1) %}
+        {% do alpha.append(1) %}
       {% else %}
-        {% do my_list.append(2) %}
+        {% do alpha.append(2) %}
       {% endif %}
     {% endfor %}
   {% else %}
-    {% do my_list.append(3) %}
+    {% for j in deferred %}
+      {% do beta.append(1) %}
+      {% if deferred %}
+        {% do alpha.append(3) %}
+      {% else %}
+        {% do alpha.append(4) %}
+      {% endif %}
+    {% endfor %}
   {% endif %}
 {% endfor %}
-{{ my_list }}
+{{ alpha ~ beta }}


### PR DESCRIPTION
Fixes a problem where when there were multiple deferred for loops and deferred if tags, it would not reconstruct the output correctly. It would either reconstruct in the wrong place, or reconstruct with the wrong value.
See my comment for what the output of this new test used to be before this change.

Also, I fixed how a namespace gets reconstructed by having it extend `PyishSerializable` so that I could override it's `toPyishString()` implementation so that it will be like `namespace(%s)`