### PR TITLE
[Eager Execution] Fix how bindings are reset in for loops

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
@@ -18,8 +18,6 @@ import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.EagerReconstructionUtils.EagerChildContextConfig;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import java.util.HashSet;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -202,42 +200,10 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
     JinjavaInterpreter interpreter,
     EagerExecutionResult result
   ) {
-    Map<String, Object> nonDeferredBindingsToRevert = result
-      .getSpeculativeBindings()
-      .entrySet()
-      .stream()
-      .filter(
-        entry ->
-          interpreter.getContext().containsKey(entry.getKey()) &&
-          !(interpreter.getContext().get(entry.getKey()) instanceof DeferredValue)
-      )
-      .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-    if (!nonDeferredBindingsToRevert.isEmpty()) {
-      nonDeferredBindingsToRevert.forEach(
-        (k, v) -> interpreter.getContext().replace(k, v)
-      );
-    }
-
     result
       .getSpeculativeBindings()
-      .keySet()
-      .stream()
-      .filter(key -> interpreter.getContext().get(key) instanceof DeferredValue)
-      .forEach(
-        key -> {
-          if (
-            ((DeferredValue) interpreter.getContext().get(key)).getOriginalValue() != null
-          ) {
-            interpreter
-              .getContext()
-              .replace(
-                key,
-                ((DeferredValue) interpreter.getContext().get(key)).getOriginalValue()
-              );
-          }
-        }
-      );
-    return nonDeferredBindingsToRevert.keySet();
+      .forEach((k, v) -> interpreter.getContext().replace(k, v));
+    return result.getSpeculativeBindings().keySet();
   }
 
   private String evaluateBranch(

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1038,4 +1038,11 @@ public class EagerTest {
   public void itHandlesSetInInnerScope() {
     expectedTemplateInterpreter.assertExpectedOutput("handles-set-in-inner-scope");
   }
+
+  @Test
+  public void itCorrectlyDefersWithMultipleLoops() {
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "correctly-defers-with-multiple-loops"
+    );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/NonRevertingEagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/NonRevertingEagerTest.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava;
 
 import com.hubspot.jinjava.mode.NonRevertingEagerExecutionMode;
 import org.junit.Before;
+import org.junit.Ignore;
 
 public class NonRevertingEagerTest extends EagerTest {
 
@@ -9,5 +10,11 @@ public class NonRevertingEagerTest extends EagerTest {
   @Before
   public void setup() {
     setupWithExecutionMode(NonRevertingEagerExecutionMode.instance());
+  }
+
+  @Ignore
+  @Override
+  public void itCorrectlyDefersWithMultipleLoops() {
+    super.itCorrectlyDefersWithMultipleLoops();
   }
 }

--- a/src/test/resources/eager/correctly-defers-with-multiple-loops.expected.jinja
+++ b/src/test/resources/eager/correctly-defers-with-multiple-loops.expected.jinja
@@ -1,0 +1,6 @@
+{% set my_list = [] %}{% for i in [0, 1] %}
+{% for j in deferred %}
+{% do my_list.append(1) %}
+{% endfor %}
+{% endfor %}
+{{ my_list }}

--- a/src/test/resources/eager/correctly-defers-with-multiple-loops.jinja
+++ b/src/test/resources/eager/correctly-defers-with-multiple-loops.jinja
@@ -1,0 +1,7 @@
+{% set my_list = [] %}
+{% for i in range(2) %}
+{% for j in deferred %}
+{% do my_list.append(1) %}
+{% endfor %}
+{% endfor %}
+{{ my_list }}


### PR DESCRIPTION
We should be resetting to the value gotten from the speculative binding as that will be the correctly tracked previous value, rather than reverting to the
DeferredValue's original value, as that could have been modified before getting deferred.

Before this change, the output of running the new test was:
```
{% set my_list = [1] %}{% for i in [0, 1] %}
{% for j in deferred %}
{% do my_list.append(1) %}
{% endfor %}
{% endfor %}
{{ my_list }}
```
because my_list would be reconstructed incorrectly.