### PR TITLE
[Eager Execution] Escape double closing curly braces in AstDict

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDict.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDict.java
@@ -82,7 +82,12 @@ public class EagerAstDict extends AstDict implements EvalResultHolder {
         joiner.add(kvJoiner.toString());
       }
     );
-    return String.format("{%s}", joiner);
+    String joined = joiner.toString();
+    if (joined.endsWith("}")) {
+      // prevent 2 closing braces from being interpreted as a closing expression token
+      joined += ' ';
+    }
+    return String.format("{%s}", joined);
   }
 
   @Override

--- a/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
@@ -170,6 +170,14 @@ public class EagerExpressionStrategyTest extends ExpressionNodeTest {
   }
 
   @Test
+  public void itDoesNotReconstructDirectlyWrittenWithDoubleCurlyBraces() {
+    assertExpectedOutput(
+      "{{ deferred ~ {\n'foo': {\n'bar': deferred\n}\n}\n }}",
+      "{{ deferred ~ {'foo': {'bar': deferred} } }}"
+    );
+  }
+
+  @Test
   public void itReconstructsWithNestedInterpretation() {
     interpreter.getContext().put("foo", "{{ print 'bar' }}");
     assertExpectedOutput(


### PR DESCRIPTION
This PR addresses an issue where in EagerAstDict, when partially resolving the dictionary, it may output two closing curly braces next to each other. This has the possibility to break nested interpretation or the final render because the two curly braces will be interpreted as the closing of an expression token. A string like `{{ {'a': {'b': 'c'}} }}` will get parsed into an expression token like: `{{ {'a': {'b': 'c'}}`
This is a similar problem to https://github.com/HubSpot/jinjava/pull/807, but that didn't handle deferred dictionaries.