### PR TITLE
Set the dateFormat to what it originally was in PyishDate

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
@@ -112,6 +112,11 @@ public final class PyishDate
     this.dateFormat = dateFormat;
   }
 
+  public PyishDate withDateFormat(String dateFormat) {
+    setDateFormat(dateFormat);
+    return this;
+  }
+
   public Date toDate() {
     return Date.from(date.toInstant());
   }
@@ -163,10 +168,12 @@ public final class PyishDate
   public <T extends Appendable & CharSequence> T appendPyishString(T appendable)
     throws IOException {
     return (T) appendable
-      .append('\'')
+      .append("('")
       .append(strftime(FULL_DATE_FORMAT))
       .append("'|strtotime(")
       .append(PyishObjectMapper.getAsPyishStringOrThrow(FULL_DATE_FORMAT))
+      .append(")).withDateFormat(")
+      .append(PyishObjectMapper.getAsPyishStringOrThrow(dateFormat))
       .append(')');
   }
 }

--- a/src/test/java/com/hubspot/jinjava/objects/date/PyishDateTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/date/PyishDateTest.java
@@ -68,6 +68,26 @@ public class PyishDateTest {
   }
 
   @Test
+  public void itPyishSerializesWithCustomDateFormat() {
+    PyishDate d1 = new PyishDate(ZonedDateTime.parse("2013-11-12T14:15:16.170+02:00"));
+    d1.setDateFormat("yyyy-MM-dd");
+    JinjavaInterpreter interpreter = new Jinjava().newInterpreter();
+    interpreter.render("{% set foo = " + PyishObjectMapper.getAsPyishString(d1) + "%}");
+    PyishDate reconstructed = (PyishDate) interpreter.getContext().get("foo");
+    assertThat(reconstructed.toString()).isEqualTo("2013-11-12");
+  }
+
+  @Test
+  public void itDoesntLoseSecondsOnReconstruction() {
+    PyishDate d1 = new PyishDate(ZonedDateTime.parse("2013-11-12T14:15:16.170+02:00"));
+    d1.setDateFormat("yyyy-MM-dd");
+    JinjavaInterpreter interpreter = new Jinjava().newInterpreter();
+    interpreter.render("{% set foo = " + PyishObjectMapper.getAsPyishString(d1) + "%}");
+    PyishDate reconstructed = (PyishDate) interpreter.getContext().get("foo");
+    assertThat(reconstructed.getSecond()).isEqualTo(16);
+  }
+
+  @Test
   public void testPyishDateToStringWithCustomDateFormatter() {
     PyishDate d1 = new PyishDate(ZonedDateTime.parse("2013-11-12T14:15:16.170+02:00"));
     JinjavaInterpreter interpreter = new Jinjava().newInterpreter();


### PR DESCRIPTION
This PR adds a new method that we can use when reconstructing to put the date format back to what it originally was