### PR TITLE
Run in deferred execution mode if output is too big

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -126,6 +126,15 @@ public class JinjavaInterpreter implements PyishSerializable {
     scopeDepth = orig.getScopeDepth() + 1;
   }
 
+  public static void checkStringLength(String string) {
+    Optional<Long> maxStringLength = getCurrentMaybe()
+      .map(interpreter -> interpreter.getConfig().getMaxStringLength())
+      .filter(max -> max > 0);
+    if (maxStringLength.map(max -> string.length() > max).orElse(false)) {
+      throw new OutputTooBigException(maxStringLength.get(), string.length());
+    }
+  }
+
   /**
    * @deprecated use {{@link #getConfig()}}
    */

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -130,7 +130,9 @@ public class JinjavaInterpreter implements PyishSerializable {
     Optional<Long> maxStringLength = getCurrentMaybe()
       .map(interpreter -> interpreter.getConfig().getMaxOutputSize())
       .filter(max -> max > 0);
-    if (maxStringLength.map(max -> string.length() > max).orElse(false)) {
+    if (
+      maxStringLength.map(max -> string != null && string.length() > max).orElse(false)
+    ) {
       throw new OutputTooBigException(maxStringLength.get(), string.length());
     }
   }

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -126,9 +126,9 @@ public class JinjavaInterpreter implements PyishSerializable {
     scopeDepth = orig.getScopeDepth() + 1;
   }
 
-  public static void checkStringLength(String string) {
+  public static void checkOutputSize(String string) {
     Optional<Long> maxStringLength = getCurrentMaybe()
-      .map(interpreter -> interpreter.getConfig().getMaxStringLength())
+      .map(interpreter -> interpreter.getConfig().getMaxOutputSize())
       .filter(max -> max > 0);
     if (maxStringLength.map(max -> string.length() > max).orElse(false)) {
       throw new OutputTooBigException(maxStringLength.get(), string.length());

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -7,9 +7,6 @@ import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.interpret.OutputTooBigException;
-import com.hubspot.jinjava.interpret.TemplateError;
-import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.tag.ForTag;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
@@ -37,7 +34,7 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
   }
 
   @Override
-  public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
+  public String innerInterpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     Set<DeferredToken> addedTokens = new HashSet<>();
     EagerExecutionResult result = EagerReconstructionUtils.executeInChildContext(
       eagerInterpreter -> {
@@ -51,42 +48,28 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
       interpreter,
       EagerChildContextConfig.newBuilder().withCheckForContextChanges(true).build()
     );
-    try {
-      if (
-        result.getResult().getResolutionState() == ResolutionState.NONE ||
-        (
-          !result.getResult().isFullyResolved() &&
-          !result.getSpeculativeBindings().isEmpty()
-        )
-      ) {
-        EagerIfTag.resetBindingsForNextBranch(interpreter, result);
-        interpreter.getContext().removeDeferredTokens(addedTokens);
-        throw new DeferredValueException(
-          result.getResult().getResolutionState() == ResolutionState.NONE
-            ? result.getResult().toString()
-            : "Modification inside partially evaluated for loop"
-        );
-      }
-      if (result.getResult().isFullyResolved()) {
-        return result.getResult().toString(true);
-      } else {
-        return EagerReconstructionUtils.wrapInChildScope(
-          result.getResult().toString(true),
-          interpreter
-        );
-      }
-    } catch (DeferredValueException | TemplateSyntaxException e) {
-      try {
-        return EagerReconstructionUtils.wrapInAutoEscapeIfNeeded(
-          eagerInterpret(tagNode, interpreter, e),
-          interpreter
-        );
-      } catch (OutputTooBigException e1) {
-        interpreter.addError(TemplateError.fromOutputTooBigException(e1));
-        throw new DeferredValueException(
-          String.format("Output too big for eager execution: %s", e1.getMessage())
-        );
-      }
+    if (
+      result.getResult().getResolutionState() == ResolutionState.NONE ||
+      (
+        !result.getResult().isFullyResolved() &&
+        !result.getSpeculativeBindings().isEmpty()
+      )
+    ) {
+      EagerIfTag.resetBindingsForNextBranch(interpreter, result);
+      interpreter.getContext().removeDeferredTokens(addedTokens);
+      throw new DeferredValueException(
+        result.getResult().getResolutionState() == ResolutionState.NONE
+          ? result.getResult().toString()
+          : "Modification inside partially evaluated for loop"
+      );
+    }
+    if (result.getResult().isFullyResolved()) {
+      return result.getResult().toString(true);
+    } else {
+      return EagerReconstructionUtils.wrapInChildScope(
+        result.getResult().toString(true),
+        interpreter
+      );
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
@@ -4,8 +4,6 @@ import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.interpret.OutputTooBigException;
-import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.tag.ElseIfTag;
 import com.hubspot.jinjava.lib.tag.ElseTag;
@@ -33,22 +31,8 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
   }
 
   @Override
-  public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
-    try {
-      return getTag().interpret(tagNode, interpreter);
-    } catch (DeferredValueException | TemplateSyntaxException e) {
-      try {
-        return EagerReconstructionUtils.wrapInAutoEscapeIfNeeded(
-          eagerInterpret(tagNode, interpreter, e),
-          interpreter
-        );
-      } catch (OutputTooBigException e1) {
-        interpreter.addError(TemplateError.fromOutputTooBigException(e1));
-        throw new DeferredValueException(
-          String.format("Output too big for eager execution: %s", e1.getMessage())
-        );
-      }
-    }
+  public String innerInterpret(TagNode tagNode, JinjavaInterpreter interpreter) {
+    return getTag().interpret(tagNode, interpreter);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
@@ -17,9 +17,9 @@ public class EagerIncludeTag extends EagerTagDecorator<IncludeTag> {
   }
 
   @Override
-  public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
+  public String innerInterpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     int numDeferredTokensStart = interpreter.getContext().getDeferredTokens().size();
-    String output = super.interpret(tagNode, interpreter);
+    String output = super.innerInterpret(tagNode, interpreter);
     if (interpreter.getContext().getDeferredTokens().size() > numDeferredTokensStart) {
       HelperStringTokenizer helper = new HelperStringTokenizer(tagNode.getHelpers());
       String path = StringUtils.trimToEmpty(helper.next());

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
@@ -18,7 +18,7 @@ public class EagerStateChangingTag<T extends Tag> extends EagerTagDecorator<T> {
   }
 
   @Override
-  public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
+  public String innerInterpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     return eagerInterpret(tagNode, interpreter, null);
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -6,7 +6,6 @@ import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.OutputTooBigException;
-import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.tag.Tag;
 import com.hubspot.jinjava.tree.Node;
@@ -34,22 +33,33 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
   }
 
   @Override
-  public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
+  public final String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     try {
-      return tag.interpret(tagNode, interpreter);
-    } catch (DeferredValueException | TemplateSyntaxException e) {
+      String output = innerInterpret(tagNode, interpreter);
+      JinjavaInterpreter.checkStringLength(output);
+      return output;
+    } catch (DeferredValueException | TemplateSyntaxException | OutputTooBigException e) {
       try {
         return EagerReconstructionUtils.wrapInAutoEscapeIfNeeded(
-          eagerInterpret(tagNode, interpreter, e),
+          eagerInterpret(
+            tagNode,
+            interpreter,
+            e instanceof InterpretException
+              ? (InterpretException) e
+              : new InterpretException("Exception with default render", e)
+          ),
           interpreter
         );
       } catch (OutputTooBigException e1) {
-        interpreter.addError(TemplateError.fromOutputTooBigException(e1));
         throw new DeferredValueException(
           String.format("Output too big for eager execution: %s", e1.getMessage())
         );
       }
     }
+  }
+
+  protected String innerInterpret(TagNode tagNode, JinjavaInterpreter interpreter) {
+    return tag.interpret(tagNode, interpreter);
   }
 
   @Override
@@ -166,6 +176,7 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
    * @return The image of the token which has been evaluated as much as possible.
    */
   public final String getEagerImage(Token token, JinjavaInterpreter interpreter) {
+    interpreter.setLineNumber(token.getLineNumber());
     String eagerImage;
     if (token instanceof TagToken) {
       eagerImage = getEagerTagImage((TagToken) token, interpreter);

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -36,7 +36,7 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
   public final String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     try {
       String output = innerInterpret(tagNode, interpreter);
-      JinjavaInterpreter.checkStringLength(output);
+      JinjavaInterpreter.checkOutputSize(output);
       return output;
     } catch (DeferredValueException | TemplateSyntaxException | OutputTooBigException e) {
       try {

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.interpret.OutputTooBigException;
 import com.hubspot.jinjava.util.WhitespaceUtils;
 import java.io.IOException;
 import java.util.Objects;
@@ -51,12 +50,7 @@ public class PyishObjectMapper {
     throws JsonProcessingException {
     String string = PYISH_OBJECT_WRITER.writeValueAsString(val);
     Optional<JinjavaInterpreter> interpreterMaybe = JinjavaInterpreter.getCurrentMaybe();
-    Optional<Long> maxStringLength = interpreterMaybe
-      .map(interpreter -> interpreter.getConfig().getMaxStringLength())
-      .filter(max -> max > 0);
-    if (maxStringLength.map(max -> string.length() > max).orElse(false)) {
-      throw new OutputTooBigException(maxStringLength.get(), string.length());
-    }
+    JinjavaInterpreter.checkStringLength(string);
     if (
       interpreterMaybe
         .map(

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -50,7 +50,7 @@ public class PyishObjectMapper {
     throws JsonProcessingException {
     String string = PYISH_OBJECT_WRITER.writeValueAsString(val);
     Optional<JinjavaInterpreter> interpreterMaybe = JinjavaInterpreter.getCurrentMaybe();
-    JinjavaInterpreter.checkStringLength(string);
+    JinjavaInterpreter.checkOutputSize(string);
     if (
       interpreterMaybe
         .map(

--- a/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
@@ -7,6 +7,7 @@ import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.el.ext.ExtendedParser;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.OutputTooBigException;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.interpret.UnknownTokenException;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
@@ -107,7 +108,7 @@ public class EagerExpressionResolver {
           return pyishString;
         }
       }
-    } catch (JsonProcessingException ignored) {}
+    } catch (JsonProcessingException | OutputTooBigException ignored) {}
     throw new DeferredValueException("Can not convert deferred result to string");
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
@@ -93,9 +93,31 @@ public class EagerForTagTest extends ForTagTest {
         MAX_OUTPUT_SIZE
       )
     );
-    assertThat(interpreter.getErrors()).hasSize(1);
-    assertThat(interpreter.getErrors().get(0).getReason())
-      .isEqualTo(ErrorReason.OUTPUT_TOO_BIG);
+    assertThat(interpreter.getContext().getDeferredNodes()).hasSize(1);
+  }
+
+  @Test
+  public void itUsesDeferredExecutionModeWhenChildrenAreLarge() {
+    assertThat(
+        interpreter.render(
+          String.format(
+            "{%% for item in range(%d) %%}1234567890{%% endfor %%}",
+            MAX_OUTPUT_SIZE / 10
+          )
+        )
+      )
+      .hasSize((int) MAX_OUTPUT_SIZE);
+    assertThat(interpreter.getContext().getDeferredTokens()).isEmpty();
+    assertThat(interpreter.getContext().getDeferredNodes()).isEmpty();
+    assertThat(interpreter.getErrors()).isEmpty();
+    String tooBigInput = String.format(
+      "{%% for item in range(%d) %%}1234567890{%% endfor %%}",
+      MAX_OUTPUT_SIZE / 10 + 1
+    );
+    assertThat(interpreter.render(tooBigInput)).isEqualTo(tooBigInput);
+    assertThat(interpreter.getContext().getDeferredTokens()).hasSize(1);
+    assertThat(interpreter.getContext().getDeferredNodes()).isEmpty();
+    assertThat(interpreter.getErrors()).isEmpty();
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
@@ -87,13 +87,13 @@ public class EagerForTagTest extends ForTagTest {
 
   @Test
   public void itLimitsLength() {
-    interpreter.render(
+    String out = interpreter.render(
       String.format(
         "{%% for item in (range(1000, %s)) + deferred %%}{%% endfor %%}",
         MAX_OUTPUT_SIZE
       )
     );
-    assertThat(interpreter.getContext().getDeferredNodes()).hasSize(1);
+    assertThat(interpreter.getContext().getDeferredTokens()).hasSize(1);
   }
 
   @Test
@@ -102,11 +102,11 @@ public class EagerForTagTest extends ForTagTest {
         interpreter.render(
           String.format(
             "{%% for item in range(%d) %%}1234567890{%% endfor %%}",
-            MAX_OUTPUT_SIZE / 10
+            MAX_OUTPUT_SIZE / 10 - 1
           )
         )
       )
-      .hasSize((int) MAX_OUTPUT_SIZE);
+      .hasSize((int) MAX_OUTPUT_SIZE - 10);
     assertThat(interpreter.getContext().getDeferredTokens()).isEmpty();
     assertThat(interpreter.getContext().getDeferredNodes()).isEmpty();
     assertThat(interpreter.getErrors()).isEmpty();

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
@@ -113,9 +113,6 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
     );
     assertThatThrownBy(() -> eagerTagDecorator.interpret(tagNode, interpreter))
       .isInstanceOf(DeferredValueException.class);
-    assertThat(interpreter.getErrors()).hasSize(1);
-    assertThat(interpreter.getErrors().get(0).getReason())
-      .isEqualTo(ErrorReason.OUTPUT_TOO_BIG);
   }
 
   @Test


### PR DESCRIPTION
For all EagerTagDecorators, we can ensure that the output is checked to not be larger than `maxOutputSize`, and if so we can throw an `OutputTooBigException`. We can catch this as well as any that may have been thrown from building string builders and try interpreting the tag with deferred execution mode (that is what is done in `eagerInterpret`).

For example, if there's a for loop that generates a very large output when using eager execution, we could defer the evaluation of all the for loop's iterations. There are other tags that this is applicable to as well, especially some of HubSpot's HubL-specific tags.