### PR TITLE
Add interface to define pre-process actions for a Node

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -19,7 +19,9 @@ import static com.hubspot.jinjava.lib.fn.Functions.DEFAULT_RANGE_LIMIT;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.jinjava.el.JinjavaInterpreterResolver;
+import com.hubspot.jinjava.el.JinjavaNodePreProcessor;
 import com.hubspot.jinjava.el.JinjavaObjectUnwrapper;
+import com.hubspot.jinjava.el.NodePreProcessor;
 import com.hubspot.jinjava.el.ObjectUnwrapper;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.Context.Library;
@@ -72,6 +74,7 @@ public class JinjavaConfig {
   private final ObjectMapper objectMapper;
 
   private final ObjectUnwrapper objectUnwrapper;
+  private final NodePreProcessor nodePreProcessor;
 
   public static Builder newBuilder() {
     return new Builder();
@@ -128,6 +131,7 @@ public class JinjavaConfig {
     enablePreciseDivideFilter = builder.enablePreciseDivideFilter;
     objectMapper = builder.objectMapper;
     objectUnwrapper = builder.objectUnwrapper;
+    nodePreProcessor = builder.nodePreProcessor;
   }
 
   public Charset getCharset() {
@@ -230,6 +234,10 @@ public class JinjavaConfig {
     return objectUnwrapper;
   }
 
+  public NodePreProcessor getNodePreProcessor() {
+    return nodePreProcessor;
+  }
+
   /**
    * @deprecated  Replaced by {@link LegacyOverrides#isIterateOverMapKeys()}
    */
@@ -282,6 +290,7 @@ public class JinjavaConfig {
     private ObjectMapper objectMapper = new ObjectMapper();
 
     private ObjectUnwrapper objectUnwrapper = new JinjavaObjectUnwrapper();
+    private NodePreProcessor nodePreProcessor = new JinjavaNodePreProcessor();
 
     private Builder() {}
 
@@ -440,6 +449,11 @@ public class JinjavaConfig {
 
     public Builder withObjectUnwrapper(ObjectUnwrapper objectUnwrapper) {
       this.objectUnwrapper = objectUnwrapper;
+      return this;
+    }
+
+    public Builder withNodePreProcessor(NodePreProcessor nodePreProcessor) {
+      this.nodePreProcessor = nodePreProcessor;
       return this;
     }
 

--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -21,15 +21,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.jinjava.el.JinjavaInterpreterResolver;
 import com.hubspot.jinjava.el.JinjavaNodePreProcessor;
 import com.hubspot.jinjava.el.JinjavaObjectUnwrapper;
-import com.hubspot.jinjava.el.NodePreProcessor;
 import com.hubspot.jinjava.el.ObjectUnwrapper;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.Context.Library;
 import com.hubspot.jinjava.interpret.InterpreterFactory;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.JinjavaInterpreterFactory;
 import com.hubspot.jinjava.mode.DefaultExecutionMode;
 import com.hubspot.jinjava.mode.ExecutionMode;
 import com.hubspot.jinjava.random.RandomNumberGeneratorStrategy;
+import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.parse.DefaultTokenScannerSymbols;
 import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
 import java.nio.charset.Charset;
@@ -40,6 +41,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import javax.el.ELResolver;
 
 public class JinjavaConfig {
@@ -74,7 +76,7 @@ public class JinjavaConfig {
   private final ObjectMapper objectMapper;
 
   private final ObjectUnwrapper objectUnwrapper;
-  private final NodePreProcessor nodePreProcessor;
+  private final BiConsumer<Node, JinjavaInterpreter> nodePreProcessor;
 
   public static Builder newBuilder() {
     return new Builder();
@@ -234,7 +236,7 @@ public class JinjavaConfig {
     return objectUnwrapper;
   }
 
-  public NodePreProcessor getNodePreProcessor() {
+  public BiConsumer<Node, JinjavaInterpreter> getNodePreProcessor() {
     return nodePreProcessor;
   }
 
@@ -290,7 +292,7 @@ public class JinjavaConfig {
     private ObjectMapper objectMapper = new ObjectMapper();
 
     private ObjectUnwrapper objectUnwrapper = new JinjavaObjectUnwrapper();
-    private NodePreProcessor nodePreProcessor = new JinjavaNodePreProcessor();
+    private BiConsumer<Node, JinjavaInterpreter> nodePreProcessor = new JinjavaNodePreProcessor();
 
     private Builder() {}
 
@@ -452,7 +454,9 @@ public class JinjavaConfig {
       return this;
     }
 
-    public Builder withNodePreProcessor(NodePreProcessor nodePreProcessor) {
+    public Builder withNodePreProcessor(
+      BiConsumer<Node, JinjavaInterpreter> nodePreProcessor
+    ) {
       this.nodePreProcessor = nodePreProcessor;
       return this;
     }

--- a/src/main/java/com/hubspot/jinjava/el/JinjavaNodePreProcessor.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaNodePreProcessor.java
@@ -1,0 +1,24 @@
+package com.hubspot.jinjava.el;
+
+import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.tree.Node;
+
+public class JinjavaNodePreProcessor implements NodePreProcessor {
+
+  @Override
+  public void preProcess(Node node, JinjavaInterpreter interpreter) {
+    interpreter.getContext().setCurrentNode(node);
+    checkForInterrupt(node);
+  }
+
+  protected void checkForInterrupt(Node node) {
+    if (Thread.currentThread().isInterrupted()) {
+      throw new InterpretException(
+        "Interrupt rendering " + getClass(),
+        node.getMaster().getLineNumber(),
+        node.getMaster().getStartPosition()
+      );
+    }
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/JinjavaNodePreProcessor.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaNodePreProcessor.java
@@ -3,11 +3,12 @@ package com.hubspot.jinjava.el;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.tree.Node;
+import java.util.function.BiConsumer;
 
-public class JinjavaNodePreProcessor implements NodePreProcessor {
+public class JinjavaNodePreProcessor implements BiConsumer<Node, JinjavaInterpreter> {
 
   @Override
-  public void preProcess(Node node, JinjavaInterpreter interpreter) {
+  public void accept(Node node, JinjavaInterpreter interpreter) {
     interpreter.getContext().setCurrentNode(node);
     checkForInterrupt(node);
   }

--- a/src/main/java/com/hubspot/jinjava/el/NodePreProcessor.java
+++ b/src/main/java/com/hubspot/jinjava/el/NodePreProcessor.java
@@ -1,0 +1,8 @@
+package com.hubspot.jinjava.el;
+
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.tree.Node;
+
+public interface NodePreProcessor {
+  void preProcess(Node node, JinjavaInterpreter interpreter);
+}

--- a/src/main/java/com/hubspot/jinjava/el/NodePreProcessor.java
+++ b/src/main/java/com/hubspot/jinjava/el/NodePreProcessor.java
@@ -1,8 +1,0 @@
-package com.hubspot.jinjava.el;
-
-import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.tree.Node;
-
-public interface NodePreProcessor {
-  void preProcess(Node node, JinjavaInterpreter interpreter);
-}

--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -47,7 +47,6 @@ public class ExpressionNode extends Node {
     try {
       return expressionStrategy.interpretOutput(master, interpreter);
     } catch (DeferredValueException e) {
-      checkForInterrupt();
       interpreter.getContext().handleDeferredNode(this);
       return new RenderedOutputNode(master.getImage());
     }

--- a/src/main/java/com/hubspot/jinjava/tree/Node.java
+++ b/src/main/java/com/hubspot/jinjava/tree/Node.java
@@ -15,7 +15,6 @@
  **********************************************************************/
 package com.hubspot.jinjava.tree;
 
-import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.tree.output.OutputNode;
 import com.hubspot.jinjava.tree.parse.Token;
@@ -100,17 +99,6 @@ public abstract class Node implements Serializable {
   }
 
   public void preProcess(JinjavaInterpreter interpreter) {
-    interpreter.getContext().setCurrentNode(this);
-    checkForInterrupt();
-  }
-
-  public final void checkForInterrupt() {
-    if (Thread.currentThread().isInterrupted()) {
-      throw new InterpretException(
-        "Interrupt rendering " + getClass(),
-        master.getLineNumber(),
-        master.getStartPosition()
-      );
-    }
+    interpreter.getConfig().getNodePreProcessor().preProcess(this, interpreter);
   }
 }

--- a/src/main/java/com/hubspot/jinjava/tree/Node.java
+++ b/src/main/java/com/hubspot/jinjava/tree/Node.java
@@ -99,6 +99,6 @@ public abstract class Node implements Serializable {
   }
 
   public void preProcess(JinjavaInterpreter interpreter) {
-    interpreter.getConfig().getNodePreProcessor().preProcess(this, interpreter);
+    interpreter.getConfig().getNodePreProcessor().accept(this, interpreter);
   }
 }

--- a/src/main/java/com/hubspot/jinjava/tree/TagNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TagNode.java
@@ -56,7 +56,6 @@ public class TagNode extends Node {
       }
       return tag.interpretOutput(this, interpreter);
     } catch (DeferredValueException e) {
-      checkForInterrupt();
       interpreter.getContext().handleDeferredNode(this);
       return new RenderedOutputNode(reconstructImage());
     } catch (


### PR DESCRIPTION
So that extenders of Jinjava can customise the pre-processing actions to take. These are actions that will be taken before any node gets processed. In HubL, we can extend this to limit resource consumption.