### PR TITLE
Improve deferred word filtering 

### DIFF
--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1324,4 +1324,11 @@ public class EagerTest {
       "doesnt-double-append-in-deferred-macro"
     );
   }
+
+  @Test
+  public void itDoesNotReconstructVariableInSetInWrongScope() {
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
+      "does-not-reconstruct-variable-in-set-in-wrong-scope"
+    );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DictSortFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DictSortFilterTest.java
@@ -2,54 +2,56 @@ package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.hubspot.jinjava.BaseJinjavaTest;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.hubspot.jinjava.BaseJinjavaTest;
-
 public class DictSortFilterTest extends BaseJinjavaTest {
-	private static Map<String, Object> context;
+  private static Map<String, Object> context;
 
-	@BeforeClass
-	public static void initTemplate() {
+  @BeforeClass
+  public static void initTemplate() {
+    context = new HashMap<>();
 
-		context = new HashMap<>();
+    Map<String, String> countryCapitals = new HashMap<>();
+    countryCapitals.put("Bhutan", "Thimpu");
+    countryCapitals.put("Australia", "Canberra");
+    countryCapitals.put("none", "none");
+    countryCapitals.put("India", "New Delhi");
+    countryCapitals.put("France", "Paris");
 
-		Map<String, String> countryCapitals = new HashMap<>();
-		countryCapitals.put("Bhutan", "Thimpu");
-		countryCapitals.put("Australia", "Canberra");
-		countryCapitals.put("none", "none");
-		countryCapitals.put("India", "New Delhi");
-		countryCapitals.put("France", "Paris");
+    context.put("countryCapitals", countryCapitals);
+  }
 
-		context.put("countryCapitals", countryCapitals);
+  @Test
+  public void sortByKeyCaseInsensitive() {
+    String template =
+      "{% for key, value in countryCapitals|dictsort %}" +
+      " {{key}},{{value}}" +
+      " {% endfor %}";
 
-	}
+    String expected =
+      " Australia,Canberra  Bhutan,Thimpu  France,Paris  India,New Delhi  none,none ";
 
-	@Test
-	public void sortByKeyCaseInsensitive() {
-		String template = "{% for key, value in countryCapitals|dictsort %}" + " {{key}},{{value}}" + " {% endfor %}";
+    String actual = jinjava.render(template, context);
 
-		String expected = " Australia,Canberra  Bhutan,Thimpu  France,Paris  India,New Delhi  none,none ";
+    assertThat(actual).isEqualTo(expected);
+  }
 
-		String actual = jinjava.render(template, context);
+  @Test
+  public void sortByValueAndCaseInsensitive() {
+    String template =
+      "{% for key, value in countryCapitals|dictsort(false,'value') %}" +
+      " {{key}},{{value}}" +
+      " {% endfor %}";
 
-		assertThat(actual).isEqualTo(expected);
-	}
+    String expected =
+      " Australia,Canberra  India,New Delhi  none,none  France,Paris  Bhutan,Thimpu ";
 
-	@Test
-	public void sortByValueAndCaseInsensitive() {
-		String template = "{% for key, value in countryCapitals|dictsort(false,'value') %}" + " {{key}},{{value}}"
-				+ " {% endfor %}";
+    String actual = jinjava.render(template, context);
 
-		String expected = " Australia,Canberra  India,New Delhi  none,none  France,Paris  Bhutan,Thimpu ";
-
-		String actual = jinjava.render(template, context);
-
-		assertThat(actual).isEqualTo(expected);
-	}
-
+    assertThat(actual).isEqualTo(expected);
+  }
 }

--- a/src/test/resources/eager/does-not-reconstruct-variable-in-set-in-wrong-scope.expected.jinja
+++ b/src/test/resources/eager/does-not-reconstruct-variable-in-set-in-wrong-scope.expected.jinja
@@ -1,0 +1,4 @@
+{% set my_list = [] %}{% set foo %}
+{% do my_list.append(deferred) %}a
+{% endset %}
+{{ my_list }}

--- a/src/test/resources/eager/does-not-reconstruct-variable-in-set-in-wrong-scope.jinja
+++ b/src/test/resources/eager/does-not-reconstruct-variable-in-set-in-wrong-scope.jinja
@@ -1,0 +1,5 @@
+{% set my_list = [] %}
+{% set foo %}
+{% do my_list.append(deferred) %}a
+{% endset %}
+{{ my_list }}

--- a/src/test/resources/eager/handles-deferred-import-vars.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-import-vars.expected.jinja
@@ -5,7 +5,7 @@ Hello {{ myname }}
 bar: {{ bar }}
 ---
 {% set myname = deferred + 7 %}{% do %}{% set current_path = 'macro-and-set.jinja' %}{% set simple = {} %}
-{% set bar = myname + 19 %}{% set simple = {}  %}{% do simple.update({'bar': bar}) %}
+{% set bar = myname + 19 %}{% do simple.update({'bar': bar}) %}
 Hello {{ myname }}
 {% do simple.update({'import_resource_path': 'macro-and-set.jinja'}) %}{% set current_path = '' %}{% enddo %}simple.foo: {% set deferred_import_resource_path = 'macro-and-set.jinja' %}{% macro simple.foo() %}Hello {{ myname }}{% endmacro %}{% set deferred_import_resource_path = null %}{{ simple.foo() }}
 simple.bar: {{ simple.bar }}


### PR DESCRIPTION
So that deferred words that aren't in the combined scope aren't attempted to be reconstructed in the wrong scope

Follow up on https://github.com/HubSpot/jinjava/pull/1032

This test demonstrates the problem:
```
{% set my_list = [] %}
{% set foo %}
{% do my_list.append(deferred) %}a
{% endset %}
{{ my_list }}
```
We don't want `my_list` to get reconstructed inside the set tag so we should filter the deferred words that we reconstruct before deferring them to only reconstruct those within the current scope.