### PR TITLE
Disallow nested tags that are broken across multiple quote blocks

### DIFF
--- a/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
@@ -682,6 +682,13 @@ public class EagerExpressionResolverTest {
     eagerResolveExpression("deferred.append('{% do foo.append(bar) %}')");
   }
 
+  @Test(expected = DeferredValueException.class)
+  public void itFailsWhenThereIsANestedTagFromSeparateQuoteBlocks() {
+    eagerResolveExpression(
+      "\"{% import '../../settings/localization/\" + deferred + \"-website.html' as config %}\""
+    );
+  }
+
   @Test
   public void itHandlesDeferredNamedParameter() {
     context.put("foo", "foo");


### PR DESCRIPTION
If an expression is deferred, and within that there appears to be a nested tag, we will throw a DeferredValueException as we can't determine which words should be deferred. Additionally, that nested tag could be broken across multiple quote blocks as demonstrated in the added test. So we'll keep track of when we see a start tag symbol and when we see the last end tag symbol and if the last end tag symbol is after the first start with symbol, we'll throw a DeferredValueException.