### PR TITLE
Handle alternate exptest syntax for is false and is true exp tests

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -281,15 +281,16 @@ public class ExtendedParser extends Parser {
     switch (getToken().getSymbol()) {
       case IDENTIFIER:
         String name = consumeToken().getImage();
-        Symbol lookahead = lookahead(0).getSymbol();
-        if (
-          getToken().getSymbol() == COLON &&
-          (lookahead == IDENTIFIER || lookahead == FALSE || lookahead == TRUE) &&
-          (lookahead(1).getSymbol() == LPAREN || (isPossibleExpTestOrFilter(name)))
-        ) { // ns:f(...)
-          consumeToken();
-          name += ":" + getToken().getImage();
-          consumeToken();
+        if (getToken().getSymbol() == COLON) {
+          Symbol lookahead = lookahead(0).getSymbol();
+          if (
+            (lookahead == IDENTIFIER || lookahead == FALSE || lookahead == TRUE) &&
+            (lookahead(1).getSymbol() == LPAREN || (isPossibleExpTestOrFilter(name)))
+          ) { // ns:f(...)
+            consumeToken();
+            name += ":" + getToken().getImage();
+            consumeToken();
+          }
         }
         if (getToken().getSymbol() == LPAREN) { // function
           v = function(name, params());

--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -281,9 +281,10 @@ public class ExtendedParser extends Parser {
     switch (getToken().getSymbol()) {
       case IDENTIFIER:
         String name = consumeToken().getImage();
+        Symbol lookahead = lookahead(0).getSymbol();
         if (
           getToken().getSymbol() == COLON &&
-          lookahead(0).getSymbol() == IDENTIFIER &&
+          (lookahead == IDENTIFIER || lookahead == FALSE || lookahead == TRUE) &&
           (lookahead(1).getSymbol() == LPAREN || (isPossibleExpTestOrFilter(name)))
         ) { // ns:f(...)
           consumeToken();

--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
@@ -602,6 +602,40 @@ public class ExpressionResolverTest {
     assertThat(interpreter.getErrorsCopy()).isEmpty();
   }
 
+  @Test
+  public void itResolvesAlternateExpTestSyntax() {
+    assertThat(interpreter.render("{% if 2 is even %}yes{% endif %}")).isEqualTo("yes");
+
+    assertThat(
+        interpreter.render(
+          "{% if exptest:even.evaluate(2, ____int3rpr3t3r____) %}yes{% endif %}"
+        )
+      )
+      .isEqualTo("yes");
+    assertThat(
+        interpreter.render(
+          "{% if exptest:false.evaluate(false, ____int3rpr3t3r____) %}yes{% endif %}"
+        )
+      )
+      .isEqualTo("yes");
+  }
+
+  @Test
+  public void itResolvesAlternateExpTestSyntaxForTrueAndFalseExpTests() {
+    assertThat(
+        interpreter.render(
+          "{% if exptest:false.evaluate(false, ____int3rpr3t3r____) %}yes{% endif %}"
+        )
+      )
+      .isEqualTo("yes");
+    assertThat(
+        interpreter.render(
+          "{% if exptest:true.evaluate(true, ____int3rpr3t3r____) %}yes{% endif %}"
+        )
+      )
+      .isEqualTo("yes");
+  }
+
   public String result(String value, TestClass testClass) {
     testClass.touch();
     return value;


### PR DESCRIPTION
Expression tests like `exptest:false.evaluate(false, ____int3rpr3t3r____)` were failing to parse because `false` is not parsed as an `IDENTIFIER` symbol. 
This PR fixes that problem and adds some tests around it.

cc @hs-lsong 