### PR TITLE
Limit pyish serialization length

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/NamedParameter.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/NamedParameter.java
@@ -26,7 +26,10 @@ public class NamedParameter implements PyishSerializable {
   }
 
   @Override
-  public String toPyishString() {
-    return name + "=" + PyishSerializable.writeValueAsString(value);
+  public StringBuilder appendPyishString(StringBuilder sb) {
+    return sb
+      .append(name)
+      .append('=')
+      .append(PyishSerializable.writeValueAsString(value));
   }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/NamedParameter.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/NamedParameter.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.el.ext;
 
 import com.hubspot.jinjava.objects.serialization.PyishSerializable;
+import java.io.IOException;
 import java.util.Objects;
 
 public class NamedParameter implements PyishSerializable {
@@ -26,8 +27,10 @@ public class NamedParameter implements PyishSerializable {
   }
 
   @Override
-  public StringBuilder appendPyishString(StringBuilder sb) {
-    return sb
+  @SuppressWarnings("unchecked")
+  public <T extends Appendable & CharSequence> T appendPyishString(T appendable)
+    throws IOException {
+    return (T) appendable
       .append(name)
       .append('=')
       .append(PyishSerializable.writeValueAsString(value));

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -882,7 +882,9 @@ public class JinjavaInterpreter implements PyishSerializable {
   }
 
   @Override
-  public String toPyishString() {
-    return ExtendedParser.INTERPRETER;
+  @SuppressWarnings("unchecked")
+  public <T extends Appendable & CharSequence> T appendPyishString(T appendable)
+    throws IOException {
+    return (T) appendable.append(ExtendedParser.INTERPRETER);
   }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/LazyReference.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/LazyReference.java
@@ -24,7 +24,7 @@ public class LazyReference extends LazyExpression implements PyishSerializable {
   }
 
   @Override
-  public String toPyishString() {
+  public CharSequence toPyishString() {
     return getReferenceKey();
   }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/LazyReference.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/LazyReference.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.interpret;
 
 import com.hubspot.jinjava.objects.serialization.PyishSerializable;
+import java.io.IOException;
 
 public class LazyReference extends LazyExpression implements PyishSerializable {
   private String referenceKey;
@@ -24,7 +25,9 @@ public class LazyReference extends LazyExpression implements PyishSerializable {
   }
 
   @Override
-  public CharSequence toPyishString() {
-    return getReferenceKey();
+  @SuppressWarnings("unchecked")
+  public <T extends Appendable & CharSequence> T appendPyishString(T appendable)
+    throws IOException {
+    return (T) appendable.append(getReferenceKey());
   }
 }

--- a/src/main/java/com/hubspot/jinjava/objects/Namespace.java
+++ b/src/main/java/com/hubspot/jinjava/objects/Namespace.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.objects;
 
 import com.hubspot.jinjava.objects.collections.SizeLimitingPyMap;
 import com.hubspot.jinjava.objects.serialization.PyishSerializable;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -20,7 +21,11 @@ public class Namespace extends SizeLimitingPyMap implements PyishSerializable {
   }
 
   @Override
-  public StringBuilder appendPyishString(StringBuilder sb) {
-    return PyishSerializable.super.appendPyishString(sb.append("namespace(")).append(')');
+  @SuppressWarnings("unchecked")
+  public <T extends Appendable & CharSequence> T appendPyishString(T appendable)
+    throws IOException {
+    return (T) PyishSerializable
+      .super.appendPyishString((T) appendable.append("namespace("))
+      .append(')');
   }
 }

--- a/src/main/java/com/hubspot/jinjava/objects/Namespace.java
+++ b/src/main/java/com/hubspot/jinjava/objects/Namespace.java
@@ -20,7 +20,7 @@ public class Namespace extends SizeLimitingPyMap implements PyishSerializable {
   }
 
   @Override
-  public String toPyishString() {
-    return String.format("namespace(%s)", PyishSerializable.super.toPyishString());
+  public StringBuilder appendPyishString(StringBuilder sb) {
+    return PyishSerializable.super.appendPyishString(sb.append("namespace(")).append(')');
   }
 }

--- a/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
@@ -4,6 +4,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.objects.PyWrapper;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.objects.serialization.PyishSerializable;
+import java.io.IOException;
 import java.io.Serializable;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -158,8 +159,10 @@ public final class PyishDate
   }
 
   @Override
-  public StringBuilder appendPyishString(StringBuilder sb) {
-    return sb
+  @SuppressWarnings("unchecked")
+  public <T extends Appendable & CharSequence> T appendPyishString(T appendable)
+    throws IOException {
+    return (T) appendable
       .append('\'')
       .append(strftime(FULL_DATE_FORMAT))
       .append("'|strtotime(")

--- a/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
@@ -166,7 +166,7 @@ public final class PyishDate
       .append('\'')
       .append(strftime(FULL_DATE_FORMAT))
       .append("'|strtotime(")
-      .append(PyishObjectMapper.getAsPyishString(FULL_DATE_FORMAT))
+      .append(PyishObjectMapper.getAsPyishStringOrThrow(FULL_DATE_FORMAT))
       .append(')');
   }
 }

--- a/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
@@ -158,11 +158,12 @@ public final class PyishDate
   }
 
   @Override
-  public String toPyishString() {
-    return String.format(
-      "'%s'|strtotime(%s)",
-      strftime(FULL_DATE_FORMAT),
-      PyishObjectMapper.getAsPyishString(FULL_DATE_FORMAT)
-    );
+  public StringBuilder appendPyishString(StringBuilder sb) {
+    return sb
+      .append('\'')
+      .append(strftime(FULL_DATE_FORMAT))
+      .append("'|strtotime(")
+      .append(PyishObjectMapper.getAsPyishString(FULL_DATE_FORMAT))
+      .append(')');
   }
 }

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/LengthLimitingJsonProcessingException.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/LengthLimitingJsonProcessingException.java
@@ -2,11 +2,11 @@ package com.hubspot.jinjava.objects.serialization;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
-public class SizeLimitingJsonProcessingException extends JsonProcessingException {
+public class LengthLimitingJsonProcessingException extends JsonProcessingException {
   private final int maxSize;
   private final int attemptedSize;
 
-  protected SizeLimitingJsonProcessingException(int maxSize, int attemptedSize) {
+  protected LengthLimitingJsonProcessingException(int maxSize, int attemptedSize) {
     super(
       String.format(
         "Max length of %d chars reached when serializing. %d chars attempted.",

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/LengthLimitingWriter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/LengthLimitingWriter.java
@@ -5,13 +5,13 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class SizeLimitingWriter extends Writer {
+public class LengthLimitingWriter extends Writer {
   public static final String REMAINING_LENGTH_ATTRIBUTE = "remainingLength";
   private final CharArrayWriter charArrayWriter;
   private final AtomicInteger remainingLength;
   private final int startingLength;
 
-  public SizeLimitingWriter(
+  public LengthLimitingWriter(
     CharArrayWriter charArrayWriter,
     AtomicInteger remainingLength
   ) {
@@ -21,28 +21,28 @@ public class SizeLimitingWriter extends Writer {
   }
 
   @Override
-  public void write(int c) throws SizeLimitingJsonProcessingException {
+  public void write(int c) throws LengthLimitingJsonProcessingException {
     checkMaxSize(1);
     charArrayWriter.write(c);
   }
 
   @Override
   public void write(char[] c, int off, int len)
-    throws SizeLimitingJsonProcessingException {
+    throws LengthLimitingJsonProcessingException {
     checkMaxSize(len);
     charArrayWriter.write(c, off, len);
   }
 
   @Override
   public void write(String str, int off, int len)
-    throws SizeLimitingJsonProcessingException {
+    throws LengthLimitingJsonProcessingException {
     checkMaxSize(len);
     charArrayWriter.write(str, off, len);
   }
 
-  private void checkMaxSize(int extra) throws SizeLimitingJsonProcessingException {
+  private void checkMaxSize(int extra) throws LengthLimitingJsonProcessingException {
     if (remainingLength.addAndGet(extra * -1) < 0) {
-      throw new SizeLimitingJsonProcessingException(
+      throw new LengthLimitingJsonProcessingException(
         startingLength,
         charArrayWriter.size() + extra
       );

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/MapEntrySerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/MapEntrySerializer.java
@@ -36,10 +36,7 @@ public class MapEntrySerializer extends JsonSerializer<Entry<?, ?>> {
         new CharArrayWriter(),
         remainingLength
       );
-      objectWriter.writeValue(
-        new SizeLimitingWriter(new CharArrayWriter(), remainingLength),
-        entry.getValue()
-      );
+      objectWriter.writeValue(sizeLimitingWriter, entry.getValue());
       value = sizeLimitingWriter.toString();
     } else {
       key = PyishObjectMapper.PYISH_OBJECT_WRITER.writeValueAsString(entry.getKey());

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/MapEntrySerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/MapEntrySerializer.java
@@ -22,22 +22,22 @@ public class MapEntrySerializer extends JsonSerializer<Entry<?, ?>> {
   )
     throws IOException {
     AtomicInteger remainingLength = (AtomicInteger) serializerProvider.getAttribute(
-      SizeLimitingWriter.REMAINING_LENGTH_ATTRIBUTE
+      LengthLimitingWriter.REMAINING_LENGTH_ATTRIBUTE
     );
     String key;
     String value;
     if (remainingLength != null) {
       ObjectWriter objectWriter = PyishObjectMapper.PYISH_OBJECT_WRITER.withAttribute(
-        SizeLimitingWriter.REMAINING_LENGTH_ATTRIBUTE,
+        LengthLimitingWriter.REMAINING_LENGTH_ATTRIBUTE,
         remainingLength
       );
       key = objectWriter.writeValueAsString(entry.getKey());
-      SizeLimitingWriter sizeLimitingWriter = new SizeLimitingWriter(
+      LengthLimitingWriter lengthLimitingWriter = new LengthLimitingWriter(
         new CharArrayWriter(),
         remainingLength
       );
-      objectWriter.writeValue(sizeLimitingWriter, entry.getValue());
-      value = sizeLimitingWriter.toString();
+      objectWriter.writeValue(lengthLimitingWriter, entry.getValue());
+      value = lengthLimitingWriter.toString();
     } else {
       key = PyishObjectMapper.PYISH_OBJECT_WRITER.writeValueAsString(entry.getKey());
       value = PyishObjectMapper.PYISH_OBJECT_WRITER.writeValueAsString(entry.getValue());

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.OutputTooBigException;
 import com.hubspot.jinjava.util.WhitespaceUtils;
@@ -47,21 +46,10 @@ public class PyishObjectMapper {
       return getAsPyishStringOrThrow(val);
     } catch (IOException e) {
       if (e instanceof LengthLimitingJsonProcessingException) {
-        if (
-          JinjavaInterpreter
-            .getCurrentMaybe()
-            .map(
-              interpreter -> interpreter.getConfig().getExecutionMode().useEagerParser()
-            )
-            .orElse(false)
-        ) {
-          throw new DeferredValueException(String.format("%s: %s", e.getMessage(), val));
-        } else {
-          throw new OutputTooBigException(
-            ((LengthLimitingJsonProcessingException) e).getMaxSize(),
-            ((LengthLimitingJsonProcessingException) e).getAttemptedSize()
-          );
-        }
+        throw new OutputTooBigException(
+          ((LengthLimitingJsonProcessingException) e).getMaxSize(),
+          ((LengthLimitingJsonProcessingException) e).getAttemptedSize()
+        );
       }
       return Objects.toString(val, "");
     }

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -24,10 +24,8 @@ public class PyishObjectMapper {
   static {
     ObjectMapper mapper = new ObjectMapper(
       new JsonFactoryBuilder().quoteChar('\'').build()
-    );
-
-    mapper =
-      mapper.registerModule(
+    )
+    .registerModule(
         new SimpleModule()
           .setSerializerModifier(PyishBeanSerializerModifier.INSTANCE)
           .addSerializer(PyishSerializable.class, PyishSerializer.INSTANCE)

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -46,7 +46,7 @@ public class PyishObjectMapper {
     try {
       return getAsPyishStringOrThrow(val);
     } catch (IOException e) {
-      if (e instanceof SizeLimitingJsonProcessingException) {
+      if (e instanceof LengthLimitingJsonProcessingException) {
         if (
           JinjavaInterpreter
             .getCurrentMaybe()
@@ -58,8 +58,8 @@ public class PyishObjectMapper {
           throw new DeferredValueException(String.format("%s: %s", e.getMessage(), val));
         } else {
           throw new OutputTooBigException(
-            ((SizeLimitingJsonProcessingException) e).getMaxSize(),
-            ((SizeLimitingJsonProcessingException) e).getAttemptedSize()
+            ((LengthLimitingJsonProcessingException) e).getMaxSize(),
+            ((LengthLimitingJsonProcessingException) e).getAttemptedSize()
           );
         }
       }
@@ -80,10 +80,10 @@ public class PyishObjectMapper {
       );
       objectWriter =
         objectWriter.withAttribute(
-          SizeLimitingWriter.REMAINING_LENGTH_ATTRIBUTE,
+          LengthLimitingWriter.REMAINING_LENGTH_ATTRIBUTE,
           remainingLength
         );
-      writer = new SizeLimitingWriter(new CharArrayWriter(), remainingLength);
+      writer = new LengthLimitingWriter(new CharArrayWriter(), remainingLength);
     } else {
       writer = new CharArrayWriter();
     }

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
@@ -53,9 +53,9 @@ public interface PyishSerializable extends PyWrapper {
     );
     jsonGenerator.writeRawValue(
       appendPyishString(
-          remainingLength != null
-            ? new LengthLimitingStringBuilder(remainingLength.get())
-            : new StringBuilder()
+          remainingLength == null
+            ? new StringBuilder()
+            : new LengthLimitingStringBuilder(remainingLength.get())
         )
         .toString()
     );

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
@@ -16,23 +16,26 @@ public interface PyishSerializable extends PyWrapper {
   )
     .writer(PyishPrettyPrinter.INSTANCE)
     .with(PyishCharacterEscapes.INSTANCE);
+
   /**
    * Allows for a class to specify a custom string representation in Jinjava.
    * By default, this will get a json representation of the object,
    * but this method can be overridden to provide a custom representation.
-   * This method will be used by {@link #writeSelf(JsonGenerator, SerializerProvider)}
-   * to specify what will be written to the json generator.
+   * This should no longer be called directly,
+   * {@link #writeSelf(JsonGenerator, SerializerProvider)} or
+   * {@link #appendPyishString(StringBuilder)} should instead be used.
    * @return A pyish/json CharSequence representation of the object
    */
+  @Deprecated
   default CharSequence toPyishString() {
     return writeValueAsString(this);
   }
 
   /**
    * Allows for a class to append the custom string representation in Jinjava.
-   * This method can be overridden to append a custom representation.
    * This method will be used by {@link #writeSelf(JsonGenerator, SerializerProvider)}
    * to specify what will be written to the json generator.
+   * <p>
    * If the pyish string representation of this object is composed of several strings,
    * it's recommended to override this method instead of {@link #toPyishString()}
    * @param sb StringBuilder to append the pyish string representation to.
@@ -45,10 +48,12 @@ public interface PyishSerializable extends PyWrapper {
   /**
    * Allows for a class to specify how its pyish string representation will
    * be written to the json generator.
-   *
+   * <p>
    * If the pyish string representation of this object can be very large, it's recommended
    * to override this method instead of {@link #toPyishString()} so that jsonGenerator
    * can be written to multiple times, allowing multiple limit checks to occur.
+   * @param jsonGenerator The JsonGenerator to write to.
+   * @param serializerProvider Provides default value serialization and attributes stored on the ObjectWriter if needed.
    */
   default void writeSelf(
     JsonGenerator jsonGenerator,

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
@@ -20,42 +20,26 @@ public interface PyishSerializable extends PyWrapper {
     .with(PyishCharacterEscapes.INSTANCE);
 
   /**
-   * Allows for a class to specify a custom string representation in Jinjava.
-   * By default, this will get a json representation of the object,
-   * but this method can be overridden to provide a custom representation.
-   * This should no longer be called directly,
-   * {@link #writePyishSelf(JsonGenerator, SerializerProvider)} or
-   * {@link #appendPyishString(Appendable)} should instead be used.
-   * @return A pyish/json CharSequence representation of the object
-   */
-  @Deprecated
-  default CharSequence toPyishString() {
-    return writeValueAsString(this);
-  }
-
-  /**
    * Allows for a class to append the custom string representation in Jinjava.
    * This method will be used by {@link #writePyishSelf(JsonGenerator, SerializerProvider)}
    * to specify what will be written to the json generator.
    * <p>
-   * If the pyish string representation of this object is composed of several strings,
-   * it's recommended to override this method instead of {@link #toPyishString()}
    * @param appendable Appendable to append the pyish string representation to.
    * @return The same appendable with an appended result
    */
   @SuppressWarnings("unchecked")
   default <T extends Appendable & CharSequence> T appendPyishString(T appendable)
     throws IOException {
-    return (T) appendable.append(toPyishString());
+    return (T) appendable.append(writeValueAsString(this));
   }
 
   /**
    * Allows for a class to specify how its pyish string representation will
    * be written to the json generator.
    * <p>
-   * If the pyish string representation of this object can be very large, it's recommended
-   * to override this method instead of {@link #toPyishString()} so that jsonGenerator
-   * can be written to multiple times, allowing multiple limit checks to occur.
+   * If the object's serialization can be broken up into multiple jsonGenerator writes,
+   * then this method can be overridden to do so instead of a single call to
+   * {@link JsonGenerator#writeRawValue(String)}.
    * @param jsonGenerator The JsonGenerator to write to.
    * @param serializerProvider Provides default value serialization and attributes stored on the ObjectWriter if needed.
    */

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
@@ -24,7 +24,7 @@ public interface PyishSerializable extends PyWrapper {
    * By default, this will get a json representation of the object,
    * but this method can be overridden to provide a custom representation.
    * This should no longer be called directly,
-   * {@link #writeSelf(JsonGenerator, SerializerProvider)} or
+   * {@link #writePyishSelf(JsonGenerator, SerializerProvider)} or
    * {@link #appendPyishString(Appendable)} should instead be used.
    * @return A pyish/json CharSequence representation of the object
    */
@@ -35,7 +35,7 @@ public interface PyishSerializable extends PyWrapper {
 
   /**
    * Allows for a class to append the custom string representation in Jinjava.
-   * This method will be used by {@link #writeSelf(JsonGenerator, SerializerProvider)}
+   * This method will be used by {@link #writePyishSelf(JsonGenerator, SerializerProvider)}
    * to specify what will be written to the json generator.
    * <p>
    * If the pyish string representation of this object is composed of several strings,
@@ -59,7 +59,7 @@ public interface PyishSerializable extends PyWrapper {
    * @param jsonGenerator The JsonGenerator to write to.
    * @param serializerProvider Provides default value serialization and attributes stored on the ObjectWriter if needed.
    */
-  default void writeSelf(
+  default void writePyishSelf(
     JsonGenerator jsonGenerator,
     SerializerProvider serializerProvider
   )

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
@@ -1,10 +1,13 @@
 package com.hubspot.jinjava.objects.serialization;
 
 import com.fasterxml.jackson.core.JsonFactoryBuilder;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializerProvider;
 import com.hubspot.jinjava.objects.PyWrapper;
+import java.io.IOException;
 import java.util.Objects;
 
 public interface PyishSerializable extends PyWrapper {
@@ -17,11 +20,27 @@ public interface PyishSerializable extends PyWrapper {
    * Allows for a class to specify a custom string representation in Jinjava.
    * By default, this will get a json representation of the object,
    * but this method can be overridden to provide a custom representation.
-   * This should use double quotes to wrap json keys/values.
-   * @return A pyish/json string representation of the object
+   * This method will be used by {@link #writeSelf(JsonGenerator, SerializerProvider)}
+   * to specify what will be written to the json generator.
+   * @return A pyish/json CharSequence representation of the object
    */
-  default String toPyishString() {
+  default CharSequence toPyishString() {
     return writeValueAsString(this);
+  }
+
+  /**
+   * Allows for a class to specify how its pyish string representation will
+   * be written to the json generator.
+   * If the pyish string representation of this object can be very large, it's recommended
+   * to override this method instead of {@link #toPyishString()} so that jsonGenerator
+   * can be written to multiple times, allowing multiple limit checks to occur.
+   */
+  default void writeSelf(
+    JsonGenerator jsonGenerator,
+    SerializerProvider serializerProvider
+  )
+    throws IOException {
+    jsonGenerator.writeRawValue(toPyishString().toString());
   }
 
   /**

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
@@ -29,8 +29,23 @@ public interface PyishSerializable extends PyWrapper {
   }
 
   /**
+   * Allows for a class to append the custom string representation in Jinjava.
+   * This method can be overridden to append a custom representation.
+   * This method will be used by {@link #writeSelf(JsonGenerator, SerializerProvider)}
+   * to specify what will be written to the json generator.
+   * If the pyish string representation of this object is composed of several strings,
+   * it's recommended to override this method instead of {@link #toPyishString()}
+   * @param sb StringBuilder to append the pyish string representation to.
+   * @return The same StringBuilder sb with an appended result
+   */
+  default StringBuilder appendPyishString(StringBuilder sb) {
+    return sb.append(toPyishString());
+  }
+
+  /**
    * Allows for a class to specify how its pyish string representation will
    * be written to the json generator.
+   *
    * If the pyish string representation of this object can be very large, it's recommended
    * to override this method instead of {@link #toPyishString()} so that jsonGenerator
    * can be written to multiple times, allowing multiple limit checks to occur.
@@ -40,7 +55,7 @@ public interface PyishSerializable extends PyWrapper {
     SerializerProvider serializerProvider
   )
     throws IOException {
-    jsonGenerator.writeRawValue(toPyishString().toString());
+    jsonGenerator.writeRawValue(appendPyishString(new StringBuilder()).toString());
   }
 
   /**

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
@@ -12,7 +12,6 @@ public class PyishSerializer extends JsonSerializer<Object> {
 
   private PyishSerializer() {}
 
-  @Override
   public void serialize(
     Object object,
     JsonGenerator jsonGenerator,
@@ -27,7 +26,7 @@ public class PyishSerializer extends JsonSerializer<Object> {
       .map(interpreter -> interpreter.wrap(object))
       .orElse(object);
     if (wrappedObject instanceof PyishSerializable) {
-      jsonGenerator.writeRawValue(((PyishSerializable) wrappedObject).toPyishString());
+      ((PyishSerializable) wrappedObject).writeSelf(jsonGenerator, serializerProvider);
     } else if (wrappedObject instanceof Boolean) {
       jsonGenerator.writeBoolean((Boolean) wrappedObject);
     } else if (wrappedObject instanceof Number) {

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
@@ -26,7 +26,10 @@ public class PyishSerializer extends JsonSerializer<Object> {
       .map(interpreter -> interpreter.wrap(object))
       .orElse(object);
     if (wrappedObject instanceof PyishSerializable) {
-      ((PyishSerializable) wrappedObject).writeSelf(jsonGenerator, serializerProvider);
+      ((PyishSerializable) wrappedObject).writePyishSelf(
+          jsonGenerator,
+          serializerProvider
+        );
     } else if (wrappedObject instanceof Boolean) {
       jsonGenerator.writeBoolean((Boolean) wrappedObject);
     } else if (wrappedObject instanceof Number) {

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/SizeLimitingJsonProcessingException.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/SizeLimitingJsonProcessingException.java
@@ -3,8 +3,26 @@ package com.hubspot.jinjava.objects.serialization;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 public class SizeLimitingJsonProcessingException extends JsonProcessingException {
+  private final int maxSize;
+  private final int attemptedSize;
 
   protected SizeLimitingJsonProcessingException(int maxSize, int attemptedSize) {
-    super("Max length of {} chars reached when serializing. {} chars attempted.");
+    super(
+      String.format(
+        "Max length of %d chars reached when serializing. %d chars attempted.",
+        maxSize,
+        attemptedSize
+      )
+    );
+    this.maxSize = maxSize;
+    this.attemptedSize = attemptedSize;
+  }
+
+  public int getAttemptedSize() {
+    return attemptedSize;
+  }
+
+  public int getMaxSize() {
+    return maxSize;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/SizeLimitingJsonProcessingException.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/SizeLimitingJsonProcessingException.java
@@ -1,0 +1,10 @@
+package com.hubspot.jinjava.objects.serialization;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public class SizeLimitingJsonProcessingException extends JsonProcessingException {
+
+  protected SizeLimitingJsonProcessingException(int maxSize, int attemptedSize) {
+    super("Max length of {} chars reached when serializing. {} chars attempted.");
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/SizeLimitingWriter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/SizeLimitingWriter.java
@@ -43,8 +43,8 @@ public class SizeLimitingWriter extends Writer {
   private void checkMaxSize(int extra) throws SizeLimitingJsonProcessingException {
     if (remainingLength.addAndGet(extra * -1) < 0) {
       throw new SizeLimitingJsonProcessingException(
-        charArrayWriter.size() + extra,
-        startingLength
+        startingLength,
+        charArrayWriter.size() + extra
       );
     }
   }

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/SizeLimitingWriter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/SizeLimitingWriter.java
@@ -1,0 +1,69 @@
+package com.hubspot.jinjava.objects.serialization;
+
+import java.io.CharArrayWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SizeLimitingWriter extends Writer {
+  public static final String REMAINING_LENGTH_ATTRIBUTE = "remainingLength";
+  private final CharArrayWriter charArrayWriter;
+  private final AtomicInteger remainingLength;
+  private final int startingLength;
+
+  public SizeLimitingWriter(
+    CharArrayWriter charArrayWriter,
+    AtomicInteger remainingLength
+  ) {
+    this.charArrayWriter = charArrayWriter;
+    this.remainingLength = remainingLength;
+    startingLength = remainingLength.get();
+  }
+
+  @Override
+  public void write(int c) throws SizeLimitingJsonProcessingException {
+    checkMaxSize(1);
+    charArrayWriter.write(c);
+  }
+
+  @Override
+  public void write(char[] c, int off, int len)
+    throws SizeLimitingJsonProcessingException {
+    checkMaxSize(len);
+    charArrayWriter.write(c, off, len);
+  }
+
+  @Override
+  public void write(String str, int off, int len)
+    throws SizeLimitingJsonProcessingException {
+    checkMaxSize(len);
+    charArrayWriter.write(str, off, len);
+  }
+
+  private void checkMaxSize(int extra) throws SizeLimitingJsonProcessingException {
+    if (remainingLength.addAndGet(extra * -1) < 0) {
+      throw new SizeLimitingJsonProcessingException(
+        charArrayWriter.size() + extra,
+        startingLength
+      );
+    }
+  }
+
+  public char[] toCharArray() {
+    return charArrayWriter.toCharArray();
+  }
+
+  public int size() {
+    return charArrayWriter.size();
+  }
+
+  public String toString() {
+    return charArrayWriter.toString();
+  }
+
+  @Override
+  public void flush() throws IOException {}
+
+  @Override
+  public void close() throws IOException {}
+}

--- a/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
@@ -1,6 +1,5 @@
 package com.hubspot.jinjava.util;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Primitives;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
@@ -17,6 +16,7 @@ import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.parse.ExpressionToken;
 import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult.ResolutionState;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -113,7 +113,7 @@ public class EagerExpressionResolver {
           return pyishString;
         }
       }
-    } catch (JsonProcessingException | OutputTooBigException ignored) {}
+    } catch (IOException | OutputTooBigException ignored) {}
     throw new DeferredValueException("Can not convert deferred result to string");
   }
 

--- a/src/main/java/com/hubspot/jinjava/util/LengthLimitingStringBuilder.java
+++ b/src/main/java/com/hubspot/jinjava/util/LengthLimitingStringBuilder.java
@@ -4,7 +4,8 @@ import com.hubspot.jinjava.interpret.OutputTooBigException;
 import java.io.Serializable;
 import java.util.stream.IntStream;
 
-public class LengthLimitingStringBuilder implements Serializable, CharSequence {
+public class LengthLimitingStringBuilder
+  implements Serializable, CharSequence, Appendable {
   private static final long serialVersionUID = -1891922886257965755L;
 
   private final StringBuilder builder;
@@ -50,14 +51,41 @@ public class LengthLimitingStringBuilder implements Serializable, CharSequence {
     append(String.valueOf(obj));
   }
 
-  public void append(String str) {
-    if (str == null) {
-      return;
+  @Override
+  public LengthLimitingStringBuilder append(CharSequence csq) {
+    int csqLength = 4; // null
+    if (csq != null) {
+      csqLength = csq.length();
     }
-    length += str.length();
+    length += csqLength;
+    checkLength();
+    builder.append(csq);
+    return this;
+  }
+
+  @Override
+  public Appendable append(CharSequence csq, int start, int end) {
+    int csqLength = 4; // null
+    if (csq != null) {
+      csqLength = end - start;
+    }
+    length += csqLength;
+    checkLength();
+    builder.append(csq, start, end);
+    return this;
+  }
+
+  @Override
+  public Appendable append(char c) {
+    length++;
+    checkLength();
+    builder.append(c);
+    return this;
+  }
+
+  private void checkLength() {
     if (maxLength > 0 && length > maxLength) {
       throw new OutputTooBigException(maxLength, length);
     }
-    builder.append(str);
   }
 }

--- a/src/main/java/com/hubspot/jinjava/util/WhitespaceUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/WhitespaceUtils.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.util;
 
 import com.google.common.base.Strings;
 import com.hubspot.jinjava.interpret.InterpretException;
+import javax.annotation.Nullable;
 
 public final class WhitespaceUtils {
   private static final char[] QUOTE_CHARS = new char[] { '\'', '"' };
@@ -140,6 +141,17 @@ public final class WhitespaceUtils {
     }
 
     return s.substring(start + prefix.length(), end - suffix.length() + 1);
+  }
+
+  @Nullable
+  public static StringBuilder quoteIfNotNull(CharSequence charSequence) {
+    if (charSequence != null) {
+      return new StringBuilder(charSequence.length() + 2)
+        .append('\'')
+        .append(charSequence)
+        .append('\'');
+    }
+    return null;
   }
 
   private WhitespaceUtils() {}

--- a/src/test/java/com/hubspot/jinjava/lib/filter/EscapeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/EscapeFilterTest.java
@@ -54,7 +54,7 @@ public class EscapeFilterTest extends BaseInterpretingTest {
 
     assertThat(newResult).isEqualTo(oldResult);
     System.out.printf("New: %d Old:%d\n", newTime.toMillis(), oldTime.toMillis());
-    int speedUpFactor = 2; // On M1, it is between 50 and 100 times faster.
+    int speedUpFactor = getVersion() < 17 ? 2 : 1; // On M1, it is between 50 and 100 times faster. Difference is much smaller on java 17
     assertThat(newTime.toMillis()).isLessThan(oldTime.toMillis() / speedUpFactor);
   }
 
@@ -64,5 +64,18 @@ public class EscapeFilterTest extends BaseInterpretingTest {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  private static int getVersion() {
+    String version = System.getProperty("java.version");
+    if (version.startsWith("1.")) {
+      version = version.substring(2, 3);
+    } else {
+      int dotIndex = version.indexOf(".");
+      if (dotIndex != -1) {
+        version = version.substring(0, dotIndex);
+      }
+    }
+    return Integer.parseInt(version);
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RejectAttrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RejectAttrFilterTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.Lists;
 import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.objects.serialization.PyishSerializable;
+import java.io.IOException;
 import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
@@ -112,8 +113,10 @@ public class RejectAttrFilterTest extends BaseJinjavaTest {
     }
 
     @Override
-    public CharSequence toPyishString() {
-      return toString();
+    @SuppressWarnings("unchecked")
+    public <T extends Appendable & CharSequence> T appendPyishString(T appendable)
+      throws IOException {
+      return (T) appendable.append(toString());
     }
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RejectAttrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RejectAttrFilterTest.java
@@ -112,7 +112,7 @@ public class RejectAttrFilterTest extends BaseJinjavaTest {
     }
 
     @Override
-    public String toPyishString() {
+    public CharSequence toPyishString() {
       return toString();
     }
   }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SelectAttrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SelectAttrFilterTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.Lists;
 import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.objects.serialization.PyishSerializable;
+import java.io.IOException;
 import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
@@ -135,8 +136,10 @@ public class SelectAttrFilterTest extends BaseJinjavaTest {
     }
 
     @Override
-    public String toPyishString() {
-      return toString();
+    @SuppressWarnings("unchecked")
+    public <T extends Appendable & CharSequence> T appendPyishString(T appendable)
+      throws IOException {
+      return (T) appendable.append(toString());
     }
   }
 
@@ -164,8 +167,10 @@ public class SelectAttrFilterTest extends BaseJinjavaTest {
     }
 
     @Override
-    public String toPyishString() {
-      return toString();
+    @SuppressWarnings("unchecked")
+    public <T extends Appendable & CharSequence> T appendPyishString(T appendable)
+      throws IOException {
+      return (T) appendable.append(toString());
     }
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SortFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SortFilterTest.java
@@ -6,6 +6,7 @@ import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import com.hubspot.jinjava.objects.serialization.PyishSerializable;
+import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -153,8 +154,10 @@ public class SortFilterTest extends BaseJinjavaTest {
     }
 
     @Override
-    public String toPyishString() {
-      return toString();
+    @SuppressWarnings("unchecked")
+    public <T extends Appendable & CharSequence> T appendPyishString(T appendable)
+      throws IOException {
+      return (T) appendable.append(toString());
     }
   }
 
@@ -175,8 +178,10 @@ public class SortFilterTest extends BaseJinjavaTest {
     }
 
     @Override
-    public String toPyishString() {
-      return toString();
+    @SuppressWarnings("unchecked")
+    public <T extends Appendable & CharSequence> T appendPyishString(T appendable)
+      throws IOException {
+      return (T) appendable.append(toString());
     }
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/UniqueFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/UniqueFilterTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.objects.serialization.PyishSerializable;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
@@ -71,8 +72,10 @@ public class UniqueFilterTest extends BaseJinjavaTest {
     }
 
     @Override
-    public String toPyishString() {
-      return toString();
+    @SuppressWarnings("unchecked")
+    public <T extends Appendable & CharSequence> T appendPyishString(T appendable)
+      throws IOException {
+      return (T) appendable.append(toString());
     }
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
@@ -125,7 +125,7 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
         () ->
           eagerTagDecorator.getEagerTagImage((TagToken) tagNode.getMaster(), interpreter)
       )
-      .isInstanceOf(DeferredValueException.class);
+      .isInstanceOf(OutputTooBigException.class);
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
@@ -2,7 +2,9 @@ package com.hubspot.jinjava.lib.tag.eager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.JinjavaConfig;
@@ -10,7 +12,6 @@ import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.OutputTooBigException;
-import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.lib.fn.ELFunctionDefinition;
 import com.hubspot.jinjava.lib.tag.Tag;
 import com.hubspot.jinjava.mode.EagerExecutionMode;
@@ -124,7 +125,7 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
         () ->
           eagerTagDecorator.getEagerTagImage((TagToken) tagNode.getMaster(), interpreter)
       )
-      .isInstanceOf(OutputTooBigException.class);
+      .isInstanceOf(DeferredValueException.class);
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
@@ -1,12 +1,14 @@
 package com.hubspot.jinjava.objects.serialization;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.objects.collections.SizeLimitingPyMap;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 
@@ -38,5 +40,30 @@ public class PyishObjectMapperTest {
     map.put("foobar", null);
     assertThat(PyishObjectMapper.getAsPyishString(map))
       .isEqualTo("{'foobar': null, 'foo': 'bar'} ");
+  }
+
+  @Test
+  public void itLimitsDepth() {
+    final List<Object> original = new ArrayList<>();
+    List<Object> list = original;
+    for (int i = 0; i < 20; i++) {
+      List<Object> temp = new ArrayList<>();
+      list.add("abcdefghijklmnopqrstuvwxyz");
+      list.add(temp);
+      list = temp;
+    }
+    list.add("a");
+    list.add(original);
+    try {
+      Jinjava jinjava = new Jinjava(
+        JinjavaConfig.newBuilder().withMaxOutputSize(10000).build()
+      );
+      JinjavaInterpreter.pushCurrent(jinjava.newInterpreter());
+      assertThatThrownBy(() -> PyishObjectMapper.getAsPyishStringOrThrow(original))
+        .as("The string to be serialized is larger than the max output size")
+        .isInstanceOf(SizeLimitingJsonProcessingException.class);
+    } finally {
+      JinjavaInterpreter.popCurrent();
+    }
   }
 }

--- a/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
@@ -83,7 +83,7 @@ public class PyishObjectMapperTest {
       JinjavaInterpreter.pushCurrent(jinjava.newInterpreter());
       assertThatThrownBy(() -> PyishObjectMapper.getAsPyishStringOrThrow(original))
         .as("The string to be serialized is larger than the max output size")
-        .isInstanceOf(SizeLimitingJsonProcessingException.class);
+        .isInstanceOf(LengthLimitingJsonProcessingException.class);
     } finally {
       JinjavaInterpreter.popCurrent();
     }

--- a/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
@@ -5,6 +5,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.objects.collections.SizeLimitingPyMap;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -31,6 +34,25 @@ public class PyishObjectMapperTest {
     String result = PyishObjectMapper.getAsPyishString(map.items());
     assertThat(result)
       .isEqualTo("[fn:map_entry('bar', {'foobar': []} ), fn:map_entry('foo', 'bar')]");
+  }
+
+  @Test
+  public void itSerializesMapEntrySetWithLimit() throws JsonProcessingException {
+    SizeLimitingPyMap map = new SizeLimitingPyMap(new HashMap<>(), 10);
+    map.put("foo", "bar");
+    map.put("bar", ImmutableMap.of("foobar", new ArrayList<>()));
+
+    Jinjava jinjava = new Jinjava(
+      JinjavaConfig.newBuilder().withMaxOutputSize(10000).build()
+    );
+    try {
+      JinjavaInterpreter.pushCurrent(jinjava.newInterpreter());
+      String result = PyishObjectMapper.getAsPyishString(map.items());
+      assertThat(result)
+        .isEqualTo("[fn:map_entry('bar', {'foobar': []} ), fn:map_entry('foo', 'bar')]");
+    } finally {
+      JinjavaInterpreter.popCurrent();
+    }
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
@@ -311,7 +311,7 @@ public class EagerExpressionResolverTest {
     EagerExpressionResult eagerExpressionResult = eagerResolveExpression("date");
 
     assertThat(WhitespaceUtils.unquoteAndUnescape(eagerExpressionResult.toString()))
-      .isEqualTo(date.toPyishString());
+      .isEqualTo(date.appendPyishString(new StringBuilder()).toString());
     interpreter.render(
       "{% set foo = " +
       PyishObjectMapper.getAsPyishString(ImmutableMap.of("a", date)) +

--- a/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
@@ -908,7 +908,9 @@ public class EagerExpressionResolverTest {
     }
 
     @Override
-    public String toPyishString() {
+    @SuppressWarnings("unchecked")
+    public <T extends Appendable & CharSequence> T appendPyishString(T appendable)
+      throws IOException {
       throw new DeferredValueException("Can't serialize");
     }
   }

--- a/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
@@ -24,6 +24,7 @@ import com.hubspot.jinjava.tree.parse.DefaultTokenScannerSymbols;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
+import java.io.IOException;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -303,7 +304,7 @@ public class EagerExpressionResolverTest {
   }
 
   @Test
-  public void itSerializesDateProperly() {
+  public void itSerializesDateProperly() throws IOException {
     PyishDate date = new PyishDate(
       ZonedDateTime.ofInstant(Instant.ofEpochMilli(1234567890L), ZoneId.systemDefault())
     );

--- a/src/test/java/com/hubspot/jinjava/util/LengthLimitingStringBuilderTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/LengthLimitingStringBuilderTest.java
@@ -25,6 +25,9 @@ public class LengthLimitingStringBuilderTest {
   public void itHandlesNullStrings() {
     LengthLimitingStringBuilder sb = new LengthLimitingStringBuilder(10);
     sb.append(null);
-    assertThat(sb.length()).isEqualTo(0);
+    assertThat(sb.toString()).isEqualTo("null");
+    LengthLimitingStringBuilder sbLimited = new LengthLimitingStringBuilder(3);
+    assertThatThrownBy(() -> sbLimited.append(null))
+      .isInstanceOf(OutputTooBigException.class);
   }
 }


### PR DESCRIPTION
Some objects may have exceptionally large serialized representations. If they're larger than the `maxOutputSize` set on the `JinjavaConfig`, then they won't be allowed into the final output and an `OutputTooBigException` will be thrown. However, the process of serializing objects that would do that can be costly in terms of time and memory. So these changes make it so we can check the size of the output as we are adding to it during the pyish serialization process.
~~This does require some cooperation from classes that implement `PyishSerializable` if they are composed of several elements in order to optimize the limit checking. For example, if there's some `PyishSerializable` container, that serializes itself in a special way while serializing 1000 objects inside of it, we'd want to check the limit before the entire operation has finished, otherwise a string that is far too large may already have been allocated, copied, and added to several times. Instead, such a class could override `writeSelf(jsonGenerator, serializerProvider)` to split each child object into it's own write to the jsonGenerator.~~ That's not needed any more since I made `LengthLimitingStringBuilder` extend appendable, and have that be used by default. So any appending to the `appendable` argument of `appendPyishString(appendable)` will also check against the limit.

The problem of large string copying is also addressed with a new method `<T extends Appendable & CharSequence> T appendPyishString(T appendable)` which can be used to recursively append to a string builder rather than copying large strings when modifying them.