### PR TITLE
[Eager Execution] Ensure hashcode is consistent when reverting to original deferred value

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -191,6 +191,19 @@ public class EagerReconstructionUtils {
                   return e.getValue();
                 }
 
+                if (
+                  e.getValue() instanceof DeferredValue &&
+                  initiallyResolvedHashes
+                    .get(e.getKey())
+                    .equals(
+                      getObjectOrHashCode(
+                        ((DeferredValue) e.getValue()).getOriginalValue()
+                      )
+                    )
+                ) {
+                  return ((DeferredValue) e.getValue()).getOriginalValue();
+                }
+
                 // This is necessary if a state-changing function, such as .update()
                 // or .append() is run against a variable in the context.
                 // It will revert the effects when takeNewValue is false.
@@ -202,9 +215,6 @@ public class EagerReconstructionUtils {
                       interpreter.getLineNumber()
                     );
                   } catch (DeferredValueException ignored) {}
-                }
-                if (e.getValue() instanceof DeferredValue) {
-                  return ((DeferredValue) e.getValue()).getOriginalValue();
                 }
 
                 // Previous value could not be mapped to a string

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -661,6 +661,20 @@ public class EagerImportTagTest extends ImportTagTest {
     assertThat(interpreter.render(result).trim()).isEqualTo("5foo\nresolved");
   }
 
+  @Test
+  public void itDoesNotSilentlyOverrideMacro() {
+    setupResourceLocator();
+    String result = interpreter.render(
+      "{% import 'macro-a.jinja' as macros %}\n" +
+      "{{ macros.doer() }}\n" +
+      "{% if deferred %}\n" +
+      "  {% import 'macro-b.jinja' as macros %}\n" +
+      "{% endif %}\n" +
+      "{{ macros.doer() }}"
+    );
+    assertThat(interpreter.getContext().getDeferredNodes()).isNotEmpty();
+  }
+
   private static JinjavaInterpreter getChildInterpreter(
     JinjavaInterpreter interpreter,
     String alias

--- a/src/test/resources/tags/eager/importtag/macro-a.jinja
+++ b/src/test/resources/tags/eager/importtag/macro-a.jinja
@@ -1,0 +1,3 @@
+{% macro doer() %}
+I am doer 'A', {{ deferred }}
+{% endmacro %}

--- a/src/test/resources/tags/eager/importtag/macro-b.jinja
+++ b/src/test/resources/tags/eager/importtag/macro-b.jinja
@@ -1,0 +1,3 @@
+{% macro doer %}
+I am doer 'A', {{ deferred }}
+{% endmacro %}

--- a/src/test/resources/tags/eager/importtag/macro-b.jinja
+++ b/src/test/resources/tags/eager/importtag/macro-b.jinja
@@ -1,3 +1,3 @@
-{% macro doer %}
-I am doer 'A', {{ deferred }}
+{% macro doer() %}
+I am doer 'b', {{ deferred }}
 {% endmacro %}


### PR DESCRIPTION
There was a problem where when importing in deferred execution mode under an alias, it would override the macro functions with those from the file that was imported in deferred execution mode. Rather than do this, we should create a Deferred Node, which signifies that the import tag could not be processed properly.

We can check for this inequality simply by making sure that when we are reverting to the original value of a deferred value, that the hashcode of the `getOriginalValue()` and whatever used to be in that spot on the context are the same.