### PR TITLE
Implement actual locale-aware datetime formatting

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
@@ -176,5 +176,9 @@ public class StrftimeFormatter {
           stripLeadingZero ? targetPattern.substring(1) : targetPattern
         );
     }
+
+    static ConversionComponent localized(FormatStyle dateStyle, FormatStyle timeStyle) {
+      return (builder, stripLeadingZero) -> builder.appendLocalized(dateStyle, timeStyle);
+    }
   }
 }

--- a/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.objects.date;
 
+import static com.hubspot.jinjava.objects.date.StrftimeFormatter.ConversionComponent.localized;
 import static com.hubspot.jinjava.objects.date.StrftimeFormatter.ConversionComponent.pattern;
 
 import com.google.common.collect.ImmutableMap;
@@ -33,7 +34,7 @@ public class StrftimeFormatter {
         .put('A', pattern("EEEE"))
         .put('b', pattern("MMM"))
         .put('B', pattern("MMMM"))
-        .put('c', pattern("EEE MMM dd HH:mm:ss yyyy"))
+        .put('c', localized(FormatStyle.MEDIUM, FormatStyle.MEDIUM))
         .put('d', pattern("dd"))
         .put('e', pattern("d")) // The day of the month like with %d, but padded with blank (range 1 through 31).
         .put('f', pattern("SSSSSS"))
@@ -50,8 +51,8 @@ public class StrftimeFormatter {
         .put('U', pattern("ww"))
         .put('w', pattern("e"))
         .put('W', pattern("ww"))
-        .put('x', pattern("MM/dd/yy"))
-        .put('X', pattern("HH:mm:ss"))
+        .put('x', localized(FormatStyle.SHORT, null))
+        .put('X', localized(null, FormatStyle.MEDIUM))
         .put('y', pattern("yy"))
         .put('Y', pattern("yyyy"))
         .put('z', pattern("Z"))

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
@@ -116,7 +116,7 @@ public class DateTimeFormatFilterTest extends BaseInterpretingTest {
           "en-US"
         )
       )
-      .isEqualTo("10/11/18 13:09:45 - Thu Oct 11 13:09:45 2018");
+      .isEqualTo("10/11/18 1:09:45 PM - Oct 11, 2018, 1:09:45 PM");
     assertThat(
         filter.filter(
           1539277785000L,
@@ -126,7 +126,7 @@ public class DateTimeFormatFilterTest extends BaseInterpretingTest {
           "de-DE"
         )
       )
-      .isEqualTo("10/11/18 13:09:45 - Do. Okt. 11 13:09:45 2018");
+      .isEqualTo("11.10.18 13:09:45 - 11.10.2018, 13:09:45");
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
@@ -54,12 +54,12 @@ public class StrftimeFormatterTest {
 
   @Test
   public void testDateTime() {
-    assertThat(StrftimeFormatter.format(d, "%c")).isEqualTo("Wed Nov 06 14:22:00 2013");
+    assertThat(StrftimeFormatter.format(d, "%c")).isEqualTo("Nov 6, 2013, 2:22:00 PM");
   }
 
   @Test
   public void testDate() {
-    assertThat(StrftimeFormatter.format(d, "%x")).isEqualTo("11/06/13");
+    assertThat(StrftimeFormatter.format(d, "%x")).isEqualTo("11/6/13");
   }
 
   @Test
@@ -69,12 +69,12 @@ public class StrftimeFormatterTest {
 
   @Test
   public void testTime() {
-    assertThat(StrftimeFormatter.format(d, "%X")).isEqualTo("14:22:00");
+    assertThat(StrftimeFormatter.format(d, "%X")).isEqualTo("2:22:00 PM");
   }
 
   @Test
   public void testMicrosecs() {
-    assertThat(StrftimeFormatter.format(d, "%X %f")).isEqualTo("14:22:00 123000");
+    assertThat(StrftimeFormatter.format(d, "%X %f")).isEqualTo("2:22:00 PM 123000");
   }
 
   @Test


### PR DESCRIPTION
Depends on #931

This PR updates the `%x`, `%X`, and `%c` `strftime` format codes so they use actual locale-specific date and time representations. Currently, they're hard-coded to more-or-less match the US format.

I used `DateTimeFormatterBuilder.appendLocalized` for the actual formatting. While the resulting format doesn't exactly match `strftime`'s, I think it's good enough for our purposes. Here's a comparison with `strftime`.

format code | locale | Jinja (`strftime`) | Jinjava
| :---:|:---:|:---:|:---:
| `%x` | en-US | 10/24/2022 | 10/24/22
| | de-DE | 24.10.2022  | 24.10.22
| `%X` | en-US | 14:17:43 | 2:17:43 PM
| | de-DE | 14:17:43 | 14:17:43
| `%c` | en-US | Mon Oct 24 14:17:43 2022 | Oct 24, 2022, 2:17:43 PM
| | de-DE | Mo 24 Okt 14:17:43 2022 | 24.10.2022, 14:17:43

For some of the codes, some information is missing in this implementation compared to Jinja (like the day of the week in `%c`). On the whole, though, I think this is a pretty implementation, and I think the Jinjava version even does better in a couple of cases (like using AM/PM for US English, which is more common, instead of 24-hour time).