### PR TITLE
Update `filesizeformat` filter

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/FileSizeFormatFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FileSizeFormatFilter.java
@@ -53,19 +53,19 @@ public class FileSizeFormatFilter implements Filter {
     }
 
     String[] sizes = binary ? BINARY_SIZES : DECIMAL_SIZES;
-    int unit = 1;
+    long unit = 1;
     String prefix = "";
 
     for (int i = 0; i < sizes.length; i++) {
-      unit = (int) Math.pow(base, i + 2);
+      unit = (long) Math.pow(base, i + 2);
       prefix = sizes[i];
 
       if (bytes < unit) {
-        return String.format("%.1f %s", (base * bytes / unit), prefix);
+        return String.format("%.1f %s", (double)(base * bytes / unit), prefix);
       }
     }
 
-    return String.format("%.1f %s", (base * bytes / unit), prefix);
+    return String.format("%.1f %s", (double)(base * bytes / unit), prefix);
   }
 
   private static final String[] BINARY_SIZES = {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/FileSizeFormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FileSizeFormatFilterTest.java
@@ -29,5 +29,9 @@ public class FileSizeFormatFilterTest extends BaseJinjavaTest {
         jinjava.render("{{3531836|filesizeformat(true)}}", new HashMap<String, Object>())
       )
       .isEqualTo("3.4 MiB");
+    assertThat(
+      jinjava.render("{{1000000000|filesizeformat}}", new HashMap<String, Object>())
+    )
+      .isEqualTo("1.0 GB");
   }
 }


### PR DESCRIPTION
Currently the `unit` variable is of type `int` so when calculating for units `GB` and larger, the `Math.pow(base, i + 2)` equation will calculate a value larger than `2147483647` (max `int` value), but due to the variable data type, it will truncate to that max value. Because of this, some calculations are returning an incorrect result. 
Example: `{{ 3309735582|filesizeformat }}` is returning `1541.2 YB` instead of `3.3 GB`

To fix this, we need to update the `unit` variable to type `long`. 