### PR TITLE
handle empty strings with range brackets

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/AstRangeBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstRangeBracket.java
@@ -117,6 +117,9 @@ public class AstRangeBracket extends AstBracket {
   }
 
   private String evalString(String base, Bindings bindings, ELContext context) {
+    if (base.length() == 0) {
+      return base;
+    }
     int startNum = intVal(property, 0, base.length(), bindings, context);
     int endNum = intVal(rangeMax, base.length(), base.length(), bindings, context);
     endNum = Math.min(endNum, base.length());

--- a/src/test/java/com/hubspot/jinjava/el/ext/RangeStringTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/RangeStringTest.java
@@ -31,7 +31,7 @@ public class RangeStringTest {
   @Before
   public void setup() {
     jinjava = new Jinjava();
-    context = ImmutableMap.of("theString", "theSimpleString");
+    context = ImmutableMap.of("theString", "theSimpleString", "emptyString", "");
   }
 
   @Test
@@ -53,6 +53,11 @@ public class RangeStringTest {
   @Test
   public void testStringRangeNegative() {
     assertThat(jinjava.render("{{ theString[-7:-4] }}", context)).isEqualTo("eSt");
+  }
+
+  @Test
+  public void testStringEmpty() {
+    assertThat(jinjava.render("{{ emptyString[-1:0] }}", context)).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
If the string was empty, it would throw a `StringOutOfBoundsException`. Since there's nothing to do with a range on an empty string, just return the empty string.