### PR TITLE
Add thread interrupt checking before handling deferred nodes

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -47,6 +47,7 @@ public class ExpressionNode extends Node {
     try {
       return expressionStrategy.interpretOutput(master, interpreter);
     } catch (DeferredValueException e) {
+      checkForInterrupt();
       interpreter.getContext().handleDeferredNode(this);
       return new RenderedOutputNode(master.getImage());
     }

--- a/src/main/java/com/hubspot/jinjava/tree/TagNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TagNode.java
@@ -56,6 +56,7 @@ public class TagNode extends Node {
       }
       return tag.interpretOutput(this, interpreter);
     } catch (DeferredValueException e) {
+      checkForInterrupt();
       interpreter.getContext().handleDeferredNode(this);
       return new RenderedOutputNode(reconstructImage());
     } catch (


### PR DESCRIPTION
We saw a thread that was not getting interrupted long after an interrupt was triggered that was handling a deferred node so I'm adding an additional interrupt check before handling a deferred node.