### PR TITLE
Filter duplicate template errors

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -754,7 +754,8 @@ public class JinjavaInterpreter implements PyishSerializable {
 
   public void removeLastError() {
     if (!errors.isEmpty()) {
-      errors.remove(errors.size() - 1);
+      TemplateError error = errors.remove(errors.size() - 1);
+      errorSet.remove(error.hashCode());
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -540,7 +540,8 @@ public class TemplateError {
       startPosition,
       category,
       categoryErrors,
-      scopeDepth
+      scopeDepth,
+      sourceTemplate
     );
   }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -461,4 +461,46 @@ public class JinjavaInterpreterTest {
         StrftimeFormatter.format(date, "medium", Locale.forLanguageTag("en-US"))
       );
   }
+
+  @Test
+  public void itFiltersDuplicateErrors() {
+    TemplateError error1 = new TemplateError(
+      TemplateError.ErrorType.WARNING,
+      TemplateError.ErrorReason.OTHER,
+      TemplateError.ErrorItem.FILTER,
+      "the first error",
+      "list",
+      interpreter.getLineNumber(),
+      interpreter.getPosition(),
+      null
+    );
+
+    TemplateError copiedError1 = new TemplateError(
+      TemplateError.ErrorType.WARNING,
+      TemplateError.ErrorReason.OTHER,
+      TemplateError.ErrorItem.FILTER,
+      "the first error",
+      "list",
+      interpreter.getLineNumber(),
+      interpreter.getPosition(),
+      null
+    );
+
+    TemplateError error2 = new TemplateError(
+      TemplateError.ErrorType.WARNING,
+      TemplateError.ErrorReason.OTHER,
+      TemplateError.ErrorItem.FILTER,
+      "the second error",
+      "list",
+      interpreter.getLineNumber(),
+      interpreter.getPosition(),
+      null
+    );
+
+    interpreter.addError(error1);
+    interpreter.addError(error2);
+    interpreter.addError(copiedError1);
+
+    assertThat(interpreter.getErrors()).containsExactly(error1, error2);
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ValidationModeTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ValidationModeTest.java
@@ -114,7 +114,7 @@ public class ValidationModeTest {
       "{{ badCode( }}" + "{% for i in [1, 2, 3] %}" + "  {{ badCode( }}" + "{% endfor %}"
     );
 
-    assertThat(validatingInterpreter.getErrors().size()).isEqualTo(4);
+    assertThat(validatingInterpreter.getErrors().size()).isEqualTo(2);
   }
 
   @Test
@@ -130,7 +130,7 @@ public class ValidationModeTest {
       "done"
     );
 
-    assertThat(validatingInterpreter.getErrors().size()).isEqualTo(4);
+    assertThat(validatingInterpreter.getErrors().size()).isEqualTo(2);
     assertThat(output.trim()).isEqualTo("done");
   }
 


### PR DESCRIPTION
Utilizes a simple `Set` to filter out duplicate errors.

This is relevant when errors occur in for loops. It isn't useful from the developer's perspective to get tons of duplicate errors littering the output log. Also you can easily hit the error max and miss errors further down the template. 