### PR TITLE
Do json serialization for arbitrary classes with overridden toString

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/SafeString.java
+++ b/src/main/java/com/hubspot/jinjava/objects/SafeString.java
@@ -1,5 +1,7 @@
 package com.hubspot.jinjava.objects;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public class SafeString {
   private final String value;
 
@@ -7,6 +9,7 @@ public class SafeString {
     this.value = value;
   }
 
+  @JsonValue
   public String getValue() {
     return value;
   }

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishBeanSerializerModifier.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishBeanSerializerModifier.java
@@ -16,17 +16,12 @@ public class PyishBeanSerializerModifier extends BeanSerializerModifier {
     BeanDescription beanDesc,
     JsonSerializer<?> serializer
   ) {
-    try {
-      if (
-        beanDesc.getBeanClass().getMethod("toString").getDeclaringClass() == Object.class
-      ) {
-        // Use the PyishSerializer if it extends the PyishSerializable class.
-        // For example, a Map implementation could then have custom string serialization.
-        if (!(PyishSerializable.class.isAssignableFrom(beanDesc.getBeanClass()))) {
-          return serializer;
-        }
-      }
-    } catch (NoSuchMethodException ignored) {}
-    return PyishSerializer.INSTANCE;
+    // Use the PyishSerializer if it extends the PyishSerializable class.
+    // For example, a Map implementation could then have custom string serialization.
+    if (!(PyishSerializable.class.isAssignableFrom(beanDesc.getBeanClass()))) {
+      return serializer;
+    } else {
+      return PyishSerializer.INSTANCE;
+    }
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RejectAttrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RejectAttrFilterTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Lists;
 import com.hubspot.jinjava.BaseJinjavaTest;
+import com.hubspot.jinjava.objects.serialization.PyishSerializable;
 import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
@@ -76,7 +77,7 @@ public class RejectAttrFilterTest extends BaseJinjavaTest {
       .isEqualTo("[1, 2]");
   }
 
-  public static class User {
+  public static class User implements PyishSerializable {
     private int num;
     private boolean isActive;
     private String email;
@@ -108,6 +109,11 @@ public class RejectAttrFilterTest extends BaseJinjavaTest {
     @Override
     public String toString() {
       return num + "";
+    }
+
+    @Override
+    public String toPyishString() {
+      return toString();
     }
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SelectAttrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SelectAttrFilterTest.java
@@ -2,8 +2,10 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.Lists;
 import com.hubspot.jinjava.BaseJinjavaTest;
+import com.hubspot.jinjava.objects.serialization.PyishSerializable;
 import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
@@ -98,7 +100,7 @@ public class SelectAttrFilterTest extends BaseJinjavaTest {
       .isEqualTo("[2]");
   }
 
-  public static class User {
+  public static class User implements PyishSerializable {
     private long num;
     private boolean isActive;
     private String email;
@@ -131,9 +133,14 @@ public class SelectAttrFilterTest extends BaseJinjavaTest {
     public String toString() {
       return num + "";
     }
+
+    @Override
+    public String toPyishString() {
+      return toString();
+    }
   }
 
-  public static class Option {
+  public static class Option implements PyishSerializable {
     private long id;
     private String name;
 
@@ -150,9 +157,15 @@ public class SelectAttrFilterTest extends BaseJinjavaTest {
       return name;
     }
 
+    @JsonValue
     @Override
     public String toString() {
       return id + "";
+    }
+
+    @Override
+    public String toPyishString() {
+      return toString();
     }
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SortFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SortFilterTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
+import com.hubspot.jinjava.objects.serialization.PyishSerializable;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -135,7 +136,7 @@ public class SortFilterTest extends BaseJinjavaTest {
     );
   }
 
-  public static class MyFoo {
+  public static class MyFoo implements PyishSerializable {
     private Date date;
 
     MyFoo(Date date) {
@@ -150,9 +151,14 @@ public class SortFilterTest extends BaseJinjavaTest {
     public String toString() {
       return "" + date.getTime();
     }
+
+    @Override
+    public String toPyishString() {
+      return toString();
+    }
   }
 
-  public static class MyBar {
+  public static class MyBar implements PyishSerializable {
     private MyFoo foo;
 
     MyBar(MyFoo foo) {
@@ -166,6 +172,11 @@ public class SortFilterTest extends BaseJinjavaTest {
     @Override
     public String toString() {
       return foo.toString();
+    }
+
+    @Override
+    public String toPyishString() {
+      return toString();
     }
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/UniqueFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/UniqueFilterTest.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hubspot.jinjava.BaseJinjavaTest;
+import com.hubspot.jinjava.objects.serialization.PyishSerializable;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
@@ -53,7 +54,7 @@ public class UniqueFilterTest extends BaseJinjavaTest {
     );
   }
 
-  public static class MyClass {
+  public static class MyClass implements PyishSerializable {
     private final String name;
 
     public MyClass(String name) {
@@ -67,6 +68,11 @@ public class UniqueFilterTest extends BaseJinjavaTest {
     @Override
     public String toString() {
       return "[Name:" + name + "]";
+    }
+
+    @Override
+    public String toPyishString() {
+      return toString();
     }
   }
 }

--- a/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
@@ -21,7 +21,7 @@ public class PyishObjectMapperTest {
   }
 
   @Test
-  public void itSerilizesMapEntrySet2() throws JsonProcessingException {
+  public void itSerializesMapEntrySet() throws JsonProcessingException {
     SizeLimitingPyMap map = new SizeLimitingPyMap(new HashMap<>(), 10);
     map.put("foo", "bar");
     String result = PyishObjectMapper.getAsPyishString(map.items());
@@ -33,7 +33,7 @@ public class PyishObjectMapperTest {
           .replaceAll("\"", "'")
       )
       .isEqualTo("[{'foo': 'bar'}]");
-    }
+  }
 
   @Test
   public void itSerializesMapWithNullValues() {

--- a/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
@@ -2,6 +2,8 @@ package com.hubspot.jinjava.objects.serialization;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.jinjava.objects.collections.SizeLimitingPyMap;
 import java.util.HashMap;
 import java.util.Map;
@@ -16,5 +18,20 @@ public class PyishObjectMapperTest {
     map.put(null, "null");
     assertThat(PyishObjectMapper.getAsPyishString(map))
       .isEqualTo("{'': 'null', 'foo': 'bar'}");
+  }
+
+  @Test
+  public void itSerilizesMapEntrySet2() throws JsonProcessingException {
+    SizeLimitingPyMap map = new SizeLimitingPyMap(new HashMap<>(), 10);
+    map.put("foo", "bar");
+    String result = PyishObjectMapper.getAsPyishString(map.items());
+    assertThat(result)
+      .isEqualTo(
+        new ObjectMapper()
+          .writer(PyishPrettyPrinter.INSTANCE)
+          .writeValueAsString(map.items())
+          .replaceAll("\"", "'")
+      )
+      .isEqualTo("[{'foo': 'bar'}]");
   }
 }


### PR DESCRIPTION
The current functionality is for arbitrary classes (classes that don't implement `PyishSerializable`), if they have an overridden `toString()` method, then it will be used when outputting the value to a string. The problem is that there are certain java classes (such as HashMap$Node) that have an overridden `toString()` method, but the output should not be used when serializing an object of that type. Therefore, when serializing objects as strings we should never default to the `toString()` method, and should default to regular json serialization. If a completely custom pyish serialization is desired, then implementing `PyishSerializable` and overriding `toPyishString()` is the way to go.

This won't change the functionality for default, legacy behaviour because of the `LegacyOverrides.isUsePyishObjectMapper()`, which is turned off by default. Therefore, by default calling `{{ obj }}` will output via `obj.toString()`, but with the override turned on, it will output via `PyishObjectMapper.getAsUnquotedPyishString(obj)`.

The reason that I have to modify the classes used in the test files is because we have this override turned on for the tests https://github.com/HubSpot/jinjava/blob/623ef80aca8f17e453080f193d778d5b469e783a/src/test/java/com/hubspot/jinjava/BaseJinjavaTest.java#L15

Thanks to @nathanielpautzke for working with me on this one