### PR TITLE
Throw warning when intersection Set elements have mismatched types

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/AbstractSetFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AbstractSetFilter.java
@@ -78,7 +78,7 @@ public abstract class AbstractSetFilter implements AdvancedFilter {
         ),
         "list",
         interpreter.getLineNumber(),
-        -1,
+        interpreter.getPosition(),
         null
       )
     );

--- a/src/main/java/com/hubspot/jinjava/lib/filter/AbstractSetFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AbstractSetFilter.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.lib.filter;
 
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
+import com.hubspot.jinjava.lib.fn.TypeFunction;
 import com.hubspot.jinjava.util.ForLoop;
 import com.hubspot.jinjava.util.ObjectIterator;
 import java.util.LinkedHashSet;
@@ -28,5 +29,12 @@ public abstract class AbstractSetFilter implements AdvancedFilter {
       result.add(loop.next());
     }
     return result;
+  }
+
+  protected String getTypeOfSetElements(Set<Object> set) {
+    if (set.isEmpty()) {
+      return "null";
+    }
+    return TypeFunction.type(set.iterator().next());
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/AbstractSetFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AbstractSetFilter.java
@@ -85,9 +85,6 @@ public abstract class AbstractSetFilter implements AdvancedFilter {
   }
 
   private String getTypeOfSetElements(Set<Object> set) {
-    if (set.isEmpty()) {
-      return "null";
-    }
     return TypeFunction.type(set.iterator().next());
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/AbstractSetFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AbstractSetFilter.java
@@ -7,6 +7,7 @@ import com.hubspot.jinjava.lib.fn.TypeFunction;
 import com.hubspot.jinjava.util.ForLoop;
 import com.hubspot.jinjava.util.ObjectIterator;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 
 public abstract class AbstractSetFilter implements AdvancedFilter {
@@ -31,6 +32,23 @@ public abstract class AbstractSetFilter implements AdvancedFilter {
     }
     return result;
   }
+
+  @Override
+  public Object filter(
+    Object var,
+    JinjavaInterpreter interpreter,
+    Object[] args,
+    Map<String, Object> kwargs
+  ) {
+    Set<Object> varSet = objectToSet(var);
+    Set<Object> argSet = objectToSet(parseArgs(interpreter, args));
+
+    attachMismatchedTypesWarning(interpreter, varSet, argSet);
+
+    return filter(varSet, argSet);
+  }
+
+  public abstract Object filter(Set<Object> varSet, Set<Object> argSet);
 
   protected void attachMismatchedTypesWarning(
     JinjavaInterpreter interpreter,

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DifferenceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DifferenceFilter.java
@@ -4,9 +4,7 @@ import com.google.common.collect.Sets;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.util.ArrayList;
-import java.util.Map;
 import java.util.Set;
 
 @JinjavaDoc(
@@ -30,17 +28,7 @@ import java.util.Set;
 public class DifferenceFilter extends AbstractSetFilter {
 
   @Override
-  public Object filter(
-    Object var,
-    JinjavaInterpreter interpreter,
-    Object[] args,
-    Map<String, Object> kwargs
-  ) {
-    Set<Object> varSet = objectToSet(var);
-    Set<Object> argSet = objectToSet(parseArgs(interpreter, args));
-
-    attachMismatchedTypesWarning(interpreter, varSet, argSet);
-
+  public Object filter(Set<Object> varSet, Set<Object> argSet) {
     return new ArrayList<>(Sets.difference(varSet, argSet));
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DifferenceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DifferenceFilter.java
@@ -7,6 +7,7 @@ import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.Set;
 
 @JinjavaDoc(
   value = "Returns a list containing elements present in the first list but not the second list",
@@ -35,9 +36,12 @@ public class DifferenceFilter extends AbstractSetFilter {
     Object[] args,
     Map<String, Object> kwargs
   ) {
-    return new ArrayList<>(
-      Sets.difference(objectToSet(var), objectToSet(parseArgs(interpreter, args)))
-    );
+    Set<Object> varSet = objectToSet(var);
+    Set<Object> argSet = objectToSet(parseArgs(interpreter, args));
+
+    attachMismatchedTypesWarning(interpreter, varSet, argSet);
+
+    return new ArrayList<>(Sets.difference(varSet, argSet));
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/IntersectFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IntersectFilter.java
@@ -4,9 +4,7 @@ import com.google.common.collect.Sets;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.util.ArrayList;
-import java.util.Map;
 import java.util.Set;
 
 @JinjavaDoc(
@@ -30,19 +28,7 @@ import java.util.Set;
 public class IntersectFilter extends AbstractSetFilter {
 
   @Override
-  public Object filter(
-    Object var,
-    JinjavaInterpreter interpreter,
-    Object[] args,
-    Map<String, Object> kwargs
-  ) {
-    Object argObj = parseArgs(interpreter, args);
-
-    Set<Object> varSet = objectToSet(var);
-    Set<Object> argSet = objectToSet(argObj);
-
-    attachMismatchedTypesWarning(interpreter, varSet, argSet);
-
+  public Object filter(Set<Object> varSet, Set<Object> argSet) {
     return new ArrayList<>(Sets.intersection(varSet, argSet));
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/IntersectFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IntersectFilter.java
@@ -6,7 +6,6 @@ import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateError;
-import com.hubspot.jinjava.lib.fn.TypeFunction;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
@@ -67,13 +66,6 @@ public class IntersectFilter extends AbstractSetFilter {
     }
 
     return new ArrayList<>(Sets.intersection(varSet, argSet));
-  }
-
-  private String getTypeOfSetElements(Set<Object> set) {
-    if (set.isEmpty()) {
-      return "null";
-    }
-    return TypeFunction.type(set.iterator().next());
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/IntersectFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IntersectFilter.java
@@ -7,10 +7,7 @@ import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.lib.fn.TypeFunction;
-import com.hubspot.jinjava.objects.collections.SizeLimitingPyList;
-import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/IntersectFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IntersectFilter.java
@@ -5,7 +5,6 @@ import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.interpret.TemplateError;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
@@ -42,28 +41,7 @@ public class IntersectFilter extends AbstractSetFilter {
     Set<Object> varSet = objectToSet(var);
     Set<Object> argSet = objectToSet(argObj);
 
-    boolean isAtLeastOneSetEmpty = varSet.isEmpty() || argSet.isEmpty();
-    boolean areMismatchedElementTypes = !getTypeOfSetElements(varSet)
-      .equals(getTypeOfSetElements(argSet));
-
-    if (areMismatchedElementTypes && !isAtLeastOneSetEmpty) {
-      interpreter.addError(
-        new TemplateError(
-          TemplateError.ErrorType.WARNING,
-          TemplateError.ErrorReason.OTHER,
-          TemplateError.ErrorItem.FILTER,
-          String.format(
-            "Mismatched Types: input set has elements of type '%s' but arg set has elements of type '%s'. Use |map filter to convert sets to the same type for filter to work correctly.",
-            getTypeOfSetElements(varSet),
-            getTypeOfSetElements(argSet)
-          ),
-          "list",
-          interpreter.getLineNumber(),
-          -1,
-          null
-        )
-      );
-    }
+    attachMismatchedTypesWarning(interpreter, varSet, argSet);
 
     return new ArrayList<>(Sets.intersection(varSet, argSet));
   }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/IntersectFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IntersectFilter.java
@@ -43,17 +43,18 @@ public class IntersectFilter extends AbstractSetFilter {
     Set<Object> varSet = objectToSet(var);
     Set<Object> argSet = objectToSet(argObj);
 
+    boolean isAtLeastOneSetEmpty = varSet.isEmpty() || argSet.isEmpty();
     boolean areMismatchedElementTypes = !getTypeOfSetElements(varSet)
       .equals(getTypeOfSetElements(argSet));
 
-    if (areMismatchedElementTypes) {
+    if (areMismatchedElementTypes && !isAtLeastOneSetEmpty) {
       interpreter.addError(
         new TemplateError(
           TemplateError.ErrorType.WARNING,
           TemplateError.ErrorReason.OTHER,
           TemplateError.ErrorItem.FILTER,
           String.format(
-            "Mismatched types. `value` elements are of type `%s` and `list` elements are of type `%s`. This may lead to unexpected behavior.",
+            "Mismatched Types: input set has elements of type '%s' but arg set has elements of type '%s'. Use |map filter to convert sets to the same type for filter to work correctly.",
             getTypeOfSetElements(varSet),
             getTypeOfSetElements(argSet)
           ),

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SymmetricDifferenceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SymmetricDifferenceFilter.java
@@ -4,9 +4,7 @@ import com.google.common.collect.Sets;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.util.ArrayList;
-import java.util.Map;
 import java.util.Set;
 
 @JinjavaDoc(
@@ -30,17 +28,7 @@ import java.util.Set;
 public class SymmetricDifferenceFilter extends AbstractSetFilter {
 
   @Override
-  public Object filter(
-    Object var,
-    JinjavaInterpreter interpreter,
-    Object[] args,
-    Map<String, Object> kwargs
-  ) {
-    Set<Object> varSet = objectToSet(var);
-    Set<Object> argSet = objectToSet(parseArgs(interpreter, args));
-
-    attachMismatchedTypesWarning(interpreter, varSet, argSet);
-
+  public Object filter(Set<Object> varSet, Set<Object> argSet) {
     return new ArrayList<>(Sets.symmetricDifference(varSet, argSet));
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SymmetricDifferenceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SymmetricDifferenceFilter.java
@@ -7,6 +7,7 @@ import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.Set;
 
 @JinjavaDoc(
   value = "Returns a list containing elements present in only one list.",
@@ -35,12 +36,12 @@ public class SymmetricDifferenceFilter extends AbstractSetFilter {
     Object[] args,
     Map<String, Object> kwargs
   ) {
-    return new ArrayList<>(
-      Sets.symmetricDifference(
-        objectToSet(var),
-        objectToSet(parseArgs(interpreter, args))
-      )
-    );
+    Set<Object> varSet = objectToSet(var);
+    Set<Object> argSet = objectToSet(parseArgs(interpreter, args));
+
+    attachMismatchedTypesWarning(interpreter, varSet, argSet);
+
+    return new ArrayList<>(Sets.symmetricDifference(varSet, argSet));
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UnionFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UnionFilter.java
@@ -4,9 +4,7 @@ import com.google.common.collect.Sets;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.util.ArrayList;
-import java.util.Map;
 import java.util.Set;
 
 @JinjavaDoc(
@@ -30,17 +28,7 @@ import java.util.Set;
 public class UnionFilter extends AbstractSetFilter {
 
   @Override
-  public Object filter(
-    Object var,
-    JinjavaInterpreter interpreter,
-    Object[] args,
-    Map<String, Object> kwargs
-  ) {
-    Set<Object> varSet = objectToSet(var);
-    Set<Object> argSet = objectToSet(parseArgs(interpreter, args));
-
-    attachMismatchedTypesWarning(interpreter, varSet, argSet);
-
+  public Object filter(Set<Object> varSet, Set<Object> argSet) {
     return new ArrayList<>(Sets.union(varSet, argSet));
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UnionFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UnionFilter.java
@@ -7,6 +7,7 @@ import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.Set;
 
 @JinjavaDoc(
   value = "Returns a list containing elements present in either list",
@@ -35,9 +36,12 @@ public class UnionFilter extends AbstractSetFilter {
     Object[] args,
     Map<String, Object> kwargs
   ) {
-    return new ArrayList<>(
-      Sets.union(objectToSet(var), objectToSet(parseArgs(interpreter, args)))
-    );
+    Set<Object> varSet = objectToSet(var);
+    Set<Object> argSet = objectToSet(parseArgs(interpreter, args));
+
+    attachMismatchedTypesWarning(interpreter, varSet, argSet);
+
+    return new ArrayList<>(Sets.union(varSet, argSet));
   }
 
   @Override

--- a/src/test/java/com/hubspot/jinjava/lib/filter/AbstractSetFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/AbstractSetFilterTest.java
@@ -1,0 +1,82 @@
+package com.hubspot.jinjava.lib.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hubspot.jinjava.BaseJinjavaTest;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateError;
+import java.util.List;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AbstractSetFilterTest extends BaseJinjavaTest {
+  private static final IntersectFilter concreteSetFilter = new IntersectFilter();
+
+  @Before
+  public void setup() {
+    jinjava.getGlobalContext().registerClasses(EscapeJsFilter.class);
+  }
+
+  @Test
+  public void itDoesNotThrowWarningOnMatchedTypes() {
+    JinjavaInterpreter interpreter = jinjava.newInterpreter();
+
+    // {{ [1, 2, 3]|intersect([1, 2, 3]) }}
+    Set<Object> varSet = concreteSetFilter.objectToSet(new Long[] { 1L, 2L, 3L });
+    Set<Object> argSet = concreteSetFilter.objectToSet(new Long[] { 1L, 2L, 3L });
+    concreteSetFilter.attachMismatchedTypesWarning(interpreter, varSet, argSet);
+
+    List<TemplateError> errors = interpreter.getErrors();
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
+  public void itDoesNotThrowWarningOnEmptyVarSet() {
+    JinjavaInterpreter interpreter = jinjava.newInterpreter();
+
+    String renderedOutput = interpreter.render("{{ []|intersect([1, 2, 3]) }}");
+    assertThat(renderedOutput).isEqualTo("[]");
+
+    // {{ []|intersect([1, 2, 3]) }}
+    Set<Object> varSet = concreteSetFilter.objectToSet(new Object[] {});
+    Set<Object> argSet = concreteSetFilter.objectToSet(new Long[] { 1L, 2L, 3L });
+    concreteSetFilter.attachMismatchedTypesWarning(interpreter, varSet, argSet);
+
+    List<TemplateError> errors = interpreter.getErrors();
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
+  public void itDoesNotThrowWarningOnEmptyArgSet() {
+    JinjavaInterpreter interpreter = jinjava.newInterpreter();
+
+    // {{ [1, 2, 3]|intersect([]) }}
+    Set<Object> varSet = concreteSetFilter.objectToSet(new Long[] { 1L, 2L, 3L });
+    Set<Object> argSet = concreteSetFilter.objectToSet(new Object[] {});
+    concreteSetFilter.attachMismatchedTypesWarning(interpreter, varSet, argSet);
+
+    List<TemplateError> errors = interpreter.getErrors();
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
+  public void itThrowsWarningOnMismatchTypes() {
+    JinjavaInterpreter interpreter = jinjava.newInterpreter();
+
+    // {{ [1, 2, 3]|intersect(['1', '2', '3']) }}
+    Set<Object> varSet = concreteSetFilter.objectToSet(new Long[] { 1L, 2L, 3L });
+    Set<Object> argSet = concreteSetFilter.objectToSet(new String[] { "1", "2", "3" });
+    concreteSetFilter.attachMismatchedTypesWarning(interpreter, varSet, argSet);
+
+    List<TemplateError> errors = interpreter.getErrors();
+    assertThat(errors).isNotEmpty();
+
+    TemplateError error = errors.get(0);
+    assertThat(error.getSeverity()).isEqualTo(TemplateError.ErrorType.WARNING);
+    assertThat(error.getMessage())
+      .isEqualTo(
+        "Mismatched Types: input set has elements of type 'long' but arg set has elements of type 'str'. Use |map filter to convert sets to the same type for filter to work correctly."
+      );
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/lib/filter/IntersectFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/IntersectFilterTest.java
@@ -3,7 +3,10 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hubspot.jinjava.BaseJinjavaTest;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateError;
 import java.util.HashMap;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -30,5 +33,25 @@ public class IntersectFilterTest extends BaseJinjavaTest {
   public void itReturnsEmptyOnNullParameters() {
     assertThat(jinjava.render("{{ [1, 2, 3]|intersect(null) }}", new HashMap<>()))
       .isEqualTo("[]");
+  }
+
+  @Test
+  public void itThrowsWarningOnMismatchTypes() {
+    JinjavaInterpreter interpreter = jinjava.newInterpreter();
+
+    String renderedOutput = interpreter.render(
+      "{{ [1, 2, 3]|intersect(['1', '2', '3']) }}"
+    );
+    assertThat(renderedOutput).isEqualTo("[]");
+
+    List<TemplateError> errors = interpreter.getErrors();
+    assertThat(errors).isNotEmpty();
+
+    TemplateError error = errors.get(0);
+    assertThat(error.getSeverity()).isEqualTo(TemplateError.ErrorType.WARNING);
+    assertThat(error.getMessage())
+      .isEqualTo(
+        "Mismatched types. `value` elements are of type `long` and `list` elements are of type `str`. This may lead to unexpected behavior."
+      );
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/IntersectFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/IntersectFilterTest.java
@@ -3,10 +3,7 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hubspot.jinjava.BaseJinjavaTest;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.interpret.TemplateError;
 import java.util.HashMap;
-import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,58 +30,5 @@ public class IntersectFilterTest extends BaseJinjavaTest {
   public void itReturnsEmptyOnNullParameters() {
     assertThat(jinjava.render("{{ [1, 2, 3]|intersect(null) }}", new HashMap<>()))
       .isEqualTo("[]");
-  }
-
-  @Test
-  public void itDoesNotThrowWarningOnMatchedTypes() {
-    JinjavaInterpreter interpreter = jinjava.newInterpreter();
-
-    String renderedOutput = interpreter.render("{{ [1, 2, 3]|intersect([1, 2, 3]) }}");
-    assertThat(renderedOutput).isEqualTo("[1, 2, 3]");
-
-    List<TemplateError> errors = interpreter.getErrors();
-    assertThat(errors).isEmpty();
-  }
-
-  @Test
-  public void itDoesNotThrowWarningOnEmptyVarSet() {
-    JinjavaInterpreter interpreter = jinjava.newInterpreter();
-
-    String renderedOutput = interpreter.render("{{ []|intersect([1, 2, 3]) }}");
-    assertThat(renderedOutput).isEqualTo("[]");
-
-    List<TemplateError> errors = interpreter.getErrors();
-    assertThat(errors).isEmpty();
-  }
-
-  @Test
-  public void itDoesNotThrowWarningOnEmptyArgSet() {
-    JinjavaInterpreter interpreter = jinjava.newInterpreter();
-
-    String renderedOutput = interpreter.render("{{ [1, 2, 3]|intersect([]) }}");
-    assertThat(renderedOutput).isEqualTo("[]");
-
-    List<TemplateError> errors = interpreter.getErrors();
-    assertThat(errors).isEmpty();
-  }
-
-  @Test
-  public void itThrowsWarningOnMismatchTypes() {
-    JinjavaInterpreter interpreter = jinjava.newInterpreter();
-
-    String renderedOutput = interpreter.render(
-      "{{ [1, 2, 3]|intersect(['1', '2', '3']) }}"
-    );
-    assertThat(renderedOutput).isEqualTo("[]");
-
-    List<TemplateError> errors = interpreter.getErrors();
-    assertThat(errors).isNotEmpty();
-
-    TemplateError error = errors.get(0);
-    assertThat(error.getSeverity()).isEqualTo(TemplateError.ErrorType.WARNING);
-    assertThat(error.getMessage())
-      .isEqualTo(
-        "Mismatched Types: input set has elements of type 'long' but arg set has elements of type 'str'. Use |map filter to convert sets to the same type for filter to work correctly."
-      );
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/IntersectFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/IntersectFilterTest.java
@@ -36,6 +36,17 @@ public class IntersectFilterTest extends BaseJinjavaTest {
   }
 
   @Test
+  public void itDoesNotThrowWarningOnMatchedTypes() {
+    JinjavaInterpreter interpreter = jinjava.newInterpreter();
+
+    String renderedOutput = interpreter.render("{{ [1, 2, 3]|intersect([1, 2, 3]) }}");
+    assertThat(renderedOutput).isEqualTo("[1, 2, 3]");
+
+    List<TemplateError> errors = interpreter.getErrors();
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
   public void itThrowsWarningOnMismatchTypes() {
     JinjavaInterpreter interpreter = jinjava.newInterpreter();
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/IntersectFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/IntersectFilterTest.java
@@ -47,6 +47,28 @@ public class IntersectFilterTest extends BaseJinjavaTest {
   }
 
   @Test
+  public void itDoesNotThrowWarningOnEmptyVarSet() {
+    JinjavaInterpreter interpreter = jinjava.newInterpreter();
+
+    String renderedOutput = interpreter.render("{{ []|intersect([1, 2, 3]) }}");
+    assertThat(renderedOutput).isEqualTo("[]");
+
+    List<TemplateError> errors = interpreter.getErrors();
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
+  public void itDoesNotThrowWarningOnEmptyArgSet() {
+    JinjavaInterpreter interpreter = jinjava.newInterpreter();
+
+    String renderedOutput = interpreter.render("{{ [1, 2, 3]|intersect([]) }}");
+    assertThat(renderedOutput).isEqualTo("[]");
+
+    List<TemplateError> errors = interpreter.getErrors();
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
   public void itThrowsWarningOnMismatchTypes() {
     JinjavaInterpreter interpreter = jinjava.newInterpreter();
 
@@ -62,7 +84,7 @@ public class IntersectFilterTest extends BaseJinjavaTest {
     assertThat(error.getSeverity()).isEqualTo(TemplateError.ErrorType.WARNING);
     assertThat(error.getMessage())
       .isEqualTo(
-        "Mismatched types. `value` elements are of type `long` and `list` elements are of type `str`. This may lead to unexpected behavior."
+        "Mismatched Types: input set has elements of type 'long' but arg set has elements of type 'str'. Use |map filter to convert sets to the same type for filter to work correctly."
       );
   }
 }


### PR DESCRIPTION
### Problem
While the `type()` function helps give developers visibility of the types of jinjava variables, sometimes developers infer the types of objects by printing them in an expression eg. `{{ some variable }}`.

This can cause some confusion when variables are evaluated to Strings.

For example, within HubL, `{{ content.topic_list }}` is evaluated to a list of strings, but are actually a list of objects.

### Solution
Throw a Warning to inform a developer that the two Sets being intersected have elements of different type to improve DX.

