### PR TITLE
Reconstruct all undefined variables when reconstructing call tag

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCallTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCallTag.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
 import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
+import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
@@ -127,6 +128,7 @@ public class EagerCallTag extends EagerStateChangingTag<CallTag> {
       StringBuilder result = new StringBuilder(
         prefixToPreserveState.toString() + joiner.toString()
       );
+      interpreter.getContext().setDynamicVariableResolver(s -> DeferredValue.instance());
       if (!tagNode.getChildren().isEmpty()) {
         result.append(
           EagerReconstructionUtils

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1167,4 +1167,11 @@ public class EagerTest {
       "handles-deferred-for-loop-var-from-macro.expected"
     );
   }
+
+  @Test
+  public void itReconstructsNullVariablesInDeferredCaller() {
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "reconstructs-null-variables-in-deferred-caller"
+    );
+  }
 }

--- a/src/test/resources/eager/reconstructs-null-variables-in-deferred-caller.expected.jinja
+++ b/src/test/resources/eager/reconstructs-null-variables-in-deferred-caller.expected.jinja
@@ -1,0 +1,10 @@
+{% if deferred %}
+{% macro foo(var) %}
+{% set second_list = [] %}
+{% do second_list.append(var) %}
+{{ caller() }}
+{% endmacro %}{% call foo(deferred) %}
+[]
+{{ second_list }}
+{% endcall %}
+{% endif %}

--- a/src/test/resources/eager/reconstructs-null-variables-in-deferred-caller.jinja
+++ b/src/test/resources/eager/reconstructs-null-variables-in-deferred-caller.jinja
@@ -1,0 +1,13 @@
+{% set first_list = [] %}
+{% macro foo(var) %}
+{% set second_list = [] %}
+{% do second_list.append(var) %}
+{{ caller() }}
+{% endmacro %}
+
+{% if deferred %}
+{% call foo(deferred) %}
+{{ first_list }}
+{{ second_list }}
+{% endcall %}
+{% endif %}


### PR DESCRIPTION
There is a situation where variables defined in a macro function that are implicitly used in a `caller()` call will be treated as `null`, and interpreted when the `caller()` function is reconstructed. To prevent this, we can treat all undefined variables as deferred values as they may be set from the macro function that is being called, as demonstrated in the added test case.