### PR TITLE
Check if loop var is deferred word

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -54,11 +54,22 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
         interpreter,
         EagerChildContextConfig.newBuilder().withCheckForContextChanges(true).build()
       );
+      Set<String> deferredUsedWords = addedTokens
+        .stream()
+        .flatMap(token -> token.getUsedDeferredWords().stream())
+        .collect(Collectors.toSet());
       if (
         result.getResult().getResolutionState() == ResolutionState.NONE ||
         (
           !result.getResult().isFullyResolved() &&
           !result.getSpeculativeBindings().isEmpty()
+        ) ||
+        (
+          getTag()
+            .getLoopVarsAndExpression((TagToken) tagNode.getMaster())
+            .getLeft()
+            .stream()
+            .anyMatch(deferredUsedWords::contains)
         )
       ) {
         EagerIfTag.resetBindingsForNextBranch(interpreter, result);

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -54,22 +54,11 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
         interpreter,
         EagerChildContextConfig.newBuilder().withCheckForContextChanges(true).build()
       );
-      Set<String> deferredUsedWords = addedTokens
-        .stream()
-        .flatMap(token -> token.getUsedDeferredWords().stream())
-        .collect(Collectors.toSet());
       if (
         result.getResult().getResolutionState() == ResolutionState.NONE ||
         (
           !result.getResult().isFullyResolved() &&
           !result.getSpeculativeBindings().isEmpty()
-        ) ||
-        (
-          getTag()
-            .getLoopVarsAndExpression((TagToken) tagNode.getMaster())
-            .getLeft()
-            .stream()
-            .anyMatch(deferredUsedWords::contains)
         )
       ) {
         EagerIfTag.resetBindingsForNextBranch(interpreter, result);

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1125,8 +1125,16 @@ public class EagerTest {
 
   @Test
   public void itHandlesDeferredForLoopVarFromMacro() {
-    expectedTemplateInterpreter.assertExpectedOutput(
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
       "handles-deferred-for-loop-var-from-macro"
+    );
+  }
+
+  @Test
+  public void itHandlesDeferredForLoopVarFromMacroSecondPass() {
+    interpreter.getContext().put("deferred", "resolved");
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
+      "handles-deferred-for-loop-var-from-macro.expected"
     );
   }
 }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1122,4 +1122,11 @@ public class EagerTest {
       "does-not-referential-defer-for-set-vars"
     );
   }
+
+  @Test
+  public void itHandlesDeferredForLoopVarFromMacro() {
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "handles-deferred-for-loop-var-from-macro"
+    );
+  }
 }

--- a/src/test/resources/eager/handles-deferred-for-loop-var-from-macro.expected.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-for-loop-var-from-macro.expected.expected.jinja
@@ -1,0 +1,5 @@
+RESOLVED{"A":"A"}
+
+
+
+RESOLVED{"B":"B"}

--- a/src/test/resources/eager/handles-deferred-for-loop-var-from-macro.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-for-loop-var-from-macro.expected.jinja
@@ -1,9 +1,13 @@
 {% macro getData() %}
 
 
-{% for val in [{'a': 'a'}, {'b': 'b'}] %}
+
 {% macro doIt(val) %}
-{{ deferred }}
-{% endmacro %}{{ filter:upper.filter(doIt(val), ____int3rpr3t3r____) }}
-{% endfor %}
+{{ deferred ~ filter:tojson.filter(val, ____int3rpr3t3r____) }}
+{% endmacro %}{% set val = {'a': 'a'} %}{{ filter:upper.filter(doIt(val), ____int3rpr3t3r____) }}
+
+{% macro doIt(val) %}
+{{ deferred ~ filter:tojson.filter(val, ____int3rpr3t3r____) }}
+{% endmacro %}{% set val = {'b': 'b'} %}{{ filter:upper.filter(doIt(val), ____int3rpr3t3r____) }}
+
 {% endmacro %}{{ filter:upper.filter(getData(), ____int3rpr3t3r____) }}

--- a/src/test/resources/eager/handles-deferred-for-loop-var-from-macro.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-for-loop-var-from-macro.expected.jinja
@@ -1,0 +1,9 @@
+{% macro getData() %}
+
+
+{% for val in [{'a': 'a'}, {'b': 'b'}] %}
+{% macro doIt(val) %}
+{{ deferred }}
+{% endmacro %}{{ filter:upper.filter(doIt(val), ____int3rpr3t3r____) }}
+{% endfor %}
+{% endmacro %}{{ filter:upper.filter(getData(), ____int3rpr3t3r____) }}

--- a/src/test/resources/eager/handles-deferred-for-loop-var-from-macro.jinja
+++ b/src/test/resources/eager/handles-deferred-for-loop-var-from-macro.jinja
@@ -1,0 +1,11 @@
+{% macro getData() %}
+{% macro doIt(val) %}
+{{ deferred }}
+{% endmacro %}
+
+{% for val in [{'a': 'a'}, {'b': 'b'}] %}
+{{ doIt(val)|upper }}
+{% endfor %}
+{% endmacro %}
+
+{{ getData()|upper }}

--- a/src/test/resources/eager/handles-deferred-for-loop-var-from-macro.jinja
+++ b/src/test/resources/eager/handles-deferred-for-loop-var-from-macro.jinja
@@ -1,6 +1,6 @@
 {% macro getData() %}
 {% macro doIt(val) %}
-{{ deferred }}
+{{ deferred ~ val|tojson }}
 {% endmacro %}
 
 {% for val in [{'a': 'a'}, {'b': 'b'}] %}


### PR DESCRIPTION
This fixes a bug which can happen when evaluating a for loop in DeferredExecutionMode and the loop variable(s) are unresolved in a token that gets deferred. Variables sent to deferred macro functions are reconstructed as their identifiers because we don't know if modifications may happen, and that causes them to not get resolved. However, they weren't getting reconstructed because they will get reconstructed at the scope level outside of deferred execution mode so we don't want to be redundant. However, if the variable doesn't exist outside of deferred execution mode, then that won't happen. The test added here demonstrates a case where this can occur, which currently results in the value of `val` being lost. The change to only skip reconstructing values that exist outside of the deferred execution mode scope fixes this problem.