### PR TITLE
add support for numeric keys in map literal

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
@@ -7,6 +7,7 @@ import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstIdentifier;
 import de.odysseus.el.tree.impl.ast.AstLiteral;
 import de.odysseus.el.tree.impl.ast.AstNode;
+import de.odysseus.el.tree.impl.ast.AstNumber;
 import de.odysseus.el.tree.impl.ast.AstString;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -44,6 +45,11 @@ public class AstDict extends AstLiteral {
         } else {
           key = ((AstIdentifier) entryKey).getName();
         }
+      } else if (entryKey instanceof AstNumber) {
+        // This is a hack to treat numeric keys as string keys in the dictionary.
+        // In most cases this is adequate since the keys are typically treated as
+        // strings.
+        key = entryKey.eval(bindings, context).toString();
       } else {
         throw new TemplateStateException(
           "Dict key must be a string or identifier, was: " + entryKey

--- a/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
@@ -187,6 +187,11 @@ public class ExtendedSyntaxBuilderTest {
   }
 
   @Test
+  public void mapLiteralWithNumericKey() {
+    assertThat((Map<String, Object>) val("{0:'test'}")).contains(entry("0", "test"));
+  }
+
+  @Test
   public void itParsesDictWithVariableRefs() {
     List<?> theList = Lists.newArrayList(1L, 2L, 3L);
     context.put("the_list", theList);


### PR DESCRIPTION
Hit this use case in our usage of jinja. 
Putting up a PR in case there's interest in merging this functionality.

This is a hack to support numeric keys declared in map literals.
Most of such usages typically use the keys as if they were strings, so this
hack is likely safe.

A hack is used as opposed to overhauling all maps used since full support would
require overhauling all maps types to `Map<Object, Object>` which seems
overkill.

Behavior is also undefined for when defining same key of same number value and number value `{'1': '1', 1: '2'}`.