### PR TITLE
Don't use arbitrary booleans in public methods

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -68,7 +68,17 @@ public class ExpressionResolver {
     return resolveExpression(expression, true);
   }
 
-  public Object resolveExpression(String expression, boolean addToResolvedExpressions) {
+  /**
+   * Resolve expression against current context without adding the expression to the set of resolved expressions.
+   *
+   * @param expression Jinja expression.
+   * @return Value of expression.
+   */
+  public Object resolveExpressionSilently(String expression) {
+    return resolveExpression(expression, false);
+  }
+
+  private Object resolveExpression(String expression, boolean addToResolvedExpressions) {
     if (StringUtils.isBlank(expression)) {
       return null;
     }

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -608,7 +608,7 @@ public class JinjavaInterpreter implements PyishSerializable {
    * @return Value of expression.
    */
   public Object resolveELExpressionSilently(String expression) {
-    return expressionResolver.resolveExpression(expression, false);
+    return expressionResolver.resolveExpressionSilently(expression);
   }
 
   /**


### PR DESCRIPTION
To improve the readability of public methods, replace the boolean that was added as a parameter with a separate method with a different name which internally references a private method that uses the boolean flag.
Added in https://github.com/HubSpot/jinjava/pull/921/files (merged today)