### PR TITLE
Allow deferred execution mode in macro function

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -77,7 +77,6 @@ public class MacroFunction extends AbstractCallableMethod {
     JinjavaInterpreter interpreter = JinjavaInterpreter.getCurrent();
     Optional<String> importFile = getImportFile(interpreter);
     try (InterpreterScopeClosable c = interpreter.enterScope()) {
-      interpreter.getContext().setDeferredExecutionMode(false);
       String result = getEvaluationResult(argMap, kwargMap, varArgs, interpreter);
 
       if (

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1266,4 +1266,11 @@ public class EagerTest {
       "only-defers-loop-item-on-current-context"
     );
   }
+
+  @Test
+  public void itRunsMacroFunctionInDeferredExecutionMode() {
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "runs-macro-function-in-deferred-execution-mode"
+    );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategyTest.java
@@ -133,13 +133,13 @@ public class EagerExpressionStrategyTest extends ExpressionNodeTest {
   }
 
   @Test
-  public void itDoesNotGoIntoDeferredExecutionModeWithMacro() {
+  public void itGoesIntoDeferredExecutionModeWithMacro() {
     assertExpectedOutput(
       "{% macro def() %}{{ is_deferred_execution_mode() }}{% endmacro %}" +
       "{{ def() }}" +
       "{% if deferred %}{{ def() }}{% endif %}" +
       "{{ def() }}",
-      "false{% if deferred %}false{% endif %}false"
+      "false{% if deferred %}true{% endif %}false"
     );
   }
 

--- a/src/test/resources/eager/runs-macro-function-in-deferred-execution-mode.expected.jinja
+++ b/src/test/resources/eager/runs-macro-function-in-deferred-execution-mode.expected.jinja
@@ -1,0 +1,10 @@
+{% set holder = {'val': -1}  %}{% for i in range(deferred) %}
+{% set __macro_modify_615470226_temp_variable_1__ %}
+{% do holder.update({'val': holder.val + 1}) %}
+{% endset %}{% do __macro_modify_615470226_temp_variable_1__ %}
+{% if holder.val >= 1 %}
+{{ i }}
+{% endif %}
+{% endfor %}
+
+{{ holder.val }}

--- a/src/test/resources/eager/runs-macro-function-in-deferred-execution-mode.jinja
+++ b/src/test/resources/eager/runs-macro-function-in-deferred-execution-mode.jinja
@@ -1,0 +1,12 @@
+{% macro modify(val) %}
+{% do holder.update({'val': holder.val + 1}) %}
+{% endmacro %}
+{% set holder = {'val': -1} %}
+{% for i in range(deferred) %}
+{% do modify(1) %}
+{% if holder.val >= 1 %}
+{{ i }}
+{% endif %}
+{% endfor %}
+
+{{ holder.val }}


### PR DESCRIPTION
I believe this is dead code after https://github.com/HubSpot/jinjava/pull/978, as I couldn't find a specific reason why this line of code was added. Before this change, the test result looks like:
```
% for i in range(deferred) %}
{{ i }}
{% endfor %}
1
```
Clearly `holder.val` is not properly updated since we didn't defer the updating in the macro function and didn't realise that it was changed when reconstructing the for loop.