### PR TITLE
Move resetBindingsForNextBranch method to EagerReconstructionUtils

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -58,7 +58,7 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
         !result.getSpeculativeBindings().isEmpty()
       )
     ) {
-      EagerIfTag.resetBindingsForNextBranch(interpreter, result);
+      EagerReconstructionUtils.resetSpeculativeBindings(interpreter, result);
       interpreter.getContext().removeDeferredTokens(addedTokens);
       throw new DeferredValueException(
         result.getResult().getResolutionState() == ResolutionState.NONE

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
@@ -121,7 +121,9 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
             .build()
         );
         sb.append(result.getResult());
-        bindingsToDefer.addAll(resetBindingsForNextBranch(interpreter, result));
+        bindingsToDefer.addAll(
+          EagerReconstructionUtils.resetSpeculativeBindings(interpreter, result)
+        );
       }
       if (branchEnd >= childrenSize || definitelyExecuted) {
         break;
@@ -178,16 +180,6 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
       return sb.toString();
     }
     return sb.toString();
-  }
-
-  public static Set<String> resetBindingsForNextBranch(
-    JinjavaInterpreter interpreter,
-    EagerExecutionResult result
-  ) {
-    result
-      .getSpeculativeBindings()
-      .forEach((k, v) -> interpreter.getContext().replace(k, v));
-    return result.getSpeculativeBindings().keySet();
   }
 
   private String evaluateBranch(

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -653,4 +653,14 @@ public class EagerReconstructionUtils {
       )
     );
   }
+
+  public static Set<String> resetSpeculativeBindings(
+    JinjavaInterpreter interpreter,
+    EagerExecutionResult result
+  ) {
+    result
+      .getSpeculativeBindings()
+      .forEach((k, v) -> interpreter.getContext().replace(k, v));
+    return result.getSpeculativeBindings().keySet();
+  }
 }


### PR DESCRIPTION
This is a nice refactor to have that we can keep from https://github.com/HubSpot/jinjava/pull/988 while the rest of it got reverted.