### PR TITLE
Implement `{% do %}` blocks and fix `{% set %}` block scoping

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -33,8 +33,8 @@ import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import com.hubspot.jinjava.interpret.errorcategory.BasicTemplateErrorCategory;
+import com.hubspot.jinjava.lib.tag.DoTag;
 import com.hubspot.jinjava.lib.tag.ExtendsTag;
-import com.hubspot.jinjava.lib.tag.SetTag;
 import com.hubspot.jinjava.lib.tag.eager.EagerGenericTag;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.objects.serialization.PyishSerializable;
@@ -399,9 +399,9 @@ public class JinjavaInterpreter implements PyishSerializable {
     resolveBlockStubs(output);
     if (ignoredOutput.length() > 0) {
       return (
-        EagerReconstructionUtils.buildBlockSetTag(
-          SetTag.IGNORED_VARIABLE_NAME,
+        EagerReconstructionUtils.wrapInTag(
           ignoredOutput.toString(),
+          DoTag.TAG_NAME,
           this,
           false
         ) +

--- a/src/main/java/com/hubspot/jinjava/lib/tag/DoTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/DoTag.java
@@ -4,40 +4,44 @@ import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.doc.annotations.JinjavaTextMateSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.tree.TagNode;
+import com.hubspot.jinjava.tree.parse.TagToken;
 import org.apache.commons.lang3.StringUtils;
 
 @JinjavaDoc(
   value = "Evaluates expression without printing out result.",
-  snippets = { @JinjavaSnippet(code = "{% do list.append('value 2') %}") }
+  snippets = {
+    @JinjavaSnippet(code = "{% do list.append('value 2') %}"),
+    @JinjavaSnippet(
+      desc = "Execute a block of code in the same scope while ignoring the output",
+      code = "{% do %}\n" +
+      "{% set foo = [] %}\n" +
+      "{{ foo.append('a') }}\n" +
+      "{% enddo %}"
+    )
+  }
 )
 @JinjavaTextMateSnippet(code = "{% do ${1:expr} %}")
-public class DoTag implements Tag {
+public class DoTag implements Tag, FlexibleTag {
   public static final String TAG_NAME = "do";
 
   @Override
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
-    if (StringUtils.isBlank(tagNode.getHelpers())) {
-      throw new TemplateSyntaxException(
-        tagNode.getMaster().getImage(),
-        "Tag 'do' expects expression",
-        tagNode.getLineNumber(),
-        tagNode.getStartPosition()
-      );
+    if (hasEndTag((TagToken) tagNode.getMaster())) {
+      tagNode.getChildren().forEach(child -> child.render(interpreter));
+    } else {
+      interpreter.resolveELExpression(tagNode.getHelpers(), tagNode.getLineNumber());
     }
-
-    interpreter.resolveELExpression(tagNode.getHelpers(), tagNode.getLineNumber());
     return "";
-  }
-
-  @Override
-  public String getEndTagName() {
-    return null;
   }
 
   @Override
   public String getName() {
     return TAG_NAME;
+  }
+
+  @Override
+  public boolean hasEndTag(TagToken tagToken) {
+    return StringUtils.isBlank(tagToken.getHelpers());
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
@@ -70,7 +70,7 @@ import org.apache.commons.lang3.StringUtils;
       code = "{% set name = 'Jack' %}\n" +
       "{% set message %}\n" +
       "My name is {{ name }}\n" +
-      "{% end_set %}"
+      "{% endset %}"
     )
   }
 )

--- a/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
@@ -138,13 +138,7 @@ public class SetTag implements Tag, FlexibleTag {
       var = tagNode.getHelpers().substring(0, filterPos).trim();
     }
     String result;
-    if (IGNORED_VARIABLE_NAME.equals(var)) {
-      result = renderChildren(tagNode, interpreter);
-    } else {
-      try (InterpreterScopeClosable c = interpreter.enterScope()) {
-        result = renderChildren(tagNode, interpreter);
-      }
-    }
+    result = renderChildren(tagNode, interpreter, var);
     try {
       executeSetBlock(tagNode, var, result, filterPos >= 0, interpreter);
     } catch (DeferredValueException e) {
@@ -152,6 +146,22 @@ public class SetTag implements Tag, FlexibleTag {
       throw e;
     }
     return "";
+  }
+
+  public static String renderChildren(
+    TagNode tagNode,
+    JinjavaInterpreter interpreter,
+    String var
+  ) {
+    String result;
+    if (IGNORED_VARIABLE_NAME.equals(var)) {
+      result = renderChildren(tagNode, interpreter);
+    } else {
+      try (InterpreterScopeClosable c = interpreter.enterScope()) {
+        result = renderChildren(tagNode, interpreter);
+      }
+    }
+    return result;
   }
 
   private static String renderChildren(TagNode tagNode, JinjavaInterpreter interpreter) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
@@ -4,7 +4,6 @@ import com.google.common.collect.Sets;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.SetTag;
-import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.EagerContextWatcher;
@@ -28,19 +27,14 @@ public class EagerBlockSetTagStrategy extends EagerSetTagStrategy {
   @Override
   protected EagerExecutionResult getEagerExecutionResult(
     TagNode tagNode,
+    String[] variables,
     String expression,
     JinjavaInterpreter interpreter
   ) {
     EagerExecutionResult result = EagerContextWatcher.executeInChildContext(
       eagerInterpreter ->
         EagerExpressionResult.fromSupplier(
-          () -> {
-            StringBuilder sb = new StringBuilder();
-            for (Node child : tagNode.getChildren()) {
-              sb.append(child.render(eagerInterpreter).getValue());
-            }
-            return sb.toString();
-          },
+          () -> SetTag.renderChildren(tagNode, eagerInterpreter, variables[0]),
           eagerInterpreter
         ),
       interpreter,
@@ -74,6 +68,7 @@ public class EagerBlockSetTagStrategy extends EagerSetTagStrategy {
       if (filterPos >= 0) {
         EagerExecutionResult filterResult = EagerInlineSetTagStrategy.INSTANCE.getEagerExecutionResult(
           tagNode,
+          variables,
           tagNode.getHelpers().trim(),
           interpreter
         );
@@ -164,6 +159,7 @@ public class EagerBlockSetTagStrategy extends EagerSetTagStrategy {
     if (filterPos >= 0) {
       EagerExecutionResult filterResult = EagerInlineSetTagStrategy.INSTANCE.getEagerExecutionResult(
         tagNode,
+        variables,
         tagNode.getHelpers().trim(),
         interpreter
       );

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTag.java
@@ -1,13 +1,12 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
-import static com.hubspot.jinjava.lib.tag.SetTag.IGNORED_VARIABLE_NAME;
-
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
+import com.hubspot.jinjava.lib.tag.DoTag;
 import com.hubspot.jinjava.lib.tag.FromTag;
 import com.hubspot.jinjava.loader.RelativePathResolver;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
@@ -119,9 +118,9 @@ public class EagerFromTag extends EagerStateChangingTag<FromTag> {
             output +
             EagerReconstructionUtils.buildSetTag(newToOldImportNames, interpreter, true);
         }
-        return EagerReconstructionUtils.buildBlockSetTag(
-          IGNORED_VARIABLE_NAME,
+        return EagerReconstructionUtils.wrapInTag(
           output,
+          DoTag.TAG_NAME,
           interpreter,
           true
         );

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -9,8 +9,8 @@ import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
+import com.hubspot.jinjava.lib.tag.DoTag;
 import com.hubspot.jinjava.lib.tag.ImportTag;
-import com.hubspot.jinjava.lib.tag.SetTag;
 import com.hubspot.jinjava.loader.RelativePathResolver;
 import com.hubspot.jinjava.objects.collections.PyMap;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
@@ -141,9 +141,9 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
             childBindings
           );
       }
-      return EagerReconstructionUtils.buildBlockSetTag(
-        SetTag.IGNORED_VARIABLE_NAME,
+      return EagerReconstructionUtils.wrapInTag(
         finalOutput,
+        DoTag.TAG_NAME,
         interpreter,
         true
       );
@@ -426,7 +426,6 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
     JinjavaInterpreter child,
     JinjavaInterpreter parent
   ) {
-    childBindings.remove(SetTag.IGNORED_VARIABLE_NAME);
     for (MacroFunction macro : child.getContext().getGlobalMacros().values()) {
       if (parent.getContext().isDeferredExecutionMode()) {
         macro.setDeferred(true);

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
@@ -28,6 +28,7 @@ public class EagerInlineSetTagStrategy extends EagerSetTagStrategy {
   @Override
   public EagerExecutionResult getEagerExecutionResult(
     TagNode tagNode,
+    String[] variables,
     String expression,
     JinjavaInterpreter interpreter
   ) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
@@ -43,6 +43,7 @@ public abstract class EagerSetTagStrategy {
 
     EagerExecutionResult eagerExecutionResult = getEagerExecutionResult(
       tagNode,
+      variables,
       expression,
       interpreter
     );
@@ -78,6 +79,7 @@ public abstract class EagerSetTagStrategy {
 
   protected abstract EagerExecutionResult getEagerExecutionResult(
     TagNode tagNode,
+    String[] variables,
     String expression,
     JinjavaInterpreter interpreter
   );

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerStateChangingTag.java
@@ -18,7 +18,7 @@ public class EagerStateChangingTag<T extends Tag> extends EagerTagDecorator<T> {
   }
 
   @Override
-  public String innerInterpret(TagNode tagNode, JinjavaInterpreter interpreter) {
+  public final String innerInterpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     return eagerInterpret(tagNode, interpreter, null);
   }
 
@@ -42,10 +42,7 @@ public class EagerStateChangingTag<T extends Tag> extends EagerTagDecorator<T> {
             eagerInterpreter ->
               EagerExpressionResult.fromString(renderChildren(tagNode, eagerInterpreter)),
             interpreter,
-            EagerContextWatcher
-              .EagerChildContextConfig.newBuilder()
-              .withForceDeferredExecutionMode(true)
-              .build()
+            EagerContextWatcher.EagerChildContextConfig.newBuilder().build()
           )
           .asTemplateString()
       );

--- a/src/test/java/com/hubspot/jinjava/lib/tag/DoTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/DoTagTest.java
@@ -17,11 +17,18 @@ public class DoTagTest extends BaseInterpretingTest {
   }
 
   @Test
-  public void itAddsTemplateErrorOnEmptyExpression() {
+  public void itAddsTemplateErrorOnEmptyExpressionAndNoEndTag() {
     String template = "{% do %}";
     RenderResult renderResult = jinjava.renderForResult(template, Maps.newHashMap());
     assertThat(renderResult.getErrors()).hasSize(1);
     assertThat(renderResult.getErrors().get(0).getReason())
       .isEqualTo(ErrorReason.SYNTAX_ERROR);
+  }
+
+  @Test
+  public void itEvaluatesDoBlockAndDiscardsResult() {
+    String template =
+      "{% do %}{% set foo = 1 %}{{ foo }}{% enddo %}{% if foo == 1 %}Yes{% endif %}";
+    assertThat(jinjava.render(template, Maps.newHashMap())).isEqualTo("Yes");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/SetTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/SetTagTest.java
@@ -299,6 +299,25 @@ public class SetTagTest extends BaseInterpretingTest {
     assertThat(result).isEqualTo("BAR");
   }
 
+  @Test
+  public void itRunsSetBlockInAChildScope() {
+    String template =
+      "{% set bar = 1 %}{% set foo %}{% set bar = 2 %}{% endset %}{{ bar }}";
+    final String result = interpreter.render(template);
+
+    assertThat(result).isEqualTo("1");
+  }
+
+  @Test
+  public void itDoesNotRunSetBlockInAChildScopeForIgnoredVariableName() {
+    // This is to preserve legacy behaviour used in Eager Execution
+    String template =
+      "{% set bar = 1 %}{% set __ignored__ %}{% set bar = 2 %}{% endset %}{{ bar }}";
+    final String result = interpreter.render(template);
+
+    assertThat(result).isEqualTo("2");
+  }
+
   private Node fixture(String name) {
     try {
       return new TreeParser(

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -462,11 +462,11 @@ public class EagerImportTagTest extends ImportTagTest {
     );
     assertThat(result)
       .isEqualTo(
-        "{% if deferred %}{% set __ignored__ %}{% set current_path = 'import-tree-b.jinja' %}{% set a,foo_b = {'foo_a': 'a', 'import_resource_path': 'import-tree-a.jinja', 'something': 'somn'} ,null %}{% set b = {} %}{% for __ignored__ in [0] %}{% set __ignored__ %}{% set current_path = 'import-tree-a.jinja' %}{% set a = {} %}{% for __ignored__ in [0] %}{% set something = 'somn' %}{% do a.update({'something': something}) %}\n" +
+        "{% if deferred %}{% do %}{% set current_path = 'import-tree-b.jinja' %}{% set a,foo_b = {'foo_a': 'a', 'import_resource_path': 'import-tree-a.jinja', 'something': 'somn'} ,null %}{% set b = {} %}{% for __ignored__ in [0] %}{% do %}{% set current_path = 'import-tree-a.jinja' %}{% set a = {} %}{% for __ignored__ in [0] %}{% set something = 'somn' %}{% do a.update({'something': something}) %}\n" +
         "{% set foo_a = 'a' %}{% do a.update({'foo_a': foo_a}) %}\n" +
-        "{% do a.update({'foo_a': 'a','import_resource_path': 'import-tree-a.jinja','something': 'somn'}) %}{% endfor %}{% set current_path = 'import-tree-b.jinja' %}{% endset %}\n" +
+        "{% do a.update({'foo_a': 'a','import_resource_path': 'import-tree-a.jinja','something': 'somn'}) %}{% endfor %}{% set current_path = 'import-tree-b.jinja' %}{% enddo %}\n" +
         "{% set foo_b = 'b' + a.foo_a %}{% do b.update({'foo_b': foo_b}) %}\n" +
-        "{% do b.update({'a': a,'foo_b': foo_b,'import_resource_path': 'import-tree-b.jinja'}) %}{% endfor %}{% set current_path = '' %}{% endset %}{% endif %}"
+        "{% do b.update({'a': a,'foo_b': foo_b,'import_resource_path': 'import-tree-b.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}{% endif %}"
       );
 
     removeDeferredContextKeys();
@@ -707,8 +707,8 @@ public class EagerImportTagTest extends ImportTagTest {
       .isEqualTo(
         "a" +
         "{% set vars = {'foo': 'a', 'import_resource_path': 'var-a.jinja'}  %}{% if deferred %}" +
-        "{% set __ignored__ %}{% set current_path = 'var-b.jinja' %}{% set vars = {} %}{% for __ignored__ in [0] %}{% set foo = 'b' %}{% do vars.update({'foo': foo}) %}\n" +
-        "{% do vars.update({'foo': 'b','import_resource_path': 'var-b.jinja'}) %}{% endfor %}{% set current_path = '' %}{% endset %}" +
+        "{% do %}{% set current_path = 'var-b.jinja' %}{% set vars = {} %}{% for __ignored__ in [0] %}{% set foo = 'b' %}{% do vars.update({'foo': foo}) %}\n" +
+        "{% do vars.update({'foo': 'b','import_resource_path': 'var-b.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}" +
         "{% endif %}" +
         "{{ vars.foo }}"
       );
@@ -734,8 +734,8 @@ public class EagerImportTagTest extends ImportTagTest {
       .isEqualTo(
         "a" +
         "{% set foo = 'a' %}{% if deferred %}" +
-        "{% set __ignored__ %}{% set current_path = 'var-b.jinja' %}{% set foo = 'b' %}\n" +
-        "{% set current_path = '' %}{% endset %}" +
+        "{% do %}{% set current_path = 'var-b.jinja' %}{% set foo = 'b' %}\n" +
+        "{% set current_path = '' %}{% enddo %}" +
         "{% endif %}" +
         "{{ foo }}"
       );
@@ -752,9 +752,9 @@ public class EagerImportTagTest extends ImportTagTest {
       .trim();
     assertThat(result)
       .isEqualTo(
-        "{% set __ignored__ %}{% set current_path = 'set-two-variables.jinja' %}{% set foo = deferred %}\n" +
+        "{% do %}{% set current_path = 'set-two-variables.jinja' %}{% set foo = deferred %}\n" +
         "\n" +
-        "{% set current_path = '' %}{% endset %}{{ foo }} bar"
+        "{% set current_path = '' %}{% enddo %}{{ foo }} bar"
       );
   }
 

--- a/src/test/resources/eager/does-not-override-import-modification-in-for.expected.jinja
+++ b/src/test/resources/eager/does-not-override-import-modification-in-for.expected.jinja
@@ -1,40 +1,40 @@
 {% for __ignored__ in [0] %}
-{% set __ignored__ %}{% set current_path = 'deferred-modification.jinja' %}{% set bar1 = {} %}{% set bar1,foo = {} ,'start' %}{% if deferred %}
+{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set bar1 = {} %}{% set bar1,foo = {} ,'start' %}{% if deferred %}
 
 {% set foo = 'starta' %}{% do bar1.update({'foo': foo}) %}
 
 {% endif %}
 
 {% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar1.update({'foo': foo}) %}
-{% do bar1.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}{% endset %}
+{% do bar1.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}{% enddo %}
 {{ bar1.foo }}
-{% set __ignored__ %}{% set current_path = 'deferred-modification.jinja' %}{% set bar2 = {} %}{% set bar2,foo = {} ,'start' %}{% if deferred %}
+{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set bar2 = {} %}{% set bar2,foo = {} ,'start' %}{% if deferred %}
 
 {% set foo = 'starta' %}{% do bar2.update({'foo': foo}) %}
 
 {% endif %}
 
 {% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar2.update({'foo': foo}) %}
-{% do bar2.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}{% endset %}
+{% do bar2.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}{% enddo %}
 {{ bar2.foo }}
 
-{% set __ignored__ %}{% set current_path = 'deferred-modification.jinja' %}{% set bar1 = {} %}{% set bar1,foo = {} ,'start' %}{% if deferred %}
+{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set bar1 = {} %}{% set bar1,foo = {} ,'start' %}{% if deferred %}
 
 {% set foo = 'starta' %}{% do bar1.update({'foo': foo}) %}
 
 {% endif %}
 
 {% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar1.update({'foo': foo}) %}
-{% do bar1.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}{% endset %}
+{% do bar1.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}{% enddo %}
 {{ bar1.foo }}
-{% set __ignored__ %}{% set current_path = 'deferred-modification.jinja' %}{% set bar2 = {} %}{% set bar2,foo = {} ,'start' %}{% if deferred %}
+{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set bar2 = {} %}{% set bar2,foo = {} ,'start' %}{% if deferred %}
 
 {% set foo = 'starta' %}{% do bar2.update({'foo': foo}) %}
 
 {% endif %}
 
 {% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar2.update({'foo': foo}) %}
-{% do bar2.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}{% endset %}
+{% do bar2.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}{% enddo %}
 {{ bar2.foo }}
 {% endfor %}
 start

--- a/src/test/resources/eager/handles-deferred-from-import-as.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-from-import-as.expected.jinja
@@ -1,5 +1,5 @@
-{% set myname = deferred + 7 %}{% set __ignored__ %}
+{% set myname = deferred + 7 %}{% do %}
 {% set bar = myname + 19 %}
 Hello {{ myname }}
-{% set from_bar = bar %}{% endset %}from_foo: Hello {{ myname }}
+{% set from_bar = bar %}{% enddo %}from_foo: Hello {{ myname }}
 from_bar: {{ from_bar }}

--- a/src/test/resources/eager/handles-deferred-import-vars.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-import-vars.expected.jinja
@@ -1,11 +1,11 @@
-{% set myname = deferred + 3 %}{% set __ignored__ %}
+{% set myname = deferred + 3 %}{% do %}
 {% set bar = myname + 19 %}
 Hello {{ myname }}
-{% endset %}foo: Hello {{ myname }}
+{% enddo %}foo: Hello {{ myname }}
 bar: {{ bar }}
 ---
-{% set myname = deferred + 7 %}{% set __ignored__ %}{% set current_path = 'macro-and-set.jinja' %}{% set simple = {} %}
+{% set myname = deferred + 7 %}{% do %}{% set current_path = 'macro-and-set.jinja' %}{% set simple = {} %}
 {% set bar = myname + 19 %}{% set simple = {}  %}{% do simple.update({'bar': bar}) %}
 Hello {{ myname }}
-{% do simple.update({'import_resource_path': 'macro-and-set.jinja'}) %}{% set current_path = '' %}{% endset %}simple.foo: {% set deferred_import_resource_path = 'macro-and-set.jinja' %}{% macro simple.foo() %}Hello {{ myname }}{% endmacro %}{% set deferred_import_resource_path = null %}{{ simple.foo() }}
+{% do simple.update({'import_resource_path': 'macro-and-set.jinja'}) %}{% set current_path = '' %}{% enddo %}simple.foo: {% set deferred_import_resource_path = 'macro-and-set.jinja' %}{% macro simple.foo() %}Hello {{ myname }}{% endmacro %}{% set deferred_import_resource_path = null %}{{ simple.foo() }}
 simple.bar: {{ simple.bar }}

--- a/src/test/resources/eager/handles-double-import-modification.expected.jinja
+++ b/src/test/resources/eager/handles-double-import-modification.expected.jinja
@@ -1,20 +1,20 @@
-{% set __ignored__ %}{% set current_path = 'deferred-modification.jinja' %}{% set foo = null %}{% set bar1 = {} %}{% set bar1 = {}  %}{% if deferred %}
+{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set foo = null %}{% set bar1 = {} %}{% set bar1 = {}  %}{% if deferred %}
 
 {% set foo = 'a' %}{% do bar1.update({'foo': foo}) %}
 
 {% endif %}
 
 {% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar1.update({'foo': foo}) %}
-{% do bar1.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}{% endset %}
+{% do bar1.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}{% enddo %}
 ---
-{% set __ignored__ %}{% set current_path = 'deferred-modification.jinja' %}{% set foo = null %}{% set bar2 = {} %}{% set bar2 = {}  %}{% if deferred %}
+{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set foo = null %}{% set bar2 = {} %}{% set bar2 = {}  %}{% if deferred %}
 
 {% set foo = 'a' %}{% do bar2.update({'foo': foo}) %}
 
 {% endif %}
 
 {% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar2.update({'foo': foo}) %}
-{% do bar2.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}{% endset %}
+{% do bar2.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}{% enddo %}
 ---
 {{ bar1.foo }}
 {{ bar2.foo }}

--- a/src/test/resources/eager/handles-import-in-deferred-if.expected.jinja
+++ b/src/test/resources/eager/handles-import-in-deferred-if.expected.jinja
@@ -1,7 +1,7 @@
 {% set primary_line_height = 100 %}{% if deferred %}
-{% set __ignored__ %}{% set current_path = '../settag/set-val.jinja' %}{% set simple = {} %}{% for __ignored__ in [0] %}{% set primary_line_height = 42 %}{% do simple.update({'primary_line_height': primary_line_height}) %}{% do simple.update({'primary_line_height': 42,'import_resource_path': '../settag/set-val.jinja'}) %}{% endfor %}{% set current_path = '' %}{% endset %}
+{% do %}{% set current_path = '../settag/set-val.jinja' %}{% set simple = {} %}{% for __ignored__ in [0] %}{% set primary_line_height = 42 %}{% do simple.update({'primary_line_height': primary_line_height}) %}{% do simple.update({'primary_line_height': 42,'import_resource_path': '../settag/set-val.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}
 {% else %}
-{% set __ignored__ %}{% set current_path = '../settag/set-val.jinja' %}{% set primary_line_height = 42 %}{% set current_path = '' %}{% endset %}
+{% do %}{% set current_path = '../settag/set-val.jinja' %}{% set primary_line_height = 42 %}{% set current_path = '' %}{% enddo %}
 {% endif %}
 simple.primary_line_height (deferred): {{ simple.primary_line_height }}
 primary_line_height (deferred): {{ primary_line_height }}

--- a/src/test/resources/eager/uses-unique-macro-names.expected.jinja
+++ b/src/test/resources/eager/uses-unique-macro-names.expected.jinja
@@ -3,8 +3,8 @@
 {% set __macro_foo_97643642_temp_variable_0__ %}
 Goodbye {{ myname }}
 {% endset %}{% set a = filter:upper.filter(__macro_foo_97643642_temp_variable_0__, ____int3rpr3t3r____) %}
-{% set __ignored__ %}{% set current_path = 'macro-with-filter.jinja' %}
+{% do %}{% set current_path = 'macro-with-filter.jinja' %}
 {% set __macro_foo_927217348_temp_variable_0__ %}Hello {{ myname }}{% endset %}{% set b = filter:upper.filter(__macro_foo_927217348_temp_variable_0__, ____int3rpr3t3r____) %}
-{% set current_path = '' %}{% endset %}
+{% set current_path = '' %}{% enddo %}
 {{ a }}
 {{ b }}

--- a/src/test/resources/tags/eager/extendstag/reconstructs-deferred-outside-block.expected.jinja
+++ b/src/test/resources/tags/eager/extendstag/reconstructs-deferred-outside-block.expected.jinja
@@ -1,9 +1,9 @@
-{% set __ignored__ %}
+{% do %}
 {% if deferred %}
 {% set foo = 'yes' %}
 {% else %}
 {% set foo = 'no' %}
-{% endif %}{% endset %}<html>
+{% endif %}{% enddo %}<html>
 <body>
 <div class="sidebar">
 <h3>Table Of Contents</h3>

--- a/src/test/resources/tags/settag/set-var-and-deferred.jinja
+++ b/src/test/resources/tags/settag/set-var-and-deferred.jinja
@@ -1,6 +1,6 @@
 {% if deferred %}
-{% set __ignored__ %}{% set path = '../settag/set-var-and-deferred.jinja' %}{% set value = null %}{% set my_var = {} %}{% set my_var = {'foo': 'bar'} %}{% set my_var = {'my_var': my_var} %}
+{% do %}{% set path = '../settag/set-var-and-deferred.jinja' %}{% set value = null %}{% set my_var = {} %}{% set my_var = {'foo': 'bar'} %}{% set my_var = {'my_var': my_var} %}
 {% set value = deferred %}{% do my_var.update({"value": value}) %}
-{% do my_var.update({'import_resource_path': '../settag/set-var-and-deferred.jinja','value': value}) %}{% set path = '' %}{% endset %}
+{% do my_var.update({'import_resource_path': '../settag/set-var-and-deferred.jinja','value': value}) %}{% set path = '' %}{% enddo %}
 {{ my_var }}
 {% endif %}


### PR DESCRIPTION
These are to inline do tags as set blocks are to inline set tags.
```
{% do %}
  {{ some_macro() }}
  {{ other_macro() }}
{% enddo %}
```
They run the block of code within their body and then discard the output. This is done without going into a child scope so variables that are set here will persist their values outside of the do block. This is unlike a `{% for %}` tag or a macro function execution.
This is also supposed to be unlike a set block, which, in jinja, executes in a child scope. I realised that we were not running set blocks in a child scope and so I wanted to fix that to have parity with jinja. However, we were using set blocks in eager execution to be able to execute code, while ignoring the string output. This is useful for `{% extends %}`, `{% from %}` and `{% import %}` as it would allow us to retain any deferred modifications that happened as a result of using those tags without adding any extra output. But this also hinged on the lack of child scoping that set blocks currently use. So the need for a solution where we could ignore the output, keep the current scope, and fix the scoping of set blocks to match their functionality in jinja arose. Implementing do blocks fit the bill perfectly, and we can continue not using a child scope when executing set blocks with that `__ignored__` variable name so as to not break any previous eager renders that used that.

Additionally, after realising that deferred macro functions should be put into their own scope https://github.com/HubSpot/jinjava/pull/1020, I have been working through another bug the past couple days and found that it's simpler to instead just use the macro function temporary variable functionality I added in https://github.com/HubSpot/jinjava/pull/920, which should scope the modifications done in the macro function properly. That's how I realised that the bug with set blocks existed because that didn't work as it was supposed to.