### PR TITLE
Upgrade jackson and serailize with single quote char

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,6 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <!--Using 2.12.6 instead of 2.13 https://github.com/FasterXML/jackson-databind/issues/3380#issuecomment-1018129505-->
         <version>2.12.6</version>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,27 @@
         <artifactId>java-ipv6</artifactId>
         <version>0.17</version>
       </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <!--Using 2.12.6 instead of 2.13 https://github.com/FasterXML/jackson-databind/issues/3380#issuecomment-1018129505-->
+        <version>2.12.6</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.12.6</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>2.12.6</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-yaml</artifactId>
+        <version>2.12.6</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -227,6 +248,16 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.basepom.maven</groupId>
+        <artifactId>duplicate-finder-maven-plugin</artifactId>
+        <configuration combine.children="append">
+          <ignoredClassPatterns>
+            <ignoredClassPattern>module-info</ignoredClassPattern>
+            <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
+          </ignoredClassPatterns>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.objects.date;
 
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.objects.PyWrapper;
+import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.objects.serialization.PyishSerializable;
 import java.io.Serializable;
 import java.time.Instant;
@@ -149,9 +150,9 @@ public final class PyishDate
   @Override
   public String toPyishString() {
     return String.format(
-      "\"%s\"|strtotime(\"%s\")",
+      "'%s'|strtotime(%s)",
       strftime(FULL_DATE_FORMAT),
-      FULL_DATE_FORMAT
+      PyishObjectMapper.getAsPyishString(FULL_DATE_FORMAT)
     );
   }
 }

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishCharacterEscapes.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishCharacterEscapes.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.objects.serialization;
 
 import com.fasterxml.jackson.core.SerializableString;
 import com.fasterxml.jackson.core.io.CharacterEscapes;
+import com.fasterxml.jackson.core.io.SerializedString;
 import java.util.Arrays;
 
 public class PyishCharacterEscapes extends CharacterEscapes {
@@ -11,9 +12,11 @@ public class PyishCharacterEscapes extends CharacterEscapes {
   private PyishCharacterEscapes() {
     int[] escapes = CharacterEscapes.standardAsciiEscapesForJSON();
     escapes['\n'] = CharacterEscapes.ESCAPE_NONE;
+    escapes['"'] = CharacterEscapes.ESCAPE_NONE;
     escapes['\t'] = CharacterEscapes.ESCAPE_NONE;
     escapes['\r'] = CharacterEscapes.ESCAPE_NONE;
     escapes['\f'] = CharacterEscapes.ESCAPE_NONE;
+    escapes['\''] = CharacterEscapes.ESCAPE_CUSTOM;
     asciiEscapes = escapes;
   }
 
@@ -23,7 +26,10 @@ public class PyishCharacterEscapes extends CharacterEscapes {
   }
 
   @Override
-  public SerializableString getEscapeSequence(int i) {
+  public SerializableString getEscapeSequence(int ch) {
+    if (ch == '\'') {
+      return new SerializedString("\\'");
+    }
     return null;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.objects.serialization;
 
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -7,7 +8,9 @@ import com.hubspot.jinjava.objects.PyWrapper;
 import java.util.Objects;
 
 public interface PyishSerializable extends PyWrapper {
-  ObjectWriter SELF_WRITER = new ObjectMapper()
+  ObjectWriter SELF_WRITER = new ObjectMapper(
+    new JsonFactoryBuilder().quoteChar('\'').build()
+  )
     .writer(PyishPrettyPrinter.INSTANCE)
     .with(PyishCharacterEscapes.INSTANCE);
   /**
@@ -31,7 +34,7 @@ public interface PyishSerializable extends PyWrapper {
     try {
       return SELF_WRITER.writeValueAsString(value);
     } catch (JsonProcessingException e) {
-      return '"' + Objects.toString(value) + '"';
+      return '\'' + Objects.toString(value) + '\'';
     }
   }
 }

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -122,7 +122,8 @@ public class EagerReconstructionUtils {
             .stream()
             .filter(entry -> initiallyResolvedHashes.containsKey(entry.getKey()))
             .filter(
-              entry -> EagerExpressionResolver.isResolvableObject(entry.getValue(), 2, 20) // TODO make this configurable
+              entry ->
+                EagerExpressionResolver.isResolvableObject(entry.getValue(), 4, 400) // TODO make this configurable
             );
       } else {
         entryStream =
@@ -132,7 +133,8 @@ public class EagerReconstructionUtils {
             .stream()
             .filter(entry -> initiallyResolvedHashes.containsKey(entry.getKey()))
             .filter(
-              entry -> EagerExpressionResolver.isResolvableObject(entry.getValue(), 2, 20) // TODO make this configurable
+              entry ->
+                EagerExpressionResolver.isResolvableObject(entry.getValue(), 4, 400) // TODO make this configurable
             );
       }
       entryStream.forEach(

--- a/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
@@ -310,7 +310,18 @@ public class EagerExpressionResolverTest {
     EagerExpressionResult eagerExpressionResult = eagerResolveExpression("date");
 
     assertThat(WhitespaceUtils.unquoteAndUnescape(eagerExpressionResult.toString()))
-      .isEqualTo(date.toPyishString().replace("'", "\\'").replace('"', '\''));
+      .isEqualTo(date.toPyishString());
+    interpreter.render(
+      "{% set foo = " +
+      PyishObjectMapper.getAsPyishString(ImmutableMap.of("a", date)) +
+      " %}"
+    );
+    assertThat(
+        (
+          (PyishDate) ((Map<String, Object>) interpreter.getContext().get("foo")).get("a")
+        ).toDateTime()
+      )
+      .isEqualTo(date.toDateTime());
   }
 
   @Test


### PR DESCRIPTION
Speed up serialization by not needing to do a regex replace on double quotes. Instead in jackson 2.10, they introduced the ability to specify the quote character. If we set the quote character to be a single quote rather than a double quote, then we don't have to use regex to replace the double quotes later.