### PR TITLE
Disable sortpom during release process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,4 +280,12 @@
     <url>git@github.com:HubSpot/jinjava.git</url>
     <tag>HEAD</tag>
   </scm>
+
+  <profiles>
+    <profile>
+      <id>basepom.oss-release</id>
+      <properties>
+        <basepom.check.skip-pom-lint>true</basepom.check.skip-pom-lint>
+      </properties>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -287,5 +287,6 @@
       <properties>
         <basepom.check.skip-pom-lint>true</basepom.check.skip-pom-lint>
       </properties>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Seems like sortpom doesn't play nicely with the release plugin, so disable it during release (but active otherwise)

/cc @jasmith-hs