### PR TITLE
Return long value when under min int value from IntFilter

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/IntFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IntFilter.java
@@ -74,7 +74,7 @@ public class IntFilter implements Filter {
   }
 
   private Object convertResult(Long result) {
-    if (result > Integer.MAX_VALUE) {
+    if (result < Integer.MIN_VALUE || result > Integer.MAX_VALUE) {
       return result;
     }
     return result.intValue();

--- a/src/test/java/com/hubspot/jinjava/lib/filter/IntFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/IntFilterTest.java
@@ -125,6 +125,11 @@ public class IntFilterTest extends BaseInterpretingTest {
   }
 
   @Test
+  public void itUsesLongsForVerySmallValues() {
+    assertThat(filter.filter("-42595200000", interpreter)).isEqualTo(-42595200000L);
+  }
+
+  @Test
   public void itConvertsProperlyInExpressionTest() {
     assertThat(interpreter.render("{{ '3'|int in [null, 4, 5, 6, null, 3] }}"))
       .isEqualTo("true");


### PR DESCRIPTION
Returning long values when over `Integer.MAX_VALUE` was added in this pr:
https://github.com/HubSpot/jinjava/pull/315

This pr also makes sure this also happens when we underflow.