### PR TITLE
Ignore unnecessary, failing test

### DIFF
--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class EagerTest {
@@ -1259,6 +1260,7 @@ public class EagerTest {
   }
 
   @Test
+  @Ignore // Test isn't necessary after https://github.com/HubSpot/jinjava/pull/988 got reverted
   public void itOnlyDefersLoopItemOnCurrentContext() {
     expectedTemplateInterpreter.assertExpectedOutput(
       "only-defers-loop-item-on-current-context"


### PR DESCRIPTION
When https://github.com/HubSpot/jinjava/pull/988 got reverted, the logic that was required for this test no longer happened. We don't need to worry about `map` not being reconstructed because we aren't trying to preserve that identifier anymore.