### PR TITLE
Use isInterrupted() to not clear the current thread's interrupted status

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/Node.java
+++ b/src/main/java/com/hubspot/jinjava/tree/Node.java
@@ -105,7 +105,7 @@ public abstract class Node implements Serializable {
   }
 
   public final void checkForInterrupt() {
-    if (Thread.interrupted()) {
+    if (Thread.currentThread().isInterrupted()) {
       throw new InterpretException(
         "Interrupt rendering " + getClass(),
         master.getLineNumber(),


### PR DESCRIPTION
Because we aren't throwing an InterruptedException or doing much cleanup (and aren't setting the interrupted flag back to `true`), we should use `isInterrupted()` because using `Thread.interrupted()` will set the flag to false after it is called, which will mean we'll lose the fact that the thread has been interrupted.