### PR TITLE
Start hiding DateTimeFormatter patterns behind StrftimeFormatter API

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
@@ -113,10 +113,6 @@ public class StrftimeFormatter {
     return result.toString();
   }
 
-  public static DateTimeFormatter formatter(String strftime) {
-    return formatter(strftime, Locale.ENGLISH);
-  }
-
   private static DateTimeFormatter formatter(String strftime, Locale locale) {
     DateTimeFormatter fmt;
 

--- a/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
@@ -117,7 +117,7 @@ public class StrftimeFormatter {
     return formatter(strftime, Locale.ENGLISH);
   }
 
-  public static DateTimeFormatter formatter(String strftime, Locale locale) {
+  private static DateTimeFormatter formatter(String strftime, Locale locale) {
     DateTimeFormatter fmt;
 
     if (strftime == null) {

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -14,6 +14,7 @@ import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import com.hubspot.jinjava.mode.PreserveRawExecutionMode;
 import com.hubspot.jinjava.objects.date.FormattedDate;
+import com.hubspot.jinjava.objects.date.StrftimeFormatter;
 import com.hubspot.jinjava.tree.TextNode;
 import com.hubspot.jinjava.tree.output.BlockInfo;
 import com.hubspot.jinjava.tree.parse.TextToken;
@@ -21,6 +22,7 @@ import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
@@ -393,6 +395,29 @@ public class JinjavaInterpreterTest {
     assertThat(result.getErrors())
       .extracting(TemplateError::getMessage)
       .containsOnly("Invalid date format: [not a real format]");
+  }
+
+  @Test
+  public void itDefaultsToMediumOnEmptyFormatInFormattedDate() {
+    ZonedDateTime date = ZonedDateTime.of(
+      2022,
+      10,
+      20,
+      17,
+      9,
+      43,
+      0,
+      ZoneId.of("America/New_York")
+    );
+    String result = jinjava.render(
+      "{{ d }}",
+      ImmutableMap.of("d", new FormattedDate("", "en_US", date))
+    );
+
+    assertThat(result)
+      .isEqualTo(
+        StrftimeFormatter.format(date, "medium", Locale.forLanguageTag("en-US"))
+      );
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -438,4 +438,27 @@ public class JinjavaInterpreterTest {
       .extracting(TemplateError::getMessage)
       .containsOnly("Invalid locale format: not a real locale");
   }
+
+  @Test
+  public void itDefaultsToUnitedStatesOnEmptyLocale() {
+    ZonedDateTime date = ZonedDateTime.of(
+      2022,
+      10,
+      20,
+      17,
+      9,
+      43,
+      0,
+      ZoneId.of("America/New_York")
+    );
+    String result = jinjava.render(
+      "{{ d }}",
+      ImmutableMap.of("d", new FormattedDate("medium", "", date))
+    );
+
+    assertThat(result)
+      .isEqualTo(
+        StrftimeFormatter.format(date, "medium", Locale.forLanguageTag("en-US"))
+      );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -440,7 +440,7 @@ public class JinjavaInterpreterTest {
   }
 
   @Test
-  public void itDefaultsToUnitedStatesOnEmptyLocale() {
+  public void itDefaultsToUnitedStatesOnEmptyLocaleInFormattedDate() {
     ZonedDateTime date = ZonedDateTime.of(
       2022,
       10,

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -372,4 +372,23 @@ public class JinjavaInterpreterTest {
 
     assertThat(result).isEqualTo("Oct 20, 2022, 9:09:43 PM");
   }
+
+  @Test
+  public void itHandlesInvalidFormatInFormattedDate() {
+    RenderResult result = jinjava.renderForResult(
+      "{{ d }}",
+      ImmutableMap.of(
+        "d",
+        new FormattedDate(
+          "not a real format",
+          "en_US",
+          ZonedDateTime.of(2022, 10, 20, 17, 9, 43, 0, ZoneId.of("America/New_York"))
+        )
+      )
+    );
+
+    assertThat(result.getErrors())
+      .extracting(TemplateError::getMessage)
+      .containsOnly("Invalid date format: [not a real format]");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -13,10 +13,12 @@ import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import com.hubspot.jinjava.mode.PreserveRawExecutionMode;
+import com.hubspot.jinjava.objects.date.FormattedDate;
 import com.hubspot.jinjava.tree.TextNode;
 import com.hubspot.jinjava.tree.output.BlockInfo;
 import com.hubspot.jinjava.tree.parse.TextToken;
 import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Optional;
@@ -352,5 +354,22 @@ public class JinjavaInterpreterTest {
   @Test
   public void itInterpretsEmptyExpressions() {
     assertThat(interpreter.render("{{}}")).isEqualTo("");
+  }
+
+  @Test
+  public void itInterpretsFormattedDates() {
+    String result = jinjava.render(
+      "{{ d }}",
+      ImmutableMap.of(
+        "d",
+        new FormattedDate(
+          "medium",
+          "en-US",
+          ZonedDateTime.of(2022, 10, 20, 17, 9, 43, 0, ZoneId.of("America/New_York"))
+        )
+      )
+    );
+
+    assertThat(result).isEqualTo("Oct 20, 2022, 9:09:43 PM");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -32,7 +32,10 @@ public class JinjavaInterpreterTest {
 
   @Before
   public void setup() {
-    jinjava = new Jinjava();
+    jinjava =
+      new Jinjava(
+        JinjavaConfig.newBuilder().withTimeZone(ZoneId.of("America/New_York")).build()
+      );
     interpreter = jinjava.newInterpreter();
     symbols = interpreter.getConfig().getTokenScannerSymbols();
   }
@@ -370,7 +373,7 @@ public class JinjavaInterpreterTest {
       )
     );
 
-    assertThat(result).isEqualTo("Oct 20, 2022, 9:09:43 PM");
+    assertThat(result).isEqualTo("Oct 20, 2022, 5:09:43 PM");
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -391,4 +391,23 @@ public class JinjavaInterpreterTest {
       .extracting(TemplateError::getMessage)
       .containsOnly("Invalid date format: [not a real format]");
   }
+
+  @Test
+  public void itHandlesInvalidLocaleInFormattedDate() {
+    RenderResult result = jinjava.renderForResult(
+      "{{ d }}",
+      ImmutableMap.of(
+        "d",
+        new FormattedDate(
+          "medium",
+          "not a real locale",
+          ZonedDateTime.of(2022, 10, 20, 17, 9, 43, 0, ZoneId.of("America/New_York"))
+        )
+      )
+    );
+
+    assertThat(result.getErrors())
+      .extracting(TemplateError::getMessage)
+      .containsOnly("Invalid locale format: not a real locale");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
@@ -92,12 +92,7 @@ public class StrftimeFormatterTest {
 
   @Test
   public void testFinnishMonths() {
-    assertThat(
-        StrftimeFormatter
-          .formatter("long")
-          .withLocale(Locale.forLanguageTag("fi"))
-          .format(d)
-      )
+    assertThat(StrftimeFormatter.format(d, "long", Locale.forLanguageTag("fi")))
       .startsWith("6. marraskuuta 2013 klo 14.22.00");
   }
 
@@ -118,10 +113,7 @@ public class StrftimeFormatterTest {
     ZonedDateTime zonedDateTime = ZonedDateTime.parse("2019-06-06T14:22:00.000+00:00");
 
     assertThat(
-        StrftimeFormatter
-          .formatter("%OB")
-          .withLocale(Locale.forLanguageTag("ru"))
-          .format(zonedDateTime)
+        StrftimeFormatter.format(zonedDateTime, "%OB", Locale.forLanguageTag("ru"))
       )
       .isIn("Июнь", "июнь");
   }


### PR DESCRIPTION
I'm looking to make some changes to the `datetimeformat` filter. Specifically, I'm implementing some format codes available in Jinja's `datetimeformat` (backed by `strftime`) which don't have direct counterparts in `DateTimeFormatter`'s pattern syntax.

To prepare for that, this PR hides some of the details around converting from a `strftime`-compatible format string to a `DateTimeFormatter`-compatible one behind the `StrftimeFormatter` API.

I also added several tests to make sure some dates are interpreted the same as before.