### PR TITLE
Fix datetime conversion value for Zones

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
@@ -46,7 +46,7 @@ public class StrftimeFormatter {
     CONVERSIONS['y'] = "yy";
     CONVERSIONS['Y'] = "yyyy";
     CONVERSIONS['z'] = "Z";
-    CONVERSIONS['Z'] = "ZZZZ";
+    CONVERSIONS['Z'] = "z";
     CONVERSIONS['%'] = "%";
 
     NOMINATIVE_CONVERSIONS['B'] = "LLLL";

--- a/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.objects.date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Locale;
 import org.junit.Before;
@@ -100,7 +101,12 @@ public class StrftimeFormatterTest {
   @Test
   public void testZoneOutput() {
     assertThat(StrftimeFormatter.format(d, "%z")).isEqualTo("+0000");
-    assertThat(StrftimeFormatter.format(d, "%Z")).isEqualTo("GMT");
+
+    ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(
+      d.toInstant(),
+      ZoneId.of("America/New_York")
+    );
+    assertThat(StrftimeFormatter.format(zonedDateTime, "%Z")).isEqualTo("EST");
   }
 
   @Test


### PR DESCRIPTION
According to the documentation `z` (https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html) should be used for time zone name for timezone name `%Z` (https://strftime.org/). It looks like my fix 4 years ago did not work https://github.com/HubSpot/jinjava/pull/260 since we were using the default null zone in the test.