### PR TITLE
Fix stack overflow for self-nested pymap.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/collections/PyMap.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/PyMap.java
@@ -58,4 +58,15 @@ public class PyMap extends ForwardingMap<String, Object> implements PyWrapper {
     }
     super.putAll(m);
   }
+
+  @Override
+  public int hashCode() {
+    int h = 0;
+    for (Entry<String, Object> entry : map.entrySet()) {
+      if (entry.getValue() != map && entry.getValue() != this) {
+        h += entry.hashCode();
+      }
+    }
+    return h;
+  }
 }


### PR DESCRIPTION
We will run to stack overflow which computing the hash code with the default method if the PyMap has nested entries. 
It is still a mystery that the nested entry can be created since we have the checks to prevent it.
https://github.com/HubSpot/jinjava/blob/33c3e328aeb70bde9dd2fb04a2d0640b26ea25b6/src/main/java/com/hubspot/jinjava/objects/collections/PyMap.java#L22
and https://github.com/HubSpot/jinjava/blob/33c3e328aeb70bde9dd2fb04a2d0640b26ea25b6/src/main/java/com/hubspot/jinjava/objects/collections/PyMap.java#L46

Thus, I am not able to make a test to create such map.

Here is the example code that will cause this issue:
```
{% set context = i.icon.image %}
{% do context.update({"image" : i.icon.image, "type" : 'raw', "border_radius" : 'border-radius-none', "class" : ''}) %}
{{ contentImage(context) }}
```
Where `contentImage` is a macro:
```
{% macro contentImage(data) %}
	{% set args = {
		"image" 		: {},
		"type" 			: "plain",
	} %}
	{% do args.update(data) %}
```
