### PR TITLE
Fix spacing in tests from hidden merge conflict

### DIFF
--- a/src/test/resources/eager/reconstructs-namespace-for-set-tags-using-period.expected.expected.jinja
+++ b/src/test/resources/eager/reconstructs-namespace-for-set-tags-using-period.expected.expected.jinja
@@ -1,2 +1,2 @@
-namespace({'a': 'aa', 'b': 'b resolved'})
-namespace({'c': 'cc', 'd': 'd resolved'})
+namespace({'a': 'aa', 'b': 'b resolved'} )
+namespace({'c': 'cc', 'd': 'd resolved'} )

--- a/src/test/resources/eager/reconstructs-namespace-for-set-tags-using-period.expected.jinja
+++ b/src/test/resources/eager/reconstructs-namespace-for-set-tags-using-period.expected.jinja
@@ -1,7 +1,7 @@
-{% set ns1 = namespace({'a': 'aa'}) %}{% set ns1.b = 'b ' ~ deferred %}
+{% set ns1 = namespace({'a': 'aa'} ) %}{% set ns1.b = 'b ' ~ deferred %}
 
 
-{% set ns2 = namespace({'c': 'cc'}) %}{% set ns2.d %}d {{ deferred }}{% endset %}
+{% set ns2 = namespace({'c': 'cc'} ) %}{% set ns2.d %}d {{ deferred }}{% endset %}
 
 {{ ns1 }}
 {{ ns2 }}


### PR DESCRIPTION
https://github.com/HubSpot/jinjava/pull/950 and https://github.com/HubSpot/jinjava/pull/962 being merged but not pulled into each other first caused these tests to fail, so update the expected results to include the extra spacing.