### PR TITLE
Move object unwrap behavior to config object

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,16 @@
       <groupId>ch.obermuhlner</groupId>
       <artifactId>big-math</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.hubspot.immutables</groupId>
+      <artifactId>hubspot-style</artifactId>
+      <version>1.3-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.hubspot.immutables</groupId>
+      <artifactId>immutables-exceptions</artifactId>
+      <version>1.3-SNAPSHOT</version>
+    </dependency>
 
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -146,16 +146,6 @@
       <groupId>ch.obermuhlner</groupId>
       <artifactId>big-math</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.hubspot.immutables</groupId>
-      <artifactId>hubspot-style</artifactId>
-      <version>1.3-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-      <groupId>com.hubspot.immutables</groupId>
-      <artifactId>immutables-exceptions</artifactId>
-      <version>1.3-SNAPSHOT</version>
-    </dependency>
 
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -19,6 +19,8 @@ import static com.hubspot.jinjava.lib.fn.Functions.DEFAULT_RANGE_LIMIT;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.jinjava.el.JinjavaInterpreterResolver;
+import com.hubspot.jinjava.el.JinjavaObjectUnwrapper;
+import com.hubspot.jinjava.el.ObjectUnwrapper;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.Context.Library;
 import com.hubspot.jinjava.interpret.InterpreterFactory;
@@ -68,6 +70,8 @@ public class JinjavaConfig {
   private final LegacyOverrides legacyOverrides;
   private final boolean enablePreciseDivideFilter;
   private final ObjectMapper objectMapper;
+
+  private final ObjectUnwrapper objectUnwrapper;
 
   public static Builder newBuilder() {
     return new Builder();
@@ -123,6 +127,7 @@ public class JinjavaConfig {
     legacyOverrides = builder.legacyOverrides;
     enablePreciseDivideFilter = builder.enablePreciseDivideFilter;
     objectMapper = builder.objectMapper;
+    objectUnwrapper = builder.objectUnwrapper;
   }
 
   public Charset getCharset() {
@@ -221,6 +226,10 @@ public class JinjavaConfig {
     return objectMapper;
   }
 
+  public ObjectUnwrapper getObjectUnwrapper() {
+    return objectUnwrapper;
+  }
+
   /**
    * @deprecated  Replaced by {@link LegacyOverrides#isIterateOverMapKeys()}
    */
@@ -271,6 +280,8 @@ public class JinjavaConfig {
     private LegacyOverrides legacyOverrides = LegacyOverrides.NONE;
     private boolean enablePreciseDivideFilter = false;
     private ObjectMapper objectMapper = new ObjectMapper();
+
+    private ObjectUnwrapper objectUnwrapper = new JinjavaObjectUnwrapper();
 
     private Builder() {}
 
@@ -424,6 +435,11 @@ public class JinjavaConfig {
 
     public Builder withObjectMapper(ObjectMapper objectMapper) {
       this.objectMapper = objectMapper;
+      return this;
+    }
+
+    public Builder withObjectUnwrapper(ObjectUnwrapper objectUnwrapper) {
+      this.objectUnwrapper = objectUnwrapper;
       return this;
     }
 

--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.el;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
 
 import com.google.common.collect.ImmutableMap;
+import com.hubspot.immutables.utils.WireSafeEnum;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.el.ext.NamedParameter;
 import com.hubspot.jinjava.interpret.CollectionTooBigException;
@@ -113,6 +114,10 @@ public class ExpressionResolver {
       // resolve the LazyExpression supplier automatically
       if (result instanceof LazyExpression) {
         result = ((LazyExpression) result).get();
+      }
+
+      if (result instanceof WireSafeEnum) {
+        result = ((WireSafeEnum) result).asEnum().orElse(null);
       }
 
       validateResult(result);

--- a/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.el;
 import static com.hubspot.jinjava.util.Logging.ENGINE_LOG;
 
 import com.google.common.collect.ImmutableMap;
+import com.hubspot.immutables.utils.WireSafeEnum;
 import com.hubspot.jinjava.el.ext.AbstractCallableMethod;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.el.ext.ExtendedParser;
@@ -219,6 +220,13 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
               }
             }
 
+            if (base instanceof WireSafeEnum) {
+              base = ((WireSafeEnum) base).asEnum().orElse(null);
+              if (base == null) {
+                return null;
+              }
+            }
+
             // java doesn't natively support negative array indices, so the
             // super class getValue returns null for them.  To make negative
             // indices work as they do in python, detect them here and convert
@@ -251,6 +259,13 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
 
             if (value instanceof LazyExpression) {
               value = ((LazyExpression) value).get();
+              if (value == null) {
+                return null;
+              }
+            }
+
+            if (value instanceof WireSafeEnum) {
+              value = ((WireSafeEnum) value).asEnum().orElse(null);
               if (value == null) {
                 return null;
               }
@@ -311,6 +326,13 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
 
     if (value instanceof LazyExpression) {
       value = ((LazyExpression) value).get();
+      if (value == null) {
+        return null;
+      }
+    }
+
+    if (value instanceof WireSafeEnum) {
+      value = ((WireSafeEnum) value).asEnum().orElse(null);
       if (value == null) {
         return null;
       }

--- a/src/main/java/com/hubspot/jinjava/el/JinjavaObjectUnwrapper.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaObjectUnwrapper.java
@@ -1,0 +1,25 @@
+package com.hubspot.jinjava.el;
+
+import com.hubspot.jinjava.interpret.LazyExpression;
+import java.util.Optional;
+
+public class JinjavaObjectUnwrapper implements ObjectUnwrapper {
+
+  @Override
+  public Object unwrapObject(Object o) {
+    if (o instanceof LazyExpression) {
+      o = ((LazyExpression) o).get();
+    }
+
+    if (o instanceof Optional) {
+      Optional<?> optValue = (Optional<?>) o;
+      if (!optValue.isPresent()) {
+        return null;
+      }
+
+      o = optValue.get();
+    }
+
+    return o;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ObjectUnwrapper.java
+++ b/src/main/java/com/hubspot/jinjava/el/ObjectUnwrapper.java
@@ -1,0 +1,5 @@
+package com.hubspot.jinjava.el;
+
+public interface ObjectUnwrapper {
+  Object unwrapObject(Object o);
+}

--- a/src/main/java/com/hubspot/jinjava/util/EagerContextWatcher.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerContextWatcher.java
@@ -1,6 +1,5 @@
 package com.hubspot.jinjava.util;
 
-import com.hubspot.immutables.utils.WireSafeEnum;
 import com.hubspot.jinjava.interpret.CannotReconstructValueException;
 import com.hubspot.jinjava.interpret.DeferredLazyReferenceSource;
 import com.hubspot.jinjava.interpret.DeferredValue;
@@ -368,10 +367,6 @@ public class EagerContextWatcher {
   private static Object getObjectOrHashCode(Object o) {
     if (o instanceof LazyExpression) {
       o = ((LazyExpression) o).get();
-    }
-
-    if (o instanceof WireSafeEnum) {
-      o = ((WireSafeEnum) o).asEnum().orElse(null);
     }
 
     if (o instanceof PyList && !((PyList) o).toList().contains(o)) {

--- a/src/main/java/com/hubspot/jinjava/util/EagerContextWatcher.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerContextWatcher.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.util;
 
+import com.hubspot.immutables.utils.WireSafeEnum;
 import com.hubspot.jinjava.interpret.CannotReconstructValueException;
 import com.hubspot.jinjava.interpret.DeferredLazyReferenceSource;
 import com.hubspot.jinjava.interpret.DeferredValue;
@@ -368,6 +369,11 @@ public class EagerContextWatcher {
     if (o instanceof LazyExpression) {
       o = ((LazyExpression) o).get();
     }
+
+    if (o instanceof WireSafeEnum) {
+      o = ((WireSafeEnum) o).asEnum().orElse(null);
+    }
+
     if (o instanceof PyList && !((PyList) o).toList().contains(o)) {
       return o.hashCode();
     }


### PR DESCRIPTION
Moves the unwrap object behavior to a separate class that implements an interface. The unwrap behavior can be modified by setting a custom object that implements that interface when constructing the config.

This allows us to extend this unwrap functionality in our own extension of Jinjava.