### PR TITLE
Use note tags to label ignored output from extends tag

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -73,6 +73,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 public class JinjavaInterpreter implements PyishSerializable {
+  public static final String IGNORED_OUTPUT_FROM_EXTENDS_NOTE =
+    "ignored_output_from_extends";
   private final Multimap<String, BlockInfo> blocks = ArrayListMultimap.create();
   private final LinkedList<Node> extendParentRoots = new LinkedList<>();
   private final Map<String, RevertibleObject> revertibleObjects = new HashMap<>();
@@ -399,11 +401,15 @@ public class JinjavaInterpreter implements PyishSerializable {
     resolveBlockStubs(output);
     if (ignoredOutput.length() > 0) {
       return (
-        EagerReconstructionUtils.wrapInTag(
-          ignoredOutput.toString(),
-          DoTag.TAG_NAME,
-          this,
-          false
+        EagerReconstructionUtils.labelWithNotes(
+          EagerReconstructionUtils.wrapInTag(
+            ignoredOutput.toString(),
+            DoTag.TAG_NAME,
+            this,
+            false
+          ),
+          IGNORED_OUTPUT_FROM_EXTENDS_NOTE,
+          this
         ) +
         output.getValue()
       );

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TokenScannerSymbols.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TokenScannerSymbols.java
@@ -22,6 +22,7 @@ public abstract class TokenScannerSymbols implements Serializable {
 
   private String expressionStart = null;
   private String expressionStartWithTag = null;
+  private String openingComment = null;
   private String closingComment = null;
   private String expressionEnd = null;
   private String expressionEndWithTag = null;
@@ -106,6 +107,13 @@ public abstract class TokenScannerSymbols implements Serializable {
       expressionEndWithTag = String.valueOf(getTagChar()) + getPostfixChar();
     }
     return expressionEndWithTag;
+  }
+
+  public String getOpeningComment() {
+    if (openingComment == null) {
+      openingComment = String.valueOf(getPrefixChar()) + getNoteChar();
+    }
+    return openingComment;
   }
 
   public String getClosingComment() {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerExtendsTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerExtendsTagTest.java
@@ -71,7 +71,7 @@ public class EagerExtendsTagTest extends ExtendsTagTest {
 
   @Test
   public void itReconstructsDeferredOutsideBlock() {
-    expectedTemplateInterpreter.assertExpectedOutput(
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
       "reconstructs-deferred-outside-block"
     );
   }

--- a/src/test/resources/tags/eager/extendstag/reconstructs-deferred-outside-block.expected.jinja
+++ b/src/test/resources/tags/eager/extendstag/reconstructs-deferred-outside-block.expected.jinja
@@ -1,9 +1,9 @@
-{% do %}
+{# Start Label:  ignored_output_from_extends #}{% do %}
 {% if deferred %}
 {% set foo = 'yes' %}
 {% else %}
 {% set foo = 'no' %}
-{% endif %}{% enddo %}<html>
+{% endif %}{% enddo %}{# End Label:  ignored_output_from_extends #}<html>
 <body>
 <div class="sidebar">
 <h3>Table Of Contents</h3>


### PR DESCRIPTION
Surrounds the reconstructed `{% do %}` tag used for preserving any functionality while ignoring output from the main template with note labels.
Previously the ignored output would look something like this:
```
{% do %}
{% set foo = [deferred] %}
{% enddo %}
```
And now it looks like:
```
{# Start Label:  ignored_output_from_extends #}{% do %}
{% set foo = [deferred] %}
{% enddo %}{# End Label:  ignored_output_from_extends #}
```
This provides some visibility into the reason that the do tag exists in the partially rendered output.