### PR TITLE
In EscapeJinjavaFilter, escape both double closing braces to not have better consistency

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilter.java
@@ -58,6 +58,7 @@ public class EscapeJinjavaFilter implements Filter {
   public static String escapeFullJinjavaEntities(String input) {
     return input
       .replace("{{", BLBRACE + BLBRACE)
+      .replace("}}", BRBRACE + BRBRACE)
       .replaceAll("\\{([{%#])", BLBRACE + "$1")
       .replaceAll("([}%#])}", "$1" + BRBRACE);
   }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilterTest.java
@@ -37,7 +37,7 @@ public class EscapeJinjavaFilterTest extends BaseInterpretingTest {
         f.filter("{'foo': 'bar', '{{{ foo }}}': '{% bar %}'}", interpreter, "false")
       )
       .isEqualTo(
-        "{'foo': 'bar', '&lbrace;&lbrace;{ foo }&rbrace;}': '&lbrace;% bar %&rbrace;'}"
+        "{'foo': 'bar', '&lbrace;&lbrace;{ foo &rbrace;&rbrace;}': '&lbrace;% bar %&rbrace;'}"
       );
   }
 }


### PR DESCRIPTION
This is essentially just for consistency. There should be an equal number of `&lbrace;` and `&rbrace;` if there are an equal number of start vs end tokens.