### PR TITLE
Skip dependency management during release process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,6 +286,7 @@
       <id>basepom.oss-release</id>
       <properties>
         <basepom.check.skip-pom-lint>true</basepom.check.skip-pom-lint>
+        <basepom.check.skip-dependency-management>true</basepom.check.skip-dependency-management>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
Similar to https://github.com/HubSpot/jinjava/pull/1022

The dependency management plugin runs during release and then has problems with the generated `dependency-reduced-pom.xml` which explicitly sets versions:
```
[INFO] --- dependency-management-maven-plugin:0.8:analyze (default) @ jinjava ---
    [WARNING] Version tag must be removed for managed dependency org.slf4j:slf4j-api:jar
    [WARNING] Version tag must be removed for managed dependency com.google.guava:guava:jar
    [WARNING] Exclusions must be removed for managed dependency com.google.guava:guava:jar
    [WARNING] Version tag must be removed for managed dependency org.javassist:javassist:jar
    [WARNING] Version tag must be removed for managed dependency org.jsoup:jsoup:jar
    [WARNING] Version tag must be removed for managed dependency com.google.re2j:re2j:jar
    [WARNING] Version tag must be removed for managed dependency org.apache.commons:commons-lang3:jar
    [WARNING] Version tag must be removed for managed dependency commons-net:commons-net:jar
    [WARNING] Version tag must be removed for managed dependency com.googlecode.java-ipv6:java-ipv6:jar
    [WARNING] Version tag must be removed for managed dependency com.google.code.findbugs:annotations:jar
    [WARNING] Exclusions must be removed for managed dependency com.google.code.findbugs:annotations:jar
    [WARNING] Version tag must be removed for managed dependency com.fasterxml.jackson.core:jackson-annotations:jar
    [WARNING] Version tag must be removed for managed dependency com.fasterxml.jackson.core:jackson-databind:jar
    [WARNING] Version tag must be removed for managed dependency com.fasterxml.jackson.core:jackson-core:jar
    [WARNING] Version tag must be removed for managed dependency com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar
    [WARNING] Version tag must be removed for managed dependency ch.obermuhlner:big-math:jar
    [WARNING] Version tag must be removed for managed dependency ch.qos.logback:logback-core:jar
    [WARNING] Version tag must be removed for managed dependency ch.qos.logback:logback-classic:jar
    [WARNING] Version tag must be removed for managed dependency junit:junit:jar
    [WARNING] Exclusions must be removed for managed dependency junit:junit:jar
    [WARNING] Version tag must be removed for managed dependency org.assertj:assertj-core:jar
    [WARNING] Version tag must be removed for managed dependency org.mockito:mockito-core:jar
    [WARNING] Exclusions must be removed for managed dependency org.mockito:mockito-core:jar
    [INFO] ------------------------------------------------------------------------
    [INFO] BUILD FAILURE
    [INFO] ------------------------------------------------------------------------
    [INFO] Total time:  30.232 s
    [INFO] Finished at: 2023-03-06T18:14:24Z
    [INFO] ------------------------------------------------------------------------
    [ERROR] Failed to execute goal com.hubspot.maven.plugins:dependency-management-maven-plugin:0.8:analyze (default) on project jinjava: Dependency management issues found -> [Help 1]
    [ERROR] 
    [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
    [ERROR] Re-run Maven using the -X switch to enable full debug logging.
    [ERROR] 
    [ERROR] For more information about the errors and possible solutions, please read the following articles:
    [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```
