### PR TITLE
Fix uncaught NoSuchElementException in CollectionMembershipOperator

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
@@ -10,6 +10,7 @@ import de.odysseus.el.tree.impl.ast.AstBinary.SimpleOperator;
 import de.odysseus.el.tree.impl.ast.AstNode;
 import java.util.Collection;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import javax.el.ELException;
 import org.apache.commons.lang3.StringUtils;
@@ -50,7 +51,7 @@ public class CollectionMembershipOperator extends SimpleOperator {
         try {
           Class<?> keyClass = map.keySet().iterator().next().getClass();
           return map.containsKey(converter.convert(o1, keyClass));
-        } catch (ELException e) {
+        } catch (ELException | NoSuchElementException e) {
           return Boolean.FALSE;
         }
       }


### PR DESCRIPTION
I cannot reproduce this in a test, but we've seen several situations where a usage of the CollectionMembershipOperator is resulting in an uncaught NoSuchElementException when calling `map.keySet().iterator().next()` (line 51). This addresses that issue by returning the expected `false`.