### PR TITLE
Fix default Zone ID

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -185,7 +185,7 @@ public class Functions {
     }
   )
   public static String dateTimeFormat(Object var, String... format) {
-    ZoneId zoneOffset = ZoneOffset.UTC;
+    ZoneId zoneOffset = ZoneId.of("UTC");
 
     if (format.length > 1 && format[1] != null) {
       String timezone = format[1];

--- a/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
@@ -14,7 +14,10 @@ public class StrftimeFormatterTest {
   @Before
   public void setup() {
     Locale.setDefault(Locale.ENGLISH);
-    d = ZonedDateTime.parse("2013-11-06T14:22:00.123+00:00");
+    d =
+      ZonedDateTime
+        .parse("2013-11-06T14:22:00.123+00:00")
+        .withZoneSameLocal(ZoneId.of("UTC"));
   }
 
   @Test
@@ -101,6 +104,7 @@ public class StrftimeFormatterTest {
   @Test
   public void testZoneOutput() {
     assertThat(StrftimeFormatter.format(d, "%z")).isEqualTo("+0000");
+    assertThat(StrftimeFormatter.format(d, "%Z")).isEqualTo("UTC");
 
     ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(
       d.toInstant(),


### PR DESCRIPTION
Using `ZoneOffset.UTC` results in a problem when displaying the timezone information as `ZoneOffset.UTC` is a ZoneId of offset Z and timezone Z. When displaying the timezone information via `%Z` the result will be `Z`. Instead using `ZoneId.of("UTC")` as the default results in a ZoneId offset of Z and timezone of UTC resulting in `UTC` being displayed which is a more user-friendly default than `Z`.