### PR TITLE
[Eager Execution] Support deferred call tags

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -34,21 +34,19 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
     JinjavaInterpreter interpreter
   ) {
     interpreter.getContext().checkNumberOfDeferredTokens();
-    EagerExecutionResult eagerExecutionResult;
-    eagerExecutionResult =
-      EagerReconstructionUtils.executeInChildContext(
-        eagerInterpreter ->
-          EagerExpressionResolver.resolveExpression(master.getExpr(), interpreter),
-        interpreter,
-        EagerChildContextConfig
-          .newBuilder()
-          .withTakeNewValue(true)
-          .withPartialMacroEvaluation(
-            interpreter.getConfig().isNestedInterpretationEnabled()
-          )
-          .withCheckForContextChanges(interpreter.getContext().isDeferredExecutionMode())
-          .build()
-      );
+    EagerExecutionResult eagerExecutionResult = EagerReconstructionUtils.executeInChildContext(
+      eagerInterpreter ->
+        EagerExpressionResolver.resolveExpression(master.getExpr(), interpreter),
+      interpreter,
+      EagerChildContextConfig
+        .newBuilder()
+        .withTakeNewValue(true)
+        .withPartialMacroEvaluation(
+          interpreter.getConfig().isNestedInterpretationEnabled()
+        )
+        .withCheckForContextChanges(interpreter.getContext().isDeferredExecutionMode())
+        .build()
+    );
 
     StringBuilder prefixToPreserveState = new StringBuilder();
     if (interpreter.getContext().isDeferredExecutionMode()) {
@@ -58,35 +56,9 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
     }
     if (eagerExecutionResult.getResult().isFullyResolved()) {
       String result = eagerExecutionResult.getResult().toString(true);
-      if (
-        !StringUtils.equals(result, master.getImage()) &&
-        (
-          StringUtils.contains(result, master.getSymbols().getExpressionStart()) ||
-          StringUtils.contains(result, master.getSymbols().getExpressionStartWithTag())
-        )
-      ) {
-        if (interpreter.getConfig().isNestedInterpretationEnabled()) {
-          long errorSizeStart = getParsingErrorsCount(interpreter);
-
-          interpreter.parse(result);
-
-          if (getParsingErrorsCount(interpreter) == errorSizeStart) {
-            try {
-              result = interpreter.renderFlat(result);
-            } catch (Exception e) {
-              Logging.ENGINE_LOG.warn("Error rendering variable node result", e);
-            }
-          }
-        } else {
-          // Possible macro/set tag in front of this one. Includes result
-          result = wrapInRawOrExpressionIfNeeded(result, interpreter);
-        }
-      }
-
-      if (interpreter.getContext().isAutoEscape()) {
-        result = EscapeFilter.escapeHtmlEntities(result);
-      }
-      return prefixToPreserveState.toString() + result;
+      return (
+        prefixToPreserveState.toString() + postProcessResult(master, result, interpreter)
+      );
     }
     prefixToPreserveState.append(
       EagerReconstructionUtils.reconstructFromContextBeforeDeferring(
@@ -126,7 +98,43 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
     );
   }
 
-  private long getParsingErrorsCount(JinjavaInterpreter interpreter) {
+  public static String postProcessResult(
+    ExpressionToken master,
+    String result,
+    JinjavaInterpreter interpreter
+  ) {
+    if (
+      !StringUtils.equals(result, master.getImage()) &&
+      (
+        StringUtils.contains(result, master.getSymbols().getExpressionStart()) ||
+        StringUtils.contains(result, master.getSymbols().getExpressionStartWithTag())
+      )
+    ) {
+      if (interpreter.getConfig().isNestedInterpretationEnabled()) {
+        long errorSizeStart = getParsingErrorsCount(interpreter);
+
+        interpreter.parse(result);
+
+        if (getParsingErrorsCount(interpreter) == errorSizeStart) {
+          try {
+            result = interpreter.renderFlat(result);
+          } catch (Exception e) {
+            Logging.ENGINE_LOG.warn("Error rendering variable node result", e);
+          }
+        }
+      } else {
+        // Possible macro/set tag in front of this one. Includes result
+        result = wrapInRawOrExpressionIfNeeded(result, interpreter);
+      }
+    }
+
+    if (interpreter.getContext().isAutoEscape()) {
+      result = EscapeFilter.escapeHtmlEntities(result);
+    }
+    return result;
+  }
+
+  private static long getParsingErrorsCount(JinjavaInterpreter interpreter) {
     return interpreter
       .getErrors()
       .stream()

--- a/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
@@ -153,7 +153,6 @@ public class EagerMacroFunction extends AbstractCallableMethod {
       return "";
     } else {
       try (InterpreterScopeClosable c = interpreter.enterScope()) {
-        int numEagerTokensStart = interpreter.getContext().getEagerTokens().size();
         String evaluation = (String) evaluate(
           macroFunction
             .getArguments()
@@ -162,7 +161,7 @@ public class EagerMacroFunction extends AbstractCallableMethod {
             .toArray()
         );
 
-        if (interpreter.getContext().getEagerTokens().size() > numEagerTokensStart) {
+        if (!interpreter.getContext().getEagerTokens().isEmpty()) {
           evaluation =
             (String) evaluate(
               macroFunction

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCallTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCallTag.java
@@ -86,6 +86,7 @@ public class EagerCallTag extends EagerStateChangingTag<CallTag> {
           )
         );
       }
+      caller.setDeferred(true);
       prefixToPreserveState.append(
         EagerReconstructionUtils.reconstructFromContextBeforeDeferring(
           eagerExecutionResult.getResult().getDeferredWords(),

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCallTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCallTag.java
@@ -1,0 +1,162 @@
+package com.hubspot.jinjava.lib.tag.eager;
+
+import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
+import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
+import com.hubspot.jinjava.lib.expression.EagerExpressionStrategy;
+import com.hubspot.jinjava.lib.fn.MacroFunction;
+import com.hubspot.jinjava.lib.tag.CallTag;
+import com.hubspot.jinjava.lib.tag.FlexibleTag;
+import com.hubspot.jinjava.tree.TagNode;
+import com.hubspot.jinjava.tree.parse.ExpressionToken;
+import com.hubspot.jinjava.tree.parse.TagToken;
+import com.hubspot.jinjava.util.EagerExpressionResolver;
+import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
+import com.hubspot.jinjava.util.EagerReconstructionUtils;
+import com.hubspot.jinjava.util.EagerReconstructionUtils.EagerChildContextConfig;
+import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
+import java.util.LinkedHashMap;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+
+public class EagerCallTag extends EagerStateChangingTag<CallTag> {
+
+  public EagerCallTag() {
+    super(new CallTag());
+  }
+
+  public EagerCallTag(CallTag tag) {
+    super(tag);
+  }
+
+  @Override
+  public String eagerInterpret(
+    TagNode tagNode,
+    JinjavaInterpreter interpreter,
+    InterpretException e
+  ) {
+    interpreter.getContext().checkNumberOfDeferredTokens();
+    try (InterpreterScopeClosable c = interpreter.enterScope()) {
+      MacroFunction caller = new MacroFunction(
+        tagNode.getChildren(),
+        "caller",
+        new LinkedHashMap<>(),
+        true,
+        interpreter.getContext(),
+        interpreter.getLineNumber(),
+        interpreter.getPosition()
+      );
+      interpreter.getContext().addGlobalMacro(caller);
+      EagerExecutionResult eagerExecutionResult = EagerReconstructionUtils.executeInChildContext(
+        eagerInterpreter ->
+          EagerExpressionResolver.resolveExpression(
+            tagNode.getHelpers().trim(),
+            interpreter
+          ),
+        interpreter,
+        EagerChildContextConfig
+          .newBuilder()
+          .withTakeNewValue(true)
+          .withPartialMacroEvaluation(
+            interpreter.getConfig().isNestedInterpretationEnabled()
+          )
+          .withCheckForContextChanges(interpreter.getContext().isDeferredExecutionMode())
+          .build()
+      );
+      StringBuilder prefixToPreserveState = new StringBuilder();
+      if (interpreter.getContext().isDeferredExecutionMode()) {
+        prefixToPreserveState.append(eagerExecutionResult.getPrefixToPreserveState());
+      } else {
+        interpreter.getContext().putAll(eagerExecutionResult.getSpeculativeBindings());
+      }
+      if (eagerExecutionResult.getResult().isFullyResolved()) {
+        // Possible macro/set tag in front of this one.
+        return (
+          prefixToPreserveState.toString() +
+          EagerExpressionStrategy.postProcessResult(
+            new ExpressionToken(
+              tagNode.getHelpers(),
+              tagNode.getLineNumber(),
+              tagNode.getStartPosition(),
+              tagNode.getSymbols()
+            ),
+            eagerExecutionResult.getResult().toString(true),
+            interpreter
+          )
+        );
+      }
+      prefixToPreserveState.append(
+        EagerReconstructionUtils.reconstructFromContextBeforeDeferring(
+          eagerExecutionResult.getResult().getDeferredWords(),
+          interpreter
+        )
+      );
+
+      LengthLimitingStringJoiner joiner = new LengthLimitingStringJoiner(
+        interpreter.getConfig().getMaxOutputSize(),
+        " "
+      );
+      joiner
+        .add(tagNode.getSymbols().getExpressionStartWithTag())
+        .add(tagNode.getTag().getName())
+        .add(eagerExecutionResult.getResult().toString().trim())
+        .add(tagNode.getSymbols().getExpressionEndWithTag());
+      interpreter
+        .getContext()
+        .handleEagerToken(
+          new EagerToken(
+            new TagToken(
+              joiner.toString(),
+              tagNode.getLineNumber(),
+              tagNode.getStartPosition(),
+              tagNode.getSymbols()
+            ),
+            eagerExecutionResult
+              .getResult()
+              .getDeferredWords()
+              .stream()
+              .filter(
+                word ->
+                  !(interpreter.getContext().get(word) instanceof DeferredMacroValueImpl)
+              )
+              .collect(Collectors.toSet())
+          )
+        );
+      StringBuilder result = new StringBuilder(
+        prefixToPreserveState.toString() + joiner.toString()
+      );
+      if (!tagNode.getChildren().isEmpty()) {
+        result.append(
+          EagerReconstructionUtils
+            .executeInChildContext(
+              eagerInterpreter ->
+                EagerExpressionResult.fromString(
+                  renderChildren(tagNode, eagerInterpreter)
+                ),
+              interpreter,
+              EagerChildContextConfig
+                .newBuilder()
+                .withCheckForContextChanges(true)
+                .withForceDeferredExecutionMode(true)
+                .build()
+            )
+            .asTemplateString()
+        );
+      }
+      if (
+        StringUtils.isNotBlank(tagNode.getEndName()) &&
+        (
+          !(getTag() instanceof FlexibleTag) ||
+          ((FlexibleTag) getTag()).hasEndTag((TagToken) tagNode.getMaster())
+        )
+      ) {
+        result.append(EagerReconstructionUtils.reconstructEnd(tagNode));
+      } // Possible set tag in front of this one.
+      return EagerReconstructionUtils.wrapInAutoEscapeIfNeeded(
+        result.toString(),
+        interpreter
+      );
+    }
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactory.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactory.java
@@ -4,6 +4,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.jinjava.lib.tag.BlockTag;
+import com.hubspot.jinjava.lib.tag.CallTag;
 import com.hubspot.jinjava.lib.tag.CycleTag;
 import com.hubspot.jinjava.lib.tag.DoTag;
 import com.hubspot.jinjava.lib.tag.ElseIfTag;
@@ -37,6 +38,7 @@ public class EagerTagFactory {
     .put(CycleTag.class, EagerCycleTag.class)
     .put(IfTag.class, EagerIfTag.class)
     .put(UnlessTag.class, EagerUnlessTag.class)
+    .put(CallTag.class, EagerCallTag.class)
     .build();
   // These classes don't need an eager decorator.
   public static final Set<Class<? extends Tag>> TAG_CLASSES_TO_SKIP = ImmutableSet

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -315,6 +315,7 @@ public class EagerReconstructionUtils {
       .filter(w -> !interpreter.getContext().containsKey(w))
       .map(w -> interpreter.getContext().getGlobalMacro(w))
       .filter(Objects::nonNull)
+      .filter(macroFunction -> !macroFunction.isCaller())
       .collect(Collectors.toMap(AbstractCallableMethod::getName, Function.identity()));
     for (String word : deferredWords) {
       if (word.contains(".")) {

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -77,7 +77,7 @@ public class EagerTest {
       .withLegacyOverrides(
         LegacyOverrides.newBuilder().withUsePyishObjectMapper(true).build()
       )
-      .withMaxMacroRecursionDepth(5)
+      .withMaxMacroRecursionDepth(20)
       .withEnableRecursiveMacroCalls(true)
       .build();
     JinjavaInterpreter parentInterpreter = new JinjavaInterpreter(
@@ -1077,5 +1077,20 @@ public class EagerTest {
   @Test
   public void itHasProperLineStripping() {
     expectedTemplateInterpreter.assertExpectedOutput("has-proper-line-stripping");
+  }
+
+  @Test
+  public void itDefersCallTagWithDeferredArgument() {
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "defers-call-tag-with-deferred-argument"
+    );
+  }
+
+  @Test
+  public void itDefersCallTagWithDeferredArgumentSecondPass() {
+    interpreter.getContext().put("deferred", "resolved");
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "defers-call-tag-with-deferred-argument.expected"
+    );
   }
 }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1089,7 +1089,7 @@ public class EagerTest {
   @Test
   public void itDefersCallTagWithDeferredArgumentSecondPass() {
     interpreter.getContext().put("deferred", "resolved");
-    expectedTemplateInterpreter.assertExpectedOutput(
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
       "defers-call-tag-with-deferred-argument.expected"
     );
   }

--- a/src/test/java/com/hubspot/jinjava/ExpectedTemplateInterpreter.java
+++ b/src/test/java/com/hubspot/jinjava/ExpectedTemplateInterpreter.java
@@ -47,6 +47,12 @@ public class ExpectedTemplateInterpreter {
       JinjavaConfig
         .newBuilder()
         .withExecutionMode(DefaultExecutionMode.instance())
+        .withNestedInterpretationEnabled(true)
+        .withLegacyOverrides(
+          LegacyOverrides.newBuilder().withUsePyishObjectMapper(true).build()
+        )
+        .withMaxMacroRecursionDepth(20)
+        .withEnableRecursiveMacroCalls(true)
         .build()
     );
     try {

--- a/src/test/resources/eager/defers-call-tag-with-deferred-argument.expected.expected.jinja
+++ b/src/test/resources/eager/defers-call-tag-with-deferred-argument.expected.expected.jinja
@@ -1,9 +1,7 @@
 resolved
 
-
 macro 1
 
-resolved
+resolved1
 
-
-Aaa resolved
+macro2

--- a/src/test/resources/eager/defers-call-tag-with-deferred-argument.expected.expected.jinja
+++ b/src/test/resources/eager/defers-call-tag-with-deferred-argument.expected.expected.jinja
@@ -1,0 +1,9 @@
+resolved
+
+
+macro 1
+
+resolved
+
+
+Aaa resolved

--- a/src/test/resources/eager/defers-call-tag-with-deferred-argument.expected.jinja
+++ b/src/test/resources/eager/defers-call-tag-with-deferred-argument.expected.jinja
@@ -1,0 +1,16 @@
+{% macro repeat(val) %}
+{{ val }}
+
+
+macro 1
+{% macro repeat(val) %}
+{{ val }}
+
+{% macro renderEntity(val) %}
+Aaa {{ val }}
+{% endmacro %}{{ renderEntity(val) }}
+
+{% endmacro %}{{ repeat(deferred) }}
+
+
+{% endmacro %}{{ repeat(deferred) }}

--- a/src/test/resources/eager/defers-call-tag-with-deferred-argument.expected.jinja
+++ b/src/test/resources/eager/defers-call-tag-with-deferred-argument.expected.jinja
@@ -1,27 +1,12 @@
-{% macro foo() -%}
-first foo definition
-{% endmacro %}
-{% macro repeat(val) -%}
-{% print val %}
-{{ foo() }}
+{% macro repeat(val) %}
+{{ val }}
 {{ caller() }}
-{% endmacro %}
-{% call repeat(1) -%}
-1st caller
-{% macro foo() -%}
-second foo definition
-{% endmacro %}
-{% macro repeat(val) -%}
-{% print val %}
-{{ foo() }}
+{% endmacro %}{% call repeat(deferred) %}
+macro 1
+{% macro repeat(val) %}
+{{ val }}
 {{ caller() }}
-{% endmacro %}
-{% for i in range(1) -%}
-{% macro foo() -%}
-third foo definition
-{% endmacro -%}
-{% call repeat(2) -%}
-2nd caller
+{% endmacro %}{% call repeat(deferred + 1) %}
+macro2
 {% endcall %}
-{% endfor %}
 {% endcall %}

--- a/src/test/resources/eager/defers-call-tag-with-deferred-argument.expected.jinja
+++ b/src/test/resources/eager/defers-call-tag-with-deferred-argument.expected.jinja
@@ -1,16 +1,27 @@
-{% macro repeat(val) %}
-{{ val }}
-
-
-macro 1
-{% macro repeat(val) %}
-{{ val }}
-
-{% macro renderEntity(val) %}
-Aaa {{ val }}
-{% endmacro %}{{ renderEntity(val) }}
-
-{% endmacro %}{{ repeat(deferred) }}
-
-
-{% endmacro %}{{ repeat(deferred) }}
+{% macro foo() -%}
+first foo definition
+{% endmacro %}
+{% macro repeat(val) -%}
+{% print val %}
+{{ foo() }}
+{{ caller() }}
+{% endmacro %}
+{% call repeat(1) -%}
+1st caller
+{% macro foo() -%}
+second foo definition
+{% endmacro %}
+{% macro repeat(val) -%}
+{% print val %}
+{{ foo() }}
+{{ caller() }}
+{% endmacro %}
+{% for i in range(1) -%}
+{% macro foo() -%}
+third foo definition
+{% endmacro -%}
+{% call repeat(2) -%}
+2nd caller
+{% endcall %}
+{% endfor %}
+{% endcall %}

--- a/src/test/resources/eager/defers-call-tag-with-deferred-argument.jinja
+++ b/src/test/resources/eager/defers-call-tag-with-deferred-argument.jinja
@@ -1,3 +1,4 @@
+{#
 {% macro repeat(val) %}
 {{ val }}
 {{ caller() }}
@@ -6,13 +7,26 @@
 Aaa {{ val }}
 {% endmacro %}
 
-{% macro renderModule() %}
+{% macro renderModule(val) %}
 macro 1
-{% call repeat(deferred) %}
+{% call repeat(deferred + 1) %}
 {{ renderEntity(val) }}
 {% endcall %}
 {% endmacro %}
 
 {% call repeat(deferred) %}
-{{ renderModule() }}
+{{ renderModule('b') }}
+{% endcall %}
+#}
+{% macro repeat(val) %}
+{{ val }}
+{{ caller() }}
+{% endmacro %}
+
+
+{% call repeat(deferred) %}
+macro 1
+{% call repeat(deferred + 1) %}
+macro2
+{% endcall %}
 {% endcall %}

--- a/src/test/resources/eager/defers-call-tag-with-deferred-argument.jinja
+++ b/src/test/resources/eager/defers-call-tag-with-deferred-argument.jinja
@@ -1,0 +1,18 @@
+{% macro repeat(val) %}
+{{ val }}
+{{ caller() }}
+{% endmacro %}
+{% macro renderEntity(val) %}
+Aaa {{ val }}
+{% endmacro %}
+
+{% macro renderModule() %}
+macro 1
+{% call repeat(deferred) %}
+{{ renderEntity(val) }}
+{% endcall %}
+{% endmacro %}
+
+{% call repeat(deferred) %}
+{{ renderModule() }}
+{% endcall %}

--- a/src/test/resources/eager/defers-call-tag-with-deferred-argument.jinja
+++ b/src/test/resources/eager/defers-call-tag-with-deferred-argument.jinja
@@ -1,23 +1,3 @@
-{#
-{% macro repeat(val) %}
-{{ val }}
-{{ caller() }}
-{% endmacro %}
-{% macro renderEntity(val) %}
-Aaa {{ val }}
-{% endmacro %}
-
-{% macro renderModule(val) %}
-macro 1
-{% call repeat(deferred + 1) %}
-{{ renderEntity(val) }}
-{% endcall %}
-{% endmacro %}
-
-{% call repeat(deferred) %}
-{{ renderModule('b') }}
-{% endcall %}
-#}
 {% macro repeat(val) %}
 {{ val }}
 {{ caller() }}

--- a/src/test/resources/eager/reconstructs-map-node.expected.expected.jinja
+++ b/src/test/resources/eager/reconstructs-map-node.expected.expected.jinja
@@ -1,8 +1,8 @@
 foo ff
 bar bb
-[resolved, resolved]
+['resolved', 'resolved']
 
 
 foo
 bar
-[resolved, resolved]
+['resolved', 'resolved']


### PR DESCRIPTION
This PR adds proper support for deferring call tags by decorating with the `EagerCallTag` decorator. This is especially helpful for rendering recursive call tags. The test case of:
```
{% macro repeat(val) %}
{{ val }}
{{ caller() }}
{% endmacro %}


{% call repeat(deferred) %}
macro 1
{% call repeat(deferred + 1) %}
macro2
{% endcall %}
{% endcall %}
```
Previously would render like:
```
{% macro repeat(val) %}
{{ val }}

macro 1
{{ repeat(deferred + 1) }}

{% endmacro %}{{ repeat(deferred) }}
```
Which would cause infinite recursion, but now with the call tags getting reconstructed properly, the result will maintain the correct order of recursive macro definition and will output correctly.