### PR TITLE
Clean up formatter methods

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
@@ -113,10 +113,6 @@ public class StrftimeFormatter {
     return result.toString();
   }
 
-  public static DateTimeFormatter formatter(String strftime) {
-    return formatter(strftime, Locale.ENGLISH);
-  }
-
   private static DateTimeFormatter formatter(String strftime, Locale locale) {
     DateTimeFormatter fmt;
 

--- a/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
@@ -117,7 +117,7 @@ public class StrftimeFormatter {
     return formatter(strftime, Locale.ENGLISH);
   }
 
-  public static DateTimeFormatter formatter(String strftime, Locale locale) {
+  private static DateTimeFormatter formatter(String strftime, Locale locale) {
     DateTimeFormatter fmt;
 
     if (strftime == null) {

--- a/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
@@ -92,12 +92,7 @@ public class StrftimeFormatterTest {
 
   @Test
   public void testFinnishMonths() {
-    assertThat(
-        StrftimeFormatter
-          .formatter("long")
-          .withLocale(Locale.forLanguageTag("fi"))
-          .format(d)
-      )
+    assertThat(StrftimeFormatter.format(d, "long", Locale.forLanguageTag("fi")))
       .startsWith("6. marraskuuta 2013 klo 14.22.00");
   }
 
@@ -118,10 +113,7 @@ public class StrftimeFormatterTest {
     ZonedDateTime zonedDateTime = ZonedDateTime.parse("2019-06-06T14:22:00.000+00:00");
 
     assertThat(
-        StrftimeFormatter
-          .formatter("%OB")
-          .withLocale(Locale.forLanguageTag("ru"))
-          .format(zonedDateTime)
+        StrftimeFormatter.format(zonedDateTime, "%OB", Locale.forLanguageTag("ru"))
       )
       .isIn("Июнь", "июнь");
   }


### PR DESCRIPTION
Depends on #917 

I'm looking to make some logic changes to the `datetimeformat` filter.

This PR simplifies the public interface of `StrftimeFormatter` by removing or reducing the visibility of the `formatter` overloads.