### PR TITLE
[Eager Execution] Limit partial AST evaluation length

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
@@ -99,7 +99,10 @@ public class EagerExpressionResolver {
     if (val == null) {
       return JINJAVA_NULL;
     } else if (isResolvableObject(val)) {
-      return PyishObjectMapper.getAsPyishString(val);
+      String pyishString = PyishObjectMapper.getAsPyishString(val);
+      if (pyishString.length() < 1048576) { // TODO maybe this should be configurable
+        return pyishString;
+      }
     }
     throw new DeferredValueException("Can not convert deferred result to string");
   }


### PR DESCRIPTION
Allowing unlimited length strings when partially evaluating the AST tree can lead to memory problems. Setting this to about 1 million. If it proves to be effective, then I may make it configurable.
Saw an issue where a value was partially evaluated several times with a length of around 2 million. It would have showed up several times in the final output, but the max output size was reached. Still, the string existed in lots of places so it caused memory problems, and a lot of time was spent in GC.