### PR TITLE
Scope isolation in partial for loops

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -69,7 +69,14 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
             : "Modification inside partially evaluated for loop"
         );
       }
-      return result.getResult().toString(true);
+      if (result.getResult().isFullyResolved()) {
+        return result.getResult().toString(true);
+      } else {
+        return EagerReconstructionUtils.wrapInChildScope(
+          result.getResult().toString(true),
+          interpreter
+        );
+      }
     } catch (DeferredValueException | TemplateSyntaxException e) {
       try {
         return EagerReconstructionUtils.wrapInAutoEscapeIfNeeded(

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -619,6 +619,22 @@ public class EagerReconstructionUtils {
     );
   }
 
+  public static String wrapInChildScope(String toWrap, JinjavaInterpreter interpreter) {
+    return (
+      String.format(
+        "%s for __ignored__ in [0] %s",
+        interpreter.getConfig().getTokenScannerSymbols().getExpressionStartWithTag(),
+        interpreter.getConfig().getTokenScannerSymbols().getExpressionEndWithTag()
+      ) +
+      toWrap +
+      String.format(
+        "%s endfor %s",
+        interpreter.getConfig().getTokenScannerSymbols().getExpressionStartWithTag(),
+        interpreter.getConfig().getTokenScannerSymbols().getExpressionEndWithTag()
+      )
+    );
+  }
+
   public static class EagerChildContextConfig {
     private final boolean takeNewValue;
     private final boolean partialMacroEvaluation;

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1122,4 +1122,11 @@ public class EagerTest {
       "does-not-referential-defer-for-set-vars"
     );
   }
+
+  @Test
+  public void itKeepsScopeIsolationFromForLoops() {
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "keeps-scope-isolation-from-for-loops"
+    );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -227,11 +227,13 @@ public class EagerTest {
       "{% for item in dict %}{% if item == deferred %} equal {% else %} not equal {% endif %}{% endfor %}"
     );
     StringBuilder expected = new StringBuilder();
+    expected.append("{% for __ignored__ in [0] %}");
     for (String item : (Set<String>) localContext.get("dict")) {
       expected
         .append(String.format("{%% if '%s' == deferred %%}", item))
         .append(" equal {% else %} not equal {% endif %}");
     }
+    expected.append("{% endfor %}");
     assertThat(output).isEqualTo(expected.toString());
     assertThat(interpreter.getErrors()).isEmpty();
   }
@@ -243,6 +245,7 @@ public class EagerTest {
       "{% for item in dict %}{% if item == 'a' %} equal {% if item == deferred %}{% endif %}{% else %} not equal {% endif %}{% endfor %}"
     );
     StringBuilder expected = new StringBuilder();
+    expected.append("{% for __ignored__ in [0] %}");
     for (String item : (Set<String>) localContext.get("dict")) {
       if (item.equals("a")) {
         expected.append(" equal {% if 'a' == deferred %}{% endif %}");
@@ -250,6 +253,7 @@ public class EagerTest {
         expected.append(" not equal ");
       }
     }
+    expected.append("{% endfor %}");
     assertThat(output).isEqualTo(expected.toString());
     assertThat(interpreter.getErrors()).isEmpty();
   }
@@ -262,7 +266,9 @@ public class EagerTest {
     );
 
     StringBuilder expected = new StringBuilder();
+    expected.append("{% for __ignored__ in [0] %}");
     for (String item : (Set<String>) localContext.get("dict")) {
+      expected.append("{% for __ignored__ in [0] %}");
       for (String item2 : (Set<String>) localContext.get("dict2")) {
         if (item2.equals("e")) {
           expected.append(" equal {% if 'e' == deferred %}{% endif %}");
@@ -270,7 +276,9 @@ public class EagerTest {
           expected.append(" not equal ");
         }
       }
+      expected.append("{% endfor %}");
     }
+    expected.append("{% endfor %}");
     assertThat(output).isEqualTo(expected.toString());
     assertThat(interpreter.getErrors()).isEmpty();
   }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1137,4 +1137,19 @@ public class EagerTest {
       "keeps-scope-isolation-from-for-loops"
     );
   }
+
+  @Test
+  public void itDoesNotOverrideImportModificationInFor() {
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
+      "does-not-override-import-modification-in-for"
+    );
+  }
+
+  @Test
+  public void itDoesNotOverrideImportModificationInForSecondPass() {
+    interpreter.getContext().put("deferred", "resolved");
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
+      "does-not-override-import-modification-in-for.expected"
+    );
+  }
 }

--- a/src/test/resources/eager/defers-large-loop.expected.jinja
+++ b/src/test/resources/eager/defers-large-loop.expected.jinja
@@ -1,3 +1,4 @@
+{% for __ignored__ in [0] %}
 Small 0 {{ deferred }} {{ deferred ~ 0 }}
 
 Small 1 {{ deferred }} {{ deferred ~ 1 }}
@@ -17,7 +18,7 @@ Small 7 {{ deferred }} {{ deferred ~ 7 }}
 Small 8 {{ deferred }} {{ deferred ~ 8 }}
 
 Small 9 {{ deferred }} {{ deferred ~ 9 }}
-
+{% endfor %}
 {% for i in range(600) %}
 Big {{ i }} {{ deferred }} {{ deferred ~ i }}
 {% endfor %}

--- a/src/test/resources/eager/does-not-override-import-modification-in-for.expected.expected.jinja
+++ b/src/test/resources/eager/does-not-override-import-modification-in-for.expected.expected.jinja
@@ -1,0 +1,10 @@
+startab
+
+startab
+
+
+startab
+
+startab
+
+start

--- a/src/test/resources/eager/does-not-override-import-modification-in-for.expected.jinja
+++ b/src/test/resources/eager/does-not-override-import-modification-in-for.expected.jinja
@@ -1,0 +1,40 @@
+{% for __ignored__ in [0] %}
+{% set __ignored__ %}{% set current_path = 'deferred-modification.jinja' %}{% set bar1 = {} %}{% set bar1,foo = {},'start' %}{% if deferred %}
+
+{% set foo = 'starta' %}{% do bar1.update({'foo': foo}) %}
+
+{% endif %}
+
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar1.update({'foo': foo}) %}
+{% do bar1.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}{% endset %}
+{{ bar1.foo }}
+{% set __ignored__ %}{% set current_path = 'deferred-modification.jinja' %}{% set bar2 = {} %}{% set bar2,foo = {},'start' %}{% if deferred %}
+
+{% set foo = 'starta' %}{% do bar2.update({'foo': foo}) %}
+
+{% endif %}
+
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar2.update({'foo': foo}) %}
+{% do bar2.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}{% endset %}
+{{ bar2.foo }}
+
+{% set __ignored__ %}{% set current_path = 'deferred-modification.jinja' %}{% set bar1 = {} %}{% set bar1,foo = {},'start' %}{% if deferred %}
+
+{% set foo = 'starta' %}{% do bar1.update({'foo': foo}) %}
+
+{% endif %}
+
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar1.update({'foo': foo}) %}
+{% do bar1.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}{% endset %}
+{{ bar1.foo }}
+{% set __ignored__ %}{% set current_path = 'deferred-modification.jinja' %}{% set bar2 = {} %}{% set bar2,foo = {},'start' %}{% if deferred %}
+
+{% set foo = 'starta' %}{% do bar2.update({'foo': foo}) %}
+
+{% endif %}
+
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar2.update({'foo': foo}) %}
+{% do bar2.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}{% endset %}
+{{ bar2.foo }}
+{% endfor %}
+start

--- a/src/test/resources/eager/does-not-override-import-modification-in-for.jinja
+++ b/src/test/resources/eager/does-not-override-import-modification-in-for.jinja
@@ -1,0 +1,8 @@
+{% set foo = 'start' %}
+{% for i in range(2) %}
+{% import "deferred-modification.jinja" as bar1 %}
+{{ bar1.foo }}
+{% import "deferred-modification.jinja" as bar2 %}
+{{ bar2.foo }}
+{% endfor %}
+{{ foo }}

--- a/src/test/resources/eager/handles-deferred-cycle-as.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-cycle-as.expected.jinja
@@ -1,6 +1,7 @@
+{% for __ignored__ in [0] %}
 {% set c = [1, deferred] %}
 {% if exptest:iterable.evaluate(c, ____int3rpr3t3r____) %}{{ c[0 % filter:length.filter(c, ____int3rpr3t3r____)] }}{% else %}{{ c }}{% endif %}
 {% set c = [2, deferred] %}
 {% if exptest:iterable.evaluate(c, ____int3rpr3t3r____) %}{{ c[1 % filter:length.filter(c, ____int3rpr3t3r____)] }}{% else %}{{ c }}{% endif %}
 {% set c = [3, deferred] %}
-{% if exptest:iterable.evaluate(c, ____int3rpr3t3r____) %}{{ c[2 % filter:length.filter(c, ____int3rpr3t3r____)] }}{% else %}{{ c }}{% endif %}
+{% if exptest:iterable.evaluate(c, ____int3rpr3t3r____) %}{{ c[2 % filter:length.filter(c, ____int3rpr3t3r____)] }}{% else %}{{ c }}{% endif %}{% endfor %}

--- a/src/test/resources/eager/handles-deferred-for-loop-var-from-macro.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-for-loop-var-from-macro.expected.jinja
@@ -1,7 +1,7 @@
 {% macro getData() %}
 
 
-
+{% for __ignored__ in [0] %}
 {% macro doIt(val) %}
 {{ deferred ~ filter:tojson.filter(val, ____int3rpr3t3r____) }}
 {% endmacro %}{% set val = {'a': 'a'} %}{{ filter:upper.filter(doIt(val), ____int3rpr3t3r____) }}
@@ -9,5 +9,5 @@
 {% macro doIt(val) %}
 {{ deferred ~ filter:tojson.filter(val, ____int3rpr3t3r____) }}
 {% endmacro %}{% set val = {'b': 'b'} %}{{ filter:upper.filter(doIt(val), ____int3rpr3t3r____) }}
-
+{% endfor %}
 {% endmacro %}{{ filter:upper.filter(getData(), ____int3rpr3t3r____) }}

--- a/src/test/resources/eager/handles-deferred-in-ifchanged.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-in-ifchanged.expected.jinja
@@ -1,1 +1,1 @@
-{{ deferred[1] }}{{ deferred[2] }}{{ deferred[1] }}
+{% for __ignored__ in [0] %}{{ deferred[1] }}{{ deferred[2] }}{{ deferred[1] }}{% endfor %}

--- a/src/test/resources/eager/handles-deferring-loop-variable.expected.jinja
+++ b/src/test/resources/eager/handles-deferring-loop-variable.expected.jinja
@@ -1,3 +1,4 @@
+{% for __ignored__ in [0] %}
 {% if deferred && true %}first time!
 {% endif %}
 1
@@ -5,7 +6,7 @@
 {% if deferred && false %}first time!
 {% endif %}
 2
-
+{% endfor %}
 {% for i in [0, 1] %}
 {% if deferred && loop.isLast() %}last time!
 {% endif %}

--- a/src/test/resources/eager/handles-higher-scope-reference-modification.expected.jinja
+++ b/src/test/resources/eager/handles-higher-scope-reference-modification.expected.jinja
@@ -4,7 +4,7 @@ C: {{ c_list }}.{% endmacro %}{{ c(b_list) }}{% do b_list.append(deferred ? 'b' 
 B: {{ b_list }}.{% set a_list = b_list %}{% do a_list.append(deferred ? 'a' : '') %}
 A: {% set a_list = b_list %}{{ a_list }}.
 ---
-{% set a_list = ['a'] %}{% for i in [0] %}{% set b_list = a_list %}{% do b_list.append('b') %}{% set c_list = b_list %}{% do c_list.append(deferred ? 'c' : '') %}
-C: {{ c_list }}.{% do b_list.append(deferred ? 'b' : '') %}
+{% set a_list = ['a'] %}{% for i in [0] %}{% set b_list = a_list %}{% do b_list.append('b') %}{% for __ignored__ in [0] %}{% set c_list = b_list %}{% do c_list.append(deferred ? 'c' : '') %}
+C: {{ c_list }}.{% endfor %}{% do b_list.append(deferred ? 'b' : '') %}
 B: {{ b_list }}.{% endfor %}{% do a_list.append(deferred ? 'a' : '') %}
 A: {{ a_list }}.

--- a/src/test/resources/eager/handles-loop-var-against-deferred-in-loop.expected.jinja
+++ b/src/test/resources/eager/handles-loop-var-against-deferred-in-loop.expected.jinja
@@ -1,3 +1,4 @@
-item1 {{ deferred }}.{% set temp = 'item1' ~ deferred %}{{ temp }}
+{% for __ignored__ in [0] %}item1 {{ deferred }}.{% set temp = 'item1' ~ deferred %}{{ temp }}
 item2 {{ deferred }}.{% set temp = 'item2' ~ deferred %}{{ temp }}
 item3 {{ deferred }}.{% set temp = 'item3' ~ deferred %}{{ temp }}
+{% endfor %}

--- a/src/test/resources/eager/keeps-scope-isolation-from-for-loops.expected.jinja
+++ b/src/test/resources/eager/keeps-scope-isolation-from-for-loops.expected.jinja
@@ -1,0 +1,15 @@
+{% for i in range(deferred) %}
+{% set foo = 'a' ~ i %}
+{% for j in range(deferred) %}
+{% set foo = 'b' ~ j %}
+{% for __ignored__ in [0] %}
+{% set foo = 'c0' %}
+c0
+
+{% set foo = 'c1' %}
+c1
+{% endfor %}
+{{ foo }}
+{% endfor %}
+{{ foo }}
+{% endfor %}

--- a/src/test/resources/eager/keeps-scope-isolation-from-for-loops.jinja
+++ b/src/test/resources/eager/keeps-scope-isolation-from-for-loops.jinja
@@ -1,0 +1,12 @@
+{% for i in range(deferred) %}
+{% set foo = 'a' ~ i %}
+{% for j in range(deferred) %}
+{% set foo = 'b' ~ j %}
+{% for k in range(2) %}
+{% set foo = 'c' ~ k %}
+{{ foo }}
+{% endfor %}
+{{ foo }}
+{% endfor %}
+{{ foo }}
+{% endfor %}

--- a/src/test/resources/eager/reverts-simple.expected.jinja
+++ b/src/test/resources/eager/reverts-simple.expected.jinja
@@ -1,7 +1,14 @@
-{% set my_list = [0, 1] %}{% if deferred %}
+{% for __ignored__ in [0] %}
+
+
+
+
+
+  {% set my_list = [0, 1] %}{% if deferred %}
     {% set my_list = [0, 1, 2] %}
   {% endif %}
   {% do my_list.append(3) %}
 
 {% do my_list.append(4) %}
 {{ my_list }}
+{% endfor %}

--- a/src/test/resources/eager/reverts-simple.expected.jinja
+++ b/src/test/resources/eager/reverts-simple.expected.jinja
@@ -1,9 +1,4 @@
 {% for __ignored__ in [0] %}
-
-
-
-
-
   {% set my_list = [0, 1] %}{% if deferred %}
     {% set my_list = [0, 1, 2] %}
   {% endif %}

--- a/src/test/resources/eager/reverts-simple.jinja
+++ b/src/test/resources/eager/reverts-simple.jinja
@@ -1,10 +1,10 @@
 {% set foo = 1 %}
-{% for i in range(1) %}
-{% set foo = null %}
-{% set my_list = [] %}
-{% do my_list.append(0) %}
-{% if 5 < 6 %}
-  {% do my_list.append(1) %}
+{%- for i in range(1) %}
+{%- set foo = null %}
+{%- set my_list = [] %}
+{%- do my_list.append(0) %}
+{%- if 5 < 6 %}
+  {%- do my_list.append(1) %}
   {% if deferred %}
     {% do my_list.append(2) %}
   {% endif %}

--- a/src/test/resources/tags/eager/fortag/handles-nested-deferred-for-loop.expected.jinja
+++ b/src/test/resources/tags/eager/fortag/handles-nested-deferred-for-loop.expected.jinja
@@ -1,3 +1,4 @@
+{% for __ignored__ in [0] %}
 {% for bar in deferred %}
 pastrami sandwich. {{ bar }}!
 {% endfor %}
@@ -8,4 +9,5 @@ pastrami salad. {{ bar }}!
 
 {% for bar in deferred %}
 pastrami smoothie. {{ bar }}!
+{% endfor %}
 {% endfor %}


### PR DESCRIPTION
When a for loop is able to get evaluated but has some unevaluted expressions inside of it, then it should wrap those expressions in a child scope so that values outside the original for loop cannot get overridden from a `{% set %}` tag.

