### PR TITLE
Add `allow_snake_case` filter and legacy override to serialize with snake_case

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -18,6 +18,7 @@ package com.hubspot.jinjava;
 import static com.hubspot.jinjava.lib.fn.Functions.DEFAULT_RANGE_LIMIT;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.hubspot.jinjava.el.JinjavaInterpreterResolver;
 import com.hubspot.jinjava.el.JinjavaNodePreProcessor;
 import com.hubspot.jinjava.el.JinjavaObjectUnwrapper;
@@ -44,6 +45,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import javax.annotation.Nullable;
 import javax.el.ELResolver;
 
 public class JinjavaConfig {
@@ -135,9 +137,19 @@ public class JinjavaConfig {
     legacyOverrides = builder.legacyOverrides;
     dateTimeProvider = builder.dateTimeProvider;
     enablePreciseDivideFilter = builder.enablePreciseDivideFilter;
-    objectMapper = builder.objectMapper;
+    objectMapper = setupObjectMapper(builder.objectMapper);
     objectUnwrapper = builder.objectUnwrapper;
     nodePreProcessor = builder.nodePreProcessor;
+  }
+
+  private ObjectMapper setupObjectMapper(@Nullable ObjectMapper objectMapper) {
+    if (objectMapper == null) {
+      objectMapper = new ObjectMapper();
+      if (legacyOverrides.isUseSnakeCasePropertyNaming()) {
+        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+      }
+    }
+    return objectMapper;
   }
 
   public Charset getCharset() {
@@ -298,7 +310,7 @@ public class JinjavaConfig {
     private ExecutionMode executionMode = DefaultExecutionMode.instance();
     private LegacyOverrides legacyOverrides = LegacyOverrides.NONE;
     private boolean enablePreciseDivideFilter = false;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = null;
 
     private ObjectUnwrapper objectUnwrapper = new JinjavaObjectUnwrapper();
     private BiConsumer<Node, JinjavaInterpreter> nodePreProcessor = new JinjavaNodePreProcessor();

--- a/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
+++ b/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
@@ -9,6 +9,7 @@ public class LegacyOverrides {
   private final boolean evaluateMapKeys;
   private final boolean iterateOverMapKeys;
   private final boolean usePyishObjectMapper;
+  private final boolean useSnakeCasePropertyNaming;
   private final boolean whitespaceRequiredWithinTokens;
   private final boolean useNaturalOperatorPrecedence;
   private final boolean parseWhitespaceControlStrictly;
@@ -17,6 +18,7 @@ public class LegacyOverrides {
     evaluateMapKeys = builder.evaluateMapKeys;
     iterateOverMapKeys = builder.iterateOverMapKeys;
     usePyishObjectMapper = builder.usePyishObjectMapper;
+    useSnakeCasePropertyNaming = builder.useSnakeCasePropertyNaming;
     whitespaceRequiredWithinTokens = builder.whitespaceRequiredWithinTokens;
     useNaturalOperatorPrecedence = builder.useNaturalOperatorPrecedence;
     parseWhitespaceControlStrictly = builder.parseWhitespaceControlStrictly;
@@ -38,6 +40,10 @@ public class LegacyOverrides {
     return usePyishObjectMapper;
   }
 
+  public boolean isUseSnakeCasePropertyNaming() {
+    return useSnakeCasePropertyNaming;
+  }
+
   public boolean isWhitespaceRequiredWithinTokens() {
     return whitespaceRequiredWithinTokens;
   }
@@ -54,6 +60,7 @@ public class LegacyOverrides {
     private boolean evaluateMapKeys = false;
     private boolean iterateOverMapKeys = false;
     private boolean usePyishObjectMapper = false;
+    private boolean useSnakeCasePropertyNaming = false;
     private boolean whitespaceRequiredWithinTokens = false;
     private boolean useNaturalOperatorPrecedence = false;
     private boolean parseWhitespaceControlStrictly = false;
@@ -69,6 +76,7 @@ public class LegacyOverrides {
         .withEvaluateMapKeys(legacyOverrides.evaluateMapKeys)
         .withIterateOverMapKeys(legacyOverrides.iterateOverMapKeys)
         .withUsePyishObjectMapper(legacyOverrides.usePyishObjectMapper)
+        .withUseSnakeCasePropertyNaming(legacyOverrides.useSnakeCasePropertyNaming)
         .withWhitespaceRequiredWithinTokens(
           legacyOverrides.whitespaceRequiredWithinTokens
         )
@@ -90,6 +98,11 @@ public class LegacyOverrides {
 
     public Builder withUsePyishObjectMapper(boolean usePyishObjectMapper) {
       this.usePyishObjectMapper = usePyishObjectMapper;
+      return this;
+    }
+
+    public Builder withUseSnakeCasePropertyNaming(boolean useSnakeCasePropertyNaming) {
+      this.useSnakeCasePropertyNaming = useSnakeCasePropertyNaming;
       return this;
     }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/AllowSnakeCaseFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AllowSnakeCaseFilter.java
@@ -1,0 +1,43 @@
+package com.hubspot.jinjava.lib.filter;
+
+import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
+import com.hubspot.jinjava.doc.annotations.JinjavaParam;
+import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.objects.collections.PyMap;
+import com.hubspot.jinjava.objects.collections.SizeLimitingPyMap;
+import com.hubspot.jinjava.objects.collections.SnakeCaseAccessibleMap;
+import java.util.Map;
+
+@JinjavaDoc(
+  value = "Allow keys on the provided camelCase map to be accessed using snake_case",
+  input = @JinjavaParam(
+    value = "map",
+    type = "dict",
+    desc = "The dict to make keys accessible using snake_case",
+    required = true
+  ),
+  snippets = { @JinjavaSnippet(code = "{{ {'fooBar': 'baz'}|allow_snake_case }}") }
+)
+public class AllowSnakeCaseFilter implements Filter {
+  public static final String NAME = "allow_snake_case";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+    if (!(var instanceof Map)) {
+      return var;
+    }
+    Map<String, Object> map = (Map<String, Object>) var;
+    if (map instanceof PyMap) {
+      map = ((PyMap) map).toMap();
+    }
+    return new SnakeCaseAccessibleMap(
+      new SizeLimitingPyMap(map, interpreter.getConfig().getMaxMapSize())
+    );
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FilterLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FilterLibrary.java
@@ -32,6 +32,7 @@ public class FilterLibrary extends SimpleLibrary<Filter> {
     registerClasses(
       AbsFilter.class,
       AddFilter.class,
+      AllowSnakeCaseFilter.class,
       AttrFilter.class,
       Base64DecodeFilter.class,
       Base64EncodeFilter.class,

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FromJsonFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FromJsonFilter.java
@@ -1,6 +1,5 @@
 package com.hubspot.jinjava.lib.filter;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
@@ -19,7 +18,6 @@ import java.io.IOException;
   snippets = { @JinjavaSnippet(code = "{{object|fromJson}}") }
 )
 public class FromJsonFilter implements Filter {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
@@ -31,7 +29,10 @@ public class FromJsonFilter implements Filter {
       throw new InvalidInputException(interpreter, this, InvalidReason.STRING);
     }
     try {
-      return OBJECT_MAPPER.readValue((String) var, Object.class);
+      return interpreter
+        .getConfig()
+        .getObjectMapper()
+        .readValue((String) var, Object.class);
     } catch (IOException e) {
       throw new InvalidInputException(interpreter, this, InvalidReason.JSON_READ);
     }

--- a/src/main/java/com/hubspot/jinjava/objects/collections/SnakeCaseAccessibleMap.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/SnakeCaseAccessibleMap.java
@@ -1,0 +1,43 @@
+package com.hubspot.jinjava.objects.collections;
+
+import com.google.common.base.CaseFormat;
+import com.hubspot.jinjava.lib.filter.AllowSnakeCaseFilter;
+import com.hubspot.jinjava.objects.serialization.PyishSerializable;
+import java.io.IOException;
+import java.util.Map;
+
+public class SnakeCaseAccessibleMap extends PyMap implements PyishSerializable {
+
+  public SnakeCaseAccessibleMap(Map<String, Object> map) {
+    super(map);
+  }
+
+  @Override
+  public Object get(Object key) {
+    Object result = super.get(key);
+    if (result == null && key instanceof String) {
+      return getWithCamelCase((String) key);
+    }
+    return result;
+  }
+
+  private Object getWithCamelCase(String key) {
+    if (key == null) {
+      return null;
+    }
+    if (key.indexOf('_') == -1) {
+      return null;
+    }
+    return super.get(CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, key));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T extends Appendable & CharSequence> T appendPyishString(T appendable)
+    throws IOException {
+    return (T) appendable
+      .append(PyishSerializable.writeValueAsString(toMap()))
+      .append('|')
+      .append(AllowSnakeCaseFilter.NAME);
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/BothCasingBeanSerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/BothCasingBeanSerializer.java
@@ -1,0 +1,24 @@
+package com.hubspot.jinjava.objects.serialization;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.hubspot.jinjava.lib.filter.AllowSnakeCaseFilter;
+import java.io.IOException;
+
+public class BothCasingBeanSerializer extends JsonSerializer<Object> {
+  public static final BothCasingBeanSerializer INSTANCE = new BothCasingBeanSerializer();
+
+  private BothCasingBeanSerializer() {}
+
+  @Override
+  public void serialize(Object value, JsonGenerator gen, SerializerProvider serializers)
+    throws IOException {
+    StringBuilder sb = new StringBuilder();
+    sb
+      .append(PyishSerializable.writeValueAsString(value))
+      .append('|')
+      .append(AllowSnakeCaseFilter.NAME);
+    gen.writeRawValue(sb.toString());
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/BothCasingBeanSerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/BothCasingBeanSerializer.java
@@ -28,9 +28,11 @@ public class BothCasingBeanSerializer<T> extends JsonSerializer<T> {
     throws IOException {
     if (
       Boolean.TRUE.equals(
-        serializerProvider.getAttribute(PyishObjectMapper.EAGER_EXECUTION_ATTRIBUTE)
+        serializerProvider.getAttribute(PyishObjectMapper.ALLOW_SNAKE_CASE_ATTRIBUTE)
       )
     ) {
+      // if it's directly for output, then we don't want to add the additional filter characters,
+      // as doing so would make the "|allow_snake_case" appear in the final output.
       StringBuilder sb = new StringBuilder();
       sb
         .append(PyishSerializable.writeValueAsString(value))

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/MapEntrySerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/MapEntrySerializer.java
@@ -26,11 +26,16 @@ public class MapEntrySerializer extends JsonSerializer<Entry<?, ?>> {
     );
     String key;
     String value;
+    ObjectWriter objectWriter = PyishObjectMapper.PYISH_OBJECT_WRITER.withAttribute(
+      PyishObjectMapper.ALLOW_SNAKE_CASE_ATTRIBUTE,
+      serializerProvider.getAttribute(PyishObjectMapper.ALLOW_SNAKE_CASE_ATTRIBUTE)
+    );
     if (remainingLength != null) {
-      ObjectWriter objectWriter = PyishObjectMapper.PYISH_OBJECT_WRITER.withAttribute(
-        LengthLimitingWriter.REMAINING_LENGTH_ATTRIBUTE,
-        remainingLength
-      );
+      objectWriter =
+        objectWriter.withAttribute(
+          LengthLimitingWriter.REMAINING_LENGTH_ATTRIBUTE,
+          remainingLength
+        );
       key = objectWriter.writeValueAsString(entry.getKey());
       LengthLimitingWriter lengthLimitingWriter = new LengthLimitingWriter(
         new CharArrayWriter(),
@@ -39,8 +44,8 @@ public class MapEntrySerializer extends JsonSerializer<Entry<?, ?>> {
       objectWriter.writeValue(lengthLimitingWriter, entry.getValue());
       value = lengthLimitingWriter.toString();
     } else {
-      key = PyishObjectMapper.PYISH_OBJECT_WRITER.writeValueAsString(entry.getKey());
-      value = PyishObjectMapper.PYISH_OBJECT_WRITER.writeValueAsString(entry.getValue());
+      key = objectWriter.writeValueAsString(entry.getKey());
+      value = objectWriter.writeValueAsString(entry.getValue());
     }
     jsonGenerator.writeRawValue(String.format("fn:map_entry(%s, %s)", key, value));
   }

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishBeanSerializerModifier.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishBeanSerializerModifier.java
@@ -24,13 +24,8 @@ public class PyishBeanSerializerModifier extends BeanSerializerModifier {
       if (Map.Entry.class.isAssignableFrom(beanDesc.getBeanClass())) {
         return MapEntrySerializer.INSTANCE;
       }
-      if (
-        serializer instanceof BeanSerializer &&
-        Boolean.TRUE.equals(
-          config.getAttributes().getAttribute(PyishObjectMapper.EAGER_EXECUTION_ATTRIBUTE)
-        )
-      ) {
-        return BothCasingBeanSerializer.INSTANCE;
+      if (serializer instanceof BeanSerializer) {
+        return BothCasingBeanSerializer.wrapping(serializer);
       }
       return serializer;
     } else {

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishBeanSerializerModifier.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishBeanSerializerModifier.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.objects.serialization;
 import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.ser.BeanSerializer;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import java.util.Map;
 
@@ -22,6 +23,14 @@ public class PyishBeanSerializerModifier extends BeanSerializerModifier {
     if (!(PyishSerializable.class.isAssignableFrom(beanDesc.getBeanClass()))) {
       if (Map.Entry.class.isAssignableFrom(beanDesc.getBeanClass())) {
         return MapEntrySerializer.INSTANCE;
+      }
+      if (
+        serializer instanceof BeanSerializer &&
+        Boolean.TRUE.equals(
+          config.getAttributes().getAttribute(PyishObjectMapper.EAGER_EXECUTION_ATTRIBUTE)
+        )
+      ) {
+        return BothCasingBeanSerializer.INSTANCE;
       }
       return serializer;
     } else {

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -19,9 +20,23 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class PyishObjectMapper {
   public static final ObjectWriter PYISH_OBJECT_WRITER;
+  public static final ObjectWriter SNAKE_CASE_PYISH_OBJECT_WRITER;
   public static final String ALLOW_SNAKE_CASE_ATTRIBUTE = "allowSnakeCase";
 
   static {
+    PYISH_OBJECT_WRITER =
+      getPyishObjectMapper()
+        .writer(PyishPrettyPrinter.INSTANCE)
+        .with(PyishCharacterEscapes.INSTANCE);
+
+    SNAKE_CASE_PYISH_OBJECT_WRITER =
+      getPyishObjectMapper()
+        .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+        .writer(PyishPrettyPrinter.INSTANCE)
+        .with(PyishCharacterEscapes.INSTANCE);
+  }
+
+  private static ObjectMapper getPyishObjectMapper() {
     ObjectMapper mapper = new ObjectMapper(
       new JsonFactoryBuilder().quoteChar('\'').build()
     )
@@ -31,8 +46,7 @@ public class PyishObjectMapper {
           .addSerializer(PyishSerializable.class, PyishSerializer.INSTANCE)
       );
     mapper.getSerializerProvider().setNullKeySerializer(new NullKeySerializer());
-    PYISH_OBJECT_WRITER =
-      mapper.writer(PyishPrettyPrinter.INSTANCE).with(PyishCharacterEscapes.INSTANCE);
+    return mapper;
   }
 
   public static String getAsUnquotedPyishString(Object val) {
@@ -66,7 +80,16 @@ public class PyishObjectMapper {
 
   public static String getAsPyishStringOrThrow(Object val, boolean forOutput)
     throws IOException {
-    ObjectWriter objectWriter = PYISH_OBJECT_WRITER;
+    boolean useSnakeCaseMappingOverride = JinjavaInterpreter
+      .getCurrentMaybe()
+      .map(
+        interpreter ->
+          interpreter.getConfig().getLegacyOverrides().isUseSnakeCasePropertyNaming()
+      )
+      .orElse(false);
+    ObjectWriter objectWriter = useSnakeCaseMappingOverride
+      ? SNAKE_CASE_PYISH_OBJECT_WRITER
+      : PYISH_OBJECT_WRITER;
     Writer writer;
     Optional<Long> maxOutputSize = JinjavaInterpreter
       .getCurrentMaybe()
@@ -85,9 +108,11 @@ public class PyishObjectMapper {
     } else {
       writer = new CharArrayWriter();
     }
-    objectWriter
-      .withAttribute(ALLOW_SNAKE_CASE_ATTRIBUTE, !forOutput)
-      .writeValue(writer, val);
+    if (!useSnakeCaseMappingOverride) {
+      objectWriter = objectWriter.withAttribute(ALLOW_SNAKE_CASE_ATTRIBUTE, !forOutput);
+    }
+    objectWriter.writeValue(writer, val);
+
     return writer.toString();
   }
 

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class PyishObjectMapper {
   public static final ObjectWriter PYISH_OBJECT_WRITER;
+  public static final String EAGER_EXECUTION_ATTRIBUTE = "eagerExecution";
 
   static {
     ObjectMapper mapper = new ObjectMapper(
@@ -75,7 +76,15 @@ public class PyishObjectMapper {
     } else {
       writer = new CharArrayWriter();
     }
-    objectWriter.writeValue(writer, val);
+    objectWriter
+      .withAttribute(
+        EAGER_EXECUTION_ATTRIBUTE,
+        JinjavaInterpreter
+          .getCurrentMaybe()
+          .map(interpreter -> interpreter.getConfig().getExecutionMode().useEagerParser())
+          .orElse(false)
+      )
+      .writeValue(writer, val);
     return writer.toString();
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/AllowSnakeCaseFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/AllowSnakeCaseFilterTest.java
@@ -1,0 +1,28 @@
+package com.hubspot.jinjava.lib.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hubspot.jinjava.BaseInterpretingTest;
+import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
+import org.junit.Test;
+
+public class AllowSnakeCaseFilterTest extends BaseInterpretingTest {
+
+  @Test
+  public void itDoesNotChangeNonMaps() {
+    assertThat(interpreter.render("{{ 'fooBar'|allow_snake_case }}")).isEqualTo("fooBar");
+  }
+
+  @Test
+  public void itMakesMapKeysAccessibleWithSnakeCase() {
+    assertThat(interpreter.render("{{ ({'fooBar': 'foo'}|allow_snake_case).foo_bar }}"))
+      .isEqualTo("foo");
+  }
+
+  @Test
+  public void itReserializesAsSnakeCaseAccessibleMap() {
+    interpreter.render("{% set map = {'fooBar': 'foo'}|allow_snake_case %}");
+    assertThat(PyishObjectMapper.getAsPyishString(interpreter.getContext().get("map")))
+      .isEqualTo("{'fooBar': 'foo'} |allow_snake_case");
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
@@ -111,6 +111,30 @@ public class PyishObjectMapperTest {
     assertThat(interpreter.render("{{ foo }}")).isEqualTo("{'fooBar': 'bar'}");
   }
 
+  @Test
+  public void itSerializesToSnakeCaseWhenLegacyOverrideIsSet() {
+    Jinjava jinjava = new Jinjava(
+      JinjavaConfig
+        .newBuilder()
+        .withLegacyOverrides(
+          LegacyOverrides
+            .newBuilder()
+            .withUsePyishObjectMapper(true)
+            .withUseSnakeCasePropertyNaming(true)
+            .build()
+        )
+        .build()
+    );
+    JinjavaInterpreter interpreter = jinjava.newInterpreter();
+    try {
+      JinjavaInterpreter.pushCurrent(interpreter);
+      interpreter.getContext().put("foo", new Foo("bar"));
+      assertThat(interpreter.render("{{ foo }}")).isEqualTo("{'foo_bar': 'bar'}");
+    } finally {
+      JinjavaInterpreter.popCurrent();
+    }
+  }
+
   static class Foo {
     private final String bar;
 

--- a/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
@@ -10,6 +10,7 @@ import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.LegacyOverrides;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.objects.collections.SizeLimitingPyMap;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -94,6 +95,16 @@ public class PyishObjectMapperTest {
   public void itSerializesToSnakeCaseAccessibleMap() {
     assertThat(PyishObjectMapper.getAsPyishString(new Foo("bar")))
       .isEqualTo("{'fooBar': 'bar'} |allow_snake_case");
+  }
+
+  @Test
+  public void itSerializesToSnakeCaseAccessibleMapWhenInMapEntry() {
+    assertThat(
+        PyishObjectMapper.getAsPyishString(
+          new AbstractMap.SimpleImmutableEntry<>("foo", new Foo("bar"))
+        )
+      )
+      .isEqualTo("fn:map_entry('foo', {'fooBar': 'bar'} |allow_snake_case)");
   }
 
   @Test


### PR DESCRIPTION
Adds a filter that allows a map using camelCase attributes to be accessible using snake_case. In jinjava, we allow bean properties to be accessed using snake_case, despite the java methods using camelCase to define them. If we serialize using a default BeanSerializer, then the keys will be in camelCase and running a second pass due to using eager execution will not work as we'd be trying to access a map with camelCase keys using snake_case properties.

I also added a simple legacy override `useSnakeCasePropertyNaming` which makes jackson serialize with `snake_case` properties by default. But we can't use that at HubSpot as we need to support legacy behaviour.