### PR TITLE
Whitelist -> Safelist in jsoup

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java
@@ -7,7 +7,7 @@ import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.util.regex.Pattern;
 import org.jsoup.Jsoup;
-import org.jsoup.safety.Whitelist;
+import org.jsoup.safety.Safelist;
 
 /**
  * striptags(value) Strip SGML/XML tags and replace adjacent whitespace by one space.
@@ -42,7 +42,7 @@ public class StripTagsFilter implements Filter {
     }
 
     String cleanedVal = Jsoup.parse(val).text();
-    cleanedVal = Jsoup.clean(cleanedVal, Whitelist.none());
+    cleanedVal = Jsoup.clean(cleanedVal, Safelist.none());
 
     // backwards compatibility with Jsoup.parse
     cleanedVal = cleanedVal.replaceAll("&nbsp;", " ");


### PR DESCRIPTION
Whitelist is officially depricated in jsoup 1.15.1+ now and this syntax works on the version of jsoup currently included

This also allow upgrading jsoup to fix a CVE https://github.com/HubSpot/jinjava/pull/914