### PR TITLE
Add option to EscapeJinjavaFilter to only escape curly braces when part of a token

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilter.java
@@ -27,6 +27,14 @@ import org.apache.commons.lang3.StringUtils;
   "Use this filter if you need to display text that might contain such characters in Jinjava. " +
   "Marks return value as markup string.",
   input = @JinjavaParam(value = "s", desc = "String to escape", required = true),
+  params = {
+    @JinjavaParam(
+      value = "all_braces",
+      type = "boolean",
+      desc = "Whether to only escape all curly braces or just when there are default expression, tag, or comment marks",
+      defaultValue = "true"
+    )
+  },
   snippets = {
     @JinjavaSnippet(
       code = "{% set escape_string = \"{{This markup is printed as text}}\" %}\n" +
@@ -47,8 +55,18 @@ public class EscapeJinjavaFilter implements Filter {
     return StringUtils.replaceEach(input, TO_REPLACE, REPLACE_WITH);
   }
 
+  public static String escapeFullJinjavaEntities(String input) {
+    return input
+      .replace("{{", BLBRACE + BLBRACE)
+      .replaceAll("\\{([{%#])", BLBRACE + "$1")
+      .replaceAll("([}%#])}", "$1" + BRBRACE);
+  }
+
   @Override
   public Object filter(Object object, JinjavaInterpreter interpreter, String... arg) {
+    if (arg.length > 0 && "false".equals(arg[0])) {
+      return escapeFullJinjavaEntities(Objects.toString(object, ""));
+    }
     return escapeJinjavaEntities(Objects.toString(object, ""));
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilterTest.java
@@ -30,4 +30,14 @@ public class EscapeJinjavaFilterTest extends BaseInterpretingTest {
     assertThat(f.filter(new SafeString("{{ me & you }}"), interpreter))
       .isInstanceOf(SafeString.class);
   }
+
+  @Test
+  public void testDoesNotEscapeJson() {
+    assertThat(
+        f.filter("{'foo': 'bar', '{{{ foo }}}': '{% bar %}'}", interpreter, "false")
+      )
+      .isEqualTo(
+        "{'foo': 'bar', '&lbrace;&lbrace;{ foo }&rbrace;}': '&lbrace;% bar %&rbrace;'}"
+      );
+  }
 }


### PR DESCRIPTION
Allows the `|escape_jinjava` filter to be used on json without breaking it.