### PR TITLE
Don't add expressions to resolved expressions when evaluating chunks

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -65,11 +65,17 @@ public class ExpressionResolver {
    * @return Value of expression.
    */
   public Object resolveExpression(String expression) {
+    return resolveExpression(expression, true);
+  }
+
+  public Object resolveExpression(String expression, boolean addToResolvedExpressions) {
     if (StringUtils.isBlank(expression)) {
       return null;
     }
     expression = expression.trim();
-    interpreter.getContext().addResolvedExpression(expression);
+    if (addToResolvedExpressions) {
+      interpreter.getContext().addResolvedExpression(expression);
+    }
 
     if (WhitespaceUtils.isWrappedWith(expression, "[", "]")) {
       Arrays

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -601,6 +601,17 @@ public class JinjavaInterpreter implements PyishSerializable {
   }
 
   /**
+   * Resolve expression against current context, but does not add the expression to the set of resolved expressions.
+   *
+   * @param expression
+   *          Jinja expression.
+   * @return Value of expression.
+   */
+  public Object resolveELExpressionSilently(String expression) {
+    return expressionResolver.resolveExpression(expression, false);
+  }
+
+  /**
    * Resolve expression against current context.
    *
    * @param expression

--- a/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
@@ -200,7 +200,7 @@ public class EagerExpressionResolver {
         // val is still null
       }
       // don't defer numbers, values such as true/false, etc.
-      return interpreter.resolveELExpression(w, interpreter.getLineNumber()) == null;
+      return interpreter.resolveELExpressionSilently(w) == null;
     } catch (ELException | DeferredValueException | TemplateSyntaxException e) {
       return true;
     }


### PR DESCRIPTION
There are a lot of junk expressions that get added to the resolvedExpression list due to using the EL expression resolver to gather whether some text should be marked as a deferred word. Only the full expression should get added to the resolved expressions list.