### PR TITLE
Limit string length for regex replace in PyishObjectMapper

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -9,9 +9,12 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.OutputTooBigException;
 import com.hubspot.jinjava.util.WhitespaceUtils;
 import java.io.IOException;
 import java.util.Objects;
+import java.util.Optional;
 
 public class PyishObjectMapper {
   public static final ObjectWriter PYISH_OBJECT_WRITER;
@@ -47,15 +50,22 @@ public class PyishObjectMapper {
 
   public static String getAsPyishStringOrThrow(Object val)
     throws JsonProcessingException {
-    String string = PYISH_OBJECT_WRITER
-      .writeValueAsString(val)
+    String string = PYISH_OBJECT_WRITER.writeValueAsString(val);
+    Optional<Long> maxStringLength = JinjavaInterpreter
+      .getCurrentMaybe()
+      .map(interpreter -> interpreter.getConfig().getMaxStringLength())
+      .filter(max -> max > 0);
+    if (maxStringLength.map(max -> string.length() > max).orElse(false)) {
+      throw new OutputTooBigException(maxStringLength.get(), string.length());
+    }
+    String result = string
       .replace("'", "\\'")
       // Replace double-quotes with single quote as they are preferred in Jinja
       .replaceAll("(?<!\\\\)(\\\\\\\\)*(?:\")", "$1'");
-    if (!string.contains("{{")) {
-      return String.join("} ", string.split("}(?=})"));
+    if (!result.contains("{{")) {
+      return String.join("} ", result.split("}(?=})"));
     }
-    return string;
+    return result;
   }
 
   public static class NullKeySerializer extends JsonSerializer<Object> {


### PR DESCRIPTION
We should limit the length of strings that we run this regex on so that we don't have strings that are Gigabytes in size which we are attempting to run regular expressions on.