### PR TITLE
Get current date and time from a provider

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -25,6 +25,8 @@ import com.hubspot.jinjava.interpret.InterpreterFactory;
 import com.hubspot.jinjava.interpret.JinjavaInterpreterFactory;
 import com.hubspot.jinjava.mode.DefaultExecutionMode;
 import com.hubspot.jinjava.mode.ExecutionMode;
+import com.hubspot.jinjava.objects.date.CurrentDateTimeProvider;
+import com.hubspot.jinjava.objects.date.DateTimeProvider;
 import com.hubspot.jinjava.random.RandomNumberGeneratorStrategy;
 import com.hubspot.jinjava.tree.parse.DefaultTokenScannerSymbols;
 import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
@@ -62,6 +64,7 @@ public class JinjavaConfig {
   private final int rangeLimit;
   private final int maxNumDeferredTokens;
   private final InterpreterFactory interpreterFactory;
+  private final DateTimeProvider dateTimeProvider;
   private TokenScannerSymbols tokenScannerSymbols;
   private final ELResolver elResolver;
   private final ExecutionMode executionMode;
@@ -121,6 +124,7 @@ public class JinjavaConfig {
     elResolver = builder.elResolver;
     executionMode = builder.executionMode;
     legacyOverrides = builder.legacyOverrides;
+    dateTimeProvider = builder.dateTimeProvider;
     enablePreciseDivideFilter = builder.enablePreciseDivideFilter;
     objectMapper = builder.objectMapper;
   }
@@ -241,6 +245,10 @@ public class JinjavaConfig {
     return enablePreciseDivideFilter;
   }
 
+  public DateTimeProvider getDateTimeProvider() {
+    return dateTimeProvider;
+  }
+
   public static class Builder {
     private Charset charset = StandardCharsets.UTF_8;
     private Locale locale = Locale.ENGLISH;
@@ -258,6 +266,7 @@ public class JinjavaConfig {
     private boolean nestedInterpretationEnabled = true;
     private RandomNumberGeneratorStrategy randomNumberGeneratorStrategy =
       RandomNumberGeneratorStrategy.THREAD_LOCAL;
+    private DateTimeProvider dateTimeProvider = new CurrentDateTimeProvider();
     private boolean validationMode = false;
     private long maxStringLength = 0;
     private int rangeLimit = DEFAULT_RANGE_LIMIT;
@@ -303,6 +312,11 @@ public class JinjavaConfig {
       RandomNumberGeneratorStrategy randomNumberGeneratorStrategy
     ) {
       this.randomNumberGeneratorStrategy = randomNumberGeneratorStrategy;
+      return this;
+    }
+
+    public Builder withDateTimeProvider(DateTimeProvider dateTimeProvider) {
+      this.dateTimeProvider = dateTimeProvider;
       return this;
     }
 

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -156,9 +156,9 @@ public class JinjavaInterpreter implements PyishSerializable {
   /**
    * Creates a new variable scope, extending from the current scope. Allows you to create a nested
    * contextual scope which can override variables from higher levels.
-   *
+   * <p>
    * Should be used in a try/finally context, similar to lock-use patterns:
-   *
+   * <p>
    * <code>
    * interpreter.enterScope();
    * try (interpreter.enterScope()) {

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -13,6 +13,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.mode.ExecutionMode;
 import com.hubspot.jinjava.objects.Namespace;
+import com.hubspot.jinjava.objects.date.DateTimeProvider;
 import com.hubspot.jinjava.objects.date.PyishDate;
 import com.hubspot.jinjava.objects.date.StrftimeFormatter;
 import com.hubspot.jinjava.tree.Node;
@@ -245,7 +246,14 @@ public class Functions {
           JinjavaInterpreter.getCurrent().getPosition()
         );
       }
-      d = ZonedDateTime.now(zoneOffset);
+      long currentMillis = JinjavaInterpreter
+        .getCurrentMaybe()
+        .map(JinjavaInterpreter::getConfig)
+        .map(JinjavaConfig::getDateTimeProvider)
+        .map(DateTimeProvider::getCurrentTimeMillis)
+        .orElse(System.currentTimeMillis());
+
+      d = ZonedDateTime.ofInstant(Instant.ofEpochMilli(currentMillis), zoneOffset);
     } else if (var instanceof Number) {
       d =
         ZonedDateTime.ofInstant(

--- a/src/main/java/com/hubspot/jinjava/objects/date/CurrentDateTimeProvider.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/CurrentDateTimeProvider.java
@@ -1,0 +1,9 @@
+package com.hubspot.jinjava.objects.date;
+
+public class CurrentDateTimeProvider implements DateTimeProvider {
+
+  @Override
+  public long getCurrentTimeMillis() {
+    return System.currentTimeMillis();
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/objects/date/DateTimeProvider.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/DateTimeProvider.java
@@ -1,0 +1,5 @@
+package com.hubspot.jinjava.objects.date;
+
+public interface DateTimeProvider {
+  long getCurrentTimeMillis();
+}

--- a/src/main/java/com/hubspot/jinjava/objects/date/FixedDateTimeProvider.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/FixedDateTimeProvider.java
@@ -1,0 +1,14 @@
+package com.hubspot.jinjava.objects.date;
+
+public class FixedDateTimeProvider implements DateTimeProvider {
+  private long currentTimeMillis;
+
+  public FixedDateTimeProvider(long currentTimeMillis) {
+    this.currentTimeMillis = currentTimeMillis;
+  }
+
+  @Override
+  public long getCurrentTimeMillis() {
+    return currentTimeMillis;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
@@ -60,7 +60,7 @@ public final class PyishDate
                   .map(JinjavaInterpreter::getConfig)
                   .map(JinjavaConfig::getDateTimeProvider)
                   .map(DateTimeProvider::getCurrentTimeMillis)
-                  .orElse(System.currentTimeMillis())
+                  .orElseGet(System::currentTimeMillis)
             )
         ),
         ZoneOffset.UTC

--- a/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.objects.date;
 
+import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.objects.PyWrapper;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
@@ -50,7 +51,17 @@ public final class PyishDate
     this(
       ZonedDateTime.ofInstant(
         Instant.ofEpochMilli(
-          Optional.ofNullable(epochMillis).orElseGet(System::currentTimeMillis)
+          Optional
+            .ofNullable(epochMillis)
+            .orElseGet(
+              () ->
+                JinjavaInterpreter
+                  .getCurrentMaybe()
+                  .map(JinjavaInterpreter::getConfig)
+                  .map(JinjavaConfig::getDateTimeProvider)
+                  .map(DateTimeProvider::getCurrentTimeMillis)
+                  .orElse(System.currentTimeMillis())
+            )
         ),
         ZoneOffset.UTC
       )

--- a/src/test/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilterTest.java
@@ -20,12 +20,12 @@ public class UnixTimestampFilterTest extends BaseInterpretingTest {
   }
 
   @After
-  public void tearDown() throws Exception {
+  public void tearDown() {
     assertThat(interpreter.getErrorsCopy()).isEmpty();
   }
 
   @Test
-  public void itRendersFromDate() throws Exception {
+  public void itRendersFromDate() {
     assertThat(interpreter.renderFlat("{{ d|unixtimestamp }}")).isEqualTo(timestamp);
   }
 }

--- a/src/test/java/com/hubspot/jinjava/objects/date/PyishDateTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/date/PyishDateTest.java
@@ -3,8 +3,11 @@ package com.hubspot.jinjava.objects.date;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
+import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Date;
@@ -16,6 +19,28 @@ public class PyishDateTest {
   public void itUsesCurrentTimeWhenNoneProvided() {
     PyishDate d = new PyishDate((Long) null);
     assertThat(d.toDate()).isCloseTo(new Date(), 10000);
+  }
+
+  @Test
+  public void itUsesDateTimeProviderWhenNoTimeProvided() {
+    long ts = 123345414223L;
+
+    JinjavaInterpreter.pushCurrent(
+      new JinjavaInterpreter(
+        new Jinjava(),
+        new Context(),
+        JinjavaConfig
+          .newBuilder()
+          .withDateTimeProvider(new FixedDateTimeProvider(ts))
+          .build()
+      )
+    );
+    try {
+      PyishDate d = new PyishDate((Long) null);
+      assertThat(d.toDate()).isEqualTo(Date.from(Instant.ofEpochMilli(ts)));
+    } finally {
+      JinjavaInterpreter.popCurrent();
+    }
   }
 
   @Test


### PR DESCRIPTION
It's useful to be able to have a fixed date and time for comparison purposes, so this implements a provider for it and allows setting it in JinjavaConfig. The default of course is to use the current date and time.