### PR TITLE
Preserve identifiers when reconstructing a tag which sets a value

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifier.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifier.java
@@ -3,7 +3,6 @@ package com.hubspot.jinjava.el.ext.eager;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.el.ext.ExtendedParser;
 import com.hubspot.jinjava.interpret.DeferredValueException;
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.filter.Filter;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
 import de.odysseus.el.tree.Bindings;
@@ -27,11 +26,9 @@ public class EagerAstIdentifier extends AstIdentifier implements EvalResultHolde
           !ExtendedParser.INTERPRETER.equals(getName()) &&
           !EagerExpressionResolver.isPrimitive(result) &&
           !(result instanceof Filter) &&
-          (
-            (JinjavaInterpreter) context
-              .getELResolver()
-              .getValue(context, null, ExtendedParser.INTERPRETER)
-          ).getContext()
+          EvalResultHolder
+            .getJinjavaInterpreter(context)
+            .getContext()
             .isPreserveAllIdentifiers()
         ) {
           throw new DeferredValueException("Preserving all non-primitive identifiers");

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifier.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifier.java
@@ -1,6 +1,11 @@
 package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.el.ext.ExtendedParser;
+import com.hubspot.jinjava.interpret.DeferredValueException;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.lib.filter.Filter;
+import com.hubspot.jinjava.util.EagerExpressionResolver;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstIdentifier;
 import javax.el.ELContext;
@@ -16,7 +21,23 @@ public class EagerAstIdentifier extends AstIdentifier implements EvalResultHolde
   @Override
   public Object eval(Bindings bindings, ELContext context) {
     return EvalResultHolder.super.eval(
-      () -> super.eval(bindings, context),
+      () -> {
+        Object result = super.eval(bindings, context);
+        if (
+          !ExtendedParser.INTERPRETER.equals(getName()) &&
+          !EagerExpressionResolver.isPrimitive(result) &&
+          !(result instanceof Filter) &&
+          (
+            (JinjavaInterpreter) context
+              .getELResolver()
+              .getValue(context, null, ExtendedParser.INTERPRETER)
+          ).getContext()
+            .isPreserveAllIdentifiers()
+        ) {
+          throw new DeferredValueException("Preserving all non-primitive identifiers");
+        }
+        return result;
+      },
       bindings,
       context
     );

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
@@ -44,12 +44,7 @@ public interface EvalResultHolder {
     if (
       evalResult instanceof Collection &&
       ((Collection<?>) evalResult).size() > 100 && // TODO make size configurable
-      (
-        (JinjavaInterpreter) context
-          .getELResolver()
-          .getValue(context, null, ExtendedParser.INTERPRETER)
-      ).getContext()
-        .isDeferLargeObjects()
+      getJinjavaInterpreter(context).getContext().isDeferLargeObjects()
     ) {
       throw new DeferredValueException("Collection too big");
     }
@@ -62,6 +57,12 @@ public interface EvalResultHolder {
     DeferredParsingException deferredParsingException,
     boolean preserveIdentifier
   );
+
+  static JinjavaInterpreter getJinjavaInterpreter(ELContext context) {
+    return (JinjavaInterpreter) context
+      .getELResolver()
+      .getValue(context, null, ExtendedParser.INTERPRETER);
+  }
 
   static String reconstructNode(
     Bindings bindings,

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -107,6 +107,8 @@ public class Context extends ScopeMap<String, Object> {
   private boolean validationMode = false;
   private boolean deferredExecutionMode = false;
   private boolean deferLargeObjects = false;
+
+  private boolean preserveAllIdentifiers = false;
   private boolean throwInterpreterErrors = false;
   private boolean partialMacroEvaluation = false;
   private boolean unwrapRawOverride = false;
@@ -211,6 +213,7 @@ public class Context extends ScopeMap<String, Object> {
       this.dynamicVariableResolver = parent.dynamicVariableResolver;
       this.deferredExecutionMode = parent.deferredExecutionMode;
       this.deferLargeObjects = parent.deferLargeObjects;
+      this.preserveAllIdentifiers = parent.preserveAllIdentifiers;
       this.throwInterpreterErrors = parent.throwInterpreterErrors;
     }
   }
@@ -726,6 +729,26 @@ public class Context extends ScopeMap<String, Object> {
       this::setDeferLargeObjects
     );
     this.deferLargeObjects = deferLargeObjects;
+    return temporaryValueClosable;
+  }
+
+  public boolean isPreserveAllIdentifiers() {
+    return preserveAllIdentifiers;
+  }
+
+  public Context setPreserveAllIdentifiers(boolean preserveAllIdentifiers) {
+    this.preserveAllIdentifiers = preserveAllIdentifiers;
+    return this;
+  }
+
+  public TemporaryValueClosable<Boolean> withPreserveAllIdentifiers(
+    boolean preserveAllIdentifiers
+  ) {
+    TemporaryValueClosable<Boolean> temporaryValueClosable = new TemporaryValueClosable<>(
+      this.preserveAllIdentifiers,
+      this::setPreserveAllIdentifiers
+    );
+    this.preserveAllIdentifiers = preserveAllIdentifiers;
     return temporaryValueClosable;
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -77,7 +77,6 @@ public class MacroFunction extends AbstractCallableMethod {
     JinjavaInterpreter interpreter = JinjavaInterpreter.getCurrent();
     Optional<String> importFile = getImportFile(interpreter);
     try (InterpreterScopeClosable c = interpreter.enterScope()) {
-      interpreter.getContext().setDeferredExecutionMode(false);
       String result = getEvaluationResult(argMap, kwargMap, varArgs, interpreter);
 
       if (

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
@@ -56,6 +56,16 @@ public class EagerBlockSetTagStrategy extends EagerSetTagStrategy {
   }
 
   @Override
+  protected EagerExecutionResult getDeferredEagerExecutionResult(
+    TagNode tagNode,
+    String expression,
+    JinjavaInterpreter interpreter,
+    EagerExecutionResult firstResult
+  ) {
+    return firstResult;
+  }
+
+  @Override
   protected Optional<String> resolveSet(
     TagNode tagNode,
     String[] variables,

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
@@ -1,7 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
 import com.google.common.collect.Sets;
-import com.hubspot.jinjava.interpret.Context.TemporaryValueClosable;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.SetTag;
@@ -32,34 +31,28 @@ public class EagerBlockSetTagStrategy extends EagerSetTagStrategy {
     String expression,
     JinjavaInterpreter interpreter
   ) {
-    try (
-      TemporaryValueClosable<Boolean> c = interpreter
-        .getContext()
-        .withPreserveAllIdentifiers(interpreter.getContext().isDeferredExecutionMode())
-    ) {
-      EagerExecutionResult result = EagerContextWatcher.executeInChildContext(
-        eagerInterpreter ->
-          EagerExpressionResult.fromSupplier(
-            () -> {
-              StringBuilder sb = new StringBuilder();
-              for (Node child : tagNode.getChildren()) {
-                sb.append(child.render(eagerInterpreter).getValue());
-              }
-              return sb.toString();
-            },
-            eagerInterpreter
-          ),
-        interpreter,
-        EagerContextWatcher
-          .EagerChildContextConfig.newBuilder()
-          .withTakeNewValue(true)
-          .build()
-      );
-      if (result.getResult().getResolutionState() == ResolutionState.NONE) {
-        throw new DeferredValueException(result.getResult().toString());
-      }
-      return result;
+    EagerExecutionResult result = EagerContextWatcher.executeInChildContext(
+      eagerInterpreter ->
+        EagerExpressionResult.fromSupplier(
+          () -> {
+            StringBuilder sb = new StringBuilder();
+            for (Node child : tagNode.getChildren()) {
+              sb.append(child.render(eagerInterpreter).getValue());
+            }
+            return sb.toString();
+          },
+          eagerInterpreter
+        ),
+      interpreter,
+      EagerContextWatcher
+        .EagerChildContextConfig.newBuilder()
+        .withTakeNewValue(true)
+        .build()
+    );
+    if (result.getResult().getResolutionState() == ResolutionState.NONE) {
+      throw new DeferredValueException(result.getResult().toString());
     }
+    return result;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerExecutionResult.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerExecutionResult.java
@@ -55,20 +55,6 @@ public class EagerExecutionResult {
     }
     JinjavaInterpreter interpreter = JinjavaInterpreter.getCurrent();
     prefixToPreserveState =
-      speculativeBindings
-        .entrySet()
-        .stream()
-        .filter(entry -> entry.getValue() instanceof PyishBlockSetSerializable)
-        .map(
-          entry ->
-            buildBlockSetTag(
-              entry.getKey(),
-              ((PyishBlockSetSerializable) entry.getValue()).getBlockSetBody(),
-              interpreter,
-              registerDeferredToken
-            )
-        )
-        .collect(Collectors.joining()) +
       buildSetTag(
         speculativeBindings
           .entrySet()
@@ -84,6 +70,20 @@ public class EagerExecutionResult {
         interpreter,
         registerDeferredToken
       ) +
+      speculativeBindings
+        .entrySet()
+        .stream()
+        .filter(entry -> entry.getValue() instanceof PyishBlockSetSerializable)
+        .map(
+          entry ->
+            buildBlockSetTag(
+              entry.getKey(),
+              ((PyishBlockSetSerializable) entry.getValue()).getBlockSetBody(),
+              interpreter,
+              registerDeferredToken
+            )
+        )
+        .collect(Collectors.joining()) +
       speculativeBindings
         .entrySet()
         .stream()

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -58,7 +58,7 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
         !result.getSpeculativeBindings().isEmpty()
       )
     ) {
-      EagerIfTag.resetBindingsForNextBranch(interpreter, result);
+      EagerReconstructionUtils.resetSpeculativeBindings(interpreter, result);
       interpreter.getContext().removeDeferredTokens(addedTokens);
       throw new DeferredValueException(
         result.getResult().getResolutionState() == ResolutionState.NONE

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -98,28 +98,34 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
           interpreter.getContext().isDeferLargeObjects()
         )
     ) {
-      // separate getEagerImage from renderChildren because the token gets evaluated once
-      // while the children are evaluated 0...n times.
-      result.append(
-        EagerContextWatcher
-          .executeInChildContext(
-            eagerInterpreter ->
-              EagerExpressionResult.fromString(
-                getEagerImage(
-                  buildToken(
-                    tagNode,
-                    e,
-                    interpreter.getLineNumber(),
-                    interpreter.getPosition()
-                  ),
-                  eagerInterpreter
-                )
-              ),
-            interpreter,
-            EagerContextWatcher.EagerChildContextConfig.newBuilder().build()
-          )
-          .asTemplateString()
-      );
+      try (
+        TemporaryValueClosable<Boolean> c1 = interpreter
+          .getContext()
+          .withPreserveAllIdentifiers(true)
+      ) {
+        // separate getEagerImage from renderChildren because the token gets evaluated once
+        // while the children are evaluated 0...n times.
+        result.append(
+          EagerContextWatcher
+            .executeInChildContext(
+              eagerInterpreter ->
+                EagerExpressionResult.fromString(
+                  getEagerImage(
+                    buildToken(
+                      tagNode,
+                      e,
+                      interpreter.getLineNumber(),
+                      interpreter.getPosition()
+                    ),
+                    eagerInterpreter
+                  )
+                ),
+              interpreter,
+              EagerContextWatcher.EagerChildContextConfig.newBuilder().build()
+            )
+            .asTemplateString()
+        );
+      }
     }
 
     EagerExecutionResult firstRunResult = runLoopOnce(tagNode, interpreter);

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
@@ -121,7 +121,9 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
             .build()
         );
         sb.append(result.getResult());
-        bindingsToDefer.addAll(resetBindingsForNextBranch(interpreter, result));
+        bindingsToDefer.addAll(
+          EagerReconstructionUtils.resetSpeculativeBindings(interpreter, result)
+        );
       }
       if (branchEnd >= childrenSize || definitelyExecuted) {
         break;
@@ -178,16 +180,6 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
       return sb.toString();
     }
     return sb.toString();
-  }
-
-  public static Set<String> resetBindingsForNextBranch(
-    JinjavaInterpreter interpreter,
-    EagerExecutionResult result
-  ) {
-    result
-      .getSpeculativeBindings()
-      .forEach((k, v) -> interpreter.getContext().replace(k, v));
-    return result.getSpeculativeBindings().keySet();
   }
 
   private String evaluateBranch(

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
@@ -35,7 +35,7 @@ public class EagerInlineSetTagStrategy extends EagerSetTagStrategy {
     try (
       TemporaryValueClosable<Boolean> c = interpreter
         .getContext()
-        .withPreserveAllIdentifiers(interpreter.getContext().isDeferredExecutionMode())
+        .withPreserveAllIdentifiers(true)
     ) {
       return EagerContextWatcher.executeInChildContext(
         eagerInterpreter ->

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
@@ -50,6 +50,7 @@ public class EagerInlineSetTagStrategy extends EagerSetTagStrategy {
     JinjavaInterpreter interpreter,
     EagerExecutionResult firstResult
   ) {
+    EagerReconstructionUtils.resetSpeculativeBindings(interpreter, firstResult);
     // Preserve identifiers when reconstructing to maintain proper object references
     try (
       TemporaryValueClosable<Boolean> c = interpreter

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
@@ -131,7 +131,10 @@ public abstract class EagerSetTagStrategy {
     JinjavaInterpreter interpreter
   ) {
     StringBuilder prefixToPreserveState = new StringBuilder();
-    if (interpreter.getContext().isDeferredExecutionMode()) {
+    if (
+      interpreter.getContext().isDeferredExecutionMode() ||
+      !eagerExecutionResult.getResult().isFullyResolved()
+    ) {
       prefixToPreserveState.append(eagerExecutionResult.getPrefixToPreserveState());
     } else {
       interpreter.getContext().putAll(eagerExecutionResult.getSpeculativeBindings());

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
@@ -61,6 +61,13 @@ public abstract class EagerSetTagStrategy {
         return maybeResolved.get();
       }
     }
+    eagerExecutionResult =
+      getDeferredEagerExecutionResult(
+        tagNode,
+        expression,
+        interpreter,
+        eagerExecutionResult
+      );
     Triple<String, String, String> triple = getPrefixTokenAndSuffix(
       tagNode,
       variables,
@@ -80,6 +87,13 @@ public abstract class EagerSetTagStrategy {
     TagNode tagNode,
     String expression,
     JinjavaInterpreter interpreter
+  );
+
+  protected abstract EagerExecutionResult getDeferredEagerExecutionResult(
+    TagNode tagNode,
+    String expression,
+    JinjavaInterpreter interpreter,
+    EagerExecutionResult firstResult
   );
 
   protected abstract Optional<String> resolveSet(

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -653,4 +653,14 @@ public class EagerReconstructionUtils {
       )
     );
   }
+
+  public static Set<String> resetSpeculativeBindings(
+    JinjavaInterpreter interpreter,
+    EagerExecutionResult result
+  ) {
+    result
+      .getSpeculativeBindings()
+      .forEach((k, v) -> interpreter.getContext().replace(k, v));
+    return result.getSpeculativeBindings().keySet();
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1264,4 +1264,11 @@ public class EagerTest {
       "correctly-preserves-identifiers-in-for-loop"
     );
   }
+
+  @Test
+  public void itCorrectlyPreservesIdentifiersInMacroFunction() {
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
+      "correctly-preserves-identifiers-in-macro-function"
+    );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -484,9 +484,8 @@ public class EagerTest {
     DeferredValueUtils.findAndMarkDeferredProperties(localContext);
     assertThat(deferredValue2).isInstanceOf(DeferredValue.class);
     assertThat(output)
-      .contains(
-        "{% set varSetInside = {'key': 'value'} [deferredValue2.nonexistentprop] %}"
-      );
+      .contains("{% set imported = {'map': {'key': 'value'} }  %}")
+      .contains("{% set varSetInside = imported.map[deferredValue2.nonexistentprop] %}");
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1250,4 +1250,19 @@ public class EagerTest {
   public void itDoesNotReconstructExtraTimes() {
     expectedTemplateInterpreter.assertExpectedOutput("does-not-reconstruct-extra-times");
   }
+
+  @Test
+  public void itCorrectlyPreservesIdentifiersInInlineSet() {
+    // This doesn't need to happen in block sets, because they only store string values
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "correctly-preserves-identifiers-in-inline-set"
+    );
+  }
+
+  @Test
+  public void itCorrectlyPreservesIdentifiersInForLoop() {
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "correctly-preserves-identifiers-in-for-loop"
+    );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
@@ -133,13 +133,13 @@ public class EagerExpressionStrategyTest extends ExpressionNodeTest {
   }
 
   @Test
-  public void itDoesNotGoIntoDeferredExecutionModeWithMacro() {
+  public void itGoesIntoDeferredExecutionModeWithMacro() {
     assertExpectedOutput(
       "{% macro def() %}{{ is_deferred_execution_mode() }}{% endmacro %}" +
       "{{ def() }}" +
       "{% if deferred %}{{ def() }}{% endif %}" +
       "{{ def() }}",
-      "false{% if deferred %}false{% endif %}false"
+      "false{% if deferred %}true{% endif %}false"
     );
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
@@ -192,7 +192,11 @@ public class EagerForTagTest extends ForTagTest {
     );
     assertThat(output.trim())
       .isEqualTo(
-        "{% for i in range(0, deferred) %}\n" + "{{ i }}\n" + "{% endfor %}\n" + "[0, 1]"
+        // now foo is being preserved because it may be used to fuel the collection we're looping through
+        "{% set foo = [0] %}{% set foo = [0] %}{% for i in range(foo.append(1) ? 0 : 1, deferred) %}\n" +
+        "{{ i }}\n" +
+        "{% endfor %}\n" +
+        "{{ foo }}"
       );
   }
 

--- a/src/test/resources/eager/correctly-preserves-identifiers-in-for-loop.expected.jinja
+++ b/src/test/resources/eager/correctly-preserves-identifiers-in-for-loop.expected.jinja
@@ -1,0 +1,8 @@
+{% set dict = {}  %}{% set dict = {}  %}{% for item in [dict] %}
+{% if deferred %}
+{% do item.update({'c': 'd'} ) %}
+{% endif %}
+{{ item }}
+{% endfor %}
+
+{% do dict.update({'a': 'b'} ) %}

--- a/src/test/resources/eager/correctly-preserves-identifiers-in-for-loop.jinja
+++ b/src/test/resources/eager/correctly-preserves-identifiers-in-for-loop.jinja
@@ -1,0 +1,10 @@
+{% set dict = {} %}
+
+{% for item in [dict] %}
+{% if deferred %}
+{% do item.update({'c': 'd'}) %}
+{% endif %}
+{{ item }}
+{% endfor %}
+
+{% do dict.update({'a': 'b'}) %}

--- a/src/test/resources/eager/correctly-preserves-identifiers-in-inline-set.expected.jinja
+++ b/src/test/resources/eager/correctly-preserves-identifiers-in-inline-set.expected.jinja
@@ -1,0 +1,5 @@
+{% set dict = {}  %}{% set foo = (dict, deferred) %}
+
+{% do dict.update({'a': 'b'} ) %}
+
+{{ foo }}

--- a/src/test/resources/eager/correctly-preserves-identifiers-in-inline-set.jinja
+++ b/src/test/resources/eager/correctly-preserves-identifiers-in-inline-set.jinja
@@ -1,0 +1,7 @@
+{% set dict = {} %}
+
+{% set foo = (dict, deferred) %}
+
+{% do dict.update({'a': 'b'}) %}
+
+{{ foo }}

--- a/src/test/resources/eager/correctly-preserves-identifiers-in-macro-function.expected.jinja
+++ b/src/test/resources/eager/correctly-preserves-identifiers-in-macro-function.expected.jinja
@@ -1,15 +1,12 @@
-{% set list = [] %}
-{% macro bar() %}
-{% set map1 = {} %}
-{% set map2 = {} %}
-{% do list.append(map1) %}
-{% if deferred %}
-{% do list.append(map2) %}
+{% set list = [{'a': 'A'} ] %}{% set __macro_bar_93535367_temp_variable_1__ %}
+{% set map1 = {}  %}
+{% set map2 = {}  %}
+{% set map1 = {}  %}{% do list.append(map1) %}
+{% set map2 = {}  %}{% if deferred %}
+{% set map2 = {}  %}{% do list.append(map2) %}
 {% endif %}
-{% do map1.update({'a': 'A'}) %}
-{% do map2.update({'b': 'B'}) %}
+{% do map1.update({'a': 'A'} ) %}
+{% do map2.update({'b': 'B'} ) %}
 {{ list }}
-{% endmacro %}
-
-{% set foobar = bar() %}
+{% endset %}{% set foobar = __macro_bar_93535367_temp_variable_1__ %}
 {{ list }}

--- a/src/test/resources/eager/correctly-preserves-identifiers-in-macro-function.expected.jinja
+++ b/src/test/resources/eager/correctly-preserves-identifiers-in-macro-function.expected.jinja
@@ -1,0 +1,15 @@
+{% set list = [] %}
+{% macro bar() %}
+{% set map1 = {} %}
+{% set map2 = {} %}
+{% do list.append(map1) %}
+{% if deferred %}
+{% do list.append(map2) %}
+{% endif %}
+{% do map1.update({'a': 'A'}) %}
+{% do map2.update({'b': 'B'}) %}
+{{ list }}
+{% endmacro %}
+
+{% set foobar = bar() %}
+{{ list }}

--- a/src/test/resources/eager/correctly-preserves-identifiers-in-macro-function.jinja
+++ b/src/test/resources/eager/correctly-preserves-identifiers-in-macro-function.jinja
@@ -1,11 +1,3 @@
-{#{% set dict = {} %}
-
-{% set foo = (dict, deferred) %}
-
-{% do dict.update({'a': 'b'}) %}
-
-{{ foo }}
-#}
 {% set list = [] %}
 {% macro bar() %}
 {% set map1 = {} %}

--- a/src/test/resources/eager/correctly-preserves-identifiers-in-macro-function.jinja
+++ b/src/test/resources/eager/correctly-preserves-identifiers-in-macro-function.jinja
@@ -1,0 +1,23 @@
+{#{% set dict = {} %}
+
+{% set foo = (dict, deferred) %}
+
+{% do dict.update({'a': 'b'}) %}
+
+{{ foo }}
+#}
+{% set list = [] %}
+{% macro bar() %}
+{% set map1 = {} %}
+{% set map2 = {} %}
+{% do list.append(map1) %}
+{% if deferred %}
+{% do list.append(map2) %}
+{% endif %}
+{% do map1.update({'a': 'A'}) %}
+{% do map2.update({'b': 'B'}) %}
+{{ list }}
+{% endmacro %}
+
+{% set foobar = bar() %}
+{{ list }}

--- a/src/test/resources/eager/handles-deferring-loop-variable.expected.jinja
+++ b/src/test/resources/eager/handles-deferring-loop-variable.expected.jinja
@@ -7,7 +7,7 @@
 {% endif %}
 2
 {% endfor %}
-{% for i in [0, 1] %}
+{% set foo = [0, 1] %}{% set foo = [0, 1] %}{% for i in foo %}
 {% if deferred && loop.isLast() %}last time!
 {% endif %}
 {{ loop.index }}

--- a/src/test/resources/eager/handles-duplicate-variable-reference-modification.expected.jinja
+++ b/src/test/resources/eager/handles-duplicate-variable-reference-modification.expected.jinja
@@ -1,5 +1,5 @@
 {% set the_list = [] %}{% if deferred %}
-{% set the_list = [] %}{% set some_list = [] %}{% set the_list = [] %}{% set some_list = the_list %}{% do some_list.append(deferred) %}
+{% set the_list = [] %}{% set some_list = the_list %}{% do some_list.append(deferred) %}
 {% endif %}
 {{ the_list }}
 

--- a/src/test/resources/eager/handles-higher-scope-reference-modification.expected.jinja
+++ b/src/test/resources/eager/handles-higher-scope-reference-modification.expected.jinja
@@ -4,7 +4,7 @@ C: {{ c_list }}.{% endmacro %}{% set b_list = a_list %}{% set b_list = a_list %}
 B: {% set b_list = a_list %}{% set b_list = a_list %}{% set b_list = a_list %}{% set b_list = a_list %}{{ b_list }}.{% do a_list.append(deferred ? 'A' : '') %}
 A: {{ a_list }}.
 ---
-{% set a_list = ['a'] %}{% set b_list = a_list %}{% for i in [0] %}{% set b_list = a_list %}{% set b_list = a_list %}{% do b_list.append('b') %}{% for __ignored__ in [0] %}{% set b_list = a_list %}{% set c_list = b_list %}{% do c_list.append(deferred ? 'c' : '') %}
+{% set a_list = ['a'] %}{% for i in [0] %}{% set b_list = a_list %}{% set b_list = a_list %}{% do b_list.append('b') %}{% for __ignored__ in [0] %}{% set b_list = a_list %}{% set c_list = b_list %}{% do c_list.append(deferred ? 'c' : '') %}
 C: {{ c_list }}.{% endfor %}{% set b_list = a_list %}{% do b_list.append(deferred ? 'B' : '') %}
 B: {% set b_list = a_list %}{{ b_list }}.{% endfor %}{% do a_list.append(deferred ? 'A' : '') %}
 A: {{ a_list }}.

--- a/src/test/resources/eager/uses-unique-macro-names.expected.jinja
+++ b/src/test/resources/eager/uses-unique-macro-names.expected.jinja
@@ -1,10 +1,10 @@
 {% set myname = deferred %}
 
-{% set __macro_foo_97643642_temp_variable_0__ %}
+{% set __macro_foo_97643642_temp_variable_1__ %}
 Goodbye {{ myname }}
-{% endset %}{% set a = filter:upper.filter(__macro_foo_97643642_temp_variable_0__, ____int3rpr3t3r____) %}
+{% endset %}{% set a = filter:upper.filter(__macro_foo_97643642_temp_variable_1__, ____int3rpr3t3r____) %}
 {% set __ignored__ %}{% set current_path = 'macro-with-filter.jinja' %}
-{% set __macro_foo_927217348_temp_variable_0__ %}Hello {{ myname }}{% endset %}{% set b = filter:upper.filter(__macro_foo_927217348_temp_variable_0__, ____int3rpr3t3r____) %}
+{% set __macro_foo_927217348_temp_variable_1__ %}Hello {{ myname }}{% endset %}{% set b = filter:upper.filter(__macro_foo_927217348_temp_variable_1__, ____int3rpr3t3r____) %}
 {% set current_path = '' %}{% endset %}
 {{ a }}
 {{ b }}


### PR DESCRIPTION
When reconstructing a tag which has the function of setting a variable to the result of an expression (both `set` and `for` do this), we should preserve the AstIdentifiers in the expression rather than resolving them because they may be directly referencing a value which can be modified later on. If instead, we set our variable to a serialized version of the object, then if that object is modified, the changes will not be reflected in the set value.

The simplest example of this is shown in one of the new tests:
```
{% set dict = {} %}

{% set foo = (dict, deferred) %}

{% do dict.update({'a': 'b'}) %}

{{ foo }}
```
If we don't preserve the identifier for `dict`, then we end up with:
```
{% set dict = {} %}

{% set foo = ({}, deferred) %}

{% do dict.update({'a': 'b'}) %}

{{ foo }}
```
Which would result in `foo` not having the correct value within it!

I realised that this can also happen if a value is reconstructed and then later one of the elements inside of that value is updated. Such a case is much more difficult to handle. I created a separate issue for that: https://github.com/HubSpot/jinjava/issues/987