### PR TITLE
Reorder resolvable object check

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
@@ -1,6 +1,5 @@
 package com.hubspot.jinjava.el.ext.eager;
 
-import com.google.common.primitives.Primitives;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.el.ext.ExtendedParser;
 import com.hubspot.jinjava.interpret.DeferredValueException;
@@ -89,7 +88,10 @@ public interface EvalResultHolder {
       } catch (DeferredParsingException ignored) {}
     }
     Object evalResult = astNode.getEvalResult();
-    if (!preserveIdentifier || (astNode.hasEvalResult() && isPrimitive(evalResult))) {
+    if (
+      !preserveIdentifier ||
+      (astNode.hasEvalResult() && EagerExpressionResolver.isPrimitive(evalResult))
+    ) {
       if (exception != null && exception.getSourceNode() == astNode) {
         return exception.getDeferredEvalResult();
       }
@@ -124,13 +126,5 @@ public interface EvalResultHolder {
       return (DeferredParsingException) deferredValueException;
     }
     return null;
-  }
-
-  static boolean isPrimitive(Object evalResult) {
-    return (
-      evalResult == null ||
-      Primitives.isWrapperType(evalResult.getClass()) ||
-      evalResult instanceof String
-    );
   }
 }

--- a/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
@@ -3,7 +3,6 @@ package com.hubspot.jinjava.util;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import com.google.common.primitives.Primitives;
 import com.hubspot.jinjava.el.ext.AbstractCallableMethod;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredLazyReference;
@@ -147,7 +146,10 @@ public class DeferredValueUtils {
     referentialDefers.forEach(
       word -> {
         Object wordValue = context.get(word);
-        if (!(wordValue instanceof DeferredValue) && !isPrimitive(wordValue)) {
+        if (
+          !(wordValue instanceof DeferredValue) &&
+          !EagerExpressionResolver.isPrimitive(wordValue)
+        ) {
           Context temp = context;
           while (temp.getParent() != null) {
             temp
@@ -167,14 +169,6 @@ public class DeferredValueUtils {
 
     markDeferredProperties(context, Sets.union(deferredProps, setProps));
     return deferredProps;
-  }
-
-  private static boolean isPrimitive(Object wordValue) {
-    return (
-      wordValue == null ||
-      Primitives.isWrapperType(wordValue.getClass()) ||
-      wordValue instanceof String
-    );
   }
 
   public static Set<String> getPropertiesSetInDeferredNodes(String templateSource) {

--- a/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Primitives;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.el.ext.ExtendedParser;
 import com.hubspot.jinjava.interpret.DeferredValueException;
@@ -51,8 +52,7 @@ public class EagerExpressionResolver {
   private static final Set<Class<?>> RESOLVABLE_CLASSES = ImmutableSet.of(
     String.class,
     Boolean.class,
-    Number.class,
-    PyishSerializable.class
+    Number.class
   );
 
   private static final Pattern NAMED_PARAMETER_KEY_PATTERN = Pattern.compile(
@@ -223,7 +223,7 @@ public class EagerExpressionResolver {
     if (depth > maxDepth) {
       return false;
     }
-    if (val == null) {
+    if (isPrimitive(val)) {
       return true;
     }
     if (val instanceof Collection || val instanceof Map) {
@@ -249,9 +249,13 @@ public class EagerExpressionResolver {
       return (Arrays.stream((Object[]) val)).filter(Objects::nonNull)
         .allMatch(item -> isResolvableObjectRec(item, depth + 1, maxDepth, maxSize));
     }
-    return RESOLVABLE_CLASSES
-      .stream()
-      .anyMatch(clazz -> clazz.isAssignableFrom(val.getClass()));
+    return PyishSerializable.class.isAssignableFrom(val.getClass());
+  }
+
+  public static boolean isPrimitive(Object val) {
+    return (
+      val == null || Primitives.isWrapperType(val.getClass()) || val instanceof String
+    );
   }
 
   public static class EagerExpressionResult {

--- a/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
@@ -223,12 +223,7 @@ public class EagerExpressionResolver {
     if (depth > maxDepth) {
       return false;
     }
-    boolean isResolvable =
-      val == null ||
-      RESOLVABLE_CLASSES
-        .stream()
-        .anyMatch(clazz -> clazz.isAssignableFrom(val.getClass()));
-    if (isResolvable) {
+    if (val == null) {
       return true;
     }
     if (val instanceof Collection || val instanceof Map) {
@@ -254,7 +249,9 @@ public class EagerExpressionResolver {
       return (Arrays.stream((Object[]) val)).filter(Objects::nonNull)
         .allMatch(item -> isResolvableObjectRec(item, depth + 1, maxDepth, maxSize));
     }
-    return false;
+    return RESOLVABLE_CLASSES
+      .stream()
+      .anyMatch(clazz -> clazz.isAssignableFrom(val.getClass()));
   }
 
   public static class EagerExpressionResult {

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -121,7 +121,7 @@ public class EagerReconstructionUtils {
             .stream()
             .filter(entry -> initiallyResolvedHashes.containsKey(entry.getKey()))
             .filter(
-              entry -> EagerExpressionResolver.isResolvableObject(entry.getValue(), 2, 10) // TODO make this configurable
+              entry -> EagerExpressionResolver.isResolvableObject(entry.getValue(), 2, 20) // TODO make this configurable
             );
       } else {
         entryStream =

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -131,7 +131,7 @@ public class EagerReconstructionUtils {
             .stream()
             .filter(entry -> initiallyResolvedHashes.containsKey(entry.getKey()))
             .filter(
-              entry -> EagerExpressionResolver.isResolvableObject(entry.getValue())
+              entry -> EagerExpressionResolver.isResolvableObject(entry.getValue(), 2, 20) // TODO make this configurable
             );
       }
       entryStream.forEach(


### PR DESCRIPTION
If an object was `PyishSerializable`, but was a really large list or map, it can still cause memory problems converting it to a string here. Rearranges the order of these checks so that the PyishSerializable check happens only if it's not a collection or map.