### PR TITLE
disallow adding lists to themselves

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
@@ -25,10 +25,16 @@ public class PyList extends ForwardingList<Object> implements PyWrapper {
   }
 
   public boolean append(Object e) {
+    if (this == e) {
+      return false;
+    }
     return add(e);
   }
 
   public void insert(int i, Object e) {
+    if (this == e) {
+      return;
+    }
     if (i >= list.size()) {
       throw createOutOfRangeException(i);
     }

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
@@ -239,4 +239,26 @@ public class PyListTest extends BaseJinjavaTest {
       )
       .isEqualTo("-1");
   }
+
+  @Test
+  public void itDisallowsInsertingSelf() {
+    assertThat(
+        jinjava.render(
+          "{% set test = [1,2] %}" + "{% do test.insert(0, test) %}" + "{{ test }}",
+          Collections.emptyMap()
+        )
+      )
+      .isEqualTo("[1, 2]");
+  }
+
+  @Test
+  public void itDisallowsAppendingSelf() {
+    assertThat(
+        jinjava.render(
+          "{% set test = [1, 2] %}" + "{% do test.append(test) %}" + "{{ test }}",
+          Collections.emptyMap()
+        )
+      )
+      .isEqualTo("[1, 2]");
+  }
 }


### PR DESCRIPTION
It's possible to add a pylist to itself making it impossible to serialize to JSON. This fixes that. 

`PyMap` throws an `IllegalArgumentException` when you try to add itself as a value, but I decided to be more lenient here and just ignore the value because throwing an `IllegalArgumentException` would cause a `FatalTemplateException` and cause templates that were previously "working" to fail.