### PR TITLE
Short circuit EagerAstChoice on ChoiceIdentifier

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoice.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoice.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.el.ext.eager;
 
+import com.hubspot.jinjava.el.NoInvokeELContext;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstChoice;
@@ -84,7 +85,7 @@ public class EagerAstChoice extends AstChoice implements EvalResultHolder {
       " ? " +
       EvalResultHolder.reconstructNode(
         bindings,
-        context,
+        new NoInvokeELContext(context),
         yes,
         deferredParsingException,
         preserveIdentifier
@@ -92,7 +93,7 @@ public class EagerAstChoice extends AstChoice implements EvalResultHolder {
       " : " +
       EvalResultHolder.reconstructNode(
         bindings,
-        context,
+        new NoInvokeELContext(context),
         no,
         deferredParsingException,
         preserveIdentifier

--- a/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoiceTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoiceTest.java
@@ -1,0 +1,93 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+import static org.junit.Assert.fail;
+
+import com.hubspot.jinjava.BaseInterpretingTest;
+import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.LegacyOverrides;
+import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.interpret.Context;
+import com.hubspot.jinjava.interpret.DeferredValue;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.mode.EagerExecutionMode;
+import com.hubspot.jinjava.objects.collections.PyList;
+import com.hubspot.jinjava.random.RandomNumberGeneratorStrategy;
+import java.util.ArrayList;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+
+public class EagerAstChoiceTest extends BaseInterpretingTest {
+
+  @Before
+  public void setup() {
+    JinjavaConfig config = JinjavaConfig
+      .newBuilder()
+      .withRandomNumberGeneratorStrategy(RandomNumberGeneratorStrategy.DEFERRED)
+      .withExecutionMode(EagerExecutionMode.instance())
+      .withNestedInterpretationEnabled(true)
+      .withLegacyOverrides(
+        LegacyOverrides.newBuilder().withUsePyishObjectMapper(true).build()
+      )
+      .withMaxMacroRecursionDepth(5)
+      .withEnableRecursiveMacroCalls(true)
+      .build();
+    JinjavaInterpreter parentInterpreter = new JinjavaInterpreter(
+      jinjava,
+      new Context(),
+      config
+    );
+    interpreter.getContext().put("foo", "foo val");
+    interpreter = new JinjavaInterpreter(parentInterpreter);
+    interpreter.getContext().put("deferred", DeferredValue.instance());
+    List<Object> fooList = new ArrayList<>();
+    fooList.add("val");
+    interpreter.getContext().put("foo_list", new PyList(fooList));
+  }
+
+  @Test
+  public void itShortCircuitsChoiceIdentifier() {
+    try {
+      interpreter.getContext().put("foo", "foo val");
+      interpreter.getContext().put("bar", "bar val");
+      interpreter.resolveELExpression(
+        "deferred ? foo_list.add(foo) : foo_list.add(bar)",
+        -1
+      );
+      fail("Should throw deferredParsingException");
+    } catch (DeferredParsingException e) {
+      Assertions
+        .assertThat(e.getDeferredEvalResult())
+        .isEqualTo("deferred ? foo_list.add('foo val') : foo_list.add('bar val')");
+    }
+  }
+
+  @Test
+  public void itDoesNotShortCircuitsChoiceYes() {
+    try {
+      interpreter.getContext().put("bar", "bar val");
+      interpreter.resolveELExpression(
+        "foo_list[0] == 'val' ? deferred : foo_list.add(bar)",
+        -1
+      );
+      fail("Should throw deferredParsingException");
+    } catch (DeferredParsingException e) {
+      Assertions.assertThat(e.getDeferredEvalResult()).isEqualTo("deferred");
+    }
+  }
+
+  @Test
+  public void itDoesNotShortCircuitsChoiceNo() {
+    try {
+      interpreter.getContext().put("bar", "bar val");
+      interpreter.resolveELExpression(
+        "foo_list[0] == 'bar' ? foo_list.add(bar) : deferred",
+        -1
+      );
+      fail("Should throw deferredParsingException");
+    } catch (DeferredParsingException e) {
+      Assertions.assertThat(e.getDeferredEvalResult()).isEqualTo("deferred");
+    }
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoiceTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoiceTest.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.el.ext.eager;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import com.hubspot.jinjava.BaseInterpretingTest;
@@ -89,5 +90,29 @@ public class EagerAstChoiceTest extends BaseInterpretingTest {
     } catch (DeferredParsingException e) {
       Assertions.assertThat(e.getDeferredEvalResult()).isEqualTo("deferred");
     }
+  }
+
+  @Test
+  public void itResolvesChoiceYes() {
+    interpreter.getContext().put("bar", "bar val");
+    interpreter.resolveELExpression(
+      "foo_list[0] == 'val' ? foo_list.add(bar) : deferred",
+      -1
+    );
+    PyList result = (PyList) interpreter.getContext().get("foo_list");
+    assertEquals(result.size(), 2);
+    assertEquals(result.get(1), "bar val");
+  }
+
+  @Test
+  public void itResolvesChoiceNo() {
+    interpreter.getContext().put("bar", "bar val");
+    interpreter.resolveELExpression(
+      "foo_list[0] == 'bar' ? deferred : foo_list.add(bar)",
+      -1
+    );
+    PyList result = (PyList) interpreter.getContext().get("foo_list");
+    assertEquals(result.size(), 2);
+    assertEquals(result.get(1), "bar val");
   }
 }


### PR DESCRIPTION
When trying to resolve a choice tag, if the identifier is deferred the yes and no options will be evaluated when they should not be. This will short circuit the expression to not evaluate the yes or no expressions. 

Expression: 
```
deferred ? foo_list.add(foo) : foo_list.add(1 + 1)
```
Before fix: 
```
deferred ? true : true
```
Now fix will be evaluated to: 
```
deferred ? foo_list.add('foo val') : foo_list.add(2)
```
Foo will be resolved to 'foo val' variable value while 1 + 1 will resolve leaving the identifier as deferred. If identifier is not deferred and is true the expression will resolve if the yes node is not deferred. Similar to if the identifier is false and the no node is valid it will resolve as well. 

Relates to issue: [Issue 865](https://github.com/HubSpot/jinjava/issues/865)