### PR TITLE
Fix tests that fail as a result of multiple merges

### DIFF
--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
@@ -204,7 +204,7 @@ public class EagerForTagTest extends ForTagTest {
 
     String input =
       "{% set my_list = [] %}" +
-      "{% for i in range(30) %}" +
+      "{% for i in range(401) %}" +
       "{{ my_list.append(i) }}" +
       "{% endfor %}" +
       "{% for i in [0, 1] %}" +

--- a/src/test/resources/eager/handles-deferred-for-loop-var-from-macro.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-for-loop-var-from-macro.expected.jinja
@@ -3,11 +3,11 @@
 
 {% for __ignored__ in [0] %}
 {% set __macro_doIt_temp_variable_0__ %}
-{{ deferred ~ '{\"a\":\"a\"}' }}
+{{ deferred ~ '{"a":"a"}' }}
 {% endset %}{{ filter:upper.filter(__macro_doIt_temp_variable_0__, ____int3rpr3t3r____) }}
 
 {% set __macro_doIt_temp_variable_1__ %}
-{{ deferred ~ '{\"b\":\"b\"}' }}
+{{ deferred ~ '{"b":"b"}' }}
 {% endset %}{{ filter:upper.filter(__macro_doIt_temp_variable_1__, ____int3rpr3t3r____) }}
 {% endfor %}
 {% endset %}{{ filter:upper.filter(__macro_getData_temp_variable_0__, ____int3rpr3t3r____) }}


### PR DESCRIPTION
https://github.com/HubSpot/jinjava/pull/920 getting merged alongside https://github.com/HubSpot/jinjava/pull/910 caused the [handles-deferred-for-loop-var-from-macro](https://github.com/HubSpot/jinjava/compare/single-quote-char?expand=1#diff-5c9501ed0aa70914cacf9b9c63f610ed59a8b401eb4efe2151ac907d44ad7cc0) test to fail.

Also need to increase the size of the range in the other test now that the max reversible list length is 400.