### PR TITLE
Handle thread interrupts by throwing an InterpretException

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -43,7 +43,7 @@ public class ExpressionNode extends Node {
 
   @Override
   public OutputNode render(JinjavaInterpreter interpreter) {
-    interpreter.getContext().setCurrentNode(this);
+    preProcess(interpreter);
     try {
       return expressionStrategy.interpretOutput(master, interpreter);
     } catch (DeferredValueException e) {

--- a/src/main/java/com/hubspot/jinjava/tree/Node.java
+++ b/src/main/java/com/hubspot/jinjava/tree/Node.java
@@ -15,6 +15,7 @@
  **********************************************************************/
 package com.hubspot.jinjava.tree;
 
+import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.tree.output.OutputNode;
 import com.hubspot.jinjava.tree.parse.Token;
@@ -96,5 +97,20 @@ public abstract class Node implements Serializable {
     }
 
     return t.toString();
+  }
+
+  public void preProcess(JinjavaInterpreter interpreter) {
+    interpreter.getContext().setCurrentNode(this);
+    checkForInterrupt();
+  }
+
+  public final void checkForInterrupt() {
+    if (Thread.interrupted()) {
+      throw new InterpretException(
+        "Interrupt rendering " + getClass(),
+        master.getLineNumber(),
+        master.getStartPosition()
+      );
+    }
   }
 }

--- a/src/main/java/com/hubspot/jinjava/tree/TagNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TagNode.java
@@ -44,13 +44,12 @@ public class TagNode extends Node {
 
   @Override
   public OutputNode render(JinjavaInterpreter interpreter) {
-    interpreter.getContext().setCurrentNode(this);
+    preProcess(interpreter);
     if (
       interpreter.getContext().isValidationMode() && !tag.isRenderedInValidationMode()
     ) {
       return new RenderedOutputNode("");
     }
-
     try {
       if (interpreter.getConfig().getExecutionMode().useEagerParser()) {
         interpreter.getContext().checkNumberOfDeferredTokens();

--- a/src/main/java/com/hubspot/jinjava/tree/TextNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TextNode.java
@@ -32,7 +32,7 @@ public class TextNode extends Node {
 
   @Override
   public OutputNode render(JinjavaInterpreter interpreter) {
-    interpreter.getContext().setCurrentNode(this);
+    preProcess(interpreter);
     return new RenderedOutputNode(
       interpreter.getContext().isValidationMode() ? "" : master.output()
     );


### PR DESCRIPTION
Jinjava will continue to process if a thread is interrupted, which in some cases can lead to it taking quite a long time for execution to stop. Rather than continuing to process through the whole template, if the thread is interrupted, we can throw an InterpretException for each node that is attempted to be rendered after the interrupt has been issued.