### PR TITLE
Use DeferredMacroValueImpl in EagerTagDecorator

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -1,7 +1,7 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
-import com.hubspot.jinjava.interpret.DeferredValue;
+import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -222,7 +222,8 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
             .getDeferredWords()
             .stream()
             .filter(
-              word -> !(interpreter.getContext().get(word) instanceof DeferredValue)
+              word ->
+                !(interpreter.getContext().get(word) instanceof DeferredMacroValueImpl)
             )
             .collect(Collectors.toSet())
         )

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTagTest.java
@@ -66,7 +66,8 @@ public class EagerIfTagTest extends IfTagTest {
       .findAny();
     assertThat(maybeEagerTagToken).isPresent();
     assertThat(maybeEagerTagToken.get().getSetDeferredWords()).isEmpty();
-    assertThat(maybeEagerTagToken.get().getUsedDeferredWords()).isEmpty();
+    assertThat(maybeEagerTagToken.get().getUsedDeferredWords())
+      .containsExactly("deferred");
   }
 
   @Test
@@ -81,7 +82,8 @@ public class EagerIfTagTest extends IfTagTest {
       .findAny();
     assertThat(maybeEagerTagToken).isPresent();
     assertThat(maybeEagerTagToken.get().getSetDeferredWords()).isEmpty();
-    assertThat(maybeEagerTagToken.get().getUsedDeferredWords()).isEmpty();
+    assertThat(maybeEagerTagToken.get().getUsedDeferredWords())
+      .containsExactly("deferred");
   }
 
   @Test
@@ -96,6 +98,7 @@ public class EagerIfTagTest extends IfTagTest {
       .findAny();
     assertThat(maybeEagerTagToken).isPresent();
     assertThat(maybeEagerTagToken.get().getSetDeferredWords()).isEmpty();
-    assertThat(maybeEagerTagToken.get().getUsedDeferredWords()).isEmpty();
+    assertThat(maybeEagerTagToken.get().getUsedDeferredWords())
+      .containsExactly("deferred");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerUnlessTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerUnlessTagTest.java
@@ -66,6 +66,7 @@ public class EagerUnlessTagTest extends UnlessTagTest {
       .findAny();
     assertThat(maybeEagerTagToken).isPresent();
     assertThat(maybeEagerTagToken.get().getSetDeferredWords()).isEmpty();
-    assertThat(maybeEagerTagToken.get().getUsedDeferredWords()).isEmpty();
+    assertThat(maybeEagerTagToken.get().getUsedDeferredWords())
+      .containsExactly("deferred");
   }
 }


### PR DESCRIPTION
In https://github.com/HubSpot/jinjava/pull/759, I changed the filtering to only filter out `DeferredMacroValueImpl` classes, but I missed doing it within EagerTagDecorator. This PR updates it as it should only be filtering out the deferred macro values.