### PR TITLE
[Eager Execution] Ignore DeferredValueException when reverting context

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -196,10 +196,12 @@ public class EagerReconstructionUtils {
                 // It will revert the effects when takeNewValue is false.
                 if (initiallyResolvedAsStrings.containsKey(e.getKey())) {
                   // convert to new list or map
-                  return interpreter.resolveELExpression(
-                    initiallyResolvedAsStrings.get(e.getKey()),
-                    interpreter.getLineNumber()
-                  );
+                  try {
+                    return interpreter.resolveELExpression(
+                      initiallyResolvedAsStrings.get(e.getKey()),
+                      interpreter.getLineNumber()
+                    );
+                  } catch (DeferredValueException ignored) {}
                 }
                 if (e.getValue() instanceof DeferredValue) {
                   return ((DeferredValue) e.getValue()).getOriginalValue();


### PR DESCRIPTION
Saw that there were some variables that referenced themselves so when they became deferred, the interpreter would try to resolve the `initiallResolvedAsStrings.get(e.getKey())` and that would throw a deferred value exception. Instead, we can just take the original value, and if it still happens that the `e.getValue()` isn't a deferred value, then we can throw the DeferredValueException.