### PR TITLE
Accumulate whitespace control parsing result

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
@@ -91,13 +91,13 @@ public abstract class Token implements Serializable {
    */
   protected final String handleTrim(String unwrapped) {
     String result = unwrapped;
-    if (unwrapped.startsWith("-")) {
+    if (result.startsWith("-")) {
       setLeftTrim(true);
-      result = unwrapped.substring(1);
+      result = result.substring(1);
     }
-    if (unwrapped.endsWith("-")) {
+    if (result.endsWith("-")) {
       setRightTrim(true);
-      result = unwrapped.substring(0, unwrapped.length() - 1);
+      result = result.substring(0, result.length() - 1);
     }
     return result;
   }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -381,4 +381,15 @@ public class JinjavaInterpreterTest {
   public void itInterpretsStandaloneNegatives() {
     assertThat(interpreter.render("{{ -10 }}")).isEqualTo("-10");
   }
+
+  @Test
+  public void itInterpretsWhitespaceControlBeforeDot() {
+    assertThat(
+        jinjava.render(
+          "{{- foo.bar -}}",
+          ImmutableMap.of("foo", ImmutableMap.of("bar", "baz"))
+        )
+      )
+      .isEqualTo("baz");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -383,8 +383,7 @@ public class JinjavaInterpreterTest {
   }
 
   @Test
-  public void itInterpretsWhitespaceControlBeforeIdentifier() {
-    assertThat(jinjava.render("{{- foo -}}", ImmutableMap.of("foo", "bar")))
-      .isEqualTo("bar");
+  public void itInterpretsWhitespaceControlOnBothSides() {
+    assertThat(interpreter.render("{{- 5 -}}")).isEqualTo("5");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -383,13 +383,8 @@ public class JinjavaInterpreterTest {
   }
 
   @Test
-  public void itInterpretsWhitespaceControlBeforeDot() {
-    assertThat(
-        jinjava.render(
-          "{{- foo.bar -}}",
-          ImmutableMap.of("foo", ImmutableMap.of("bar", "baz"))
-        )
-      )
-      .isEqualTo("baz");
+  public void itInterpretsWhitespaceControlBeforeIdentifier() {
+    assertThat(jinjava.render("{{- foo -}}", ImmutableMap.of("foo", "bar")))
+      .isEqualTo("bar");
   }
 }


### PR DESCRIPTION
With my changes in #896, I introduced a bug where expressions or tags with whitespace control characters on both sides would accidentally retain the leading control character. This would then get erroneously parsed as a unary minus.

This PR fixes that issue.