### PR TITLE
Only defer loop item on current context

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -17,6 +17,7 @@ import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult.Re
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -162,6 +163,11 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
         if (!(eagerInterpreter.getContext().get("loop") instanceof DeferredValue)) {
           eagerInterpreter.getContext().put("loop", DeferredValue.instance());
         }
+
+        getTag()
+          .getLoopVarsAndExpression((TagToken) tagNode.getMaster())
+          .getLeft()
+          .forEach(var -> interpreter.getContext().put(var, DeferredValue.instance()));
         return EagerExpressionResult.fromString(
           renderChildren(tagNode, eagerInterpreter)
         );
@@ -227,7 +233,7 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
                 !(interpreter.getContext().get(word) instanceof DeferredMacroValueImpl)
             )
             .collect(Collectors.toSet()),
-          new HashSet<>(loopVars)
+          Collections.emptySet()
         )
       )
     );

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -562,7 +562,7 @@ public class EagerReconstructionUtils {
     );
   }
 
-  public static void removeMetaContextVariables(
+  public static Set<String> removeMetaContextVariables(
     Stream<String> varStream,
     Context context
   ) {
@@ -575,6 +575,7 @@ public class EagerReconstructionUtils {
       )
       .immutableCopy();
     context.getMetaContextVariables().removeAll(metaSetVars);
+    return metaSetVars;
   }
 
   public static Boolean isDeferredExecutionMode() {

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -504,7 +504,7 @@ public class EagerTest {
           .flatMap(deferredToken -> deferredToken.getSetDeferredWords().stream())
           .collect(Collectors.toSet())
       )
-      .containsExactlyInAnyOrder("item");
+      .isEmpty();
     assertThat(
         localContext
           .getDeferredTokens()
@@ -973,7 +973,7 @@ public class EagerTest {
   public void itAllowsMetaContextVarOverriding() {
     interpreter.getContext().getMetaContextVariables().add("meta");
     interpreter.getContext().put("meta", "META");
-    expectedTemplateInterpreter.assertExpectedOutput(
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
       "allows-meta-context-var-overriding"
     );
   }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1271,4 +1271,11 @@ public class EagerTest {
       "correctly-preserves-identifiers-in-macro-function"
     );
   }
+
+  @Test
+  public void itOnlyDefersLoopItemOnCurrentContext() {
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "only-defers-loop-item-on-current-context"
+    );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
@@ -57,8 +57,7 @@ public class EagerForTagTest extends ForTagTest {
       .filter(e -> ((TagToken) e.getToken()).getTagName().equals(tag.getName()))
       .findAny();
     assertThat(maybeDeferredToken).isPresent();
-    assertThat(maybeDeferredToken.get().getSetDeferredWords())
-      .containsExactlyInAnyOrder("item");
+    assertThat(maybeDeferredToken.get().getSetDeferredWords()).isEmpty();
     assertThat(maybeDeferredToken.get().getUsedDeferredWords()).contains("deferred");
   }
 
@@ -72,8 +71,7 @@ public class EagerForTagTest extends ForTagTest {
       .filter(e -> ((TagToken) e.getToken()).getTagName().equals(tag.getName()))
       .findAny();
     assertThat(maybeDeferredToken).isPresent();
-    assertThat(maybeDeferredToken.get().getSetDeferredWords())
-      .containsExactlyInAnyOrder("item", "item2");
+    assertThat(maybeDeferredToken.get().getSetDeferredWords()).isEmpty();
     assertThat(maybeDeferredToken.get().getUsedDeferredWords()).contains("deferred");
   }
 

--- a/src/test/resources/eager/allows-meta-context-var-overriding.expected.jinja
+++ b/src/test/resources/eager/allows-meta-context-var-overriding.expected.jinja
@@ -1,6 +1,6 @@
 0
 META
-{% set meta = 'META' %}{% for meta in deferred %}
+{% for meta in deferred %}
 {{ meta }}{% endfor %}
 {{ meta }}
 {% set meta = [] %}{% if deferred %}

--- a/src/test/resources/eager/only-defers-loop-item-on-current-context.expected.jinja
+++ b/src/test/resources/eager/only-defers-loop-item-on-current-context.expected.jinja
@@ -1,0 +1,13 @@
+{% set outer_val = 'start' %}{% for def in deferred %}
+{% set outer_list = [{'a': ['b']} ] %}
+{% for __ignored__ in [0] %}
+{% set map = {'a': ['b']}  %}{% set inner_list = map.a %}
+{% for x in inner_list %}
+
+{% set outer_val = outer_val ~ '-' %}
+{% if outer_val == deferred %}
+{{ outer_val }}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% endfor %}

--- a/src/test/resources/eager/only-defers-loop-item-on-current-context.jinja
+++ b/src/test/resources/eager/only-defers-loop-item-on-current-context.jinja
@@ -1,0 +1,14 @@
+{% set outer_val = 'start' %}
+{% for def in deferred %}
+{% set outer_list = [{'a': ['b']}] %}
+{% for map in outer_list %}
+{% set inner_list = map.a %}
+{% for x in inner_list %}
+{# make outer_val a speculative binding #}
+{% set outer_val = outer_val ~ '-' %}
+{% if outer_val == deferred %}
+{{ outer_val }}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
This is a bit difficult to demonstrate in a test why it's a bug, but what it boils down to is because in a for loop `{% for x in y %}`, `x` is only set to that value within the context inside the loop. So if we defer `x` on the context surrounding the loop, there may be unintended side effects.
This test demonstrates such a side effect, of which the output before this fix looked an input of:

```
{% set outer_val = 'start' %}
{% for def in deferred %}
{% set outer_list = [{'a': ['b']}] %}
{% for map in outer_list %}
{% set inner_list = map.a %}
{% for x in inner_list %}
{# make outer_val a speculative binding #}
{% set outer_val = outer_val ~ '-' %}
{% if outer_val == deferred %}
{{ outer_val }}
{% endif %}
{% endfor %}
{% endfor %}
{% endfor %}
```
Would be output like this:
```
{% set outer_val = 'start' %}{% for def in deferred %}
{% set outer_list = [{'a': ['b']} ] %}
{% for __ignored__ in [0] %}
{% set inner_list = map.a %}
{% for x in inner_list %}

{% set outer_val = outer_val ~ '-' %}
{% if outer_val == deferred %}
{{ outer_val }}
{% endif %}
{% endfor %}
{% endfor %}{% endfor %}
```
`map` is never reconstructed because when checking to see if it needs to be reconstructed, we see that it's already a deferred value so it must have already been reconstructed. That happens because the deferral of `map` leaked outside of the for loop. If we confine the deferral of `map` to be within the for loop only, then `map` will get reconstructed properly. 