### PR TITLE
[Eager Execution] Don't swallow JsonProcessingException when reconstructing AST nodes

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
@@ -112,7 +112,11 @@ public interface EvalResultHolder {
         return e.getDeferredEvalResult();
       }
     }
-    return EagerExpressionResolver.getValueAsJinjavaStringSafe(evalResult);
+    try {
+      return EagerExpressionResolver.getValueAsJinjavaStringSafe(evalResult);
+    } catch (DeferredValueException e) {
+      return astNode.getPartiallyResolved(bindings, context, exception, true);
+    }
   }
 
   static DeferredParsingException convertToDeferredParsingException(

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -39,18 +39,23 @@ public class PyishObjectMapper {
 
   public static String getAsPyishString(Object val) {
     try {
-      String string = PYISH_OBJECT_WRITER
-        .writeValueAsString(val)
-        .replace("'", "\\'")
-        // Replace double-quotes with single quote as they are preferred in Jinja
-        .replaceAll("(?<!\\\\)(\\\\\\\\)*(?:\")", "$1'");
-      if (!string.contains("{{")) {
-        return String.join("} ", string.split("}(?=})"));
-      }
-      return string;
+      return getAsPyishStringOrThrow(val);
     } catch (JsonProcessingException e) {
       return Objects.toString(val, "");
     }
+  }
+
+  public static String getAsPyishStringOrThrow(Object val)
+    throws JsonProcessingException {
+    String string = PYISH_OBJECT_WRITER
+      .writeValueAsString(val)
+      .replace("'", "\\'")
+      // Replace double-quotes with single quote as they are preferred in Jinja
+      .replaceAll("(?<!\\\\)(\\\\\\\\)*(?:\")", "$1'");
+    if (!string.contains("{{")) {
+      return String.join("} ", string.split("}(?=})"));
+    }
+    return string;
   }
 
   public static class NullKeySerializer extends JsonSerializer<Object> {

--- a/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.el.ext.ExtendedParser;
@@ -96,14 +97,16 @@ public class EagerExpressionResolver {
   }
 
   public static String getValueAsJinjavaStringSafe(Object val) {
-    if (val == null) {
-      return JINJAVA_NULL;
-    } else if (isResolvableObject(val)) {
-      String pyishString = PyishObjectMapper.getAsPyishString(val);
-      if (pyishString.length() < 1048576) { // TODO maybe this should be configurable
-        return pyishString;
+    try {
+      if (val == null) {
+        return JINJAVA_NULL;
+      } else if (isResolvableObject(val)) {
+        String pyishString = PyishObjectMapper.getAsPyishStringOrThrow(val);
+        if (pyishString.length() < 1048576) { // TODO maybe this should be configurable
+          return pyishString;
+        }
       }
-    }
+    } catch (JsonProcessingException ignored) {}
     throw new DeferredValueException("Can not convert deferred result to string");
   }
 


### PR DESCRIPTION
If there is some object that is used in an EL expression and we are reconstructing that expression, which when trying to call:
```java
PYISH_OBJECT_WRITER
      .writeValueAsString(val)
```
it throws a JsonProcessingException, then instead of using `Objects.toString(val, "")`, we will throw a DeferredValueException. We can then catch this DeferredValueException and preserve the identifier of this node.

In the test, there is an object on the context `foo`, and when reconstructing the expression `{{ deferred && (1 == 2 || foo) }}`, we first try to get the string representation of foo's value. Since `toPyishString()` throws a DeferredValueException, that gets wrapped in a JsonProcessingException. So we will then preserve the `foo` identifier, rather than trying to output the pyish representation of its value.

This specifically targets a case I saw in HubL where `content_group` was used in a boolean expression and part of the expression was deferred. We ended up reconstructing it with the default java `toString()` method `Objects.toString(val, "")`, and it caused the EL expression's reconstruction to be invalid Jinjava syntax.