### PR TITLE
Write null map values within PyishObjectMapper

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -1,12 +1,10 @@
 package com.hubspot.jinjava.objects.serialization;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.hubspot.jinjava.util.WhitespaceUtils;
@@ -18,13 +16,11 @@ public class PyishObjectMapper {
 
   static {
     ObjectMapper mapper = new ObjectMapper()
-      .registerModule(
+    .registerModule(
         new SimpleModule()
           .setSerializerModifier(PyishBeanSerializerModifier.INSTANCE)
           .addSerializer(PyishSerializable.class, PyishSerializer.INSTANCE)
-      )
-      .configure(SerializationFeature.WRITE_NULL_MAP_VALUES, false)
-      .setSerializationInclusion(Include.NON_NULL);
+      );
     mapper.getSerializerProvider().setNullKeySerializer(new NullKeySerializer());
     PYISH_OBJECT_WRITER =
       mapper.writer(PyishPrettyPrinter.INSTANCE).with(PyishCharacterEscapes.INSTANCE);

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -23,6 +23,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -103,6 +104,13 @@ public class EagerTest {
     } finally {
       JinjavaInterpreter.popCurrent();
     }
+  }
+
+  @Test
+  public void itReconstructsMapWithNullValues() {
+    interpreter.render("{% set foo = {'foo': null} %}");
+    assertThat(interpreter.getContext().get("foo")).isInstanceOf(Map.class);
+    assertThat((Map) interpreter.getContext().get("foo")).hasSize(1);
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
@@ -17,4 +17,13 @@ public class PyishObjectMapperTest {
     assertThat(PyishObjectMapper.getAsPyishString(map))
       .isEqualTo("{'': 'null', 'foo': 'bar'}");
   }
+
+  @Test
+  public void itSerializesMapWithNullValues() {
+    Map<String, Object> map = new SizeLimitingPyMap(new HashMap<>(), 10);
+    map.put("foo", "bar");
+    map.put("foobar", null);
+    assertThat(PyishObjectMapper.getAsPyishString(map))
+      .isEqualTo("{'foobar': null, 'foo': 'bar'}");
+  }
 }


### PR DESCRIPTION
When I handled null keys within maps, I unnecessarily added configuration to disable writing null values https://github.com/HubSpot/jinjava/pull/835

In the case of an operation like `{% do my_map.update({'foo': null}) %}`, the update map would get serialized as `{}`, which is not correct. 