### PR TITLE
Only defer imported variables when in deferred execution mode

### DIFF
--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -744,6 +744,20 @@ public class EagerImportTagTest extends ImportTagTest {
     assertThat(interpreter.render(result)).isEqualTo("ab");
   }
 
+  @Test
+  public void itDoesNotDeferImportedVariablesWhenNotInDeferredExecutionMode() {
+    setupResourceLocator();
+    String result = interpreter
+      .render("{% import 'set-two-variables.jinja' %}" + "{{ foo }} {{ bar }}")
+      .trim();
+    assertThat(result)
+      .isEqualTo(
+        "{% set __ignored__ %}{% set current_path = 'set-two-variables.jinja' %}{% set foo = deferred %}\n" +
+        "\n" +
+        "{% set current_path = '' %}{% endset %}{{ foo }} bar"
+      );
+  }
+
   private static JinjavaInterpreter getChildInterpreter(
     JinjavaInterpreter interpreter,
     String alias

--- a/src/test/resources/tags/eager/importtag/set-two-variables.jinja
+++ b/src/test/resources/tags/eager/importtag/set-two-variables.jinja
@@ -1,0 +1,2 @@
+{% set foo = deferred %}
+{% set bar = 'bar' %}


### PR DESCRIPTION
When not in deferred execution mode, the resolved variables can still be put onto the context regularly.

Before this change, the test I added had an output like:
```
{% set __ignored__ %}{% set current_path = 'set-two-variables.jinja' %}{% set foo = deferred %}
{% set current_path = '' %}{% endset %}{{ foo }} {{ bar }}
```
Which is no good because `bar` is fully resolved and wouldn't get reconstructed anywhere.

The reason we need to defer variables when in deferred execution mode is because `set` tags attempt to set fully resolved values even when in deferred execution mode (so that the following code in deferred execution mode can use that value). Without deferring them, you could end up with a situation where `EagerTest.itHandlesImportInDeferredIf` has an output like:
```
{% if deferred %}
{% set __ignored__ %}{% set current_path = '../settag/set-val.jinja' %}{% set simple = {} %}{% for __ignored__ in [0] %}{% set primary_line_height = 42 %}{% do simple.update({'primary_line_height': primary_line_height}) %}{% do simple.update({'primary_line_height': 42,'import_resource_path': '../settag/set-val.jinja'}) %}{% endfor %}{% set current_path = '' %}{% endset %}
{% else %}
{% set __ignored__ %}{% set current_path = '../settag/set-val.jinja' %}{% set primary_line_height = 42 %}{% set current_path = '' %}{% endset %}
{% endif %}
simple.primary_line_height (deferred): {{ simple.primary_line_height }}
primary_line_height (deferred): 100
secondary_line_height: 200
```
The problem being that `primary_line_height` would stay resolved at `100` after the deferred if branches, when it could end up being `42` if `deferred == false` in a second render pass.

This bug was introduced when adding the speedup for eager execution in https://github.com/HubSpot/jinjava/pull/978