### PR TITLE
[Eager Execution] Remove discarded eager tokens when not partially evaluating macro functions

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -405,6 +405,17 @@ public class Context extends ScopeMap<String, Object> {
     }
   }
 
+  public void removeEagerTokens(Collection<EagerToken> toRemove) {
+    eagerTokens.removeAll(toRemove);
+    if (getParent() != null) {
+      Context parent = getParent();
+      //Ignore global context
+      if (parent.getParent() != null) {
+        parent.removeEagerTokens(toRemove);
+      }
+    }
+  }
+
   public Set<EagerToken> getEagerTokens() {
     return eagerTokens;
   }

--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -9,6 +9,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -81,6 +82,9 @@ public class MacroFunction extends AbstractCallableMethod {
           !interpreter.getContext().getEagerTokens().isEmpty()
         )
       ) {
+        interpreter
+          .getContext()
+          .removeEagerTokens(new HashSet<>(interpreter.getContext().getEagerTokens()));
         // If the macro function could not be fully evaluated, throw a DeferredValueException.
         throw new DeferredValueException(
           getName(),


### PR DESCRIPTION
This helps to better track the total number of eager tokens, which when reaching a certain threshold will start killing the eager execution processing. With partial macro function evaluation turned off, however many tokens were deferred during the macro function's evaluation are replaced by a single token, which is the deferral of the macro function's call itself. This will improve the tracking of eager tokens that are actually used, and will prevent there from being "dead" eager tokens tracked on the context.