### PR TITLE
Reintroduce whitespace control parsing fix with legacy override

### DIFF
--- a/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
+++ b/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
@@ -11,6 +11,7 @@ public class LegacyOverrides {
   private final boolean usePyishObjectMapper;
   private final boolean whitespaceRequiredWithinTokens;
   private final boolean useNaturalOperatorPrecedence;
+  private final boolean strictWhitespaceControlParsing;
 
   private LegacyOverrides(Builder builder) {
     evaluateMapKeys = builder.evaluateMapKeys;
@@ -18,6 +19,7 @@ public class LegacyOverrides {
     usePyishObjectMapper = builder.usePyishObjectMapper;
     whitespaceRequiredWithinTokens = builder.whitespaceRequiredWithinTokens;
     useNaturalOperatorPrecedence = builder.useNaturalOperatorPrecedence;
+    strictWhitespaceControlParsing = builder.strictWhitespaceControlParsing;
   }
 
   public static Builder newBuilder() {
@@ -44,12 +46,17 @@ public class LegacyOverrides {
     return useNaturalOperatorPrecedence;
   }
 
+  public boolean isStrictWhitespaceControlParsing() {
+    return strictWhitespaceControlParsing;
+  }
+
   public static class Builder {
     private boolean evaluateMapKeys = false;
     private boolean iterateOverMapKeys = false;
     private boolean usePyishObjectMapper = false;
     private boolean whitespaceRequiredWithinTokens = false;
     private boolean useNaturalOperatorPrecedence = false;
+    private boolean strictWhitespaceControlParsing = false;
 
     private Builder() {}
 
@@ -65,7 +72,10 @@ public class LegacyOverrides {
         .withWhitespaceRequiredWithinTokens(
           legacyOverrides.whitespaceRequiredWithinTokens
         )
-        .withUseNaturalOperatorPrecedence(legacyOverrides.useNaturalOperatorPrecedence);
+        .withUseNaturalOperatorPrecedence(legacyOverrides.useNaturalOperatorPrecedence)
+        .withStrictWhitespaceControlParsing(
+          legacyOverrides.strictWhitespaceControlParsing
+        );
     }
 
     public Builder withEvaluateMapKeys(boolean evaluateMapKeys) {
@@ -94,6 +104,13 @@ public class LegacyOverrides {
       boolean useNaturalOperatorPrecedence
     ) {
       this.useNaturalOperatorPrecedence = useNaturalOperatorPrecedence;
+      return this;
+    }
+
+    public Builder withStrictWhitespaceControlParsing(
+      boolean strictWhitespaceControlParsing
+    ) {
+      this.strictWhitespaceControlParsing = strictWhitespaceControlParsing;
       return this;
     }
   }

--- a/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
+++ b/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
@@ -11,7 +11,7 @@ public class LegacyOverrides {
   private final boolean usePyishObjectMapper;
   private final boolean whitespaceRequiredWithinTokens;
   private final boolean useNaturalOperatorPrecedence;
-  private final boolean strictWhitespaceControlParsing;
+  private final boolean parseWhitespaceControlStrictly;
 
   private LegacyOverrides(Builder builder) {
     evaluateMapKeys = builder.evaluateMapKeys;
@@ -19,7 +19,7 @@ public class LegacyOverrides {
     usePyishObjectMapper = builder.usePyishObjectMapper;
     whitespaceRequiredWithinTokens = builder.whitespaceRequiredWithinTokens;
     useNaturalOperatorPrecedence = builder.useNaturalOperatorPrecedence;
-    strictWhitespaceControlParsing = builder.strictWhitespaceControlParsing;
+    parseWhitespaceControlStrictly = builder.parseWhitespaceControlStrictly;
   }
 
   public static Builder newBuilder() {
@@ -46,8 +46,8 @@ public class LegacyOverrides {
     return useNaturalOperatorPrecedence;
   }
 
-  public boolean isStrictWhitespaceControlParsing() {
-    return strictWhitespaceControlParsing;
+  public boolean isParseWhitespaceControlStrictly() {
+    return parseWhitespaceControlStrictly;
   }
 
   public static class Builder {
@@ -56,7 +56,7 @@ public class LegacyOverrides {
     private boolean usePyishObjectMapper = false;
     private boolean whitespaceRequiredWithinTokens = false;
     private boolean useNaturalOperatorPrecedence = false;
-    private boolean strictWhitespaceControlParsing = false;
+    private boolean parseWhitespaceControlStrictly = false;
 
     private Builder() {}
 
@@ -73,8 +73,8 @@ public class LegacyOverrides {
           legacyOverrides.whitespaceRequiredWithinTokens
         )
         .withUseNaturalOperatorPrecedence(legacyOverrides.useNaturalOperatorPrecedence)
-        .withStrictWhitespaceControlParsing(
-          legacyOverrides.strictWhitespaceControlParsing
+        .withParseWhitespaceControlStrictly(
+          legacyOverrides.parseWhitespaceControlStrictly
         );
     }
 
@@ -107,10 +107,10 @@ public class LegacyOverrides {
       return this;
     }
 
-    public Builder withStrictWhitespaceControlParsing(
-      boolean strictWhitespaceControlParsing
+    public Builder withParseWhitespaceControlStrictly(
+      boolean parseWhitespaceControlStrictly
     ) {
-      this.strictWhitespaceControlParsing = strictWhitespaceControlParsing;
+      this.parseWhitespaceControlStrictly = parseWhitespaceControlStrictly;
       return this;
     }
   }

--- a/src/main/java/com/hubspot/jinjava/tree/parse/ExpressionToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/ExpressionToken.java
@@ -44,16 +44,7 @@ public class ExpressionToken extends Token {
   @Override
   protected void parse() {
     this.expr = WhitespaceUtils.unwrap(image, "{{", "}}");
-
-    if (WhitespaceUtils.startsWith(expr, "-")) {
-      setLeftTrim(true);
-      this.expr = WhitespaceUtils.unwrap(expr, "-", "");
-    }
-    if (WhitespaceUtils.endsWith(expr, "-")) {
-      setRightTrim(true);
-      this.expr = WhitespaceUtils.unwrap(expr, "", "-");
-    }
-
+    this.expr = handleTrim(expr);
     this.expr = StringUtils.trimToEmpty(this.expr);
   }
 

--- a/src/main/java/com/hubspot/jinjava/tree/parse/LenientWhitespaceControlParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/LenientWhitespaceControlParser.java
@@ -1,0 +1,26 @@
+package com.hubspot.jinjava.tree.parse;
+
+import com.hubspot.jinjava.util.WhitespaceUtils;
+
+public class LenientWhitespaceControlParser implements WhitespaceControlParser {
+
+  @Override
+  public boolean hasLeftTrim(String unwrapped) {
+    return WhitespaceUtils.startsWith(unwrapped, "-");
+  }
+
+  @Override
+  public String stripLeft(String unwrapped) {
+    return WhitespaceUtils.unwrap(unwrapped, "-", "");
+  }
+
+  @Override
+  public boolean hasRightTrim(String unwrapped) {
+    return WhitespaceUtils.endsWith(unwrapped, "-");
+  }
+
+  @Override
+  public String stripRight(String unwrapped) {
+    return WhitespaceUtils.unwrap(unwrapped, "", "-");
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/tree/parse/StrictWhitespaceControlParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/StrictWhitespaceControlParser.java
@@ -4,7 +4,7 @@ public class StrictWhitespaceControlParser implements WhitespaceControlParser {
 
   @Override
   public boolean hasLeftTrim(String unwrapped) {
-    return unwrapped.startsWith("-");
+    return unwrapped.charAt(0) == '-';
   }
 
   @Override
@@ -14,7 +14,7 @@ public class StrictWhitespaceControlParser implements WhitespaceControlParser {
 
   @Override
   public boolean hasRightTrim(String unwrapped) {
-    return unwrapped.endsWith("-");
+    return unwrapped.charAt(unwrapped.length() - 1) == '-';
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/tree/parse/StrictWhitespaceControlParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/StrictWhitespaceControlParser.java
@@ -1,0 +1,24 @@
+package com.hubspot.jinjava.tree.parse;
+
+public class StrictWhitespaceControlParser implements WhitespaceControlParser {
+
+  @Override
+  public boolean hasLeftTrim(String unwrapped) {
+    return unwrapped.startsWith("-");
+  }
+
+  @Override
+  public String stripLeft(String unwrapped) {
+    return unwrapped.substring(1);
+  }
+
+  @Override
+  public boolean hasRightTrim(String unwrapped) {
+    return unwrapped.endsWith("-");
+  }
+
+  @Override
+  public String stripRight(String unwrapped) {
+    return unwrapped.substring(0, unwrapped.length() - 1);
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TagToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TagToken.java
@@ -16,7 +16,6 @@ limitations under the License.
 package com.hubspot.jinjava.tree.parse;
 
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
-import com.hubspot.jinjava.util.WhitespaceUtils;
 
 public class TagToken extends Token {
   private static final long serialVersionUID = -4927751270481832992L;
@@ -54,15 +53,7 @@ public class TagToken extends Token {
     }
 
     content = image.substring(2, image.length() - 2);
-
-    if (WhitespaceUtils.startsWith(content, "-")) {
-      setLeftTrim(true);
-      content = WhitespaceUtils.unwrap(content, "-", "");
-    }
-    if (WhitespaceUtils.endsWith(content, "-")) {
-      setRightTrim(true);
-      content = WhitespaceUtils.unwrap(content, "", "-");
-    }
+    content = handleTrim(content);
 
     int nameStart = -1, pos = 0, len = content.length();
 

--- a/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
@@ -17,10 +17,7 @@ package com.hubspot.jinjava.tree.parse;
 
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.UnexpectedTokenException;
-import com.hubspot.jinjava.util.WhitespaceUtils;
 import java.io.Serializable;
-import java.util.function.BiPredicate;
-import java.util.function.Function;
 
 public abstract class Token implements Serializable {
   private static final long serialVersionUID = 3359084948763661809L;
@@ -102,27 +99,18 @@ public abstract class Token implements Serializable {
         .getLegacyOverrides()
         .isParseWhitespaceControlStrictly();
 
-    BiPredicate<String, String> startsWith = parseWhitespaceControlStrictly
-      ? String::startsWith
-      : WhitespaceUtils::startsWith;
-    Function<String, String> stripLeft = parseWhitespaceControlStrictly
-      ? s -> s.substring(1)
-      : s -> WhitespaceUtils.unwrap(s, "-", "");
-    BiPredicate<String, String> endsWith = parseWhitespaceControlStrictly
-      ? String::endsWith
-      : WhitespaceUtils::endsWith;
-    Function<String, String> stripRight = parseWhitespaceControlStrictly
-      ? s -> s.substring(0, s.length() - 1)
-      : s -> WhitespaceUtils.unwrap(s, "", "-");
+    WhitespaceControlParser parser = parseWhitespaceControlStrictly
+      ? WhitespaceControlParser.STRICT
+      : WhitespaceControlParser.LENIENT;
 
     String result = unwrapped;
-    if (startsWith.test(result, "-")) {
+    if (parser.hasLeftTrim(result)) {
       setLeftTrim(true);
-      result = stripLeft.apply(result);
+      result = parser.stripLeft(result);
     }
-    if (endsWith.test(result, "-")) {
+    if (parser.hasRightTrim(result)) {
       setRightTrim(true);
-      result = stripRight.apply(result);
+      result = parser.stripRight(result);
     }
     return result;
   }

--- a/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
@@ -20,6 +20,7 @@ import com.hubspot.jinjava.interpret.UnexpectedTokenException;
 import com.hubspot.jinjava.util.WhitespaceUtils;
 import java.io.Serializable;
 import java.util.function.BiPredicate;
+import java.util.function.Function;
 
 public abstract class Token implements Serializable {
   private static final long serialVersionUID = 3359084948763661809L;
@@ -104,18 +105,24 @@ public abstract class Token implements Serializable {
     BiPredicate<String, String> startsWith = parseWhitespaceControlStrictly
       ? String::startsWith
       : WhitespaceUtils::startsWith;
+    Function<String, String> stripLeft = parseWhitespaceControlStrictly
+      ? s -> s.substring(1)
+      : s -> WhitespaceUtils.unwrap(s, "-", "");
     BiPredicate<String, String> endsWith = parseWhitespaceControlStrictly
       ? String::endsWith
       : WhitespaceUtils::endsWith;
+    Function<String, String> stripRight = parseWhitespaceControlStrictly
+      ? s -> s.substring(0, s.length() - 1)
+      : s -> WhitespaceUtils.unwrap(s, "", "-");
 
     String result = unwrapped;
     if (startsWith.test(result, "-")) {
       setLeftTrim(true);
-      result = result.substring(1);
+      result = stripLeft.apply(result);
     }
     if (endsWith.test(result, "-")) {
       setRightTrim(true);
-      result = result.substring(0, result.length() - 1);
+      result = stripRight.apply(result);
     }
     return result;
   }

--- a/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
@@ -15,6 +15,8 @@ limitations under the License.
  **********************************************************************/
 package com.hubspot.jinjava.tree.parse;
 
+import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.LegacyOverrides;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.UnexpectedTokenException;
 import java.io.Serializable;
@@ -91,13 +93,12 @@ public abstract class Token implements Serializable {
    * @return the content stripped of any whitespace control characters.
    */
   protected final String handleTrim(String unwrapped) {
-    boolean parseWhitespaceControlStrictly =
-      JinjavaInterpreter.getCurrent() != null &&
-      JinjavaInterpreter
-        .getCurrent()
-        .getConfig()
-        .getLegacyOverrides()
-        .isParseWhitespaceControlStrictly();
+    boolean parseWhitespaceControlStrictly = JinjavaInterpreter
+      .getCurrentMaybe()
+      .map(JinjavaInterpreter::getConfig)
+      .map(JinjavaConfig::getLegacyOverrides)
+      .map(LegacyOverrides::isParseWhitespaceControlStrictly)
+      .orElse(false);
 
     WhitespaceControlParser parser = parseWhitespaceControlStrictly
       ? WhitespaceControlParser.STRICT

--- a/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
@@ -83,6 +83,25 @@ public abstract class Token implements Serializable {
     this.rightTrimAfterEnd = rightTrimAfterEnd;
   }
 
+  /**
+   * Handle any whitespace control characters, capturing whether leading or trailing
+   * whitespace should be stripped.
+   * @param unwrapped the content of the block stripped of its delimeters
+   * @return the content stripped of any whitespace control characters.
+   */
+  protected final String handleTrim(String unwrapped) {
+    String result = unwrapped;
+    if (result.startsWith("-")) {
+      setLeftTrim(true);
+      result = result.substring(1);
+    }
+    if (result.endsWith("-")) {
+      setRightTrim(true);
+      result = result.substring(0, result.length() - 1);
+    }
+    return result;
+  }
+
   public int getStartPosition() {
     return startPosition;
   }

--- a/src/main/java/com/hubspot/jinjava/tree/parse/WhitespaceControlParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/WhitespaceControlParser.java
@@ -1,0 +1,12 @@
+package com.hubspot.jinjava.tree.parse;
+
+public interface WhitespaceControlParser {
+  WhitespaceControlParser LENIENT = new LenientWhitespaceControlParser();
+  WhitespaceControlParser STRICT = new StrictWhitespaceControlParser();
+
+  boolean hasLeftTrim(String unwrapped);
+  String stripLeft(String unwrapped);
+
+  boolean hasRightTrim(String unwrapped);
+  String stripRight(String unwrapped);
+}

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -348,4 +348,9 @@ public class JinjavaInterpreterTest {
   public void itInterpretsWhitespaceControl() {
     assertThat(interpreter.render(".  {%- set x = 5 -%}  .")).isEqualTo("..");
   }
+
+  @Test
+  public void itInterpretsEmptyExpressions() {
+    assertThat(interpreter.render("{{}}")).isEqualTo("");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -343,4 +343,9 @@ public class JinjavaInterpreterTest {
     assertThat(interpreter.render("{{ 'foo' | upper | replace('O', 'A') }}"))
       .isEqualTo("FAA");
   }
+
+  @Test
+  public void itInterpretsWhitespaceControl() {
+    assertThat(interpreter.render(".  {%- set x = 5 -%}  .")).isEqualTo("..");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/LegacyWhitespaceControlParsingTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/LegacyWhitespaceControlParsingTest.java
@@ -23,7 +23,9 @@ public class LegacyWhitespaceControlParsingTest {
       new Jinjava(
         JinjavaConfig
           .newBuilder()
-          .withLegacyOverrides(LegacyOverrides.newBuilder().build())
+          .withLegacyOverrides(
+            LegacyOverrides.newBuilder().withParseWhitespaceControlStrictly(true).build()
+          )
           .build()
       );
   }

--- a/src/test/java/com/hubspot/jinjava/interpret/LegacyWhitespaceControlParsingTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/LegacyWhitespaceControlParsingTest.java
@@ -34,6 +34,7 @@ public class LegacyWhitespaceControlParsingTest {
   @Test
   public void itInterpretsStandaloneNegatives() {
     String template = "{{ -10 }}";
+
     assertThat(legacy.render(template, new HashMap<>())).isEqualTo("10");
     assertThat(modern.render(template, new HashMap<>())).isEqualTo("-10");
   }
@@ -41,6 +42,7 @@ public class LegacyWhitespaceControlParsingTest {
   @Test
   public void itInterpretsStandaloneNegativesWithWhitespace() {
     String template = "{{ - 10 }}";
+
     assertThat(legacy.render(template, new HashMap<>())).isEqualTo("10");
 
     // Somewhat surprising, but this aligns with Jinja
@@ -50,6 +52,7 @@ public class LegacyWhitespaceControlParsingTest {
   @Test
   public void itErrorsOnTrailingDash() {
     String template = "{{ 10- }}";
+
     assertThat(legacy.render(template, new HashMap<>())).isEqualTo("10");
     assertThatExceptionOfType(FatalTemplateErrorsException.class)
       .isThrownBy(() -> modern.render(template, new HashMap<>()))
@@ -59,6 +62,7 @@ public class LegacyWhitespaceControlParsingTest {
   @Test
   public void itErrorsOnSpacedTrailingDash() {
     String template = "{{ 10 - }}";
+
     assertThat(legacy.render(template, new HashMap<>())).isEqualTo("10");
     assertThatExceptionOfType(FatalTemplateErrorsException.class)
       .isThrownBy(() -> modern.render(template, new HashMap<>()))
@@ -68,6 +72,7 @@ public class LegacyWhitespaceControlParsingTest {
   @Test
   public void itErrorsOnSpacedDashesOnBothSides() {
     String template = "{{ - 10 - }}";
+
     assertThat(legacy.render(template, new HashMap<>())).isEqualTo("10");
     assertThatExceptionOfType(FatalTemplateErrorsException.class)
       .isThrownBy(() -> modern.render(template, new HashMap<>()))

--- a/src/test/java/com/hubspot/jinjava/interpret/LegacyWhitespaceControlParsingTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/LegacyWhitespaceControlParsingTest.java
@@ -1,0 +1,37 @@
+package com.hubspot.jinjava.interpret;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.LegacyOverrides;
+import java.util.HashMap;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LegacyWhitespaceControlParsingTest {
+  Jinjava legacy;
+  Jinjava modern;
+
+  @Before
+  public void setUp() throws Exception {
+    legacy =
+      new Jinjava(
+        JinjavaConfig.newBuilder().withLegacyOverrides(LegacyOverrides.NONE).build()
+      );
+    modern =
+      new Jinjava(
+        JinjavaConfig
+          .newBuilder()
+          .withLegacyOverrides(LegacyOverrides.newBuilder().build())
+          .build()
+      );
+  }
+
+  @Test
+  public void itInterpretsStandaloneNegatives() {
+    String template = "{{ -10 }}";
+    assertThat(legacy.render(template, new HashMap<>())).isEqualTo("10");
+    assertThat(modern.render(template, new HashMap<>())).isEqualTo("-10");
+  }
+}


### PR DESCRIPTION
Closes #892 
Depends on #902 

This PR is basically #896 but with the changes disabled by default. They can be enabled by setting a new flag on `LegacyOverrides` as part of the `JinjavaConfig`.