### PR TITLE
[Eager Execution] Fully defer macro function if it is used inside as a parameter

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/AstMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstMacroFunction.java
@@ -44,7 +44,7 @@ public class AstMacroFunction extends AstFunction {
       }
 
       try {
-        return super.invoke(
+        return invoke(
           bindings,
           context,
           macroFunction,

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
@@ -1,7 +1,10 @@
 package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.el.ext.ExtendedParser;
+import com.hubspot.jinjava.interpret.Context.TemporaryValueClosable;
 import com.hubspot.jinjava.interpret.DeferredValueException;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstMethod;
@@ -34,7 +37,14 @@ public class EagerAstMethod extends AstMethod implements EvalResultHolder {
 
   @Override
   public Object eval(Bindings bindings, ELContext context) {
-    try {
+    try (
+      TemporaryValueClosable<Boolean> c = (
+        (JinjavaInterpreter) context
+          .getELResolver()
+          .getValue(context, null, ExtendedParser.INTERPRETER)
+      ).getContext()
+        .withPartialMacroEvaluation(false)
+    ) {
       setEvalResult(super.eval(bindings, context));
       return evalResult;
     } catch (DeferredValueException | ELException originalException) {

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
@@ -1,10 +1,7 @@
 package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
-import com.hubspot.jinjava.el.ext.ExtendedParser;
-import com.hubspot.jinjava.interpret.Context.TemporaryValueClosable;
 import com.hubspot.jinjava.interpret.DeferredValueException;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstMethod;
@@ -37,14 +34,7 @@ public class EagerAstMethod extends AstMethod implements EvalResultHolder {
 
   @Override
   public Object eval(Bindings bindings, ELContext context) {
-    try (
-      TemporaryValueClosable<Boolean> c = (
-        (JinjavaInterpreter) context
-          .getELResolver()
-          .getValue(context, null, ExtendedParser.INTERPRETER)
-      ).getContext()
-        .withPartialMacroEvaluation(false)
-    ) {
+    try {
       setEvalResult(super.eval(bindings, context));
       return evalResult;
     } catch (DeferredValueException | ELException originalException) {

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -712,11 +712,17 @@ public class Context extends ScopeMap<String, Object> {
   }
 
   public TemporaryValueClosable<Boolean> withPartialMacroEvaluation() {
+    return withPartialMacroEvaluation(true);
+  }
+
+  public TemporaryValueClosable<Boolean> withPartialMacroEvaluation(
+    boolean partialMacroEvaluation
+  ) {
     TemporaryValueClosable<Boolean> temporaryValueClosable = new TemporaryValueClosable<>(
       this.partialMacroEvaluation,
       this::setPartialMacroEvaluation
     );
-    this.partialMacroEvaluation = true;
+    this.partialMacroEvaluation = partialMacroEvaluation;
     return temporaryValueClosable;
   }
 

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1020,4 +1020,12 @@ public class EagerTest {
   public void itFullyDefersFilteredMacro() {
     expectedTemplateInterpreter.assertExpectedOutput("fully-defers-filtered-macro");
   }
+
+  @Test
+  public void itFullyDefersFilteredMacroSecondPass() {
+    interpreter.getContext().put("deferred", "resolved");
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "fully-defers-filtered-macro.expected"
+    );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1015,4 +1015,9 @@ public class EagerTest {
   public void itReconstructsWithMultipleLoops() {
     expectedTemplateInterpreter.assertExpectedOutput("reconstructs-with-multiple-loops");
   }
+
+  @Test
+  public void itFullyDefersFilteredMacro() {
+    expectedTemplateInterpreter.assertExpectedOutput("fully-defers-filtered-macro");
+  }
 }

--- a/src/test/resources/eager/fully-defers-filtered-macro.expected.expected.jinja
+++ b/src/test/resources/eager/fully-defers-filtered-macro.expected.expected.jinja
@@ -1,0 +1,6 @@
+BAR
+  A FLASHY RESOLVED.
+  A flashy resolved.
+---
+
+A SILLY RESOLVED.

--- a/src/test/resources/eager/fully-defers-filtered-macro.expected.jinja
+++ b/src/test/resources/eager/fully-defers-filtered-macro.expected.jinja
@@ -1,1 +1,4 @@
-{% macro thing() %}A flashy {{ deferred }}.{% endmacro %}{{ filter:upper.filter(thing(), ____int3rpr3t3r____) }}
+{% macro thing(foo) %}{{ filter:upper.filter(foo, ____int3rpr3t3r____) }}
+  A flashy {{ deferred }}.{% endmacro %}{{ thing(thing('bar')) }}
+
+{% macro other() %}A fancy {{ deferred }}.{% endmacro %}{{ filter:upper.filter(other(), ____int3rpr3t3r____) }}

--- a/src/test/resources/eager/fully-defers-filtered-macro.expected.jinja
+++ b/src/test/resources/eager/fully-defers-filtered-macro.expected.jinja
@@ -1,4 +1,5 @@
-{% macro thing(foo) %}{{ filter:upper.filter(foo, ____int3rpr3t3r____) }}
-  A flashy {{ deferred }}.{% endmacro %}{{ thing(thing('bar')) }}
+{% macro flashy(foo) %}{{ filter:upper.filter(foo, ____int3rpr3t3r____) }}
+  A flashy {{ deferred }}.{% endmacro %}{{ flashy(flashy('bar')) }}
+---
 
-{% macro other() %}A fancy {{ deferred }}.{% endmacro %}{{ filter:upper.filter(other(), ____int3rpr3t3r____) }}
+{% macro silly() %}A silly {{ deferred }}.{% endmacro %}{{ filter:upper.filter(silly(), ____int3rpr3t3r____) }}

--- a/src/test/resources/eager/fully-defers-filtered-macro.expected.jinja
+++ b/src/test/resources/eager/fully-defers-filtered-macro.expected.jinja
@@ -1,0 +1,1 @@
+{% macro thing() %}A flashy {{ deferred }}.{% endmacro %}{{ filter:upper.filter(thing(), ____int3rpr3t3r____) }}

--- a/src/test/resources/eager/fully-defers-filtered-macro.jinja
+++ b/src/test/resources/eager/fully-defers-filtered-macro.jinja
@@ -1,4 +1,9 @@
-{% macro thing() -%}
+{% macro thing(foo) -%}
+{{ foo|upper }}
   A flashy {{ deferred }}.
 {%- endmacro %}
-{{ thing()|upper }}
+{{ thing(thing('bar')) }}
+{% macro other() -%}
+A fancy {{ deferred }}.
+{%- endmacro %}
+{{ other()|upper }}

--- a/src/test/resources/eager/fully-defers-filtered-macro.jinja
+++ b/src/test/resources/eager/fully-defers-filtered-macro.jinja
@@ -1,0 +1,4 @@
+{% macro thing() -%}
+  A flashy {{ deferred }}.
+{%- endmacro %}
+{{ thing()|upper }}

--- a/src/test/resources/eager/fully-defers-filtered-macro.jinja
+++ b/src/test/resources/eager/fully-defers-filtered-macro.jinja
@@ -1,9 +1,10 @@
-{% macro thing(foo) -%}
-{{ foo|upper }}
+{% macro flashy(foo) -%}
+  {{ foo|upper }}
   A flashy {{ deferred }}.
 {%- endmacro %}
-{{ thing(thing('bar')) }}
-{% macro other() -%}
-A fancy {{ deferred }}.
+{{ flashy(flashy('bar')) }}
+---
+{% macro silly() -%}
+A silly {{ deferred }}.
 {%- endmacro %}
-{{ other()|upper }}
+{{ silly()|upper }}


### PR DESCRIPTION
If a macro function is used inside of a filter or some other function, then it cannot be partially evaluated, and must be fully evaluated or deferred. In the test below, the macro function is passed through an `|upper` filter. Clearly, if there are any reconstructed tags, then they will get broken by the upper filter. If we were to partially resolve the macro, then we would have, `'A flashy {{ deferred }}'|upper`, which becomes `A FLASHY {{ DEFERRED }}`, which no longer would get rendered properly.

We can therefore turn off partial macro evaluation whenever we are evaluating AstParameters (used in filters and functions). However, macro functions process AstParameters differently, so we have to override `AstFunction.invoke()` and turn off partial macro evaluation while we are evaluating the parameters (but keep the original state while evaluating the macro function itself)