### PR TITLE
[Eager Execution] Don't try to revert nonserializable objects

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/RevertibleObject.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/RevertibleObject.java
@@ -1,19 +1,26 @@
 package com.hubspot.jinjava.interpret;
 
+import java.util.Optional;
+
 public class RevertibleObject {
   private final Object hashCode;
-  private final String pyishString;
+  private final Optional<String> pyishString;
+
+  public RevertibleObject(Object hashCode) {
+    this.hashCode = hashCode;
+    pyishString = Optional.empty();
+  }
 
   public RevertibleObject(Object hashCode, String pyishString) {
     this.hashCode = hashCode;
-    this.pyishString = pyishString;
+    this.pyishString = Optional.ofNullable(pyishString);
   }
 
   public Object getHashCode() {
     return hashCode;
   }
 
-  public String getPyishString() {
+  public Optional<String> getPyishString() {
     return pyishString;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -134,11 +134,11 @@ public class EagerReconstructionUtils {
       }
       entryStream.forEach(
         entry -> {
+          RevertibleObject revertibleObject = interpreter
+            .getRevertibleObjects()
+            .get(entry.getKey());
+          Object hashCode = initiallyResolvedHashes.get(entry.getKey());
           try {
-            RevertibleObject revertibleObject = interpreter
-              .getRevertibleObjects()
-              .get(entry.getKey());
-            Object hashCode = initiallyResolvedHashes.get(entry.getKey());
             if (
               revertibleObject == null || !hashCode.equals(revertibleObject.getHashCode())
             ) {
@@ -149,11 +149,16 @@ public class EagerReconstructionUtils {
                 );
               interpreter.getRevertibleObjects().put(entry.getKey(), revertibleObject);
             }
-            initiallyResolvedAsStrings.put(
-              entry.getKey(),
-              revertibleObject.getPyishString()
-            );
-          } catch (Exception ignored) {}
+            revertibleObject
+              .getPyishString()
+              .ifPresent(
+                pyishString -> initiallyResolvedAsStrings.put(entry.getKey(), pyishString)
+              );
+          } catch (Exception e) {
+            interpreter
+              .getRevertibleObjects()
+              .put(entry.getKey(), new RevertibleObject(hashCode));
+          }
         }
       );
     } else {

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -145,7 +145,7 @@ public class EagerReconstructionUtils {
               revertibleObject =
                 new RevertibleObject(
                   hashCode,
-                  PyishObjectMapper.getAsPyishString(entry.getValue())
+                  PyishObjectMapper.getAsPyishStringOrThrow(entry.getValue())
                 );
               interpreter.getRevertibleObjects().put(entry.getKey(), revertibleObject);
             }


### PR DESCRIPTION
If there is a problem when trying to serialize an object with pyish serialization for use in reverting then we should instead throw the exception and not try to serialize it. This way, if the object gets modified, we will throw a DeferredValueException, and what would happen is that a DeferredNode would get created, invalidating the initial pre-render. We can still memorize this so that we don't repeatedly try to serialize it and fail to.