### PR TITLE
[Eager Execution] Improve ForTag with deferred tokens

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -389,7 +389,12 @@ public class Context extends ScopeMap<String, Object> {
   public void handleEagerToken(EagerToken eagerToken) {
     eagerTokens.add(eagerToken);
 
-    DeferredValueUtils.findAndMarkDeferredProperties(this, eagerToken);
+    if (
+      eagerToken.getImportResourcePath() == null ||
+      eagerToken.getImportResourcePath().equals(get(Context.IMPORT_RESOURCE_PATH_KEY))
+    ) {
+      DeferredValueUtils.findAndMarkDeferredProperties(this, eagerToken);
+    }
     if (getParent() != null) {
       Context parent = getParent();
       //Ignore global context

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -388,12 +388,8 @@ public class Context extends ScopeMap<String, Object> {
 
   public void handleEagerToken(EagerToken eagerToken) {
     eagerTokens.add(eagerToken);
-    if (
-      eagerToken.getImportResourcePath() == null ||
-      eagerToken.getImportResourcePath().equals(get(Context.IMPORT_RESOURCE_PATH_KEY))
-    ) {
-      DeferredValueUtils.findAndMarkDeferredProperties(this, eagerToken);
-    }
+
+    DeferredValueUtils.findAndMarkDeferredProperties(this, eagerToken);
     if (getParent() != null) {
       Context parent = getParent();
       //Ignore global context

--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -11,6 +11,7 @@ import com.hubspot.jinjava.tree.output.RenderedOutputNode;
 import com.hubspot.jinjava.tree.parse.ExpressionToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
+import com.hubspot.jinjava.util.EagerReconstructionUtils.EagerChildContextConfig;
 import com.hubspot.jinjava.util.Logging;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -37,10 +38,16 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
         eagerInterpreter ->
           EagerExpressionResolver.resolveExpression(master.getExpr(), interpreter),
         interpreter,
-        true,
-        interpreter.getConfig().isNestedInterpretationEnabled(),
-        interpreter.getContext().isDeferredExecutionMode()
+        EagerChildContextConfig
+          .newBuilder()
+          .withTakeNewValue(true)
+          .withPartialMacroEvaluation(
+            interpreter.getConfig().isNestedInterpretationEnabled()
+          )
+          .withCheckForContextChanges(interpreter.getContext().isDeferredExecutionMode())
+          .build()
       );
+
     StringBuilder prefixToPreserveState = new StringBuilder();
     if (interpreter.getContext().isDeferredExecutionMode()) {
       prefixToPreserveState.append(eagerExecutionResult.getPrefixToPreserveState());

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
@@ -10,6 +10,7 @@ import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult.ResolutionState;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
+import com.hubspot.jinjava.util.EagerReconstructionUtils.EagerChildContextConfig;
 import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
 import java.util.Collections;
 import java.util.Optional;
@@ -46,9 +47,7 @@ public class EagerBlockSetTagStrategy extends EagerSetTagStrategy {
         );
       },
       interpreter,
-      true,
-      false,
-      false
+      EagerChildContextConfig.newBuilder().withTakeNewValue(true).build()
     );
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
@@ -8,6 +8,7 @@ import com.hubspot.jinjava.lib.tag.CycleTag;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
+import com.hubspot.jinjava.util.EagerReconstructionUtils.EagerChildContextConfig;
 import com.hubspot.jinjava.util.HelperStringTokenizer;
 import com.hubspot.jinjava.util.WhitespaceUtils;
 import java.util.ArrayList;
@@ -46,9 +47,11 @@ public class EagerCycleTag extends EagerStateChangingTag<CycleTag> {
       eagerInterpreter ->
         EagerExpressionResolver.resolveExpression(expression, interpreter),
       interpreter,
-      true,
-      false,
-      interpreter.getContext().isDeferredExecutionMode()
+      EagerChildContextConfig
+        .newBuilder()
+        .withTakeNewValue(true)
+        .withCheckForContextChanges(interpreter.getContext().isDeferredExecutionMode())
+        .build()
     );
 
     StringBuilder prefixToPreserveState = new StringBuilder();

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -17,6 +17,7 @@ import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
+import com.hubspot.jinjava.util.EagerReconstructionUtils.EagerChildContextConfig;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
 import java.util.HashSet;
@@ -46,9 +47,7 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
             getTag().interpretUnchecked(tagNode, interpreter)
           ),
         interpreter,
-        false,
-        false,
-        false
+        EagerChildContextConfig.newBuilder().withCheckForContextChanges(true).build()
       );
       if (
         interpreter.getContext().getEagerTokens().size() > numEagerTokensStart &&
@@ -112,9 +111,7 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
                 )
               ),
             interpreter,
-            false,
-            false,
-            false
+            EagerChildContextConfig.newBuilder().build()
           )
           .asTemplateString()
       );
@@ -167,9 +164,11 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
         );
       },
       interpreter,
-      false,
-      false,
-      true
+      EagerChildContextConfig
+        .newBuilder()
+        .withForceDeferredExecutionMode(true)
+        .withCheckForContextChanges(true)
+        .build()
     );
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
@@ -15,6 +15,7 @@ import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.NoteToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
+import com.hubspot.jinjava.util.EagerReconstructionUtils.EagerChildContextConfig;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import java.util.HashSet;
 import java.util.Map;
@@ -78,9 +79,11 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
               eagerRenderBranches(tagNode, eagerInterpreter, e)
             ),
           interpreter,
-          false,
-          false,
-          true
+          EagerChildContextConfig
+            .newBuilder()
+            .withForceDeferredExecutionMode(true)
+            .withCheckForContextChanges(true)
+            .build()
         )
         .asTemplateString()
     );
@@ -130,9 +133,11 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
               evaluateBranch(tagNode, finalBranchStart, branchEnd, interpreter)
             ),
           interpreter,
-          false,
-          false,
-          true
+          EagerChildContextConfig
+            .newBuilder()
+            .withForceDeferredExecutionMode(true)
+            .withCheckForContextChanges(true)
+            .build()
         );
         sb.append(result.getResult());
         bindingsToDefer.addAll(resetBindingsForNextBranch(interpreter, result));

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
@@ -193,7 +193,7 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
     return sb.toString();
   }
 
-  private Set<String> resetBindingsForNextBranch(
+  public static Set<String> resetBindingsForNextBranch(
     JinjavaInterpreter interpreter,
     EagerExecutionResult result
   ) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
@@ -8,6 +8,7 @@ import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
+import com.hubspot.jinjava.util.EagerReconstructionUtils.EagerChildContextConfig;
 import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
 import com.hubspot.jinjava.util.WhitespaceUtils;
 import java.util.Arrays;
@@ -34,9 +35,11 @@ public class EagerInlineSetTagStrategy extends EagerSetTagStrategy {
       eagerInterpreter ->
         EagerExpressionResolver.resolveExpression('[' + expression + ']', interpreter),
       interpreter,
-      true,
-      false,
-      interpreter.getContext().isDeferredExecutionMode()
+      EagerChildContextConfig
+        .newBuilder()
+        .withTakeNewValue(true)
+        .withCheckForContextChanges(interpreter.getContext().isDeferredExecutionMode())
+        .build()
     );
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
@@ -7,6 +7,7 @@ import com.hubspot.jinjava.lib.tag.PrintTag;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
+import com.hubspot.jinjava.util.EagerReconstructionUtils.EagerChildContextConfig;
 import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -55,9 +56,11 @@ public class EagerPrintTag extends EagerStateChangingTag<PrintTag> {
     EagerExecutionResult eagerExecutionResult = EagerReconstructionUtils.executeInChildContext(
       eagerInterpreter -> EagerExpressionResolver.resolveExpression(expr, interpreter),
       interpreter,
-      true,
-      false,
-      interpreter.getContext().isDeferredExecutionMode()
+      EagerChildContextConfig
+        .newBuilder()
+        .withTakeNewValue(true)
+        .withCheckForContextChanges(interpreter.getContext().isDeferredExecutionMode())
+        .build()
     );
     StringBuilder prefixToPreserveState = new StringBuilder();
     if (interpreter.getContext().isDeferredExecutionMode()) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
@@ -8,6 +8,7 @@ import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
+import com.hubspot.jinjava.util.EagerReconstructionUtils.EagerChildContextConfig;
 import org.apache.commons.lang3.StringUtils;
 
 public class EagerStateChangingTag<T extends Tag> extends EagerTagDecorator<T> {
@@ -36,17 +37,20 @@ public class EagerStateChangingTag<T extends Tag> extends EagerTagDecorator<T> {
 
     if (!tagNode.getChildren().isEmpty()) {
       result.append(
-        EagerReconstructionUtils.executeInChildContext(
-          eagerInterpreter ->
-            EagerExpressionResult.fromString(renderChildren(tagNode, eagerInterpreter)),
-          interpreter,
-          false,
-          false,
-          true
-        )
+        EagerReconstructionUtils
+          .executeInChildContext(
+            eagerInterpreter ->
+              EagerExpressionResult.fromString(renderChildren(tagNode, eagerInterpreter)),
+            interpreter,
+            EagerChildContextConfig
+              .newBuilder()
+              .withCheckForContextChanges(true)
+              .withForceDeferredExecutionMode(true)
+              .build()
+          )
+          .asTemplateString()
       );
     }
-
     if (
       StringUtils.isNotBlank(tagNode.getEndName()) &&
       (

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -16,6 +16,7 @@ import com.hubspot.jinjava.tree.parse.Token;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
+import com.hubspot.jinjava.util.EagerReconstructionUtils.EagerChildContextConfig;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
 import java.util.stream.Collectors;
@@ -100,9 +101,11 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
               renderChildren(tagNode, eagerInterpreter)
             ),
           interpreter,
-          false,
-          false,
-          true
+          EagerChildContextConfig
+            .newBuilder()
+            .withForceDeferredExecutionMode(true)
+            .withCheckForContextChanges(true)
+            .build()
         )
         .asTemplateString()
     );

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerToken.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerToken.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.hubspot.jinjava.interpret.CallStack;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.tree.parse.Token;
@@ -14,6 +15,8 @@ public class EagerToken {
   // These words are those which will be set to a value which has been deferred.
   private final Set<String> setDeferredWords;
 
+  private final CallStack currentPathStack;
+
   private final String importResourcePath;
   private final String currentMacroFunction;
 
@@ -23,6 +26,7 @@ public class EagerToken {
     this.setDeferredWords = Collections.emptySet();
     importResourcePath = acquireImportResourcePath();
     currentMacroFunction = acquireCurrentMacroFunction();
+    currentPathStack = acquireCurrentPathStack();
   }
 
   public EagerToken(
@@ -35,6 +39,7 @@ public class EagerToken {
     this.setDeferredWords = setDeferredWords;
     importResourcePath = acquireImportResourcePath();
     currentMacroFunction = acquireCurrentMacroFunction();
+    currentPathStack = acquireCurrentPathStack();
   }
 
   public Token getToken() {
@@ -57,6 +62,10 @@ public class EagerToken {
     return currentMacroFunction;
   }
 
+  public CallStack getCurrentPathStack() {
+    return currentPathStack;
+  }
+
   private static String acquireImportResourcePath() {
     return (String) JinjavaInterpreter
       .getCurrentMaybe()
@@ -69,6 +78,13 @@ public class EagerToken {
     return JinjavaInterpreter
       .getCurrentMaybe()
       .flatMap(interpreter -> interpreter.getContext().getMacroStack().peek())
+      .orElse(null);
+  }
+
+  private static CallStack acquireCurrentPathStack() {
+    return JinjavaInterpreter
+      .getCurrentMaybe()
+      .map(interpreter -> interpreter.getContext().getCurrentPathStack())
       .orElse(null);
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerToken.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerToken.java
@@ -15,17 +15,17 @@ public class EagerToken {
   // These words are those which will be set to a value which has been deferred.
   private final Set<String> setDeferredWords;
 
+  // Used to determine the combine scope
   private final CallStack currentPathStack;
 
+  // Used to determine if in separate file
   private final String importResourcePath;
-  private final String currentMacroFunction;
 
   public EagerToken(Token token, Set<String> usedDeferredWords) {
     this.token = token;
     this.usedDeferredWords = usedDeferredWords;
     this.setDeferredWords = Collections.emptySet();
     importResourcePath = acquireImportResourcePath();
-    currentMacroFunction = acquireCurrentMacroFunction();
     currentPathStack = acquireCurrentPathStack();
   }
 
@@ -38,7 +38,6 @@ public class EagerToken {
     this.usedDeferredWords = usedDeferredWords;
     this.setDeferredWords = setDeferredWords;
     importResourcePath = acquireImportResourcePath();
-    currentMacroFunction = acquireCurrentMacroFunction();
     currentPathStack = acquireCurrentPathStack();
   }
 
@@ -58,10 +57,6 @@ public class EagerToken {
     return importResourcePath;
   }
 
-  public String getCurrentMacroFunction() {
-    return currentMacroFunction;
-  }
-
   public CallStack getCurrentPathStack() {
     return currentPathStack;
   }
@@ -71,13 +66,6 @@ public class EagerToken {
       .getCurrentMaybe()
       .map(interpreter -> interpreter.getContext().get(Context.IMPORT_RESOURCE_PATH_KEY))
       .filter(path -> path instanceof String)
-      .orElse(null);
-  }
-
-  private static String acquireCurrentMacroFunction() {
-    return JinjavaInterpreter
-      .getCurrentMaybe()
-      .flatMap(interpreter -> interpreter.getContext().getMacroStack().peek())
       .orElse(null);
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerToken.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerToken.java
@@ -16,7 +16,7 @@ public class EagerToken {
   private final Set<String> setDeferredWords;
 
   // Used to determine the combine scope
-  private final CallStack currentPathStack;
+  private final CallStack macroStack;
 
   // Used to determine if in separate file
   private final String importResourcePath;
@@ -26,7 +26,7 @@ public class EagerToken {
     this.usedDeferredWords = usedDeferredWords;
     this.setDeferredWords = Collections.emptySet();
     importResourcePath = acquireImportResourcePath();
-    currentPathStack = acquireCurrentPathStack();
+    macroStack = acquireMacroStack();
   }
 
   public EagerToken(
@@ -38,7 +38,7 @@ public class EagerToken {
     this.usedDeferredWords = usedDeferredWords;
     this.setDeferredWords = setDeferredWords;
     importResourcePath = acquireImportResourcePath();
-    currentPathStack = acquireCurrentPathStack();
+    macroStack = acquireMacroStack();
   }
 
   public Token getToken() {
@@ -57,8 +57,8 @@ public class EagerToken {
     return importResourcePath;
   }
 
-  public CallStack getCurrentPathStack() {
-    return currentPathStack;
+  public CallStack getMacroStack() {
+    return macroStack;
   }
 
   private static String acquireImportResourcePath() {
@@ -69,10 +69,10 @@ public class EagerToken {
       .orElse(null);
   }
 
-  private static CallStack acquireCurrentPathStack() {
+  private static CallStack acquireMacroStack() {
     return JinjavaInterpreter
       .getCurrentMaybe()
-      .map(interpreter -> interpreter.getContext().getCurrentPathStack())
+      .map(interpreter -> interpreter.getContext().getMacroStack())
       .orElse(null);
   }
 }

--- a/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
@@ -112,8 +112,9 @@ public class DeferredValueUtils {
           )
         );
       } else {
-        List<String> macroArgs = Optional
-          .ofNullable(eagerToken.getCurrentMacroFunction())
+        List<String> macroArgs = context
+          .getMacroStack()
+          .peek()
           .map(
             name ->
               Optional

--- a/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
@@ -92,10 +92,8 @@ public class DeferredValueUtils {
     Set<String> setProps = getPropertiesSetInDeferredNodes(templateSource);
     if (eagerToken != null) {
       if (
-        (
-          eagerToken.getCurrentPathStack() == null ||
-          eagerToken.getCurrentPathStack() == context.getCurrentPathStack()
-        )
+        eagerToken.getMacroStack() == null ||
+        eagerToken.getMacroStack() == context.getMacroStack()
       ) {
         deferredProps.addAll(
           getPropertiesUsedInDeferredNodes(
@@ -112,7 +110,7 @@ public class DeferredValueUtils {
           )
         );
       } else {
-        List<String> macroArgs = context
+        List<String> macroArgs = eagerToken
           .getMacroStack()
           .peek()
           .map(

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -157,14 +157,25 @@ public class EagerReconstructionUtils {
       sessionBindings
         .entrySet()
         .stream()
+        //        .filter(
+        //          entry -> {
+        //            if (entry.getValue() != null) {
+        //              Object current = interpreter.getContext().get(entry.getKey());
+        //              if (entry.getValue() instanceof DeferredValue) {
+        //                return (
+        //                  (current instanceof DeferredValue) &&
+        //                    ((DeferredValue) current).getOriginalValue() != null
+        //                );
+        //              }
+        //              return !entry.getValue().equals(current);
+        //            }
+        //            return false;
+        //          }
+        //        )
         .filter(
           entry ->
             entry.getValue() != null &&
             !entry.getValue().equals(interpreter.getContext().get(entry.getKey()))
-        )
-        .filter(
-          entry ->
-            !(interpreter.getContext().get(entry.getKey()) instanceof DeferredValue)
         )
         .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
     if (checkForContextChanges) {

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -157,25 +157,14 @@ public class EagerReconstructionUtils {
       sessionBindings
         .entrySet()
         .stream()
-        //        .filter(
-        //          entry -> {
-        //            if (entry.getValue() != null) {
-        //              Object current = interpreter.getContext().get(entry.getKey());
-        //              if (entry.getValue() instanceof DeferredValue) {
-        //                return (
-        //                  (current instanceof DeferredValue) &&
-        //                    ((DeferredValue) current).getOriginalValue() != null
-        //                );
-        //              }
-        //              return !entry.getValue().equals(current);
-        //            }
-        //            return false;
-        //          }
-        //        )
         .filter(
           entry ->
             entry.getValue() != null &&
             !entry.getValue().equals(interpreter.getContext().get(entry.getKey()))
+        )
+        .filter(
+          entry ->
+            !(interpreter.getContext().get(entry.getKey()) instanceof DeferredValue)
         )
         .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
     if (checkForContextChanges) {
@@ -580,5 +569,9 @@ public class EagerReconstructionUtils {
         interpreter.getConfig().getTokenScannerSymbols().getExpressionEndWithTag()
       )
     );
+  }
+
+  public class EagerChildContextConfig {
+    private boolean takeNewValue
   }
 }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1033,4 +1033,9 @@ public class EagerTest {
   public void itDefersLargeLoop() {
     expectedTemplateInterpreter.assertExpectedOutput("defers-large-loop");
   }
+
+  @Test
+  public void itHandlesSetInInnerScope() {
+    expectedTemplateInterpreter.assertExpectedOutput("handles-set-in-inner-scope");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -548,7 +548,7 @@ public class EagerImportTagTest extends ImportTagTest {
         "{% set deferred_import_resource_path = 'import-macro.jinja' %}{% macro print_path_macro(var) %}\n" +
         "{{ filter:print_path.filter(var, ____int3rpr3t3r____) }}\n" +
         "{{ var }}\n" +
-        "{% endmacro %}{% set deferred_import_resource_path = null %}{{ print_path_macro(var) }}{% endmacro %}{% set deferred_import_resource_path = null %}{{ print_path_macro2(foo) }}"
+        "{% endmacro %}{% set deferred_import_resource_path = 'double-import-macro.jinja' %}{{ print_path_macro(var) }}{% endmacro %}{% set deferred_import_resource_path = null %}{{ print_path_macro2(foo) }}"
       );
     context.put("foo", "foo");
     context.put(Context.GLOBAL_MACROS_SCOPE_KEY, null);

--- a/src/test/java/com/hubspot/jinjava/util/EagerReconstructionUtilsTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerReconstructionUtilsTest.java
@@ -23,6 +23,7 @@ import com.hubspot.jinjava.objects.collections.PyMap;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.DefaultTokenScannerSymbols;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
+import com.hubspot.jinjava.util.EagerReconstructionUtils.EagerChildContextConfig;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -71,9 +72,12 @@ public class EagerReconstructionUtilsTest extends BaseInterpretingTest {
         }
       ),
       interpreter,
-      true,
-      false,
-      true
+      EagerChildContextConfig
+        .newBuilder()
+        .withTakeNewValue(true)
+        .withForceDeferredExecutionMode(true)
+        .withCheckForContextChanges(true)
+        .build()
     );
 
     assertThat(context.get("foo")).isEqualTo(ImmutableList.of(1));
@@ -98,9 +102,11 @@ public class EagerReconstructionUtilsTest extends BaseInterpretingTest {
         }
       ),
       interpreter,
-      false,
-      false,
-      true
+      EagerChildContextConfig
+        .newBuilder()
+        .withForceDeferredExecutionMode(true)
+        .withCheckForContextChanges(true)
+        .build()
     );
     assertThat(result.getResult().toString()).isEqualTo("function return");
     assertThat(result.getPrefixToPreserveState()).isEqualTo("{% set foo = [] %}");

--- a/src/test/resources/eager/defers-on-immutable-mode.expected.jinja
+++ b/src/test/resources/eager/defers-on-immutable-mode.expected.jinja
@@ -5,6 +5,5 @@
 {% endif %}
 {{ foo }}
 
-{% set bar = 1 + deferred %}
-{% set bar = bar + deferred %}
-{{ bar }}
+{% set bar = 1 %}{% for item in [0, 1] %}{% set bar = bar + deferred %}
+{% endfor %}{{ bar }}

--- a/src/test/resources/eager/handles-set-in-inner-scope.expected.jinja
+++ b/src/test/resources/eager/handles-set-in-inner-scope.expected.jinja
@@ -1,5 +1,4 @@
-{% set foo = 1 %}
-{% for i in range(3) %}
+{% set foo = 1 %}{% for i in [0] %}
 {% set foo = deferred %}
 {{ foo }}
 {% endfor %}

--- a/src/test/resources/eager/handles-set-in-inner-scope.expected.jinja
+++ b/src/test/resources/eager/handles-set-in-inner-scope.expected.jinja
@@ -1,0 +1,6 @@
+{% set foo = 1 %}
+{% for i in range(3) %}
+{% set foo = deferred %}
+{{ foo }}
+{% endfor %}
+{{ foo }}

--- a/src/test/resources/eager/handles-set-in-inner-scope.jinja
+++ b/src/test/resources/eager/handles-set-in-inner-scope.jinja
@@ -1,0 +1,6 @@
+{% set foo = 1 %}
+{% for i in range(1) %}
+{% set foo = deferred %}
+{{ foo }}
+{% endfor %}
+{{ foo }}


### PR DESCRIPTION
This PR addresses an issue where because a for loop uses a separate scope, if there are modifications done inside of a for loop that has some deferred tokens, then the for loop must be deferred rather than exploded. For example, we can't explode this:
```
{% set foo = 1 %}
{% for i in range(2) %}
{% set foo = deferred %}
{{ foo }}
{% endfor %}
{{ foo }}
```
to:
```
{% set foo = 1 %}
{% set foo = deferred %}
{{ foo }}
{% set foo = deferred %}
{{ foo }}
{{ foo }}
```
because the `{{ foo }}` that comes after the for loop should have a value of `1`. This is because a set tag inside of a for loop will not modify variables outside of the for loop. So we'd need to defer the for loop so that the correct scope can remain.

As part of this, I'm also making a modification to what we store inside of the `EagerToken`. Rather than storing the name of the current macro function, we will store one of the Context's call stacks (specifically the macro stack). We are using the call stack to be able to track the scope in which the eager token was created because adding a new scope will create a new call stack. So we will be able to check if the scope of the eager token is the same as the context's current scope. If they are the same scope, then we will defer normally, but if they're on different scopes, we won't defer any of the "set" variables. As they would be set on a different scope level.

In order to track this information and revert when running a for loop, we need to add a new boolean option to the `executeInChildContext()` method that will allow us to watch for context changes, but not run in deferred execution mode. This way, if nothing ends up getting deferred, then we can simply allow any changes to the context to happen, as they would've for a regular for loop execution. Rather than just adding another boolean flag, I converted all the flags into an immutable object so it is more visible what the config options are for that method call. Previously, `checkForContextChanges` would always force deferred execution mode to be on, but now, we can check for context changes without needing deferred execution mode to be on, which is what we'll use to run the for loop initially.