### PR TITLE
Add test for overriding built-in filters

### DIFF
--- a/src/test/java/com/hubspot/jinjava/FilterOverrideTest.java
+++ b/src/test/java/com/hubspot/jinjava/FilterOverrideTest.java
@@ -12,11 +12,12 @@ public class FilterOverrideTest {
   @Test
   public void itAllowsUsersToOverrideBuiltInFilters() {
     Jinjava jinjava = new Jinjava();
-    assertThat(jinjava.render("{{ 5 | add(6) }}", new HashMap<>())).isEqualTo("11");
+    String template = "{{ 5 | add(6) }}";
+
+    assertThat(jinjava.render(template, new HashMap<>())).isEqualTo("11");
 
     jinjava.getGlobalContext().registerClasses(DescriptiveAddFilter.class);
-    assertThat(jinjava.render("{{ 5 | add(6) }}", new HashMap<>()))
-      .isEqualTo("5 + 6 = 11");
+    assertThat(jinjava.render(template, new HashMap<>())).isEqualTo("5 + 6 = 11");
   }
 
   public static class DescriptiveAddFilter implements Filter {

--- a/src/test/java/com/hubspot/jinjava/FilterOverrideTest.java
+++ b/src/test/java/com/hubspot/jinjava/FilterOverrideTest.java
@@ -1,0 +1,40 @@
+package com.hubspot.jinjava;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.lib.filter.Filter;
+import java.util.HashMap;
+import org.junit.Test;
+
+public class FilterOverrideTest {
+
+  @Test
+  public void itAllowsUsersToOverrideBuiltInFilters() {
+    Jinjava jinjava = new Jinjava();
+    assertThat(jinjava.render("{{ 5 | add(6) }}", new HashMap<>())).isEqualTo("11");
+
+    jinjava.getGlobalContext().registerClasses(DescriptiveAddFilter.class);
+    assertThat(jinjava.render("{{ 5 | add(6) }}", new HashMap<>()))
+      .isEqualTo("5 + 6 = 11");
+  }
+
+  public static class DescriptiveAddFilter implements Filter {
+
+    @Override
+    public String getName() {
+      return "add";
+    }
+
+    @Override
+    public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+      return (
+        var +
+        " + " +
+        args[0] +
+        " = " +
+        (Integer.parseInt(var.toString()) + Integer.parseInt(args[0]))
+      );
+    }
+  }
+}


### PR DESCRIPTION
I'm planning on adding some new filters to Jinjava. I wanted to be sure that these new filters wouldn't interfere with any users of Jinjava that had bound custom filters using the names of the new filters I create.

This PR adds a test that confirms user-registered filters override built-in ones. I implemented this as a test to make sure any refactoring of the filter libraries in the future doesn't accidentally break this property.