### PR TITLE
Add random_int function to JinJava

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/FunctionLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/FunctionLibrary.java
@@ -111,6 +111,15 @@ public class FunctionLibrary extends SimpleLibrary<ELFunctionDefinition> {
         Object.class
       )
     );
+    register(
+      new ELFunctionDefinition(
+        "",
+        "random_int",
+        Functions.class,
+        "randomInt",
+        Object[].class
+      )
+    );
   }
 
   public void addFunction(ELFunctionDefinition fn) {

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -577,7 +577,11 @@ public class Functions {
   @JinjavaDoc(
     value = "Return a random positive integer within bound, the default bound is integer max value",
     params = {
-      @JinjavaParam(value = "bound", type = "number", defaultValue = "" + Integer.MAX_VALUE)
+      @JinjavaParam(
+        value = "bound",
+        type = "number",
+        defaultValue = "" + Integer.MAX_VALUE
+      )
     }
   )
   public static int randomInt(Object... var) {

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -573,4 +573,23 @@ public class Functions {
 
     return result;
   }
+
+  @JinjavaDoc(
+    value = "Return a random positive integer within bound, the default bound is integer max value",
+    params = {
+      @JinjavaParam(value = "bound", type = "number", defaultValue = "" + Integer.MAX_VALUE)
+    }
+  )
+  public static int randomInt(Object... var) {
+    int bound = Integer.MAX_VALUE;
+
+    if (var.length == 1) {
+      String arg = var[0].toString();
+      if (NumberUtils.isCreatable(arg)) {
+        bound = NumberUtils.toInt(arg, bound);
+      }
+    }
+
+    return JinjavaInterpreter.getCurrent().getRandom().nextInt(bound);
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/fn/RandomIntFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/RandomIntFunctionTest.java
@@ -48,11 +48,19 @@ public class RandomIntFunctionTest {
   @Test
   public void jinJavaRendersRandomIntFunctionWithBound() {
     int bound = 100;
-    assertThat(Integer.valueOf(jinjava.render("{{ random_int(" + bound + ") }}", Collections.emptyMap()))).isBetween(0,bound);
+    assertThat(
+        Integer.valueOf(
+          jinjava.render("{{ random_int(" + bound + ") }}", Collections.emptyMap())
+        )
+      )
+      .isBetween(0, bound);
   }
 
   @Test
   public void jinJavaRendersRandomIntFunction() {
-    assertThat(Integer.valueOf(jinjava.render("{{ random_int() }}", Collections.emptyMap()))).isBetween(0, Integer.MAX_VALUE);
+    assertThat(
+        Integer.valueOf(jinjava.render("{{ random_int() }}", Collections.emptyMap()))
+      )
+      .isBetween(0, Integer.MAX_VALUE);
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/fn/RandomIntFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/RandomIntFunctionTest.java
@@ -1,0 +1,58 @@
+package com.hubspot.jinjava.lib.fn;
+
+import static com.hubspot.jinjava.interpret.JinjavaInterpreter.pushCurrent;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RandomIntFunctionTest {
+  private Jinjava jinjava;
+
+  @Before
+  public void beforeEach() {
+    jinjava = new Jinjava(JinjavaConfig.newBuilder().build());
+    pushCurrent(new JinjavaInterpreter(jinjava.newInterpreter()));
+  }
+
+  @After
+  public void afterEach() {
+    JinjavaInterpreter.popCurrent();
+  }
+
+  @Test
+  public void interpreterInstanceIsMandatory() {
+    JinjavaInterpreter.popCurrent();
+    assertThatThrownBy(Functions::randomInt).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void itGeneratesRandomIntWithBound() {
+    int bound = 100;
+    assertThat(Functions.randomInt(bound)).isBetween(0, bound);
+  }
+
+  @Test
+  public void itGeneratesRandomInt() {
+    assertThat(Functions.randomInt()).isBetween(0, Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void jinJavaRendersRandomIntFunctionWithBound() {
+    int bound = 100;
+    assertThat(Integer.valueOf(jinjava.render("{{ random_int(" + bound + ") }}", Collections.emptyMap()))).isBetween(0,bound);
+  }
+
+  @Test
+  public void jinJavaRendersRandomIntFunction() {
+    assertThat(Integer.valueOf(jinjava.render("{{ random_int() }}", Collections.emptyMap()))).isBetween(0, Integer.MAX_VALUE);
+  }
+}


### PR DESCRIPTION
Current we use `{{ range(1,40000) | random }}`  to generate a random integer. But it’s `{{ range(1,40000) }} ` only returns the first 1000 numbers because of the  RAM or CPU concerns. 

add new `random_int()` function to generate a positive random int. It could also useful to CMS developers. 




 