### PR TITLE
Escape double quotes normally rather than not escaping them

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishCharacterEscapes.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishCharacterEscapes.java
@@ -12,7 +12,6 @@ public class PyishCharacterEscapes extends CharacterEscapes {
   private PyishCharacterEscapes() {
     int[] escapes = CharacterEscapes.standardAsciiEscapesForJSON();
     escapes['\n'] = CharacterEscapes.ESCAPE_NONE;
-    escapes['"'] = CharacterEscapes.ESCAPE_NONE;
     escapes['\t'] = CharacterEscapes.ESCAPE_NONE;
     escapes['\r'] = CharacterEscapes.ESCAPE_NONE;
     escapes['\f'] = CharacterEscapes.ESCAPE_NONE;

--- a/src/test/resources/eager/handles-deferred-for-loop-var-from-macro.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-for-loop-var-from-macro.expected.jinja
@@ -3,11 +3,11 @@
 
 {% for __ignored__ in [0] %}
 {% set __macro_doIt_temp_variable_0__ %}
-{{ deferred ~ '{"a":"a"}' }}
+{{ deferred ~ '{\"a\":\"a\"}' }}
 {% endset %}{{ filter:upper.filter(__macro_doIt_temp_variable_0__, ____int3rpr3t3r____) }}
 
 {% set __macro_doIt_temp_variable_1__ %}
-{{ deferred ~ '{"b":"b"}' }}
+{{ deferred ~ '{\"b\":\"b\"}' }}
 {% endset %}{{ filter:upper.filter(__macro_doIt_temp_variable_1__, ____int3rpr3t3r____) }}
 {% endfor %}
 {% endset %}{{ filter:upper.filter(__macro_getData_temp_variable_0__, ____int3rpr3t3r____) }}


### PR DESCRIPTION
This is to maintain functionality before changes to jackson/pyish object mapper
In https://github.com/HubSpot/jinjava/pull/910/files#diff-5cd2f8867eddbf995867e610b1a06abdc08721a77bf7ce5e42228d2c597f0817R15, I turned off escaping for the double quote, but as shown in this test, that changes the output, which was undesirable as it would cause the output to interact differently with the HTML post-processing that we were doing in the HubL engine.