### PR TITLE
Add Null Checks to Interpreter for Error counts and Split Filter

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -717,21 +717,27 @@ public class JinjavaInterpreter implements PyishSerializable {
     }
 
     // Limit the number of error.
-    if (errors.size() < MAX_ERROR_SIZE) {
-      this.errors.add(templateError.withScopeDepth(scopeDepth));
+    synchronized (this) {
+      if (errors.size() < MAX_ERROR_SIZE) {
+        errors.add(templateError.withScopeDepth(scopeDepth));
+      }
     }
   }
 
   public void removeLastError() {
-    if (!errors.isEmpty()) {
-      errors.remove(errors.size() - 1);
+    synchronized (this) {
+      if (!errors.isEmpty()) {
+        errors.remove(errors.size() - 1);
+      }
     }
   }
 
   public Optional<TemplateError> getLastError() {
-    return errors.isEmpty()
-      ? Optional.empty()
-      : Optional.of(errors.get(errors.size() - 1));
+    synchronized (this) {
+      return errors.isEmpty()
+        ? Optional.empty()
+        : Optional.of(errors.get(errors.size() - 1));
+    }
   }
 
   public int getScopeDepth() {
@@ -780,7 +786,9 @@ public class JinjavaInterpreter implements PyishSerializable {
 
   // Explicitly indicate this returns a copy of the errors list.
   public List<TemplateError> getErrorsCopy() {
-    return Lists.newArrayList(errors);
+    synchronized (this) {
+      return Lists.newArrayList(errors);
+    }
   }
 
   private static final ThreadLocal<Stack<JinjavaInterpreter>> CURRENT_INTERPRETER = ThreadLocal.withInitial(

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -717,27 +717,21 @@ public class JinjavaInterpreter implements PyishSerializable {
     }
 
     // Limit the number of error.
-    synchronized (this) {
-      if (errors.size() < MAX_ERROR_SIZE) {
-        errors.add(templateError.withScopeDepth(scopeDepth));
-      }
+    if (errors.size() < MAX_ERROR_SIZE) {
+      this.errors.add(templateError.withScopeDepth(scopeDepth));
     }
   }
 
   public void removeLastError() {
-    synchronized (this) {
-      if (!errors.isEmpty()) {
-        errors.remove(errors.size() - 1);
-      }
+    if (!errors.isEmpty()) {
+      errors.remove(errors.size() - 1);
     }
   }
 
   public Optional<TemplateError> getLastError() {
-    synchronized (this) {
-      return errors.isEmpty()
-        ? Optional.empty()
-        : Optional.of(errors.get(errors.size() - 1));
-    }
+    return errors.isEmpty()
+      ? Optional.empty()
+      : Optional.of(errors.get(errors.size() - 1));
   }
 
   public int getScopeDepth() {
@@ -786,9 +780,7 @@ public class JinjavaInterpreter implements PyishSerializable {
 
   // Explicitly indicate this returns a copy of the errors list.
   public List<TemplateError> getErrorsCopy() {
-    synchronized (this) {
-      return Lists.newArrayList(errors);
-    }
+    return Lists.newArrayList(errors);
   }
 
   private static final ThreadLocal<Stack<JinjavaInterpreter>> CURRENT_INTERPRETER = ThreadLocal.withInitial(

--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -14,6 +14,7 @@ import com.hubspot.jinjava.util.EagerExpressionResolver;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.EagerReconstructionUtils.EagerChildContextConfig;
 import com.hubspot.jinjava.util.Logging;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
@@ -129,6 +130,7 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
     return interpreter
       .getErrors()
       .stream()
+      .filter(Objects::nonNull)
       .filter(
         error ->
           "Unclosed comment".equals(error.getMessage()) ||

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SplitFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SplitFilter.java
@@ -58,13 +58,17 @@ public class SplitFilter implements Filter {
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
     Splitter splitter;
 
-    if (args.length > 0) {
-      splitter = Splitter.on(args[0]);
+    if (args != null && args.length > 0) {
+      if (args[0] != null) {
+        splitter = Splitter.on(args[0]);
+      } else {
+        splitter = Splitter.on(CharMatcher.whitespace());
+      }
     } else {
       splitter = Splitter.on(CharMatcher.whitespace());
     }
 
-    if (args.length > 1) {
+    if (args != null && args.length > 1) {
       int limit = NumberUtils.toInt(args[1], 0);
       if (limit > 0) {
         splitter = splitter.limit(limit);

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SplitFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SplitFilterTest.java
@@ -45,4 +45,25 @@ public class SplitFilterTest extends BaseInterpretingTest {
     );
     assertThat(result).containsExactly("hello", "world  this is fred");
   }
+
+  @Test
+  public void itReturnsDefaultIfSeparatorIsNull() {
+    List<String> result = (List<String>) filter.filter(
+      "hello world  this is fred",
+      interpreter,
+      null
+    );
+    assertThat(result).containsExactly("hello", "world", "this", "is", "fred");
+  }
+
+  @Test
+  public void itReturnsDefaultSeparatorIfNullAndTruncated() {
+    List<String> result = (List<String>) filter.filter(
+      "hello world  this is fred",
+      interpreter,
+      null,
+      "2"
+    );
+    assertThat(result).containsExactly("hello", "world  this is fred");
+  }
 }


### PR DESCRIPTION
Adding a filter on jinjava interpreter for counting errors to only allow non null objects. Unable to reproduce how null values are getting into the LinkedList. Also, adding null check to Split filter to default a null value to using whitespace character as the default separator does already. Null as the separator caused a Null Pointer exception in the google splitter library. 

@jasmith-hs 