### PR TITLE
Don't preserve exp tests as well as filters

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifier.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifier.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.el.ext.eager;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.el.ext.ExtendedParser;
 import com.hubspot.jinjava.interpret.DeferredValueException;
+import com.hubspot.jinjava.lib.exptest.ExpTest;
 import com.hubspot.jinjava.lib.filter.Filter;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
 import de.odysseus.el.tree.Bindings;
@@ -26,6 +27,7 @@ public class EagerAstIdentifier extends AstIdentifier implements EvalResultHolde
           !ExtendedParser.INTERPRETER.equals(getName()) &&
           !EagerExpressionResolver.isPrimitive(result) &&
           !(result instanceof Filter) &&
+          !(result instanceof ExpTest) &&
           EvalResultHolder
             .getJinjavaInterpreter(context)
             .getContext()

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1271,4 +1271,11 @@ public class EagerTest {
       "correctly-preserves-identifiers-in-macro-function"
     );
   }
+
+  @Test
+  public void itDoesNotPreserveFilterAndExpTestIdentifiers() {
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
+      "does-not-preserve-filter-and-exp-test-identifiers"
+    );
+  }
 }

--- a/src/test/resources/eager/does-not-preserve-filter-and-exp-test-identifiers.expected.jinja
+++ b/src/test/resources/eager/does-not-preserve-filter-and-exp-test-identifiers.expected.jinja
@@ -1,0 +1,2 @@
+{% set foo = ({'foo': 'bar'} , false, deferred) %}
+{{ foo }}

--- a/src/test/resources/eager/does-not-preserve-filter-and-exp-test-identifiers.jinja
+++ b/src/test/resources/eager/does-not-preserve-filter-and-exp-test-identifiers.jinja
@@ -1,0 +1,2 @@
+{% set foo = ('{"foo": "bar"}'|fromjson, 5 is gt 5, deferred) %}
+{{ foo }}


### PR DESCRIPTION
I realised that in https://github.com/HubSpot/jinjava/pull/988 I check for filters, but forgot to check exp tests. I also add a test to ensure that they're not needlessly preserved