### PR TITLE
Store temporary macro function result vars

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
@@ -6,6 +6,7 @@ import com.hubspot.jinjava.el.ext.ExtendedParser;
 import com.hubspot.jinjava.interpret.Context.TemporaryValueClosable;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.lib.fn.MacroFunction;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstParameters;
 import java.lang.reflect.Array;
@@ -147,6 +148,12 @@ public class EagerAstMacroFunction extends AstMacroFunction implements EvalResul
     DeferredParsingException deferredParsingException,
     boolean preserveIdentifier
   ) {
+    if (
+      deferredParsingException != null &&
+      deferredParsingException.getSourceNode() instanceof MacroFunction
+    ) {
+      return deferredParsingException.getDeferredEvalResult();
+    }
     StringBuilder sb = new StringBuilder();
     sb.append(getName());
     try {

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/MacroFunctionTempVariable.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/MacroFunctionTempVariable.java
@@ -1,0 +1,39 @@
+package com.hubspot.jinjava.el.ext.eager;
+
+import com.hubspot.jinjava.objects.serialization.PyishBlockSetSerializable;
+import java.util.Objects;
+
+public class MacroFunctionTempVariable implements PyishBlockSetSerializable {
+  private static final String CONTEXT_KEY_PREFIX = "__macro_%s_temp_variable_%d__";
+  private final String deferredResult;
+
+  public MacroFunctionTempVariable(String deferredResult) {
+    this.deferredResult = deferredResult;
+  }
+
+  public static String getVarName(String macroFunctionName, int callCount) {
+    return String.format(CONTEXT_KEY_PREFIX, macroFunctionName, callCount);
+  }
+
+  @Override
+  public String getBlockSetBody() {
+    return deferredResult;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MacroFunctionTempVariable that = (MacroFunctionTempVariable) o;
+    return deferredResult.equals(that.deferredResult);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(deferredResult);
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishBlockSetSerializable.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishBlockSetSerializable.java
@@ -1,0 +1,5 @@
+package com.hubspot.jinjava.objects.serialization;
+
+public interface PyishBlockSetSerializable {
+  String getBlockSetBody();
+}

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -366,25 +366,26 @@ public class EagerReconstructionUtils {
     Set<String> deferredWords,
     JinjavaInterpreter interpreter
   ) {
+    Set<String> filteredDeferredWords = deferredWords;
     if (interpreter.getContext().isDeferredExecutionMode()) {
       Context parent = interpreter.getContext().getParent();
       while (parent.isDeferredExecutionMode()) {
         parent = parent.getParent();
       }
       final Context finalParent = parent;
-      deferredWords =
+      filteredDeferredWords =
         deferredWords
           .stream()
           .filter(word -> interpreter.getContext().get(word) != finalParent.get(word))
           .collect(Collectors.toSet());
     }
-    if (deferredWords.isEmpty()) {
+    if (filteredDeferredWords.isEmpty()) {
       return "";
     }
     Set<String> metaContextVariables = interpreter.getContext().getMetaContextVariables();
     Map<String, PyishBlockSetSerializable> blockSetMap = new HashMap<>();
 
-    deferredWords
+    filteredDeferredWords
       .stream()
       .map(w -> w.split("\\.", 2)[0]) // get base prop
       .filter(w -> !metaContextVariables.contains(w))
@@ -393,7 +394,7 @@ public class EagerReconstructionUtils {
         w ->
           blockSetMap.put(w, (PyishBlockSetSerializable) interpreter.getContext().get(w))
       );
-    deferredWords
+    filteredDeferredWords
       .stream()
       .map(w -> w.split("\\.", 2)[0]) // get base prop
       .filter(

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -22,6 +22,7 @@ import com.hubspot.jinjava.lib.tag.eager.DeferredToken;
 import com.hubspot.jinjava.lib.tag.eager.EagerExecutionResult;
 import com.hubspot.jinjava.objects.collections.PyList;
 import com.hubspot.jinjava.objects.collections.PyMap;
+import com.hubspot.jinjava.objects.serialization.PyishBlockSetSerializable;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
@@ -296,7 +297,8 @@ public class EagerReconstructionUtils {
   ) {
     return (
       reconstructMacroFunctionsBeforeDeferring(deferredWords, interpreter) +
-      reconstructVariablesBeforeDeferring(deferredWords, interpreter)
+      reconstructBlockSetVariablesBeforeDeferring(deferredWords, interpreter) +
+      reconstructInlineSetVariablesBeforeDeferring(deferredWords, interpreter)
     );
   }
 
@@ -360,7 +362,79 @@ public class EagerReconstructionUtils {
     return result;
   }
 
-  private static String reconstructVariablesBeforeDeferring(
+  private static String reconstructBlockSetVariablesBeforeDeferring(
+    Set<String> deferredWords,
+    JinjavaInterpreter interpreter
+  ) {
+    if (interpreter.getContext().isDeferredExecutionMode()) {
+      Context parent = interpreter.getContext().getParent();
+      while (parent.isDeferredExecutionMode()) {
+        parent = parent.getParent();
+      }
+      final Context finalParent = parent;
+      deferredWords =
+        deferredWords
+          .stream()
+          .filter(word -> interpreter.getContext().get(word) != finalParent.get(word))
+          .collect(Collectors.toSet());
+    }
+    if (deferredWords.isEmpty()) {
+      return "";
+    }
+    Set<String> metaContextVariables = interpreter.getContext().getMetaContextVariables();
+    Map<String, PyishBlockSetSerializable> blockSetMap = new HashMap<>();
+
+    deferredWords
+      .stream()
+      .map(w -> w.split("\\.", 2)[0]) // get base prop
+      .filter(w -> !metaContextVariables.contains(w))
+      .filter(w -> interpreter.getContext().get(w) instanceof PyishBlockSetSerializable)
+      .forEach(
+        w ->
+          blockSetMap.put(w, (PyishBlockSetSerializable) interpreter.getContext().get(w))
+      );
+    deferredWords
+      .stream()
+      .map(w -> w.split("\\.", 2)[0]) // get base prop
+      .filter(
+        w -> {
+          Object value = interpreter.getContext().get(w);
+          return (
+            value instanceof DeferredLazyReference &&
+            (
+              (DeferredLazyReference) value
+            ).getOriginalValue() instanceof PyishBlockSetSerializable
+          );
+        }
+      )
+      .forEach(
+        w -> {
+          blockSetMap.put(
+            w,
+            (PyishBlockSetSerializable) (
+              (DeferredLazyReference) interpreter.getContext().get(w)
+            ).getOriginalValue()
+          );
+        }
+      );
+    String blockSetTags = blockSetMap
+      .entrySet()
+      .stream()
+      .map(
+        entry ->
+          buildBlockSetTag(
+            entry.getKey(),
+            entry.getValue().getBlockSetBody(),
+            interpreter,
+            false
+          )
+      )
+      .collect(Collectors.joining());
+    deferredWords.removeAll(blockSetMap.keySet());
+    return blockSetTags;
+  }
+
+  private static String reconstructInlineSetVariablesBeforeDeferring(
     Set<String> deferredWords,
     JinjavaInterpreter interpreter
   ) {

--- a/src/test/resources/eager/eagerly-defers-macro.expected.jinja
+++ b/src/test/resources/eager/eagerly-defers-macro.expected.jinja
@@ -1,6 +1,6 @@
-{% macro big_guy() %}
+{% set __macro_big_guy_temp_variable_0__ %}
 {% if deferred %}I am foo{% else %}I am bar{% endif %}
-{% endmacro %}{% print big_guy() %}
-{% macro big_guy() %}
+{% endset %}{% print __macro_big_guy_temp_variable_0__ %}
+{% set __macro_big_guy_temp_variable_1__ %}
 {% if deferred %}No more foo{% else %}I am bar{% endif %}
-{% endmacro %}{% print big_guy() %}
+{% endset %}{% print __macro_big_guy_temp_variable_1__ %}

--- a/src/test/resources/eager/fully-defers-filtered-macro.expected.jinja
+++ b/src/test/resources/eager/fully-defers-filtered-macro.expected.jinja
@@ -2,4 +2,4 @@
   A flashy {{ deferred }}.{% endmacro %}{{ flashy(flashy('bar')) }}
 ---
 
-{% macro silly() %}A silly {{ deferred }}.{% endmacro %}{{ filter:upper.filter(silly(), ____int3rpr3t3r____) }}
+{% set __macro_silly_temp_variable_0__ %}A silly {{ deferred }}.{% endset %}{{ filter:upper.filter(__macro_silly_temp_variable_0__, ____int3rpr3t3r____) }}

--- a/src/test/resources/eager/handles-deferred-for-loop-var-from-macro.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-for-loop-var-from-macro.expected.jinja
@@ -1,13 +1,13 @@
-{% macro getData() %}
+{% set __macro_getData_temp_variable_0__ %}
 
 
 {% for __ignored__ in [0] %}
-{% macro doIt(val) %}
-{{ deferred ~ filter:tojson.filter(val, ____int3rpr3t3r____) }}
-{% endmacro %}{% set val = {'a': 'a'} %}{{ filter:upper.filter(doIt(val), ____int3rpr3t3r____) }}
+{% set __macro_doIt_temp_variable_0__ %}
+{{ deferred ~ '{\"a\":\"a\"}' }}
+{% endset %}{{ filter:upper.filter(__macro_doIt_temp_variable_0__, ____int3rpr3t3r____) }}
 
-{% macro doIt(val) %}
-{{ deferred ~ filter:tojson.filter(val, ____int3rpr3t3r____) }}
-{% endmacro %}{% set val = {'b': 'b'} %}{{ filter:upper.filter(doIt(val), ____int3rpr3t3r____) }}
+{% set __macro_doIt_temp_variable_1__ %}
+{{ deferred ~ '{\"b\":\"b\"}' }}
+{% endset %}{{ filter:upper.filter(__macro_doIt_temp_variable_1__, ____int3rpr3t3r____) }}
 {% endfor %}
-{% endmacro %}{{ filter:upper.filter(getData(), ____int3rpr3t3r____) }}
+{% endset %}{{ filter:upper.filter(__macro_getData_temp_variable_0__, ____int3rpr3t3r____) }}

--- a/src/test/resources/eager/puts-deferred-fromed-macro-in-output.expected.jinja
+++ b/src/test/resources/eager/puts-deferred-fromed-macro-in-output.expected.jinja
@@ -1,1 +1,1 @@
-{% set myname = deferred + 3 %}{% set deferred_import_resource_path = 'simple-with-call.jinja' %}{% macro getPath() %}Hello {{ myname }}{% endmacro %}{% set deferred_import_resource_path = null %}{% print getPath() %}
+{% set myname = deferred + 3 %}{% set __macro_getPath_temp_variable_1__ %}Hello {{ myname }}{% endset %}{% print __macro_getPath_temp_variable_1__ %}


### PR DESCRIPTION
Currently if there is a macro function that cannot be fully evaluated and it's used in a situation where partial evaluation is not an option, the evaluation result will be discarded. For example:
```
{{ caller()|replace('\n', ' ' ) }}
```
If calling `caller()` had some deferred tokens, we would have to discard the result because we couldn't run the filter on the non-fully evaluated macro result. This meant that the macro function would need to get run again later, which was expensive and could cause some issues if the function was not idempotent.
Instead, if the result is stored, we can convert it to:
```
{% set __macro_caller_temp_variable_0 %}
...
{% endset %}
{{ __macro_caller_temp_variable_0|replace('\n', ' ') }}
```
This reduces the duplication of work needed, leading to a faster final render and a faster initial render in many circumstances.