### PR TITLE
sort json attributes and maps

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -17,7 +17,9 @@ package com.hubspot.jinjava;
 
 import static com.hubspot.jinjava.lib.fn.Functions.DEFAULT_RANGE_LIMIT;
 
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.hubspot.jinjava.el.JinjavaInterpreterResolver;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.Context.Library;
@@ -272,7 +274,14 @@ public class JinjavaConfig {
     private boolean enablePreciseDivideFilter = false;
     private ObjectMapper objectMapper = new ObjectMapper();
 
-    private Builder() {}
+    private Builder() {
+      objectMapper.setConfig(
+        objectMapper
+          .getSerializationConfig()
+          .with(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
+          .with(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+      );
+    }
 
     public Builder withCharset(Charset charset) {
       this.charset = charset;

--- a/src/test/java/com/hubspot/jinjava/lib/filter/ToJsonFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/ToJsonFilterTest.java
@@ -22,9 +22,12 @@ public class ToJsonFilterTest extends BaseInterpretingTest {
     assertThat(filter.filter(testArray, interpreter)).isEqualTo("[4,1,2]");
 
     Map<String, Object> testMap = new LinkedHashMap<>();
-    testMap.put("testArray", testArray);
     testMap.put("testString", "testString");
+    testMap.put("testBoolean", true);
+    testMap.put("testArray", testArray);
     assertThat(filter.filter(testMap, interpreter))
-      .isEqualTo("{\"testArray\":[4,1,2],\"testString\":\"testString\"}");
+      .isEqualTo(
+        "{\"testArray\":[4,1,2],\"testBoolean\":true,\"testString\":\"testString\"}"
+      );
   }
 }


### PR DESCRIPTION
To have more consistent output, it's desirable that JSON output always looks the same, regardless of how maps were constructed. This configures the Jackson object mapper to always sort the keys alphabetically.