### PR TITLE
Bind custom operators between `mul` and `unary`

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -427,6 +427,37 @@ public class ExtendedParser extends Parser {
   }
 
   @Override
+  protected AstNode mul(boolean required) throws ScanException, ParseException {
+    AstNode v = unary(required);
+    if (v == null) {
+      return null;
+    }
+    while (true) {
+      switch (getToken().getSymbol()) {
+        case MUL:
+          consumeToken();
+          v = createAstBinary(v, unary(true), AstBinary.MUL);
+          break;
+        case DIV:
+          consumeToken();
+          v = createAstBinary(v, unary(true), AstBinary.DIV);
+          break;
+        case MOD:
+          consumeToken();
+          v = createAstBinary(v, unary(true), AstBinary.MOD);
+          break;
+        case EXTENSION:
+          if (getExtensionHandler(getToken()).getExtensionPoint() == ExtensionPoint.MUL) {
+            v = getExtensionHandler(consumeToken()).createAstNode(v, unary(true));
+            break;
+          }
+        default:
+          return v;
+      }
+    }
+  }
+
+  @Override
   protected AstNode value() throws ScanException, ParseException {
     boolean lvalue = true;
     AstNode v = nonliteral();

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -334,23 +334,23 @@ public class JinjavaInterpreterTest {
   }
 
   @Test
-  public void unaryMinusBindsTighterThanCmp() {
+  public void itBindsUnaryMinusTighterThanCmp() {
     assertThat(interpreter.render("{{ (-5 > 4) }}")).isEqualTo("false");
   }
 
   @Test
-  public void unaryMinusBindsTighterThanIs() {
+  public void itBindsUnaryMinusTighterThanIs() {
     assertThat(interpreter.render("{{ (-5 is integer) == true }}")).isEqualTo("true");
   }
 
   @Test
-  public void unaryMinusBindsTighterThanIsNot() {
+  public void itBindsUnaryMinusTighterThanIsNot() {
     assertThat(interpreter.render("{{ (-5 is not integer) == false }}"))
       .isEqualTo("true");
   }
 
   @Test
-  public void unaryMinusBindsTighterThanPipe() {
+  public void itBindsUnaryMinusTighterThanPipe() {
     assertThat(interpreter.render("{{ (-5 | abs) }}")).isEqualTo("5");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -358,4 +358,10 @@ public class JinjavaInterpreterTest {
   public void itBindsFiltersTighterThanMul() {
     assertThat(interpreter.render("{{ (-5 * -4 | abs) }}")).isEqualTo("-20");
   }
+
+  @Test
+  public void itInterpretsFilterChainsInOrder() {
+    assertThat(interpreter.render("{{ 'foo' | upper | replace('O', 'A') }}"))
+      .isEqualTo("FAA");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -350,7 +350,7 @@ public class JinjavaInterpreterTest {
   }
 
   @Test
-  public void itBindsUnaryMinusTighterThanPipe() {
+  public void itBindsUnaryMinusTighterThanFilters() {
     assertThat(interpreter.render("{{ (-5 | abs) }}")).isEqualTo("5");
   }
 

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -332,4 +332,25 @@ public class JinjavaInterpreterTest {
     );
     assertThat(interpreter.getErrors()).isEmpty();
   }
+
+  @Test
+  public void unaryMinusBindsTighterThanCmp() {
+    assertThat(interpreter.render("{{ (-5 > 4) }}")).isEqualTo("false");
+  }
+
+  @Test
+  public void unaryMinusBindsTighterThanIs() {
+    assertThat(interpreter.render("{{ (-5 is integer) == true }}")).isEqualTo("true");
+  }
+
+  @Test
+  public void unaryMinusBindsTighterThanIsNot() {
+    assertThat(interpreter.render("{{ (-5 is not integer) == false }}"))
+      .isEqualTo("true");
+  }
+
+  @Test
+  public void unaryMinusBindsTighterThanPipe() {
+    assertThat(interpreter.render("{{ (-5 | abs) }}")).isEqualTo("5");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -353,4 +353,9 @@ public class JinjavaInterpreterTest {
   public void itBindsUnaryMinusTighterThanPipe() {
     assertThat(interpreter.render("{{ (-5 | abs) }}")).isEqualTo("5");
   }
+
+  @Test
+  public void itBindsFiltersTighterThanMul() {
+    assertThat(interpreter.render("{{ (-5 * -4 | abs) }}")).isEqualTo("-20");
+  }
 }


### PR DESCRIPTION
Closes #893 

Currently, our custom operators like `|` and `is` bind tighter than unary operators. This means `-1 is integer` incorrectly evaluates like `-(1 is integer)`, leading to an error when Jinjava tries to make `true` negative. This is because these operators are defined within `value` which is called by `unary`, and therefore have precedence greater than the unary operators.

This PR pulls our custom operators up from the `unary` level of the JUEL grammar to the `mul` level. This means they bind tighter than `mul` but less tightly than `unary`. From my testing, this aligns with Jinja's precedence rules.