### PR TITLE
Don't reconstruct already deferred keys when getting basic speculative bindings

### DIFF
--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1245,4 +1245,9 @@ public class EagerTest {
       "reconstructs-words-from-inside-nested-expressions.expected"
     );
   }
+
+  @Test
+  public void itDoesNotReconstructExtraTimes() {
+    expectedTemplateInterpreter.assertExpectedOutput("does-not-reconstruct-extra-times");
+  }
 }

--- a/src/test/resources/eager/does-not-reconstruct-extra-times.expected.jinja
+++ b/src/test/resources/eager/does-not-reconstruct-extra-times.expected.jinja
@@ -1,0 +1,6 @@
+{% set foo = deferred %}
+
+{% if deferred %}
+{% set foo = 'second' %}
+{% endif %}
+{{ foo }}

--- a/src/test/resources/eager/does-not-reconstruct-extra-times.expected.jinja
+++ b/src/test/resources/eager/does-not-reconstruct-extra-times.expected.jinja
@@ -1,4 +1,21 @@
+{% for __ignored__ in [0] %}
+
 {% set foo = deferred %}
+{% endfor %}
+
+
+{% set foo = deferred %}
+
+
+{% for __ignored__ in [0] %}
+{% if deferred %}
+{{ foo }}
+{% set foo = 'second' %}
+{% endif %}
+{{ foo }}
+{% endfor %}
+{{ foo }}
+
 
 {% if deferred %}
 {% set foo = 'second' %}

--- a/src/test/resources/eager/does-not-reconstruct-extra-times.jinja
+++ b/src/test/resources/eager/does-not-reconstruct-extra-times.jinja
@@ -1,7 +1,25 @@
 {% set foo = 'first' %}
+{% for i in range(1) %}
+{# this should do nothing because it's in a for loop #}
+{% set foo = deferred %}
+{% endfor %}
+
+{# actually defer foo #}
 {% set foo = deferred %}
 
+{# make sure we don't reconstruct foo = 'first' in front of the for block #}
+{% for i in range(1) %}
+{% if deferred %}
+{{ foo }}
+{% set foo = 'second' %}
+{% endif %}
+{{ foo }}
+{% endfor %}
+{{ foo }}
+
+{# make sure we don't reconstruct foo = 'first' in front of the if block #}
 {% if deferred %}
 {% set foo = 'second' %}
 {% endif %}
 {{ foo }}
+

--- a/src/test/resources/eager/does-not-reconstruct-extra-times.jinja
+++ b/src/test/resources/eager/does-not-reconstruct-extra-times.jinja
@@ -1,0 +1,7 @@
+{% set foo = 'first' %}
+{% set foo = deferred %}
+
+{% if deferred %}
+{% set foo = 'second' %}
+{% endif %}
+{{ foo }}


### PR DESCRIPTION
As part of https://github.com/HubSpot/jinjava/pull/978, the `getBasicSpeculativeBindings()` method was added. It employs a much faster way of determining what changes have been made to the context. However, we should also know which keys were already deferred before the `function` is run so that we don't defer the values again. Since we're just using `deferredValue.getOriginalValue()`, if they've already been reconstructed, we may be attempting to set them to an incorrect value.
The simplest example of this is:
```
{% set foo = 'first' %}
{% set foo = deferred %}
{% if deferred %}
{% set foo = 'second' %}
{% endif %}
{{ foo }}
```

Which, before this change would get reconstructed like:
```
{% set foo = deferred %}
{% set foo = 'first' %}
{% if deferred %}
{% set foo = 'second' %}
{% endif %}
{{ foo }}
```
Which, if `deferred` ends up being `false`, `foo` will be `'first'` instead of `false`!
The proper reconstruction is like:
```
{% set foo = deferred %}
{% if deferred %}
{% set foo = 'second' %}
{% endif %}
{{ foo }}
```