### PR TITLE
[Eager Execution] Defer for loop with too big of output

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.fn;
 
+import com.google.common.collect.ImmutableList;
 import com.hubspot.jinjava.el.ext.AbstractCallableMethod;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.Context.TemporaryValueClosable;
@@ -10,7 +11,6 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -85,7 +85,9 @@ public class MacroFunction extends AbstractCallableMethod {
       ) {
         interpreter
           .getContext()
-          .removeEagerTokens(new HashSet<>(interpreter.getContext().getEagerTokens()));
+          .removeEagerTokens(
+            ImmutableList.copyOf(interpreter.getContext().getEagerTokens())
+          );
         // If the macro function could not be fully evaluated, throw a DeferredValueException.
         throw new DeferredValueException(
           getName(),

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -240,6 +240,9 @@ public class ForTag implements Tag {
             try {
               buff.append(node.render(interpreter));
             } catch (OutputTooBigException e) {
+              if (interpreter.getConfig().getExecutionMode().useEagerParser()) {
+                throw new DeferredValueException(TOO_LARGE_EXCEPTION_MESSAGE);
+              }
               interpreter.addError(TemplateError.fromOutputTooBigException(e));
               return checkLoopVariable(interpreter, buff);
             }


### PR DESCRIPTION
In eager execution, there may be extra tag reconstruction that can bloat the output of a for loop and if the loop has enough iterations, it could cause an `OutputTooBigException`, which otherwise wouldn't happen when running in default execution mode. In this circumstance, instead of adding an error and returning normally, we can throw a DeferredValueException to instead have the loop get processed in a second render when there won't be reconstructed tags to bloat the output.
We also should remove any `eagerTokens` that were added during the first attempt of the for loop that was run not using `deferredExecutionMode` because those tokens won't be in the final output, and their counterparts will be added during the `EagerForTag.eagerInterpret()` method. This helps to remove irrelevant/duplicate `eagerTokens`