### PR TITLE
Revert parsing fixes

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -427,83 +427,6 @@ public class ExtendedParser extends Parser {
   }
 
   @Override
-  protected AstNode mul(boolean required) throws ScanException, ParseException {
-    AstNode v = filter(required);
-    if (v == null) {
-      return null;
-    }
-    while (true) {
-      switch (getToken().getSymbol()) {
-        case MUL:
-          consumeToken();
-          v = createAstBinary(v, filter(true), AstBinary.MUL);
-          break;
-        case DIV:
-          consumeToken();
-          v = createAstBinary(v, filter(true), AstBinary.DIV);
-          break;
-        case MOD:
-          consumeToken();
-          v = createAstBinary(v, filter(true), AstBinary.MOD);
-          break;
-        case EXTENSION:
-          if (getExtensionHandler(getToken()).getExtensionPoint() == ExtensionPoint.MUL) {
-            v = getExtensionHandler(consumeToken()).createAstNode(v, filter(true));
-            break;
-          }
-        default:
-          return v;
-      }
-    }
-  }
-
-  protected AstNode filter(boolean required) throws ScanException, ParseException {
-    AstNode v = unary(required);
-    if (v == null) {
-      return null;
-    }
-    while (true) {
-      if ("|".equals(getToken().getImage()) && lookahead(0).getSymbol() == IDENTIFIER) {
-        do {
-          consumeToken(); // '|'
-          String filterName = consumeToken().getImage();
-          List<AstNode> filterParams = Lists.newArrayList(v, interpreter());
-
-          // optional filter args
-          if (getToken().getSymbol() == Symbol.LPAREN) {
-            AstParameters astParameters = params();
-            for (int i = 0; i < astParameters.getCardinality(); i++) {
-              filterParams.add(astParameters.getChild(i));
-            }
-          }
-
-          AstProperty filterProperty = createAstDot(
-            identifier(FILTER_PREFIX + filterName),
-            "filter",
-            true
-          );
-          v = createAstMethod(filterProperty, createAstParameters(filterParams)); // function("filter:" + filterName, new AstParameters(filterParams));
-        } while ("|".equals(getToken().getImage()));
-      } else if (
-        "is".equals(getToken().getImage()) &&
-        "not".equals(lookahead(0).getImage()) &&
-        isPossibleExpTest(lookahead(1).getSymbol())
-      ) {
-        consumeToken(); // 'is'
-        consumeToken(); // 'not'
-        v = buildAstMethodForIdentifier(v, "evaluateNegated");
-      } else if (
-        "is".equals(getToken().getImage()) && isPossibleExpTest(lookahead(0).getSymbol())
-      ) {
-        consumeToken(); // 'is'
-        v = buildAstMethodForIdentifier(v, "evaluate");
-      } else {
-        return v;
-      }
-    }
-  }
-
-  @Override
   protected AstNode value() throws ScanException, ParseException {
     boolean lvalue = true;
     AstNode v = nonliteral();
@@ -552,6 +475,45 @@ public class ExtendedParser extends Parser {
 
           break;
         default:
+          if (
+            "|".equals(getToken().getImage()) && lookahead(0).getSymbol() == IDENTIFIER
+          ) {
+            do {
+              consumeToken(); // '|'
+              String filterName = consumeToken().getImage();
+              List<AstNode> filterParams = Lists.newArrayList(v, interpreter());
+
+              // optional filter args
+              if (getToken().getSymbol() == Symbol.LPAREN) {
+                AstParameters astParameters = params();
+                for (int i = 0; i < astParameters.getCardinality(); i++) {
+                  filterParams.add(astParameters.getChild(i));
+                }
+              }
+
+              AstProperty filterProperty = createAstDot(
+                identifier(FILTER_PREFIX + filterName),
+                "filter",
+                true
+              );
+              v = createAstMethod(filterProperty, createAstParameters(filterParams)); // function("filter:" + filterName, new AstParameters(filterParams));
+            } while ("|".equals(getToken().getImage()));
+          } else if (
+            "is".equals(getToken().getImage()) &&
+            "not".equals(lookahead(0).getImage()) &&
+            isPossibleExpTest(lookahead(1).getSymbol())
+          ) {
+            consumeToken(); // 'is'
+            consumeToken(); // 'not'
+            v = buildAstMethodForIdentifier(v, "evaluateNegated");
+          } else if (
+            "is".equals(getToken().getImage()) &&
+            isPossibleExpTest(lookahead(0).getSymbol())
+          ) {
+            consumeToken(); // 'is'
+            v = buildAstMethodForIdentifier(v, "evaluate");
+          }
+
           return v;
       }
     }

--- a/src/main/java/com/hubspot/jinjava/tree/parse/ExpressionToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/ExpressionToken.java
@@ -44,7 +44,16 @@ public class ExpressionToken extends Token {
   @Override
   protected void parse() {
     this.expr = WhitespaceUtils.unwrap(image, "{{", "}}");
-    this.expr = handleTrim(expr);
+
+    if (WhitespaceUtils.startsWith(expr, "-")) {
+      setLeftTrim(true);
+      this.expr = WhitespaceUtils.unwrap(expr, "-", "");
+    }
+    if (WhitespaceUtils.endsWith(expr, "-")) {
+      setRightTrim(true);
+      this.expr = WhitespaceUtils.unwrap(expr, "", "-");
+    }
+
     this.expr = StringUtils.trimToEmpty(this.expr);
   }
 

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TagToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TagToken.java
@@ -16,6 +16,7 @@ limitations under the License.
 package com.hubspot.jinjava.tree.parse;
 
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
+import com.hubspot.jinjava.util.WhitespaceUtils;
 
 public class TagToken extends Token {
   private static final long serialVersionUID = -4927751270481832992L;
@@ -53,7 +54,15 @@ public class TagToken extends Token {
     }
 
     content = image.substring(2, image.length() - 2);
-    content = handleTrim(content);
+
+    if (WhitespaceUtils.startsWith(content, "-")) {
+      setLeftTrim(true);
+      content = WhitespaceUtils.unwrap(content, "-", "");
+    }
+    if (WhitespaceUtils.endsWith(content, "-")) {
+      setRightTrim(true);
+      content = WhitespaceUtils.unwrap(content, "", "-");
+    }
 
     int nameStart = -1, pos = 0, len = content.length();
 

--- a/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
@@ -83,25 +83,6 @@ public abstract class Token implements Serializable {
     this.rightTrimAfterEnd = rightTrimAfterEnd;
   }
 
-  /**
-   * Handle any whitespace control characters, capturing whether leading or trailing
-   * whitespace should be stripped.
-   * @param unwrapped the content of the block stripped of its delimeters
-   * @return the content stripped of any whitespace control characters.
-   */
-  protected final String handleTrim(String unwrapped) {
-    String result = unwrapped;
-    if (unwrapped.startsWith("-")) {
-      setLeftTrim(true);
-      result = unwrapped.substring(1);
-    }
-    if (unwrapped.endsWith("-")) {
-      setRightTrim(true);
-      result = unwrapped.substring(0, unwrapped.length() - 1);
-    }
-    return result;
-  }
-
   public int getStartPosition() {
     return startPosition;
   }

--- a/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
@@ -91,13 +91,13 @@ public abstract class Token implements Serializable {
    */
   protected final String handleTrim(String unwrapped) {
     String result = unwrapped;
-    if (result.startsWith("-")) {
+    if (unwrapped.startsWith("-")) {
       setLeftTrim(true);
-      result = result.substring(1);
+      result = unwrapped.substring(1);
     }
-    if (result.endsWith("-")) {
+    if (unwrapped.endsWith("-")) {
       setRightTrim(true);
-      result = result.substring(0, result.length() - 1);
+      result = unwrapped.substring(0, unwrapped.length() - 1);
     }
     return result;
   }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -335,7 +335,7 @@ public class JinjavaInterpreterTest {
 
   @Test
   public void itBindsUnaryMinusTighterThanCmp() {
-    assertThat(interpreter.render("{{ -5 > 4 }}")).isEqualTo("false");
+    assertThat(interpreter.render("{{ (-5 > 4) }}")).isEqualTo("false");
   }
 
   @Test
@@ -351,34 +351,17 @@ public class JinjavaInterpreterTest {
 
   @Test
   public void itBindsUnaryMinusTighterThanFilters() {
-    assertThat(interpreter.render("{{ -5 | abs }}")).isEqualTo("5");
-  }
-
-  @Test
-  public void itBindsUnaryMinusTighterThanPlus() {
-    assertThat(interpreter.render("{{ -10 + 4 }}")).isEqualTo("-6");
-    assertThat(interpreter.render("{{ 4 + -10 }}")).isEqualTo("-6");
+    assertThat(interpreter.render("{{ (-5 | abs) }}")).isEqualTo("5");
   }
 
   @Test
   public void itBindsFiltersTighterThanMul() {
-    assertThat(interpreter.render("{{ -5 * -4 | abs }}")).isEqualTo("-20");
-  }
-
-  @Test
-  public void itBindsFiltersTighterThanPlus() {
-    assertThat(interpreter.render("{{ -10 | abs + 4 }}")).isEqualTo("14");
-    assertThat(interpreter.render("{{ 4 + -10 | abs }}")).isEqualTo("14");
+    assertThat(interpreter.render("{{ (-5 * -4 | abs) }}")).isEqualTo("-20");
   }
 
   @Test
   public void itInterpretsFilterChainsInOrder() {
     assertThat(interpreter.render("{{ 'foo' | upper | replace('O', 'A') }}"))
       .isEqualTo("FAA");
-  }
-
-  @Test
-  public void itInterpretsStandaloneNegatives() {
-    assertThat(interpreter.render("{{ -10 }}")).isEqualTo("-10");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -381,9 +381,4 @@ public class JinjavaInterpreterTest {
   public void itInterpretsStandaloneNegatives() {
     assertThat(interpreter.render("{{ -10 }}")).isEqualTo("-10");
   }
-
-  @Test
-  public void itInterpretsWhitespaceControlOnBothSides() {
-    assertThat(interpreter.render("{{- 5 -}}")).isEqualTo("5");
-  }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -332,36 +332,4 @@ public class JinjavaInterpreterTest {
     );
     assertThat(interpreter.getErrors()).isEmpty();
   }
-
-  @Test
-  public void itBindsUnaryMinusTighterThanCmp() {
-    assertThat(interpreter.render("{{ (-5 > 4) }}")).isEqualTo("false");
-  }
-
-  @Test
-  public void itBindsUnaryMinusTighterThanIs() {
-    assertThat(interpreter.render("{{ (-5 is integer) == true }}")).isEqualTo("true");
-  }
-
-  @Test
-  public void itBindsUnaryMinusTighterThanIsNot() {
-    assertThat(interpreter.render("{{ (-5 is not integer) == false }}"))
-      .isEqualTo("true");
-  }
-
-  @Test
-  public void itBindsUnaryMinusTighterThanFilters() {
-    assertThat(interpreter.render("{{ (-5 | abs) }}")).isEqualTo("5");
-  }
-
-  @Test
-  public void itBindsFiltersTighterThanMul() {
-    assertThat(interpreter.render("{{ (-5 * -4 | abs) }}")).isEqualTo("-20");
-  }
-
-  @Test
-  public void itInterpretsFilterChainsInOrder() {
-    assertThat(interpreter.render("{{ 'foo' | upper | replace('O', 'A') }}"))
-      .isEqualTo("FAA");
-  }
 }

--- a/src/test/resources/eager/handles-deferred-in-ifchanged.jinja
+++ b/src/test/resources/eager/handles-deferred-in-ifchanged.jinja
@@ -1,6 +1,6 @@
 {% set foo = [1, 1, 2, 1] %}
 {%- for item in foo -%}
-{%- ifchanged item -%}
+{%- ifchanged item- %}
 {{ deferred[item] }}
 {%- endifchanged -%}
 {% endfor%}


### PR DESCRIPTION
Reverts #898, #896, and #895 

We're noticing some existing templates which no longer parse with these operator binding precedence and whitespace control changes. Reverting for now to unblock the deploy while I look into how widespread the issues are.