### PR TITLE
Update title filter to ignore special characters

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/TitleFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TitleFilter.java
@@ -1,10 +1,10 @@
 package com.hubspot.jinjava.lib.filter;
 
+import com.google.common.base.Splitter;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import org.apache.commons.lang3.text.WordUtils;
 
 /**
  * Return a titlecased version of the value. I.e. words will start with uppercase letters, all remaining characters are lowercase.
@@ -23,6 +23,8 @@ import org.apache.commons.lang3.text.WordUtils;
 )
 public class TitleFilter implements Filter {
 
+  private static final Splitter WORD_SPLITTER = Splitter.on(' ');
+
   @Override
   public String getName() {
     return "title";
@@ -30,10 +32,36 @@ public class TitleFilter implements Filter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
-    if (var instanceof String) {
-      String value = (String) var;
-      return WordUtils.capitalize(value.toLowerCase());
+    if (var == null) {
+      return null;
     }
-    return var;
+
+    String value = var.toString();
+
+    char[] chars = value.toCharArray();
+    boolean titleCased = false;
+
+    for (int i = 0; i < chars.length; i++) {
+      if (chars[i] == ' ') {
+        titleCased = false;
+        continue;
+      }
+
+      char original = chars[i];
+      if (titleCased) {
+        chars[i] = Character.toLowerCase(original);
+      } else {
+        if (charCanBeTitlecased(original)) {
+          chars[i] = Character.toTitleCase(original);
+          titleCased = true;
+        }
+      }
+    }
+
+    return new String(chars);
+  }
+
+  private boolean charCanBeTitlecased(char c) {
+    return Character.toLowerCase(c) != Character.toTitleCase(c);
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TitleFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TitleFilter.java
@@ -22,7 +22,6 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
   snippets = { @JinjavaSnippet(code = "{{ \"My title should be titlecase\"|title }} ") }
 )
 public class TitleFilter implements Filter {
-
   private static final Splitter WORD_SPLITTER = Splitter.on(' ');
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TitleFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TitleFilter.java
@@ -1,6 +1,5 @@
 package com.hubspot.jinjava.lib.filter;
 
-import com.google.common.base.Splitter;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
@@ -22,7 +21,6 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
   snippets = { @JinjavaSnippet(code = "{{ \"My title should be titlecase\"|title }} ") }
 )
 public class TitleFilter implements Filter {
-  private static final Splitter WORD_SPLITTER = Splitter.on(' ');
 
   @Override
   public String getName() {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/TitleFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/TitleFilterTest.java
@@ -33,7 +33,7 @@ public class TitleFilterTest {
   @Test
   public void itIgnoresParenthesesWhenCapitalizing() {
     assertThat(new TitleFilter().filter("test (company) name", null))
-            .isEqualTo("Test (Company) Name");
+      .isEqualTo("Test (Company) Name");
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/filter/TitleFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/TitleFilterTest.java
@@ -13,6 +13,12 @@ public class TitleFilterTest {
   }
 
   @Test
+  public void itPreservesWhitespace() {
+    assertThat(new TitleFilter().filter("this   is string   ", null))
+      .isEqualTo("This   Is String   ");
+  }
+
+  @Test
   public void itDoesNotChangeAlreadyTitleCasedString() {
     assertThat(new TitleFilter().filter("This Is String", null))
       .isEqualTo("This Is String");
@@ -22,5 +28,17 @@ public class TitleFilterTest {
   public void itLowercasesOtherUppercasedCharactersInString() {
     assertThat(new TitleFilter().filter("this is sTRING", null))
       .isEqualTo("This Is String");
+  }
+
+  @Test
+  public void itIgnoresParenthesesWhenCapitalizing() {
+    assertThat(new TitleFilter().filter("test (company) name", null))
+            .isEqualTo("Test (Company) Name");
+  }
+
+  @Test
+  public void itIgnoresMultipleSpecialCharactersWhenCapitalizing() {
+    assertThat(new TitleFilter().filter("@@@@mcoley t@est !@#$%^&*()_+plop", null))
+      .isEqualTo("@@@@Mcoley T@est !@#$%^&*()_+Plop");
   }
 }


### PR DESCRIPTION
Technically a deviation from the Jinja2 implementation but a better one IMO. The issue comes when you have special characters like parenthesis: `(Test Company Name)`. Because the old implementation only took the first characters, uppercased it, and then lowercase the rest of the characters `(Test Company Name)|title` would output `(test Company Name)`. Instead we iterate over the characters until we find the first one that is uppercaseable, uppercase that, and then lowercase the rest of the chars.