### PR TITLE
Add beta annotations for eager execution logic

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/CannotReconstructValueException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/CannotReconstructValueException.java
@@ -1,5 +1,8 @@
 package com.hubspot.jinjava.interpret;
 
+import com.google.common.annotations.Beta;
+
+@Beta
 public class CannotReconstructValueException extends DeferredValueException {
   public static final String CANNOT_RECONSTRUCT_MESSAGE = "Cannot reconstruct value";
 

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -16,6 +16,7 @@
 
 package com.hubspot.jinjava.interpret;
 
+import com.google.common.annotations.Beta;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;
@@ -87,6 +88,8 @@ public class Context extends ScopeMap<String, Object> {
   private final Set<String> resolvedFunctions = new HashSet<>();
 
   private Set<Node> deferredNodes = new HashSet<>();
+
+  @Beta
   private Set<DeferredToken> deferredTokens = new HashSet<>();
 
   private final ExpTestLibrary expTestLibrary;
@@ -368,6 +371,7 @@ public class Context extends ScopeMap<String, Object> {
     return ImmutableSet.copyOf(deferredNodes);
   }
 
+  @Beta
   public void checkNumberOfDeferredTokens() {
     Context secondToLastContext = this;
     if (parent != null) {
@@ -386,6 +390,7 @@ public class Context extends ScopeMap<String, Object> {
     }
   }
 
+  @Beta
   public void handleDeferredToken(DeferredToken deferredToken) {
     deferredTokens.add(deferredToken);
 
@@ -406,6 +411,7 @@ public class Context extends ScopeMap<String, Object> {
     }
   }
 
+  @Beta
   public void removeDeferredTokens(Collection<DeferredToken> toRemove) {
     deferredTokens.removeAll(toRemove);
     if (getParent() != null) {
@@ -417,6 +423,7 @@ public class Context extends ScopeMap<String, Object> {
     }
   }
 
+  @Beta
   public Set<DeferredToken> getDeferredTokens() {
     return deferredTokens;
   }

--- a/src/main/java/com/hubspot/jinjava/interpret/DeferredLazyReference.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/DeferredLazyReference.java
@@ -1,5 +1,8 @@
 package com.hubspot.jinjava.interpret;
 
+import com.google.common.annotations.Beta;
+
+@Beta
 public class DeferredLazyReference implements DeferredValue {
   private final LazyReference lazyReference;
 

--- a/src/main/java/com/hubspot/jinjava/interpret/DeferredLazyReferenceSource.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/DeferredLazyReferenceSource.java
@@ -1,5 +1,8 @@
 package com.hubspot.jinjava.interpret;
 
+import com.google.common.annotations.Beta;
+
+@Beta
 public class DeferredLazyReferenceSource implements DeferredValue {
   private static final DeferredLazyReferenceSource INSTANCE = new DeferredLazyReferenceSource();
 

--- a/src/main/java/com/hubspot/jinjava/interpret/DeferredMacroValueImpl.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/DeferredMacroValueImpl.java
@@ -1,5 +1,8 @@
 package com.hubspot.jinjava.interpret;
 
+import com.google.common.annotations.Beta;
+
+@Beta
 public class DeferredMacroValueImpl implements DeferredValue {
   private static final DeferredValue INSTANCE = new DeferredMacroValueImpl();
 

--- a/src/main/java/com/hubspot/jinjava/interpret/PartiallyDeferredValue.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/PartiallyDeferredValue.java
@@ -1,7 +1,10 @@
 package com.hubspot.jinjava.interpret;
 
+import com.google.common.annotations.Beta;
+
 /**
  * An interface for a type of DeferredValue that as a whole is not deferred,
  * but certain attributes or methods within it are deferred.
  */
+@Beta
 public interface PartiallyDeferredValue extends DeferredValue {}

--- a/src/main/java/com/hubspot/jinjava/interpret/RevertibleObject.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/RevertibleObject.java
@@ -1,7 +1,9 @@
 package com.hubspot.jinjava.interpret;
 
+import com.google.common.annotations.Beta;
 import java.util.Optional;
 
+@Beta
 public class RevertibleObject {
   private final Object hashCode;
   private final Optional<String> pyishString;

--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.expression;
 
+import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -18,6 +19,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
+@Beta
 public class EagerExpressionStrategy implements ExpressionStrategy {
   private static final long serialVersionUID = -6792345439237764193L;
 

--- a/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.fn.eager;
 
+import com.google.common.annotations.Beta;
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.el.ext.AbstractCallableMethod;
 import com.hubspot.jinjava.el.ext.AstMacroFunction;
@@ -19,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.StringJoiner;
 
+@Beta
 public class EagerMacroFunction extends AbstractCallableMethod {
   private String fullName;
   private MacroFunction macroFunction;

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/DeferredToken.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/DeferredToken.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.interpret.CallStack;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -7,6 +8,7 @@ import com.hubspot.jinjava.tree.parse.Token;
 import java.util.Collections;
 import java.util.Set;
 
+@Beta
 public class DeferredToken {
   private final Token token;
   // These words aren't yet DeferredValues, but are unresolved

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.annotations.Beta;
 import com.google.common.collect.Sets;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -16,6 +17,7 @@ import java.util.Collections;
 import java.util.Optional;
 import org.apache.commons.lang3.tuple.Triple;
 
+@Beta
 public class EagerBlockSetTagStrategy extends EagerSetTagStrategy {
   public static final EagerBlockSetTagStrategy INSTANCE = new EagerBlockSetTagStrategy(
     new SetTag()

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCallTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCallTag.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.InterpretException;
@@ -21,6 +22,7 @@ import java.util.LinkedHashMap;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
+@Beta
 public class EagerCallTag extends EagerStateChangingTag<CallTag> {
 
   public EagerCallTag() {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.annotations.Beta;
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.el.ext.ExtendedParser;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -16,6 +17,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Beta
 public class EagerCycleTag extends EagerStateChangingTag<CycleTag> {
 
   public EagerCycleTag() {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerDoTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerDoTag.java
@@ -1,11 +1,13 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.tag.DoTag;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import org.apache.commons.lang3.StringUtils;
 
+@Beta
 public class EagerDoTag extends EagerStateChangingTag<DoTag> {
 
   public EagerDoTag() {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerExecutionResult.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerExecutionResult.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.lib.tag.eager;
 import static com.hubspot.jinjava.util.EagerReconstructionUtils.buildBlockSetTag;
 import static com.hubspot.jinjava.util.EagerReconstructionUtils.buildSetTag;
 
+import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.LazyReference;
 import com.hubspot.jinjava.objects.serialization.PyishBlockSetSerializable;
@@ -19,6 +20,7 @@ import org.apache.commons.lang3.tuple.Pair;
  * got deferred, then the <code>prefixToPreserveState</code> can be added to the output
  * that would preserve the state for a second pass.
  */
+@Beta
 public class EagerExecutionResult {
   private final EagerExpressionResult result;
   private final Map<String, Object> speculativeBindings;

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.interpret.CannotReconstructValueException;
 import com.hubspot.jinjava.interpret.Context.TemporaryValueClosable;
 import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
@@ -24,6 +25,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 
+@Beta
 public class EagerForTag extends EagerTagDecorator<ForTag> {
 
   public EagerForTag() {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTag.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.lib.tag.eager;
 
 import static com.hubspot.jinjava.lib.tag.SetTag.IGNORED_VARIABLE_NAME;
 
+import com.google.common.annotations.Beta;
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValueException;
@@ -22,6 +23,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Beta
 public class EagerFromTag extends EagerStateChangingTag<FromTag> {
 
   public EagerFromTag() {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerGenericTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerGenericTag.java
@@ -1,7 +1,9 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.lib.tag.Tag;
 
+@Beta
 public class EagerGenericTag<T extends Tag> extends EagerTagDecorator<T> implements Tag {
 
   public EagerGenericTag(T tag) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InterpretException;
@@ -20,6 +21,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
+@Beta
 public class EagerIfTag extends EagerTagDecorator<IfTag> {
 
   public EagerIfTag() {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.annotations.Beta;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
@@ -30,6 +31,7 @@ import java.util.StringJoiner;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
+@Beta
 public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
 
   public EagerImportTag() {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.annotations.Beta;
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.IncludeTag;
@@ -10,6 +11,7 @@ import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.HelperStringTokenizer;
 import org.apache.commons.lang3.StringUtils;
 
+@Beta
 public class EagerIncludeTag extends EagerTagDecorator<IncludeTag> {
 
   public EagerIncludeTag(IncludeTag tag) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -16,6 +17,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Triple;
 
+@Beta
 public class EagerInlineSetTagStrategy extends EagerSetTagStrategy {
   public static final EagerInlineSetTagStrategy INSTANCE = new EagerInlineSetTagStrategy(
     new SetTag()

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
@@ -12,6 +13,7 @@ import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
+@Beta
 public class EagerPrintTag extends EagerStateChangingTag<PrintTag> {
 
   public EagerPrintTag() {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTag.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.FlexibleTag;
@@ -7,6 +8,7 @@ import com.hubspot.jinjava.lib.tag.SetTag;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
 
+@Beta
 public class EagerSetTag extends EagerStateChangingTag<SetTag> implements FlexibleTag {
 
   public EagerSetTag() {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.SetTag;
 import com.hubspot.jinjava.tree.TagNode;
@@ -12,6 +13,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Triple;
 
+@Beta
 public abstract class EagerSetTagStrategy {
   protected final SetTag setTag;
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.FlexibleTag;
@@ -11,6 +12,7 @@ import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import org.apache.commons.lang3.StringUtils;
 
+@Beta
 public class EagerStateChangingTag<T extends Tag> extends EagerTagDecorator<T> {
 
   public EagerStateChangingTag(T tag) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
 import com.hubspot.jinjava.interpret.DeferredValueException;
@@ -21,6 +22,7 @@ import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
+@Beta
 public abstract class EagerTagDecorator<T extends Tag> implements Tag {
   private final T tag;
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactory.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactory.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.annotations.Beta;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -25,6 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+@Beta
 public class EagerTagFactory {
   public static final Map<Class<? extends Tag>, Class<? extends EagerTagDecorator<? extends Tag>>> EAGER_TAG_OVERRIDES = ImmutableMap
     .<Class<? extends Tag>, Class<? extends EagerTagDecorator<?>>>builder()

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerUnlessTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerUnlessTag.java
@@ -1,7 +1,9 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
+import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.lib.tag.UnlessTag;
 
+@Beta
 public class EagerUnlessTag extends EagerIfTag {
 
   public EagerUnlessTag() {

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/LengthLimitingJsonProcessingException.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/LengthLimitingJsonProcessingException.java
@@ -1,7 +1,9 @@
 package com.hubspot.jinjava.objects.serialization;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.annotations.Beta;
 
+@Beta
 public class LengthLimitingJsonProcessingException extends JsonProcessingException {
   private final int maxSize;
   private final int attemptedSize;

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/LengthLimitingWriter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/LengthLimitingWriter.java
@@ -1,10 +1,12 @@
 package com.hubspot.jinjava.objects.serialization;
 
+import com.google.common.annotations.Beta;
 import java.io.CharArrayWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.concurrent.atomic.AtomicInteger;
 
+@Beta
 public class LengthLimitingWriter extends Writer {
   public static final String REMAINING_LENGTH_ATTRIBUTE = "remainingLength";
   private final CharArrayWriter charArrayWriter;

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/MapEntrySerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/MapEntrySerializer.java
@@ -4,11 +4,13 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.google.common.annotations.Beta;
 import java.io.CharArrayWriter;
 import java.io.IOException;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicInteger;
 
+@Beta
 public class MapEntrySerializer extends JsonSerializer<Entry<?, ?>> {
   public static final MapEntrySerializer INSTANCE = new MapEntrySerializer();
 

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishBeanSerializerModifier.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishBeanSerializerModifier.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+import com.google.common.annotations.Beta;
 import java.util.Map;
 
+@Beta
 public class PyishBeanSerializerModifier extends BeanSerializerModifier {
   public static final PyishBeanSerializerModifier INSTANCE = new PyishBeanSerializerModifier();
 

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishBlockSetSerializable.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishBlockSetSerializable.java
@@ -1,5 +1,8 @@
 package com.hubspot.jinjava.objects.serialization;
 
+import com.google.common.annotations.Beta;
+
+@Beta
 public interface PyishBlockSetSerializable {
   String getBlockSetBody();
 }

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishCharacterEscapes.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishCharacterEscapes.java
@@ -3,8 +3,10 @@ package com.hubspot.jinjava.objects.serialization;
 import com.fasterxml.jackson.core.SerializableString;
 import com.fasterxml.jackson.core.io.CharacterEscapes;
 import com.fasterxml.jackson.core.io.SerializedString;
+import com.google.common.annotations.Beta;
 import java.util.Arrays;
 
+@Beta
 public class PyishCharacterEscapes extends CharacterEscapes {
   public static final PyishCharacterEscapes INSTANCE = new PyishCharacterEscapes();
   private final int[] asciiEscapes;

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.OutputTooBigException;
@@ -18,6 +19,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
+@Beta
 public class PyishObjectMapper {
   public static final ObjectWriter PYISH_OBJECT_WRITER;
 

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishPrettyPrinter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishPrettyPrinter.java
@@ -2,8 +2,10 @@ package com.hubspot.jinjava.objects.serialization;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.google.common.annotations.Beta;
 import java.io.IOException;
 
+@Beta
 public class PyishPrettyPrinter extends DefaultPrettyPrinter {
   public static final PyishPrettyPrinter INSTANCE = new PyishPrettyPrinter();
 

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
@@ -6,12 +6,14 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.objects.PyWrapper;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
+@Beta
 public interface PyishSerializable extends PyWrapper {
   ObjectWriter SELF_WRITER = new ObjectMapper(
     new JsonFactoryBuilder().quoteChar('\'').build()

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
@@ -3,10 +3,12 @@ package com.hubspot.jinjava.objects.serialization;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.io.IOException;
 import java.util.Objects;
 
+@Beta
 public class PyishSerializer extends JsonSerializer<Object> {
   public static final PyishSerializer INSTANCE = new PyishSerializer();
 

--- a/src/main/java/com/hubspot/jinjava/util/EagerContextWatcher.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerContextWatcher.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.util;
 
+import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.interpret.CannotReconstructValueException;
 import com.hubspot.jinjava.interpret.DeferredLazyReferenceSource;
 import com.hubspot.jinjava.interpret.DeferredValue;
@@ -23,6 +24,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@Beta
 public class EagerContextWatcher {
 
   /**

--- a/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.util;
 
+import com.google.common.annotations.Beta;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Primitives;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
@@ -32,6 +33,7 @@ import java.util.stream.Stream;
 import javax.el.ELException;
 import org.apache.commons.lang3.StringUtils;
 
+@Beta
 public class EagerExpressionResolver {
   public static final String JINJAVA_NULL = "null";
   public static final String JINJAVA_EMPTY_STRING = "''";

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.util;
 
+import com.google.common.annotations.Beta;
 import com.google.common.collect.Sets;
 import com.hubspot.jinjava.el.ext.AbstractCallableMethod;
 import com.hubspot.jinjava.interpret.Context;
@@ -38,6 +39,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@Beta
 public class EagerReconstructionUtils {
 
   /**


### PR DESCRIPTION
Marks eager execution logic as unstable as it changes frequently and sometimes breaking changes are necessary to avoid tremendous amounts of bloat.