### PR TITLE
[Eager Execution] Skip nested interpretation if there are syntax errors while parsing

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.lib.expression;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.filter.EscapeFilter;
 import com.hubspot.jinjava.lib.tag.RawTag;
 import com.hubspot.jinjava.lib.tag.eager.EagerExecutionResult;
@@ -58,13 +59,26 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
       ) {
         if (interpreter.getConfig().isNestedInterpretationEnabled()) {
           long errorSizeStart = getUnclosedCommentErrorsCount(interpreter);
-          interpreter.parse(result);
-          if (getUnclosedCommentErrorsCount(interpreter) == errorSizeStart) {
-            try {
-              result = interpreter.renderFlat(result);
-            } catch (Exception e) {
-              Logging.ENGINE_LOG.warn("Error rendering variable node result", e);
+          boolean throwInterpreterErrorsStart = interpreter
+            .getContext()
+            .getThrowInterpreterErrors();
+          interpreter.getContext().setThrowInterpreterErrors(true);
+          try {
+            interpreter.parse(result);
+            interpreter
+              .getContext()
+              .setThrowInterpreterErrors(throwInterpreterErrorsStart);
+            if (getUnclosedCommentErrorsCount(interpreter) == errorSizeStart) {
+              try {
+                result = interpreter.renderFlat(result);
+              } catch (Exception e) {
+                Logging.ENGINE_LOG.warn("Error rendering variable node result", e);
+              }
             }
+          } catch (TemplateSyntaxException ignored) {} finally {
+            interpreter
+              .getContext()
+              .setThrowInterpreterErrors(throwInterpreterErrorsStart);
           }
         } else {
           // Possible macro/set tag in front of this one. Includes result


### PR DESCRIPTION
In eager execution, it is possible to reconstruct a tag that is disabled in the current context due to memorization. This PR circumvents that problem by looking for any FATAL syntax errors when parsing the initial output of the expression. We can throw and catch these TemplateSyntaxExceptions by temporarily turning on `interpreter.setThrowInterpreterErrors(true)`.
For example, if there is some disabled tag in the current interpreter scope, parsing with nested interpretation would remove the token using that tag entirely, which can break eager execution.