### PR TITLE
Bind new date formatting filters as functions

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/time/DateTimeFormatHelper.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/time/DateTimeFormatHelper.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.filter.time;
 
+import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.fn.Functions;
@@ -26,12 +27,19 @@ final class DateTimeFormatHelper {
     this.cannedFormatterFunction = cannedFormatterFunction;
   }
 
-  String format(Object var, JinjavaInterpreter interpreter, String... args) {
+  String format(Object var, String... args) {
     String format = arg(args, 0).orElse("medium");
     ZoneId zoneId = arg(args, 1).map(this::parseZone).orElse(ZoneOffset.UTC);
     Locale locale = arg(args, 2)
       .map(this::parseLocale)
-      .orElseGet(() -> interpreter.getConfig().getLocale());
+      .orElseGet(
+        () ->
+          JinjavaInterpreter
+            .getCurrentMaybe()
+            .map(JinjavaInterpreter::getConfig)
+            .map(JinjavaConfig::getLocale)
+            .orElse(Locale.ENGLISH)
+      );
 
     return buildFormatter(format)
       .withLocale(locale)

--- a/src/main/java/com/hubspot/jinjava/lib/filter/time/FormatDateFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/time/FormatDateFilter.java
@@ -48,7 +48,11 @@ public class FormatDateFilter implements Filter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
-    return HELPER.format(var, interpreter, args);
+    return format(var, args);
+  }
+
+  public static Object format(Object var, String... args) {
+    return HELPER.format(var, args);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/time/FormatDatetimeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/time/FormatDatetimeFilter.java
@@ -50,7 +50,11 @@ public class FormatDatetimeFilter implements Filter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
-    return HELPER.format(var, interpreter, args);
+    return format(var, args);
+  }
+
+  public static Object format(Object var, String... args) {
+    return HELPER.format(var, args);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/time/FormatTimeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/time/FormatTimeFilter.java
@@ -48,7 +48,11 @@ public class FormatTimeFilter implements Filter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
-    return HELPER.format(var, interpreter, args);
+    return format(var, args);
+  }
+
+  public static Object format(Object var, String... args) {
+    return HELPER.format(var, args);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/fn/FunctionLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/FunctionLibrary.java
@@ -2,6 +2,9 @@ package com.hubspot.jinjava.lib.fn;
 
 import com.google.common.collect.Lists;
 import com.hubspot.jinjava.lib.SimpleLibrary;
+import com.hubspot.jinjava.lib.filter.time.FormatDateFilter;
+import com.hubspot.jinjava.lib.filter.time.FormatDatetimeFilter;
+import com.hubspot.jinjava.lib.filter.time.FormatTimeFilter;
 import java.util.Set;
 
 public class FunctionLibrary extends SimpleLibrary<ELFunctionDefinition> {
@@ -18,6 +21,36 @@ public class FunctionLibrary extends SimpleLibrary<ELFunctionDefinition> {
         "datetimeformat",
         Functions.class,
         "dateTimeFormat",
+        Object.class,
+        String[].class
+      )
+    );
+    register(
+      new ELFunctionDefinition(
+        "",
+        "format_date",
+        FormatDateFilter.class,
+        "format",
+        Object.class,
+        String[].class
+      )
+    );
+    register(
+      new ELFunctionDefinition(
+        "",
+        "format_time",
+        FormatTimeFilter.class,
+        "format",
+        Object.class,
+        String[].class
+      )
+    );
+    register(
+      new ELFunctionDefinition(
+        "",
+        "format_datetime",
+        FormatDatetimeFilter.class,
+        "format",
         Object.class,
         String[].class
       )

--- a/src/test/java/com/hubspot/jinjava/lib/fn/DateFormatFunctionsTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/DateFormatFunctionsTest.java
@@ -1,0 +1,61 @@
+package com.hubspot.jinjava.lib.fn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.hubspot.jinjava.Jinjava;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DateFormatFunctionsTest {
+  Jinjava jinjava;
+
+  @Before
+  public void setUp() throws Exception {
+    jinjava = new Jinjava();
+  }
+
+  @Test
+  public void itFormatsDates() {
+    assertThat(
+        jinjava.render(
+          "{{ format_date(d, 'medium') }}",
+          ImmutableMap.of(
+            "d",
+            ZonedDateTime.of(2022, 11, 28, 16, 30, 4, 0, ZoneOffset.UTC)
+          )
+        )
+      )
+      .isEqualTo("Nov 28, 2022");
+  }
+
+  @Test
+  public void itFormatsTimes() {
+    assertThat(
+        jinjava.render(
+          "{{ format_time(d, 'medium') }}",
+          ImmutableMap.of(
+            "d",
+            ZonedDateTime.of(2022, 11, 28, 16, 30, 4, 0, ZoneOffset.UTC)
+          )
+        )
+      )
+      .isEqualTo("4:30:04 PM");
+  }
+
+  @Test
+  public void itFormatsDateTimes() {
+    assertThat(
+        jinjava.render(
+          "{{ format_datetime(d, 'medium') }}",
+          ImmutableMap.of(
+            "d",
+            ZonedDateTime.of(2022, 11, 28, 16, 30, 4, 0, ZoneOffset.UTC)
+          )
+        )
+      )
+      .isEqualTo("Nov 28, 2022, 4:30:04 PM");
+  }
+}


### PR DESCRIPTION
This PR binds the new date formatting filters added in #953 as functions. This allows them to be called with both filter and function syntax just like `datetimeformat` today.