### PR TITLE
[Eager Execution] Defer extends tag when evaluated in deferred execution mode

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/ExtendsTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ExtendsTag.java
@@ -18,6 +18,7 @@ package com.hubspot.jinjava.lib.tag;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
@@ -84,6 +85,9 @@ public class ExtendsTag implements Tag {
 
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
+    if (interpreter.getContext().isDeferredExecutionMode()) {
+      throw new DeferredValueException("extends tag");
+    }
     HelperStringTokenizer tokenizer = new HelperStringTokenizer(tagNode.getHelpers());
     if (!tokenizer.hasNext()) {
       throw new TemplateSyntaxException(

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactory.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactory.java
@@ -9,6 +9,7 @@ import com.hubspot.jinjava.lib.tag.DoTag;
 import com.hubspot.jinjava.lib.tag.ElseIfTag;
 import com.hubspot.jinjava.lib.tag.ElseTag;
 import com.hubspot.jinjava.lib.tag.EndTag;
+import com.hubspot.jinjava.lib.tag.ExtendsTag;
 import com.hubspot.jinjava.lib.tag.ForTag;
 import com.hubspot.jinjava.lib.tag.FromTag;
 import com.hubspot.jinjava.lib.tag.IfTag;
@@ -45,6 +46,7 @@ public class EagerTagFactory {
     .add(ElseIfTag.class)
     .add(ElseTag.class)
     .add(RawTag.class)
+    .add(ExtendsTag.class) // TODO support reconstructing extends tags
     .build();
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/com/hubspot/jinjava/ExpectedTemplateInterpreter.java
+++ b/src/test/java/com/hubspot/jinjava/ExpectedTemplateInterpreter.java
@@ -62,7 +62,7 @@ public class ExpectedTemplateInterpreter {
     }
   }
 
-  private String getFixtureTemplate(String name) {
+  public String getFixtureTemplate(String name) {
     try {
       return Resources.toString(
         Resources.getResource(String.format("%s/%s.jinja", path, name)),

--- a/src/test/java/com/hubspot/jinjava/NonRevertingEagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/NonRevertingEagerTest.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava;
 import com.hubspot.jinjava.mode.NonRevertingEagerExecutionMode;
 import org.junit.Before;
 import org.junit.Ignore;
+import org.junit.Test;
 
 public class NonRevertingEagerTest extends EagerTest {
 
@@ -14,6 +15,7 @@ public class NonRevertingEagerTest extends EagerTest {
 
   @Ignore
   @Override
+  @Test
   public void itCorrectlyDefersWithMultipleLoops() {
     super.itCorrectlyDefersWithMultipleLoops();
   }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerExtendsTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerExtendsTagTest.java
@@ -1,5 +1,7 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
 import com.hubspot.jinjava.ExpectedTemplateInterpreter;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.LegacyOverrides;
@@ -81,6 +83,14 @@ public class EagerExtendsTagTest extends ExtendsTagTest {
     expectedTemplateInterpreter.assertExpectedOutput(
       "reconstructs-deferred-outside-block.expected"
     );
+  }
+
+  @Test
+  public void itThrowsWhenDeferredExtendsTag() {
+    interpreter.render(
+      expectedTemplateInterpreter.getFixtureTemplate("throws-when-deferred-extends-tag")
+    );
+    assertThat(interpreter.getContext().getDeferredNodes()).hasSize(2);
   }
 
   @Override

--- a/src/test/resources/tags/eager/extendstag/throws-when-deferred-extends-tag.jinja
+++ b/src/test/resources/tags/eager/extendstag/throws-when-deferred-extends-tag.jinja
@@ -1,0 +1,9 @@
+{% if deferred %}
+{% extends "../eager/extendstag/base.html" %}
+{% else %}
+{% extends "../eager/extendstag/base.html" %}
+{% endif %}
+
+{%- block sidebar -%}
+<h3>Table Of Contents</h3>
+{%- endblock -%}


### PR DESCRIPTION
Encountered a situation where someone changed what the extends parent was via an if tag that used a deferred value. Eventually, I hope to support that in some fashion, but for now that can't be handled so we can turn the extends tag into a deferred node so that we know it cannot be used for a second rendering phase.