### PR TITLE
Don't swallow exceptions thrown from executeInChildContext

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -40,20 +40,20 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
 
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
+    Set<DeferredToken> addedTokens = new HashSet<>();
+    EagerExecutionResult result = EagerReconstructionUtils.executeInChildContext(
+      eagerInterpreter -> {
+        EagerExpressionResult expressionResult = EagerExpressionResult.fromSupplier(
+          () -> getTag().interpretUnchecked(tagNode, eagerInterpreter),
+          eagerInterpreter
+        );
+        addedTokens.addAll(eagerInterpreter.getContext().getDeferredTokens());
+        return expressionResult;
+      },
+      interpreter,
+      EagerChildContextConfig.newBuilder().withCheckForContextChanges(true).build()
+    );
     try {
-      Set<DeferredToken> addedTokens = new HashSet<>();
-      EagerExecutionResult result = EagerReconstructionUtils.executeInChildContext(
-        eagerInterpreter -> {
-          EagerExpressionResult expressionResult = EagerExpressionResult.fromSupplier(
-            () -> getTag().interpretUnchecked(tagNode, eagerInterpreter),
-            eagerInterpreter
-          );
-          addedTokens.addAll(eagerInterpreter.getContext().getDeferredTokens());
-          return expressionResult;
-        },
-        interpreter,
-        EagerChildContextConfig.newBuilder().withCheckForContextChanges(true).build()
-      );
       if (
         result.getResult().getResolutionState() == ResolutionState.NONE ||
         (

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.in;
 
 import com.google.common.collect.ImmutableList;
 import com.hubspot.jinjava.ExpectedNodeInterpreter;
@@ -193,5 +194,28 @@ public class EagerForTagTest extends ForTagTest {
         "1\n" +
         "2"
       );
+  }
+
+  @Test
+  public void itDoesNotSwallowDeferredValueException() {
+    interpreter.getContext().registerTag(new EagerDoTag());
+    interpreter.getContext().registerTag(new EagerIfTag());
+    interpreter.getContext().registerTag(new EagerSetTag());
+
+    String input =
+      "{% set my_list = [] %}" +
+      "{% for i in range(30) %}" +
+      "{{ my_list.append(i) }}" +
+      "{% endfor %}" +
+      "{% for i in [0, 1] %}" +
+      "{% for j in deferred %}" +
+      "{% if loop.first %}" +
+      "{% do my_list.append(1) %}" +
+      "{% endif %}" +
+      "{% endfor %}" +
+      "{% endfor %}" +
+      "{{ my_list }}";
+    interpreter.render(input);
+    assertThat(interpreter.getContext().getDeferredNodes()).isNotEmpty();
   }
 }


### PR DESCRIPTION
We should not have this call inside of the try-catch because it will swallow the deferred value exception that gets thrown when a value cannot be mapped to its previous value through context reverting.