### PR TITLE
[Eager Execution] Defer large loops with many deferred tokens

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoice.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoice.java
@@ -37,7 +37,7 @@ public class EagerAstChoice extends AstChoice implements EvalResultHolder {
   public Object eval(Bindings bindings, ELContext context) throws ELException {
     try {
       setEvalResult(super.eval(bindings, context));
-      return evalResult;
+      return checkEvalResultSize(context);
     } catch (DeferredParsingException e) {
       if (question.hasEvalResult()) {
         // the question was evaluated so jump to either yes or no

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
@@ -2,12 +2,9 @@ package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.AstMacroFunction;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
-import com.hubspot.jinjava.el.ext.ExtendedParser;
 import com.hubspot.jinjava.interpret.DeferredValueException;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstParameters;
-import java.util.Collection;
 import java.util.StringJoiner;
 import javax.el.ELContext;
 import javax.el.ELException;
@@ -41,19 +38,7 @@ public class EagerAstMacroFunction extends AstMacroFunction implements EvalResul
   public Object eval(Bindings bindings, ELContext context) {
     try {
       setEvalResult(super.eval(bindings, context));
-      if (
-        evalResult instanceof Collection &&
-        ((Collection<?>) evalResult).size() > 100 &&
-        (
-          (JinjavaInterpreter) context
-            .getELResolver()
-            .getValue(context, null, ExtendedParser.INTERPRETER)
-        ).getContext()
-          .isDeferLargeObjects()
-      ) {
-        throw new DeferredValueException("Collection too big");
-      }
-      return evalResult;
+      return checkEvalResultSize(context);
     } catch (DeferredValueException | ELException originalException) {
       DeferredParsingException e = EvalResultHolder.convertToDeferredParsingException(
         originalException

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
@@ -2,9 +2,12 @@ package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.AstMacroFunction;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.el.ext.ExtendedParser;
 import com.hubspot.jinjava.interpret.DeferredValueException;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstParameters;
+import java.util.Collection;
 import java.util.StringJoiner;
 import javax.el.ELContext;
 import javax.el.ELException;
@@ -38,6 +41,18 @@ public class EagerAstMacroFunction extends AstMacroFunction implements EvalResul
   public Object eval(Bindings bindings, ELContext context) {
     try {
       setEvalResult(super.eval(bindings, context));
+      if (
+        evalResult instanceof Collection &&
+        ((Collection<?>) evalResult).size() > 100 &&
+        (
+          (JinjavaInterpreter) context
+            .getELResolver()
+            .getValue(context, null, ExtendedParser.INTERPRETER)
+        ).getContext()
+          .isDeferLargeObjects()
+      ) {
+        throw new DeferredValueException("Collection too big");
+      }
       return evalResult;
     } catch (DeferredValueException | ELException originalException) {
       DeferredParsingException e = EvalResultHolder.convertToDeferredParsingException(

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
@@ -36,7 +36,7 @@ public class EagerAstMethod extends AstMethod implements EvalResultHolder {
   public Object eval(Bindings bindings, ELContext context) {
     try {
       setEvalResult(super.eval(bindings, context));
-      return evalResult;
+      return checkEvalResultSize(context);
     } catch (DeferredValueException | ELException originalException) {
       DeferredParsingException e = EvalResultHolder.convertToDeferredParsingException(
         originalException

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNodeDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNodeDecorator.java
@@ -56,7 +56,7 @@ public class EagerAstNodeDecorator extends AstNode implements EvalResultHolder {
   @Override
   public Object eval(Bindings bindings, ELContext elContext) {
     setEvalResult(astNode.eval(bindings, elContext));
-    return evalResult;
+    return checkEvalResultSize(elContext);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -106,6 +106,7 @@ public class Context extends ScopeMap<String, Object> {
 
   private boolean validationMode = false;
   private boolean deferredExecutionMode = false;
+  private boolean deferLargeObjects = false;
   private boolean throwInterpreterErrors = false;
   private boolean partialMacroEvaluation = false;
   private boolean unwrapRawOverride = false;
@@ -209,6 +210,7 @@ public class Context extends ScopeMap<String, Object> {
       this.unwrapRawOverride = parent.unwrapRawOverride;
       this.dynamicVariableResolver = parent.dynamicVariableResolver;
       this.deferredExecutionMode = parent.deferredExecutionMode;
+      this.deferLargeObjects = parent.deferLargeObjects;
       this.throwInterpreterErrors = parent.throwInterpreterErrors;
     }
   }
@@ -693,6 +695,26 @@ public class Context extends ScopeMap<String, Object> {
   public Context setDeferredExecutionMode(boolean deferredExecutionMode) {
     this.deferredExecutionMode = deferredExecutionMode;
     return this;
+  }
+
+  public boolean isDeferLargeObjects() {
+    return deferLargeObjects;
+  }
+
+  public Context setDeferLargeObjects(boolean deferLargeObjects) {
+    this.deferLargeObjects = deferLargeObjects;
+    return this;
+  }
+
+  public TemporaryValueClosable<Boolean> withDeferLargeObjects(
+    boolean deferLargeObjects
+  ) {
+    TemporaryValueClosable<Boolean> temporaryValueClosable = new TemporaryValueClosable<>(
+      this.deferLargeObjects,
+      this::setDeferLargeObjects
+    );
+    this.deferLargeObjects = deferLargeObjects;
+    return temporaryValueClosable;
   }
 
   public boolean getThrowInterpreterErrors() {

--- a/src/main/java/com/hubspot/jinjava/interpret/DeferredValueException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/DeferredValueException.java
@@ -6,16 +6,13 @@ package com.hubspot.jinjava.interpret;
  * and instead echo its contents to the output.
  */
 public class DeferredValueException extends InterpretException {
+  public static final String MESSAGE_PREFIX = "Encountered a deferred value: ";
 
   public DeferredValueException(String message) {
-    super("Encountered a deferred value: " + message);
+    super(MESSAGE_PREFIX + message);
   }
 
   public DeferredValueException(String variable, int lineNumber, int startPosition) {
-    super(
-      "Encountered a deferred value: \"" + variable + "\"",
-      lineNumber,
-      startPosition
-    );
+    super(MESSAGE_PREFIX + '\"' + variable + '\"', lineNumber, startPosition);
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -98,6 +98,9 @@ public class ForTag implements Tag {
   private static final long serialVersionUID = 6175143875754966497L;
   private static final String LOOP = "loop";
   private static final Pattern IN_PATTERN = Pattern.compile("\\sin\\s");
+  public static final String TOO_LARGE_EXCEPTION_MESSAGE = "Loop too large";
+  public static final String FULL_TOO_LARGE_EXCEPTION_MESSAGE =
+    DeferredValueException.MESSAGE_PREFIX + TOO_LARGE_EXCEPTION_MESSAGE;
 
   @Override
   public boolean isRenderedInValidationMode() {
@@ -243,6 +246,16 @@ public class ForTag implements Tag {
               return checkLoopVariable(interpreter, buff);
             }
           }
+        }
+        if (
+          interpreter.getConfig().getMaxNumEagerTokens() <
+          (
+            loop.getLength() *
+            interpreter.getContext().getEagerTokens().size() /
+            loop.getIndex()
+          )
+        ) {
+          throw new DeferredValueException(TOO_LARGE_EXCEPTION_MESSAGE);
         }
       }
       return checkLoopVariable(interpreter, buff);

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1015,4 +1015,9 @@ public class EagerTest {
   public void itReconstructsWithMultipleLoops() {
     expectedTemplateInterpreter.assertExpectedOutput("reconstructs-with-multiple-loops");
   }
+
+  @Test
+  public void itDefersLargeLoop() {
+    expectedTemplateInterpreter.assertExpectedOutput("defers-large-loop");
+  }
 }

--- a/src/test/resources/eager/defers-large-loop.expected.jinja
+++ b/src/test/resources/eager/defers-large-loop.expected.jinja
@@ -1,0 +1,23 @@
+Small 0 {{ deferred }} {{ deferred ~ 0 }}
+
+Small 1 {{ deferred }} {{ deferred ~ 1 }}
+
+Small 2 {{ deferred }} {{ deferred ~ 2 }}
+
+Small 3 {{ deferred }} {{ deferred ~ 3 }}
+
+Small 4 {{ deferred }} {{ deferred ~ 4 }}
+
+Small 5 {{ deferred }} {{ deferred ~ 5 }}
+
+Small 6 {{ deferred }} {{ deferred ~ 6 }}
+
+Small 7 {{ deferred }} {{ deferred ~ 7 }}
+
+Small 8 {{ deferred }} {{ deferred ~ 8 }}
+
+Small 9 {{ deferred }} {{ deferred ~ 9 }}
+
+{% for i in range(600) %}
+Big {{ i }} {{ deferred }} {{ deferred ~ i }}
+{% endfor %}

--- a/src/test/resources/eager/defers-large-loop.jinja
+++ b/src/test/resources/eager/defers-large-loop.jinja
@@ -1,0 +1,6 @@
+{% for i in range(10) %}
+Small {{ i }} {{ deferred }} {{ deferred ~ i }}
+{% endfor %}
+{% for i in range(500 + 100) %}
+Big {{ i }} {{ deferred }} {{ deferred ~ i }}
+{% endfor %}


### PR DESCRIPTION
If there is a for loop that has a lot of objects such that if we exploded it fully, we would have more than the max number of eager tokens, then we should instead defer looping through the collection.
Additionally, if the collection is quite large, we can defer whatever was evaluated to get it to limit the length of the reconstructed string output.