### PR TITLE
Fix number truthiness by casting to individual types

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/ObjectTruthValue.java
+++ b/src/main/java/com/hubspot/jinjava/util/ObjectTruthValue.java
@@ -39,19 +39,7 @@ public final class ObjectTruthValue {
     }
 
     if (object instanceof Number) {
-      if (object instanceof Integer) {
-        return (Integer) object != 0;
-      }
-      if (object instanceof Double) {
-        return (Double) object != 0;
-      }
-      if (object instanceof Long) {
-        return (Long) object != 0;
-      }
-      if (object instanceof Short) {
-        return (Short) object != 0;
-      }
-      return (Float) object != 0;
+      return ((Number) object).doubleValue() != 0;
     }
 
     if (object instanceof String) {

--- a/src/main/java/com/hubspot/jinjava/util/ObjectTruthValue.java
+++ b/src/main/java/com/hubspot/jinjava/util/ObjectTruthValue.java
@@ -39,7 +39,19 @@ public final class ObjectTruthValue {
     }
 
     if (object instanceof Number) {
-      return ((Number) object).intValue() != 0;
+      if (object instanceof Integer) {
+        return (Integer) object != 0;
+      }
+      if (object instanceof Double) {
+        return (Double) object != 0;
+      }
+      if (object instanceof Long) {
+        return (Long) object != 0;
+      }
+      if (object instanceof Short) {
+        return (Short) object != 0;
+      }
+      return (Float) object != 0;
     }
 
     if (object instanceof String) {

--- a/src/test/java/com/hubspot/jinjava/util/ObjectTruthValueTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ObjectTruthValueTest.java
@@ -16,41 +16,31 @@ public class ObjectTruthValueTest {
 
   @Test
   public void itEvaluatesIntegers() {
-    int a = 1;
-    assertThat(ObjectTruthValue.evaluate(a)).isTrue();
-    int b = 0;
-    assertThat(ObjectTruthValue.evaluate(b)).isFalse();
+    checkNumberTruthiness(1, 0);
   }
 
   @Test
   public void itEvaluatesDoubles() {
-    double a = 0.5;
-    assertThat(ObjectTruthValue.evaluate(a)).isTrue();
-    double b = 0.0;
-    assertThat(ObjectTruthValue.evaluate(b)).isFalse();
+    checkNumberTruthiness(0.5, 0.0);
   }
 
   @Test
   public void itEvaluatesLongs() {
-    long a = 1;
-    assertThat(ObjectTruthValue.evaluate(a)).isTrue();
-    long b = 0;
-    assertThat(ObjectTruthValue.evaluate(b)).isFalse();
+    checkNumberTruthiness(1L, 0L);
   }
 
   @Test
   public void itEvaluatesShorts() {
-    short a = 1;
-    assertThat(ObjectTruthValue.evaluate(a)).isTrue();
-    short b = 0;
-    assertThat(ObjectTruthValue.evaluate(b)).isFalse();
+    checkNumberTruthiness((short) 1, (short) 0);
   }
 
   @Test
   public void itEvaluatesFloats() {
-    float a = 0.5f;
+    checkNumberTruthiness(0.5f, 0.0f);
+  }
+
+  private void checkNumberTruthiness(Object a, Object b) {
     assertThat(ObjectTruthValue.evaluate(a)).isTrue();
-    float b = 0.0f;
     assertThat(ObjectTruthValue.evaluate(b)).isFalse();
   }
 

--- a/src/test/java/com/hubspot/jinjava/util/ObjectTruthValueTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ObjectTruthValueTest.java
@@ -2,7 +2,6 @@ package com.hubspot.jinjava.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
 import org.junit.Test;
 
 public class ObjectTruthValueTest {
@@ -13,6 +12,46 @@ public class ObjectTruthValueTest {
       .isTrue();
     assertThat(ObjectTruthValue.evaluate(new TestObject().setObjectTruthValue(false)))
       .isFalse();
+  }
+
+  @Test
+  public void itEvaluatesIntegers() {
+    int a = 1;
+    assertThat(ObjectTruthValue.evaluate(a)).isTrue();
+    int b = 0;
+    assertThat(ObjectTruthValue.evaluate(b)).isFalse();
+  }
+
+  @Test
+  public void itEvaluatesDoubles() {
+    double a = 0.5;
+    assertThat(ObjectTruthValue.evaluate(a)).isTrue();
+    double b = 0.0;
+    assertThat(ObjectTruthValue.evaluate(b)).isFalse();
+  }
+
+  @Test
+  public void itEvaluatesLongs() {
+    long a = 1;
+    assertThat(ObjectTruthValue.evaluate(a)).isTrue();
+    long b = 0;
+    assertThat(ObjectTruthValue.evaluate(b)).isFalse();
+  }
+
+  @Test
+  public void itEvaluatesShorts() {
+    short a = 1;
+    assertThat(ObjectTruthValue.evaluate(a)).isTrue();
+    short b = 0;
+    assertThat(ObjectTruthValue.evaluate(b)).isFalse();
+  }
+
+  @Test
+  public void itEvaluatesFloats() {
+    float a = 0.5f;
+    assertThat(ObjectTruthValue.evaluate(a)).isTrue();
+    float b = 0.0f;
+    assertThat(ObjectTruthValue.evaluate(b)).isFalse();
   }
 
   private class TestObject implements HasObjectTruthValue {


### PR DESCRIPTION
Truthiness for non-integer numbers functions differently in Jinjava than it does in Jinja. The following should print `yes`, but since it currently only takes the `Number.intvalue()`, it would return false. This PR fixes the issue by checking which type of Number the object is.
```
{% if 0.5 %}
yes
{% else %}
no
{% endif %}
```