### PR TITLE
[Eager Execution] Handle for loop resetting when a DeferredValueException is thrown

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/DeferredValueException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/DeferredValueException.java
@@ -9,7 +9,7 @@ public class DeferredValueException extends InterpretException {
   public static final String MESSAGE_PREFIX = "Encountered a deferred value: ";
 
   public DeferredValueException(String message) {
-    super(MESSAGE_PREFIX + message);
+    super(message);
   }
 
   public DeferredValueException(String variable, int lineNumber, int startPosition) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -99,8 +99,6 @@ public class ForTag implements Tag {
   private static final String LOOP = "loop";
   private static final Pattern IN_PATTERN = Pattern.compile("\\sin\\s");
   public static final String TOO_LARGE_EXCEPTION_MESSAGE = "Loop too large";
-  public static final String FULL_TOO_LARGE_EXCEPTION_MESSAGE =
-    DeferredValueException.MESSAGE_PREFIX + TOO_LARGE_EXCEPTION_MESSAGE;
 
   @Override
   public boolean isRenderedInValidationMode() {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
@@ -47,7 +47,7 @@ public class EagerBlockSetTagStrategy extends EagerSetTagStrategy {
       EagerChildContextConfig.newBuilder().withTakeNewValue(true).build()
     );
     if (result.getResult().getResolutionState() == ResolutionState.NONE) {
-      throw new DeferredValueException("Block set tag children could not be rendered");
+      throw new DeferredValueException(result.getResult().toString());
     }
     return result;
   }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -16,6 +16,7 @@ import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
+import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult.ResolutionState;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.EagerReconstructionUtils.EagerChildContextConfig;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
@@ -40,18 +41,21 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     try {
-      int numEagerTokensStart = interpreter.getContext().getEagerTokens().size();
       EagerExecutionResult result = EagerReconstructionUtils.executeInChildContext(
         eagerInterpreter ->
-          EagerExpressionResult.fromString(
-            getTag().interpretUnchecked(tagNode, interpreter)
+          EagerExpressionResult.fromSupplier(
+            () -> getTag().interpretUnchecked(tagNode, eagerInterpreter),
+            eagerInterpreter
           ),
         interpreter,
         EagerChildContextConfig.newBuilder().withCheckForContextChanges(true).build()
       );
       if (
-        interpreter.getContext().getEagerTokens().size() > numEagerTokensStart &&
-        !result.getSpeculativeBindings().isEmpty()
+        result.getResult().getResolutionState() == ResolutionState.NONE ||
+        (
+          result.getResult().isFullyResolved() &&
+          !result.getSpeculativeBindings().isEmpty()
+        )
       ) {
         EagerIfTag.resetBindingsForNextBranch(interpreter, result);
         throw new DeferredValueException(

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -53,13 +53,15 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
       if (
         result.getResult().getResolutionState() == ResolutionState.NONE ||
         (
-          result.getResult().isFullyResolved() &&
+          !result.getResult().isFullyResolved() &&
           !result.getSpeculativeBindings().isEmpty()
         )
       ) {
         EagerIfTag.resetBindingsForNextBranch(interpreter, result);
         throw new DeferredValueException(
-          "Modification inside partially evaluated for loop"
+          result.getResult().getResolutionState() == ResolutionState.NONE
+            ? result.getResult().toString()
+            : "Modification inside partially evaluated for loop"
         );
       }
       return result.getResult().toString(true);
@@ -93,7 +95,7 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
       TemporaryValueClosable<Boolean> c = interpreter
         .getContext()
         .withDeferLargeObjects(
-          ForTag.FULL_TOO_LARGE_EXCEPTION_MESSAGE.equals(e.getMessage()) ||
+          ForTag.TOO_LARGE_EXCEPTION_MESSAGE.equals(e.getMessage()) ||
           interpreter.getContext().isDeferLargeObjects()
         )
     ) {

--- a/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.el.ELException;
@@ -316,6 +317,10 @@ public class EagerExpressionResolver {
       throw new DeferredValueException("Object is not resolved");
     }
 
+    public ResolutionState getResolutionState() {
+      return resolutionState;
+    }
+
     public boolean isFullyResolved() {
       return resolutionState.fullyResolved;
     }
@@ -357,9 +362,26 @@ public class EagerExpressionResolver {
       );
     }
 
+    public static EagerExpressionResult fromSupplier(
+      Supplier<String> stringSupplier,
+      JinjavaInterpreter interpreter
+    ) {
+      try {
+        return EagerExpressionResult.fromString(
+          stringSupplier.get(),
+          interpreter.getContext().getEagerTokens().isEmpty()
+            ? ResolutionState.FULL
+            : ResolutionState.PARTIAL
+        );
+      } catch (DeferredValueException e) {
+        return EagerExpressionResult.fromString("", ResolutionState.NONE);
+      }
+    }
+
     public enum ResolutionState {
       FULL(true),
-      PARTIAL(false);
+      PARTIAL(false),
+      NONE(false);
 
       boolean fullyResolved;
 

--- a/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
@@ -362,6 +362,16 @@ public class EagerExpressionResolver {
       );
     }
 
+    /**
+     * Method to supply a string value to the EagerExpressionResult class.
+     * In the event that a DeferredValueException is thrown, the message will be the wrapped
+     * value, and the resolutionState will be NONE
+     * Manually provide whether the string has been fully resolved.
+     * @param stringSupplier Supplier function to run, which could potentially throw a DeferredValueException.
+     * @param interpreter The JinjavaInterpreter
+     * @return A EagerExpressionResult that wraps either
+     * <code>stringSupplier.get()</code> or the thrown DeferredValueException's message.
+     */
     public static EagerExpressionResult fromSupplier(
       Supplier<String> stringSupplier,
       JinjavaInterpreter interpreter
@@ -374,7 +384,7 @@ public class EagerExpressionResolver {
             : ResolutionState.PARTIAL
         );
       } catch (DeferredValueException e) {
-        return EagerExpressionResult.fromString("", ResolutionState.NONE);
+        return EagerExpressionResult.fromString(e.getMessage(), ResolutionState.NONE);
       }
     }
 

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1053,4 +1053,11 @@ public class EagerTest {
       "correctly-defers-with-multiple-loops"
     );
   }
+
+  @Test
+  public void itRevertsModificationWithDeferredLoop() {
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "reverts-modification-with-deferred-loop"
+    );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/NonRevertingEagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/NonRevertingEagerTest.java
@@ -19,4 +19,11 @@ public class NonRevertingEagerTest extends EagerTest {
   public void itCorrectlyDefersWithMultipleLoops() {
     super.itCorrectlyDefersWithMultipleLoops();
   }
+
+  @Ignore
+  @Override
+  @Test
+  public void itRevertsModificationWithDeferredLoop() {
+    super.itRevertsModificationWithDeferredLoop();
+  }
 }

--- a/src/test/resources/eager/reverts-modification-with-deferred-loop.expected.jinja
+++ b/src/test/resources/eager/reverts-modification-with-deferred-loop.expected.jinja
@@ -1,0 +1,8 @@
+{% set my_list = [] %}{% for i in [0, 1] %}
+{% for j in deferred %}
+{% if loop.first %}
+{% do my_list.append(1) %}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{{ my_list }}

--- a/src/test/resources/eager/reverts-modification-with-deferred-loop.jinja
+++ b/src/test/resources/eager/reverts-modification-with-deferred-loop.jinja
@@ -1,0 +1,9 @@
+{% set my_list = [] %}
+{% for i in range(2) %}
+{% for j in deferred %}
+{% if loop.first %}
+{% do my_list.append(1) %}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{{ my_list }}


### PR DESCRIPTION
With https://github.com/HubSpot/jinjava/pull/872, I fixed how values are reverted in for loops, but I didn't handle the case when a DeferredValueException is thrown by calling `getTag().interpretUnchecked(tagNode, interpreter)` inside EagerForTag. This can happen if the `loop` variable gets deferred as a DeferredValueException will get thrown here: https://github.com/HubSpot/jinjava/blob/3a35687a4ffab46cd3955b01b5d399676aefd28f/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java#L265-L277

The test case does a good job of demonstrating this bug.
```
{% set my_list = [] %}
{% for i in range(2) %}
{% for j in deferred %}
{% if loop.first %}
{% do my_list.append(1) %}
{% endif %}
{% endfor %}
{% endfor %}
{{ my_list }}
```
Before this fix, the output would look like:
```
{% for i in [0, 1] %}
{% for j in deferred %}
{% if loop.first %}
{% do my_list.append(1) %}
{% endif %}
{% endfor %}
{% endfor %}
{{ my_list }}
```
We would lose the initial value of `my_list` as it would fail to get reconstructed. This is because it would become a DeferredValue. Normally, if a variable becomes a DeferredVariable, it will get reconstructed within the logic of `EagerReconstructionUtils.executeInChildContext()`, but since the aforementioned DeferredValueException was not getting caught, it was breaking out of the `executeInChildContext()` logic and we weren't ever flagging the `my_list` variable as one that had been deferred within the supplied function's evaluation.
By adding a new `ResolutionState.NONE` and catching the exception here: https://github.com/HubSpot/jinjava/blob/014a49d435eebc5b215feccea4403ce17b14d602/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java#L386-L388
We are able to revert the `my_list` value to what it was originally, and properly run the for loop in `deferredExecutionMode`