### PR TITLE
Fix macro function scoping inside of another macro function

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -9,6 +9,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -130,6 +131,13 @@ public class MacroFunction extends AbstractCallableMethod {
     for (Map.Entry<String, Object> scopeEntry : localContextScope.getScope().entrySet()) {
       if (scopeEntry.getValue() instanceof MacroFunction) {
         interpreter.getContext().addGlobalMacro((MacroFunction) scopeEntry.getValue());
+      } else if (scopeEntry.getKey().equals(Context.GLOBAL_MACROS_SCOPE_KEY)) {
+        interpreter
+          .getContext()
+          .put(
+            Context.GLOBAL_MACROS_SCOPE_KEY,
+            new HashMap<>((Map<String, MacroFunction>) scopeEntry.getValue())
+          );
       } else {
         if (!alreadyDeferredInEarlierCall(scopeEntry.getKey(), interpreter)) {
           interpreter.getContext().put(scopeEntry.getKey(), scopeEntry.getValue());

--- a/src/test/resources/tags/macrotag/scoping.jinja
+++ b/src/test/resources/tags/macrotag/scoping.jinja
@@ -1,0 +1,12 @@
+{%- macro foo() -%}
+{%- macro foo() -%}
+child
+{%- endmacro %}
+{%- macro bar() -%}
+the bar
+{%- endmacro -%}
+parent & {{ foo() }} & {{ bar() }}
+{%- endmacro %}
+{{ foo() }}.
+{{ foo() }}.
+{{ bar() }}.


### PR DESCRIPTION
Addresses https://github.com/HubSpot/jinjava/issues/868
Rather than copying the global macros over when evaluating a macro function, we'll instead create a new HashMap copy of it so that if any new macro functions are added, they will be localised to the current scope, rather than the parent's scope.