### PR TITLE
check iterator before calling next

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/TypeConvertingMapELResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/TypeConvertingMapELResolver.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.el;
 
+import java.util.Iterator;
 import java.util.Map;
 import javax.el.ELContext;
 import javax.el.ELException;
@@ -21,14 +22,17 @@ public class TypeConvertingMapELResolver extends MapELResolver {
     }
 
     if (base instanceof Map && !((Map) base).isEmpty()) {
-      Class<?> keyClass = ((Map) base).keySet().iterator().next().getClass();
-      try {
-        value = ((Map) base).get(TYPE_CONVERTER.convert(property, keyClass));
-        if (value != null) {
-          context.setPropertyResolved(true);
+      Iterator<?> iterator = ((Map) base).keySet().iterator();
+      if (iterator.hasNext()) {
+        Class<?> keyClass = iterator.next().getClass();
+        try {
+          value = ((Map) base).get(TYPE_CONVERTER.convert(property, keyClass));
+          if (value != null) {
+            context.setPropertyResolved(true);
+          }
+        } catch (ELException ex) {
+          value = null;
         }
-      } catch (ELException ex) {
-        value = null;
       }
     }
 


### PR DESCRIPTION
I'm not able to reproduce this, but we can see from our logs that sometimes a `NoSuchElement` exception can be thrown here. It may be due to a bad map implementation that claims it's not empty, but has no elements to iterate over.