### PR TITLE
Parse leading negatives

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/parse/ExpressionToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/ExpressionToken.java
@@ -44,16 +44,7 @@ public class ExpressionToken extends Token {
   @Override
   protected void parse() {
     this.expr = WhitespaceUtils.unwrap(image, "{{", "}}");
-
-    if (WhitespaceUtils.startsWith(expr, "-")) {
-      setLeftTrim(true);
-      this.expr = WhitespaceUtils.unwrap(expr, "-", "");
-    }
-    if (WhitespaceUtils.endsWith(expr, "-")) {
-      setRightTrim(true);
-      this.expr = WhitespaceUtils.unwrap(expr, "", "-");
-    }
-
+    this.expr = handleTrim(expr);
     this.expr = StringUtils.trimToEmpty(this.expr);
   }
 

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TagToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TagToken.java
@@ -16,7 +16,6 @@ limitations under the License.
 package com.hubspot.jinjava.tree.parse;
 
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
-import com.hubspot.jinjava.util.WhitespaceUtils;
 
 public class TagToken extends Token {
   private static final long serialVersionUID = -4927751270481832992L;
@@ -54,15 +53,7 @@ public class TagToken extends Token {
     }
 
     content = image.substring(2, image.length() - 2);
-
-    if (WhitespaceUtils.startsWith(content, "-")) {
-      setLeftTrim(true);
-      content = WhitespaceUtils.unwrap(content, "-", "");
-    }
-    if (WhitespaceUtils.endsWith(content, "-")) {
-      setRightTrim(true);
-      content = WhitespaceUtils.unwrap(content, "", "-");
-    }
+    content = handleTrim(content);
 
     int nameStart = -1, pos = 0, len = content.length();
 

--- a/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
@@ -83,6 +83,25 @@ public abstract class Token implements Serializable {
     this.rightTrimAfterEnd = rightTrimAfterEnd;
   }
 
+  /**
+   * Handle any whitespace control characters, capturing whether leading or trailing
+   * whitespace should be stripped.
+   * @param unwrapped the content of the block stripped of its delimeters
+   * @return the content stripped of any whitespace control characters.
+   */
+  protected final String handleTrim(String unwrapped) {
+    String result = unwrapped;
+    if (unwrapped.startsWith("-")) {
+      setLeftTrim(true);
+      result = unwrapped.substring(1);
+    }
+    if (unwrapped.endsWith("-")) {
+      setRightTrim(true);
+      result = unwrapped.substring(0, unwrapped.length() - 1);
+    }
+    return result;
+  }
+
   public int getStartPosition() {
     return startPosition;
   }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -355,8 +355,20 @@ public class JinjavaInterpreterTest {
   }
 
   @Test
+  public void itBindsUnaryMinusTighterThanPlus() {
+    assertThat(interpreter.render("{{ -10 + 4 }}")).isEqualTo("-6");
+    assertThat(new Jinjava().render("{{ 4 + -10 }}", new HashMap<>())).isEqualTo("-6");
+  }
+
+  @Test
   public void itBindsFiltersTighterThanMul() {
     assertThat(interpreter.render("{{ (-5 * -4 | abs) }}")).isEqualTo("-20");
+  }
+
+  @Test
+  public void itBindsFiltersTighterThanPlus() {
+    assertThat(interpreter.render("{{ -10 | abs + 4 }}")).isEqualTo("14");
+    assertThat(interpreter.render("{{ 4 + -10 | abs }}")).isEqualTo("14");
   }
 
   @Test
@@ -366,19 +378,7 @@ public class JinjavaInterpreterTest {
   }
 
   @Test
-  public void unaryMinusBindsTighterThanPlus() {
-    assertThat(interpreter.render("{{ -10 + 4 }}")).isEqualTo("-6");
-    assertThat(new Jinjava().render("{{ 4 + -10 }}", new HashMap<>())).isEqualTo("-6");
-  }
-
-  @Test
-  public void filterChainsBindTighterThanPlus() {
-    assertThat(interpreter.render("{{ -10 | abs + 4 }}")).isEqualTo("14");
-    assertThat(interpreter.render("{{ 4 + -10 | abs }}")).isEqualTo("14");
-  }
-
-  @Test
-  public void standaloneNegativesParse() {
+  public void itInterpretsStandaloneNegatives() {
     assertThat(interpreter.render("{{ -10 }}")).isEqualTo("-10");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -364,4 +364,20 @@ public class JinjavaInterpreterTest {
     assertThat(interpreter.render("{{ 'foo' | upper | replace('O', 'A') }}"))
       .isEqualTo("FAA");
   }
+
+  @Test
+  public void filterChainsHavePrecedence() {
+    assertThat(new Jinjava().render("{{ -10 | abs + 4 }}", new HashMap<>()))
+      .isEqualTo("14");
+    assertThat(new Jinjava().render("{{ 4 + -10 | abs }}", new HashMap<>()))
+      .isEqualTo("14");
+  }
+
+  @Test
+  public void redundantParenthesesDoNotAffectFilterChainPrecedence() {
+    assertThat(new Jinjava().render("{{ (-10 | abs) + 4 }}", new HashMap<>()))
+      .isEqualTo("14");
+    assertThat(new Jinjava().render("{{ 4 + (-10 | abs) }}", new HashMap<>()))
+      .isEqualTo("14");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -367,20 +367,20 @@ public class JinjavaInterpreterTest {
 
   @Test
   public void unaryMinusBindsTighterThanPlus() {
-    assertThat(new Jinjava().render("{{ -10 + 4 }}", new HashMap<>())).isEqualTo("-6");
+    assertThat(jinjava.render("{{ -10 + 4 }}", new HashMap<>())).isEqualTo("-6");
     assertThat(new Jinjava().render("{{ 4 + -10 }}", new HashMap<>())).isEqualTo("-6");
   }
 
   @Test
   public void filterChainsBindTighterThanPlus() {
-    assertThat(new Jinjava().render("{{ -10 | abs + 4 }}", new HashMap<>()))
+    assertThat(jinjava.render("{{ -10 | abs + 4 }}", new HashMap<>()))
       .isEqualTo("14");
-    assertThat(new Jinjava().render("{{ 4 + -10 | abs }}", new HashMap<>()))
+    assertThat(jinjava.render("{{ 4 + -10 | abs }}", new HashMap<>()))
       .isEqualTo("14");
   }
 
   @Test
   public void negativesParse() {
-    assertThat(new Jinjava().render("{{ -10 }}", new HashMap<>())).isEqualTo("-10");
+    assertThat(jinjava.render("{{ -10 }}", new HashMap<>())).isEqualTo("-10");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -335,7 +335,7 @@ public class JinjavaInterpreterTest {
 
   @Test
   public void itBindsUnaryMinusTighterThanCmp() {
-    assertThat(interpreter.render("{{ (-5 > 4) }}")).isEqualTo("false");
+    assertThat(interpreter.render("{{ -5 > 4 }}")).isEqualTo("false");
   }
 
   @Test
@@ -351,7 +351,7 @@ public class JinjavaInterpreterTest {
 
   @Test
   public void itBindsUnaryMinusTighterThanFilters() {
-    assertThat(interpreter.render("{{ (-5 | abs) }}")).isEqualTo("5");
+    assertThat(interpreter.render("{{ -5 | abs }}")).isEqualTo("5");
   }
 
   @Test
@@ -362,7 +362,7 @@ public class JinjavaInterpreterTest {
 
   @Test
   public void itBindsFiltersTighterThanMul() {
-    assertThat(interpreter.render("{{ (-5 * -4 | abs) }}")).isEqualTo("-20");
+    assertThat(interpreter.render("{{ -5 * -4 | abs }}")).isEqualTo("-20");
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -378,4 +378,9 @@ public class JinjavaInterpreterTest {
     assertThat(new Jinjava().render("{{ 4 + -10 | abs }}", new HashMap<>()))
       .isEqualTo("14");
   }
+
+  @Test
+  public void negativesParse() {
+    assertThat(new Jinjava().render("{{ -10 }}", new HashMap<>())).isEqualTo("-10");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -366,18 +366,16 @@ public class JinjavaInterpreterTest {
   }
 
   @Test
-  public void filterChainsHavePrecedence() {
-    assertThat(new Jinjava().render("{{ -10 | abs + 4 }}", new HashMap<>()))
-      .isEqualTo("14");
-    assertThat(new Jinjava().render("{{ 4 + -10 | abs }}", new HashMap<>()))
-      .isEqualTo("14");
+  public void unaryMinusBindsTighterThanPlus() {
+    assertThat(new Jinjava().render("{{ -10 + 4 }}", new HashMap<>())).isEqualTo("-6");
+    assertThat(new Jinjava().render("{{ 4 + -10 }}", new HashMap<>())).isEqualTo("-6");
   }
 
   @Test
-  public void redundantParenthesesDoNotAffectFilterChainPrecedence() {
-    assertThat(new Jinjava().render("{{ (-10 | abs) + 4 }}", new HashMap<>()))
+  public void filterChainsBindTighterThanPlus() {
+    assertThat(new Jinjava().render("{{ -10 | abs + 4 }}", new HashMap<>()))
       .isEqualTo("14");
-    assertThat(new Jinjava().render("{{ 4 + (-10 | abs) }}", new HashMap<>()))
+    assertThat(new Jinjava().render("{{ 4 + -10 | abs }}", new HashMap<>()))
       .isEqualTo("14");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -367,20 +367,18 @@ public class JinjavaInterpreterTest {
 
   @Test
   public void unaryMinusBindsTighterThanPlus() {
-    assertThat(jinjava.render("{{ -10 + 4 }}", new HashMap<>())).isEqualTo("-6");
+    assertThat(interpreter.render("{{ -10 + 4 }}")).isEqualTo("-6");
     assertThat(new Jinjava().render("{{ 4 + -10 }}", new HashMap<>())).isEqualTo("-6");
   }
 
   @Test
   public void filterChainsBindTighterThanPlus() {
-    assertThat(jinjava.render("{{ -10 | abs + 4 }}", new HashMap<>()))
-      .isEqualTo("14");
-    assertThat(jinjava.render("{{ 4 + -10 | abs }}", new HashMap<>()))
-      .isEqualTo("14");
+    assertThat(interpreter.render("{{ -10 | abs + 4 }}")).isEqualTo("14");
+    assertThat(interpreter.render("{{ 4 + -10 | abs }}")).isEqualTo("14");
   }
 
   @Test
   public void negativesParse() {
-    assertThat(jinjava.render("{{ -10 }}", new HashMap<>())).isEqualTo("-10");
+    assertThat(interpreter.render("{{ -10 }}")).isEqualTo("-10");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -378,7 +378,7 @@ public class JinjavaInterpreterTest {
   }
 
   @Test
-  public void negativesParse() {
+  public void standaloneNegativesParse() {
     assertThat(interpreter.render("{{ -10 }}")).isEqualTo("-10");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -357,7 +357,7 @@ public class JinjavaInterpreterTest {
   @Test
   public void itBindsUnaryMinusTighterThanPlus() {
     assertThat(interpreter.render("{{ -10 + 4 }}")).isEqualTo("-6");
-    assertThat(new Jinjava().render("{{ 4 + -10 }}", new HashMap<>())).isEqualTo("-6");
+    assertThat(interpreter.render("{{ 4 + -10 }}")).isEqualTo("-6");
   }
 
   @Test

--- a/src/test/resources/eager/handles-deferred-in-ifchanged.jinja
+++ b/src/test/resources/eager/handles-deferred-in-ifchanged.jinja
@@ -1,6 +1,6 @@
 {% set foo = [1, 1, 2, 1] %}
 {%- for item in foo -%}
-{%- ifchanged item- %}
+{%- ifchanged item -%}
 {{ deferred[item] }}
 {%- endifchanged -%}
 {% endfor%}


### PR DESCRIPTION
Closes #892 
Depends on #895 

Currently, the expression `{{ -10 }}` is interpreted by Jinjava as `10` with leading whitespace removed when it should be interpreted as `-10`. The problem is that Jinjava interprets the unary minus as a whitespace control character because the parser is lenient about whitespace between the tag and the dash.

This PR adjusts the whitespace control character parsing to require no space between the tag and the control character. This aligns with [Jinja's behavior](https://jinja.palletsprojects.com/en/3.1.x/templates/#whitespace-control):

> You must not add whitespace between the tag and the minus sign.