### PR TITLE
add timings

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -80,9 +80,7 @@ public class JinjavaConfig {
   private final LegacyOverrides legacyOverrides;
   private final boolean enablePreciseDivideFilter;
   private final ObjectMapper objectMapper;
-
   private final TimingLevel timingLevel;
-
   private final ObjectUnwrapper objectUnwrapper;
   private final BiConsumer<Node, JinjavaInterpreter> nodePreProcessor;
 
@@ -320,7 +318,7 @@ public class JinjavaConfig {
     private boolean enablePreciseDivideFilter = false;
     private ObjectMapper objectMapper = null;
 
-    private TimingLevel timingLevel = TimingLevel.NONE;
+    private TimingLevel timingLevel = TimingLevel.ALWAYS;
 
     private ObjectUnwrapper objectUnwrapper = new JinjavaObjectUnwrapper();
     private BiConsumer<Node, JinjavaInterpreter> nodePreProcessor = new JinjavaNodePreProcessor();

--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -28,6 +28,7 @@ import com.hubspot.jinjava.interpret.Context.Library;
 import com.hubspot.jinjava.interpret.InterpreterFactory;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.JinjavaInterpreterFactory;
+import com.hubspot.jinjava.interpret.timing.TimingLevel;
 import com.hubspot.jinjava.mode.DefaultExecutionMode;
 import com.hubspot.jinjava.mode.ExecutionMode;
 import com.hubspot.jinjava.objects.date.CurrentDateTimeProvider;
@@ -79,6 +80,8 @@ public class JinjavaConfig {
   private final LegacyOverrides legacyOverrides;
   private final boolean enablePreciseDivideFilter;
   private final ObjectMapper objectMapper;
+
+  private final TimingLevel timingLevel;
 
   private final ObjectUnwrapper objectUnwrapper;
   private final BiConsumer<Node, JinjavaInterpreter> nodePreProcessor;
@@ -140,6 +143,7 @@ public class JinjavaConfig {
     objectMapper = setupObjectMapper(builder.objectMapper);
     objectUnwrapper = builder.objectUnwrapper;
     nodePreProcessor = builder.nodePreProcessor;
+    timingLevel = builder.timingLevel;
   }
 
   private ObjectMapper setupObjectMapper(@Nullable ObjectMapper objectMapper) {
@@ -280,6 +284,10 @@ public class JinjavaConfig {
     return dateTimeProvider;
   }
 
+  public TimingLevel getTimingLevel() {
+    return timingLevel;
+  }
+
   public static class Builder {
     private Charset charset = StandardCharsets.UTF_8;
     private Locale locale = Locale.ENGLISH;
@@ -311,6 +319,8 @@ public class JinjavaConfig {
     private LegacyOverrides legacyOverrides = LegacyOverrides.NONE;
     private boolean enablePreciseDivideFilter = false;
     private ObjectMapper objectMapper = null;
+
+    private TimingLevel timingLevel = TimingLevel.NONE;
 
     private ObjectUnwrapper objectUnwrapper = new JinjavaObjectUnwrapper();
     private BiConsumer<Node, JinjavaInterpreter> nodePreProcessor = new JinjavaNodePreProcessor();
@@ -484,6 +494,11 @@ public class JinjavaConfig {
       BiConsumer<Node, JinjavaInterpreter> nodePreProcessor
     ) {
       this.nodePreProcessor = nodePreProcessor;
+      return this;
+    }
+
+    public Builder withTimingLevel(TimingLevel timingLevel) {
+      this.timingLevel = timingLevel;
       return this;
     }
 

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -216,6 +216,8 @@ public class Context extends ScopeMap<String, Object> {
       disabled = new HashMap<>();
     }
 
+    this.timings = new Timings(maxLevel);
+
     this.expTestLibrary =
       new ExpTestLibrary(parent == null, disabled.get(Library.EXP_TEST));
     this.filterLibrary = new FilterLibrary(parent == null, disabled.get(Library.FILTER));

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -58,6 +58,8 @@ public class Context extends ScopeMap<String, Object> {
   public static final String DEFERRED_IMPORT_RESOURCE_PATH_KEY =
     "deferred_import_resource_path";
 
+  private static final TimingLevel DEFAULT_TIMING_LEVEL = TimingLevel.ALWAYS;
+
   public static final String IMPORT_RESOURCE_ALIAS_KEY = "import_resource_alias";
   private final TimingLevel maxLevel;
 
@@ -124,15 +126,15 @@ public class Context extends ScopeMap<String, Object> {
   private Node currentNode;
 
   public Context() {
-    this(null, null, null, true, TimingLevel.NONE);
+    this(null, null, null, true, DEFAULT_TIMING_LEVEL);
   }
 
   public Context(Context parent) {
-    this(parent, null, null, true, TimingLevel.NONE);
+    this(parent, null, null, true, DEFAULT_TIMING_LEVEL);
   }
 
   public Context(Context parent, Map<String, ?> bindings) {
-    this(parent, bindings, null, true, TimingLevel.NONE);
+    this(parent, bindings, null, true, DEFAULT_TIMING_LEVEL);
   }
 
   public Context(
@@ -140,7 +142,7 @@ public class Context extends ScopeMap<String, Object> {
     Map<String, ?> bindings,
     Map<Library, Set<String>> disabled
   ) {
-    this(parent, bindings, disabled, true, TimingLevel.NONE);
+    this(parent, bindings, disabled, true, DEFAULT_TIMING_LEVEL);
   }
 
   public Context(
@@ -149,7 +151,7 @@ public class Context extends ScopeMap<String, Object> {
     Map<Library, Set<String>> disabled,
     boolean makeNewCallStacks
   ) {
-    this(parent, bindings, disabled, makeNewCallStacks, TimingLevel.NONE);
+    this(parent, bindings, disabled, makeNewCallStacks, DEFAULT_TIMING_LEVEL);
   }
 
   public Context(

--- a/src/main/java/com/hubspot/jinjava/interpret/RenderTimings.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/RenderTimings.java
@@ -1,9 +1,0 @@
-package com.hubspot.jinjava.interpret;
-
-import java.util.Map;
-
-public interface RenderTimings {
-  void start(JinjavaInterpreter interpreter, String name);
-  void end(JinjavaInterpreter interpreter, String name);
-  void end(JinjavaInterpreter interpreter, String name, Map<String, Object> data);
-}

--- a/src/main/java/com/hubspot/jinjava/interpret/RenderTimings.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/RenderTimings.java
@@ -1,0 +1,10 @@
+package com.hubspot.jinjava.interpret;
+
+import java.util.Map;
+
+@Deprecated
+public interface RenderTimings {
+  void start(JinjavaInterpreter interpreter, String name);
+  void end(JinjavaInterpreter interpreter, String name);
+  void end(JinjavaInterpreter interpreter, String name, Map<String, Object> data);
+}

--- a/src/main/java/com/hubspot/jinjava/interpret/timing/TimingBlock.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/timing/TimingBlock.java
@@ -80,7 +80,7 @@ public class TimingBlock {
   /**
    * Override the duration. Will not be overwritten by any subsequent calls to {@link #end()}
    */
-  void end(Duration duration) {
+  public void end(Duration duration) {
     end = start.plus(duration);
   }
 
@@ -122,7 +122,7 @@ public class TimingBlock {
 
     StringBuilder s = new StringBuilder(name)
       .append(": ")
-      .append(getDuration())
+      .append(getDuration().toMillis())
       .append(" ms.");
 
     if (data != null && !data.isEmpty()) {

--- a/src/main/java/com/hubspot/jinjava/interpret/timing/TimingBlock.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/timing/TimingBlock.java
@@ -64,12 +64,16 @@ public class TimingBlock {
   }
 
   public TimingBlock start() {
-    this.start = System.nanoTime();
+    if (start == 0) {
+      this.start = System.nanoTime();
+    }
     return this;
   }
 
   void end() {
-    this.end = System.nanoTime();
+    if (end == 0) {
+      this.end = System.nanoTime();
+    }
   }
 
   public long getDuration() {

--- a/src/main/java/com/hubspot/jinjava/interpret/timing/TimingBlock.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/timing/TimingBlock.java
@@ -3,8 +3,10 @@ package com.hubspot.jinjava.interpret.timing;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class TimingBlock {
@@ -71,10 +73,10 @@ public class TimingBlock {
   }
 
   public long getDuration() {
-    return this.end - this.start;
+    return TimeUnit.NANOSECONDS.toMillis(this.end - this.start);
   }
 
-  public LinkedList<TimingBlock> getChildren() {
+  public List<TimingBlock> getChildren() {
     return children;
   }
 
@@ -98,13 +100,17 @@ public class TimingBlock {
     return block;
   }
 
-  public String toString(TimingLevel maxLevel) {
+  public String toString(TimingLevel maxLevel, int minMillis) {
     if (timingLevel.getValue() > maxLevel.getValue()) {
       return "";
     }
+    if (getDuration() < minMillis) {
+      return "";
+    }
+
     StringBuilder s = new StringBuilder(name)
       .append(": ")
-      .append(getDuration() / 1000)
+      .append(getDuration())
       .append(" ms.");
 
     if (data != null && !data.isEmpty()) {
@@ -122,7 +128,7 @@ public class TimingBlock {
     if (children.size() > 0) {
       StringBuilder childrenStringBuilder = new StringBuilder();
       for (TimingBlock b : children) {
-        for (String line : b.toString(maxLevel).split("\n")) {
+        for (String line : b.toString(maxLevel, minMillis).split("\n")) {
           if (!line.isEmpty()) {
             childrenStringBuilder.append('\t').append(line).append('\n');
           }

--- a/src/main/java/com/hubspot/jinjava/interpret/timing/TimingBlock.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/timing/TimingBlock.java
@@ -116,7 +116,9 @@ public class TimingBlock {
     if (timingLevel.getValue() > maxLevel.getValue()) {
       return "";
     }
-    if (getDuration().toNanos() < minDuration.toNanos()) {
+    if (
+      timingLevel != TimingLevel.ALWAYS && getDuration().toNanos() < minDuration.toNanos()
+    ) {
       return "";
     }
 

--- a/src/main/java/com/hubspot/jinjava/interpret/timing/TimingBlock.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/timing/TimingBlock.java
@@ -1,0 +1,155 @@
+package com.hubspot.jinjava.interpret.timing;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+
+public class TimingBlock {
+  final String name;
+  private final String fileName;
+  private final int lineNumber;
+  private final TimingLevel timingLevel;
+  private final int position;
+  private long start;
+  private long end;
+
+  private Map<String, Object> data;
+  final LinkedList<TimingBlock> children = new LinkedList<>();
+
+  public TimingBlock(
+    String name,
+    String fileName,
+    int lineNumber,
+    int position,
+    TimingLevel timingLevel
+  ) {
+    this.name = name == null ? null : name.substring(0, Math.min(name.length(), 20));
+    this.fileName = fileName;
+    this.lineNumber = lineNumber;
+    this.position = position;
+    this.timingLevel = timingLevel;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getFileName() {
+    return fileName;
+  }
+
+  public int getLineNumber() {
+    return lineNumber;
+  }
+
+  public int getPosition() {
+    return position;
+  }
+
+  public long getStart() {
+    return start;
+  }
+
+  public long getEnd() {
+    return end;
+  }
+
+  public TimingLevel getLevel() {
+    return timingLevel;
+  }
+
+  public TimingBlock start() {
+    this.start = System.nanoTime();
+    return this;
+  }
+
+  void end() {
+    this.end = System.nanoTime();
+  }
+
+  public long getDuration() {
+    return this.end - this.start;
+  }
+
+  public LinkedList<TimingBlock> getChildren() {
+    return children;
+  }
+
+  public TimingBlock putData(String key, Object value) {
+    if (data == null) {
+      data = new HashMap<>();
+      data.put(key, value);
+    }
+    return this;
+  }
+
+  public Map<String, Object> getData() {
+    if (data == null) {
+      return Collections.emptyMap();
+    }
+    return data;
+  }
+
+  TimingBlock startChild(TimingBlock block) {
+    this.children.add(block.start());
+    return block;
+  }
+
+  public String toString(TimingLevel maxLevel) {
+    if (timingLevel.getValue() > maxLevel.getValue()) {
+      return "";
+    }
+    StringBuilder s = new StringBuilder(name)
+      .append(": ")
+      .append(getDuration() / 1000)
+      .append(" ms.");
+
+    if (data != null && !data.isEmpty()) {
+      s.append(" [");
+      s.append(
+        data
+          .entrySet()
+          .stream()
+          .map(d -> d.getKey() + " = " + d.getValue().toString())
+          .collect(Collectors.joining(","))
+      );
+      s.append("] ");
+    }
+
+    if (children.size() > 0) {
+      StringBuilder childrenStringBuilder = new StringBuilder();
+      for (TimingBlock b : children) {
+        for (String line : b.toString(maxLevel).split("\n")) {
+          if (!line.isEmpty()) {
+            childrenStringBuilder.append('\t').append(line).append('\n');
+          }
+        }
+      }
+      if (childrenStringBuilder.length() > 0) {
+        s.append(" {\n");
+        s.append(childrenStringBuilder);
+        s.append("}");
+      }
+    }
+
+    return s.toString();
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", TimingBlock.class.getSimpleName() + "[", "]")
+      .add("name='" + name + "'")
+      .add("fileName='" + fileName + "'")
+      .add("lineNumber=" + lineNumber)
+      .add("timingLevel=" + timingLevel)
+      .add("position=" + position)
+      .add("start=" + start)
+      .add("end=" + end)
+      .add("data=" + data)
+      .add("children=" + children)
+      .toString();
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/interpret/timing/TimingBlock.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/timing/TimingBlock.java
@@ -80,7 +80,7 @@ public class TimingBlock {
   /**
    * Override the duration. Will not be overwritten by any subsequent calls to {@link #end()}
    */
-  public void end(Duration duration) {
+  public void setDuration(Duration duration) {
     end = start.plus(duration);
   }
 

--- a/src/main/java/com/hubspot/jinjava/interpret/timing/TimingBlock.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/timing/TimingBlock.java
@@ -29,7 +29,7 @@ public class TimingBlock {
     int position,
     TimingLevel timingLevel
   ) {
-    this.name = name == null ? null : name.substring(0, Math.min(name.length(), 20));
+    this.name = name == null ? null : name.substring(0, Math.min(name.length(), 50));
     this.fileName = fileName;
     this.lineNumber = lineNumber;
     this.position = position;

--- a/src/main/java/com/hubspot/jinjava/interpret/timing/TimingLevel.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/timing/TimingLevel.java
@@ -1,0 +1,18 @@
+package com.hubspot.jinjava.interpret.timing;
+
+public enum TimingLevel {
+  NONE(0),
+  LOW(10),
+  HIGH(20),
+  ALL(30);
+
+  private final int value;
+
+  TimingLevel(int value) {
+    this.value = value;
+  }
+
+  public int getValue() {
+    return value;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/interpret/timing/TimingLevel.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/timing/TimingLevel.java
@@ -1,7 +1,13 @@
 package com.hubspot.jinjava.interpret.timing;
 
+import java.time.Duration;
+
 public enum TimingLevel {
   NONE(0),
+
+  /**
+   * Ignores the duration when calling {@link Timings#toString(TimingLevel, Duration)}
+   */
   ALWAYS(1),
   LOW(10),
   HIGH(20),

--- a/src/main/java/com/hubspot/jinjava/interpret/timing/TimingLevel.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/timing/TimingLevel.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.interpret.timing;
 
 public enum TimingLevel {
   NONE(0),
+  ALWAYS(1),
   LOW(10),
   HIGH(20),
   ALL(30);

--- a/src/main/java/com/hubspot/jinjava/interpret/timing/Timings.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/timing/Timings.java
@@ -67,5 +67,6 @@ public class Timings {
 
   public void clear() {
     this.blockStack.clear();
+    this.blocks.clear();
   }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/timing/Timings.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/timing/Timings.java
@@ -1,0 +1,79 @@
+package com.hubspot.jinjava.interpret.timing;
+
+import java.util.Stack;
+import java.util.StringJoiner;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class Timings {
+  private final Stack<TimingBlock> blockStack = new Stack<>();
+  private final long start;
+
+  private final TimingLevel maxLevel;
+
+  public Timings(TimingLevel maxLevel) {
+    this.start = System.nanoTime();
+    this.maxLevel = maxLevel;
+    blockStack.add(new TimingBlock("root", "", 0, 0, TimingLevel.LOW));
+  }
+
+  public TimingBlock start(TimingBlock block) {
+    if (block.getLevel().getValue() < maxLevel.getValue()) {
+      blockStack.peek().startChild(block);
+      blockStack.push(block);
+    }
+    return block;
+  }
+
+  public void end(TimingBlock block) {
+    block.end();
+    if (blockStack.peek() == block) {
+      blockStack.pop();
+    }
+  }
+
+  public long getStart() {
+    return start;
+  }
+
+  public Stack<TimingBlock> getBlocks() {
+    return blockStack;
+  }
+
+  public <I> I record(TimingBlock timingBlock, Supplier<I> func) {
+    timingBlock.start();
+    try {
+      return func.get();
+    } finally {
+      timingBlock.end();
+    }
+  }
+
+  public void record(TimingBlock timingBlock, Runnable func) {
+    timingBlock.start();
+    try {
+      func.run();
+    } finally {
+      timingBlock.end();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", Timings.class.getSimpleName() + "[", "]")
+      .add("blockStack=" + blockStack)
+      .add("start=" + start)
+      .toString();
+  }
+
+  public String toString(TimingLevel maxLevel) {
+    return getBlocks()
+      .stream()
+      .map(b -> b.toString(maxLevel))
+      .collect(Collectors.joining(","));
+  }
+
+  public void clear() {
+    this.blockStack.clear();
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/interpret/timing/Timings.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/timing/Timings.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.interpret.timing;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
@@ -58,10 +59,10 @@ public class Timings {
     }
   }
 
-  public String toString(TimingLevel maxLevel, int minMillis) {
+  public String toString(TimingLevel maxLevel, Duration minDuration) {
     return getBlocks()
       .stream()
-      .map(b -> b.toString(maxLevel, minMillis))
+      .map(b -> b.toString(maxLevel, minDuration))
       .collect(Collectors.joining("\n"));
   }
 

--- a/src/main/java/com/hubspot/jinjava/interpret/timing/Timings.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/timing/Timings.java
@@ -3,19 +3,16 @@ package com.hubspot.jinjava.interpret.timing;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
-import java.util.StringJoiner;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public class Timings {
   private final Stack<TimingBlock> blockStack = new Stack<>();
   private final List<TimingBlock> blocks = new ArrayList<>();
-  private final long start;
 
   private final TimingLevel maxLevel;
 
   public Timings(TimingLevel maxLevel) {
-    this.start = System.nanoTime();
     this.maxLevel = maxLevel;
   }
 
@@ -37,10 +34,6 @@ public class Timings {
     if (!blockStack.isEmpty() && blockStack.peek() == block) {
       blockStack.pop();
     }
-  }
-
-  public long getStart() {
-    return start;
   }
 
   public List<TimingBlock> getBlocks() {
@@ -65,14 +58,6 @@ public class Timings {
     }
   }
 
-  @Override
-  public String toString() {
-    return new StringJoiner(", ", Timings.class.getSimpleName() + "[", "]")
-      .add("blockStack=" + blockStack)
-      .add("start=" + start)
-      .toString();
-  }
-
   public String toString(TimingLevel maxLevel, int minMillis) {
     return getBlocks()
       .stream()
@@ -82,6 +67,5 @@ public class Timings {
 
   public void clear() {
     this.blockStack.clear();
-    blockStack.add(new TimingBlock("root", "", 0, 0, TimingLevel.LOW));
   }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/timing/Timings.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/timing/Timings.java
@@ -18,6 +18,7 @@ public class Timings {
   }
 
   public TimingBlock start(TimingBlock block) {
+    block.start();
     if (block.getLevel().getValue() < maxLevel.getValue()) {
       if (blockStack.isEmpty()) {
         blockStack.push(block.start());

--- a/src/main/java/com/hubspot/jinjava/interpret/timing/Timings.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/timing/Timings.java
@@ -19,7 +19,7 @@ public class Timings {
 
   public TimingBlock start(TimingBlock block) {
     block.start();
-    if (block.getLevel().getValue() < maxLevel.getValue()) {
+    if (block.getLevel().getValue() <= maxLevel.getValue()) {
       if (blockStack.isEmpty()) {
         blockStack.push(block.start());
         blocks.add(block);

--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -17,6 +17,9 @@ package com.hubspot.jinjava.tree;
 
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.timing.TimingBlock;
+import com.hubspot.jinjava.interpret.timing.TimingLevel;
+import com.hubspot.jinjava.interpret.timing.Timings;
 import com.hubspot.jinjava.lib.expression.DefaultExpressionStrategy;
 import com.hubspot.jinjava.lib.expression.ExpressionStrategy;
 import com.hubspot.jinjava.tree.output.OutputNode;
@@ -43,12 +46,24 @@ public class ExpressionNode extends Node {
 
   @Override
   public OutputNode render(JinjavaInterpreter interpreter) {
+    Timings timings = interpreter.getContext().getTimings();
+    TimingBlock timingBlock = timings.start(
+      new TimingBlock(
+        master.getImage(),
+        "",
+        interpreter.getLineNumber(),
+        interpreter.getPosition(),
+        TimingLevel.HIGH
+      )
+    );
     preProcess(interpreter);
     try {
       return expressionStrategy.interpretOutput(master, interpreter);
     } catch (DeferredValueException e) {
       interpreter.getContext().handleDeferredNode(this);
       return new RenderedOutputNode(master.getImage());
+    } finally {
+      timings.end(timingBlock);
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/tree/Node.java
+++ b/src/main/java/com/hubspot/jinjava/tree/Node.java
@@ -85,14 +85,14 @@ public abstract class Node implements Serializable {
 
   public String toTreeString(int level) {
     String prefix = StringUtils.repeat(" ", level * 4) + " ";
-    StringBuilder t = new StringBuilder(prefix).append(toString()).append('\n');
+    StringBuilder t = new StringBuilder(prefix).append(this).append('\n');
 
     for (Node n : getChildren()) {
       t.append(n.toTreeString(level + 1));
     }
 
     if (getChildren().size() > 0) {
-      t.append(prefix).append("end :: ").append(toString()).append('\n');
+      t.append(prefix).append("end :: ").append(this).append('\n');
     }
 
     return t.toString();

--- a/src/main/java/com/hubspot/jinjava/tree/TagNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TagNode.java
@@ -21,6 +21,9 @@ import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.OutputTooBigException;
+import com.hubspot.jinjava.interpret.timing.TimingBlock;
+import com.hubspot.jinjava.interpret.timing.TimingLevel;
+import com.hubspot.jinjava.interpret.timing.Timings;
 import com.hubspot.jinjava.lib.tag.FlexibleTag;
 import com.hubspot.jinjava.lib.tag.Tag;
 import com.hubspot.jinjava.tree.output.OutputNode;
@@ -44,6 +47,16 @@ public class TagNode extends Node {
 
   @Override
   public OutputNode render(JinjavaInterpreter interpreter) {
+    Timings timings = interpreter.getContext().getTimings();
+    TimingBlock timingBlock = timings.start(
+      new TimingBlock(
+        master.getImage(),
+        "",
+        master.getLineNumber(),
+        master.getStartPosition(),
+        TimingLevel.HIGH
+      )
+    );
     preProcess(interpreter);
     if (
       interpreter.getContext().isValidationMode() && !tag.isRenderedInValidationMode()
@@ -72,6 +85,8 @@ public class TagNode extends Node {
         master.getLineNumber(),
         master.getStartPosition()
       );
+    } finally {
+      timings.end(timingBlock);
     }
   }
 

--- a/src/test/java/com/hubspot/jinjava/interpret/TimingTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/TimingTest.java
@@ -1,0 +1,104 @@
+package com.hubspot.jinjava.interpret;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.hubspot.jinjava.interpret.timing.TimingBlock;
+import com.hubspot.jinjava.interpret.timing.TimingLevel;
+import com.hubspot.jinjava.interpret.timing.Timings;
+import java.util.LinkedList;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TimingTest {
+  private Timings timings;
+
+  @Before
+  public void setUp() {
+    timings = new Timings(TimingLevel.ALL);
+  }
+
+  private void sleep(long t) {
+    try {
+      Thread.sleep(t);
+    } catch (InterruptedException ignored) {}
+  }
+
+  @Test
+  public void itAddsTimings() {
+    TimingBlock timingBlock = timings.start(
+      new TimingBlock("foo1", "bar", 1, 1, TimingLevel.LOW)
+    );
+    sleep(10);
+    timings.end(timingBlock);
+
+    timingBlock = timings.start(new TimingBlock("foo2", "bar", 2, 1, TimingLevel.LOW));
+    sleep(10);
+    timingBlock.putData("new", "zealand");
+    timings.end(timingBlock);
+
+    assertThat(timings.getBlocks()).hasSize(1);
+    LinkedList<TimingBlock> children = timings.getBlocks().get(0).getChildren();
+    assertThat(children).hasSize(2);
+    assertThat(children.get(0).getName()).isEqualTo("foo1");
+    assertThat(children.get(0).getDuration()).isGreaterThan(9);
+    assertThat(children.get(1).getName()).isEqualTo("foo2");
+    assertThat(children.get(1).getData()).isEqualTo(ImmutableMap.of("new", "zealand"));
+  }
+
+  @Test
+  public void itAddsNestedTimings() {
+    TimingBlock parent = timings.start(
+      new TimingBlock("parent", "bar", 1, 1, TimingLevel.LOW)
+    );
+    sleep(10);
+    TimingBlock child = timings.start(
+      new TimingBlock("child", "bar", 1, 1, TimingLevel.LOW)
+    );
+    sleep(10);
+    timings.end(child);
+    timings.end(parent);
+
+    LinkedList<TimingBlock> children = timings.getBlocks().get(0).getChildren();
+    assertThat(timings.getBlocks()).hasSize(1);
+    assertThat(children).hasSize(1);
+    assertThat(children.get(0)).isEqualTo(parent);
+    assertThat(children.get(0).getChildren()).hasSize(1);
+    assertThat(children.get(0).getChildren().get(0)).isEqualTo(child);
+  }
+
+  @Test
+  public void itFiltersToStringByLevel() {
+    TimingBlock parent = timings.start(
+      new TimingBlock("parent", "bar", 1, 1, TimingLevel.LOW)
+    );
+    TimingBlock child1 = timings.start(
+      new TimingBlock("child1", "bar", 1, 1, TimingLevel.LOW)
+    );
+    timings.end(child1);
+    TimingBlock child2 = timings.start(
+      new TimingBlock("child2", "bar", 1, 1, TimingLevel.HIGH)
+    );
+    timings.end(child2);
+    timings.end(parent);
+
+    assertThat(timings.toString(TimingLevel.ALL)).contains("child1").contains("child2");
+
+    assertThat(timings.toString(TimingLevel.LOW))
+      .contains("child1")
+      .doesNotContain("child2");
+  }
+
+  @Test
+  public void itIgnoresTimingsAboveMaxLevel() {
+    timings = new Timings(TimingLevel.NONE);
+    TimingBlock parent = timings.start(
+      new TimingBlock("parent", "bar", 1, 1, TimingLevel.LOW)
+    );
+    timings.end(parent);
+
+    LinkedList<TimingBlock> children = timings.getBlocks().get(0).getChildren();
+    assertThat(timings.getBlocks()).hasSize(1);
+    assertThat(children).hasSize(0);
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/interpret/TimingTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/TimingTest.java
@@ -131,12 +131,19 @@ public class TimingTest {
   }
 
   @Test
+  public void itIncludesShortDurationsWithAlways() {
+    timings.end(timings.start(new TimingBlock("always", "", 1, 1, TimingLevel.ALWAYS)));
+    timings.end(timings.start(new TimingBlock("low", "", 1, 1, TimingLevel.LOW)));
+
+    assertThat(timings.toString(TimingLevel.LOW, Duration.of(50, ChronoUnit.MILLIS)))
+      .contains("always")
+      .doesNotContain("low");
+  }
+
+  @Test
   public void itIgnoresTimingsAboveMaxLevel() {
-    timings = new Timings(TimingLevel.NONE);
-    TimingBlock parent = timings.start(
-      new TimingBlock("parent", "bar", 1, 1, TimingLevel.LOW)
-    );
-    timings.end(parent);
+    timings = new Timings(TimingLevel.LOW);
+    timings.end(timings.start(new TimingBlock("parent", "", 1, 1, TimingLevel.LOW)));
 
     assertThat(timings.getBlocks()).isEmpty();
   }

--- a/src/test/java/com/hubspot/jinjava/interpret/TimingTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/TimingTest.java
@@ -6,6 +6,8 @@ import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.interpret.timing.TimingBlock;
 import com.hubspot.jinjava.interpret.timing.TimingLevel;
 import com.hubspot.jinjava.interpret.timing.Timings;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,7 +42,8 @@ public class TimingTest {
     assertThat(timings.getBlocks()).hasSize(2);
     List<TimingBlock> children = timings.getBlocks();
     assertThat(children.get(0).getName()).isEqualTo("foo1");
-    assertThat(children.get(0).getDuration()).isGreaterThan(9);
+    assertThat(children.get(0).getDuration())
+      .isGreaterThan(Duration.of(9, ChronoUnit.MILLIS));
     assertThat(children.get(1).getName()).isEqualTo("foo2");
     assertThat(children.get(1).getData()).isEqualTo(ImmutableMap.of("new", "zealand"));
   }
@@ -92,11 +95,11 @@ public class TimingTest {
     timings.end(child2);
     timings.end(parent);
 
-    assertThat(timings.toString(TimingLevel.ALL, 0))
+    assertThat(timings.toString(TimingLevel.ALL, Duration.ZERO))
       .contains("child1")
       .contains("child2");
 
-    assertThat(timings.toString(TimingLevel.LOW, 0))
+    assertThat(timings.toString(TimingLevel.LOW, Duration.ZERO))
       .contains("child1")
       .doesNotContain("child2");
   }
@@ -118,11 +121,11 @@ public class TimingTest {
     timings.end(child2);
     timings.end(parent);
 
-    assertThat(timings.toString(TimingLevel.ALL, 0))
+    assertThat(timings.toString(TimingLevel.ALL, Duration.ZERO))
       .contains("slowKid")
       .contains("fastKid");
 
-    assertThat(timings.toString(TimingLevel.ALL, 100))
+    assertThat(timings.toString(TimingLevel.ALL, Duration.of(100, ChronoUnit.MILLIS)))
       .contains("slowKid")
       .doesNotContain("fastKid");
   }

--- a/src/test/java/com/hubspot/jinjava/interpret/TimingTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/TimingTest.java
@@ -109,7 +109,7 @@ public class TimingTest {
     TimingBlock child1 = timings.start(
       new TimingBlock("slowKid", "bar", 1, 1, TimingLevel.LOW)
     );
-    sleep(100);
+    sleep(200);
     timings.end(child1);
     TimingBlock child2 = timings.start(
       new TimingBlock("fastKid", "bar", 1, 1, TimingLevel.HIGH)
@@ -122,7 +122,7 @@ public class TimingTest {
       .contains("slowKid")
       .contains("fastKid");
 
-    assertThat(timings.toString(TimingLevel.ALL, 10))
+    assertThat(timings.toString(TimingLevel.ALL, 100))
       .contains("slowKid")
       .doesNotContain("fastKid");
   }

--- a/src/test/java/com/hubspot/jinjava/interpret/TimingTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/TimingTest.java
@@ -143,7 +143,7 @@ public class TimingTest {
   @Test
   public void itIgnoresTimingsAboveMaxLevel() {
     timings = new Timings(TimingLevel.LOW);
-    timings.end(timings.start(new TimingBlock("parent", "", 1, 1, TimingLevel.LOW)));
+    timings.end(timings.start(new TimingBlock("parent", "", 1, 1, TimingLevel.HIGH)));
 
     assertThat(timings.getBlocks()).isEmpty();
   }

--- a/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
@@ -19,14 +19,14 @@ public class TreeParserTest extends BaseInterpretingTest {
   }
 
   @Test
-  public void itStripsRightWhiteSpace() throws Exception {
+  public void itStripsRightWhiteSpace() {
     String expression = "{% for foo in [1,2,3] -%} \n .{{ foo }}\n{% endfor %}";
     final Node tree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(tree)).isEqualTo(".1\n.2\n.3\n");
   }
 
   @Test
-  public void itStripsRightWhiteSpaceWithComment() throws Exception {
+  public void itStripsRightWhiteSpaceWithComment() {
     String expression =
       "{% for foo in [1,2,3] -%} \n {#- comment -#} \n {#- comment -#} .{{ foo }}\n{% endfor %}";
     final Node tree = new TreeParser(interpreter, expression).buildTree();
@@ -34,14 +34,14 @@ public class TreeParserTest extends BaseInterpretingTest {
   }
 
   @Test
-  public void itStripsLeftWhiteSpace() throws Exception {
+  public void itStripsLeftWhiteSpace() {
     String expression = "{% for foo in [1,2,3] %}\n{{ foo }}. \n {%- endfor %}";
     final Node tree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(tree)).isEqualTo("\n1.\n2.\n3.");
   }
 
   @Test
-  public void itStripsLeftWhiteSpaceWithComment() throws Exception {
+  public void itStripsLeftWhiteSpaceWithComment() {
     String expression =
       "{% for foo in [1,2,3] %}\n{{ foo }}. \n {#- comment -#} {%- endfor %}";
     final Node tree = new TreeParser(interpreter, expression).buildTree();
@@ -49,14 +49,14 @@ public class TreeParserTest extends BaseInterpretingTest {
   }
 
   @Test
-  public void itStripsLeftAndRightWhiteSpace() throws Exception {
+  public void itStripsLeftAndRightWhiteSpace() {
     String expression = "{% for foo in [1,2,3] -%} \n .{{ foo }}. \n {%- endfor %}";
     final Node tree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(tree)).isEqualTo(".1..2..3.");
   }
 
   @Test
-  public void itStripsLeftAndRightWhiteSpaceWithComment() throws Exception {
+  public void itStripsLeftAndRightWhiteSpaceWithComment() {
     String expression =
       "{% for foo in [1,2,3] -%} \n {#- comment -#} \n {#- comment -#} .{{ foo }}. \n {#- comment -#} \n {#- comment -#} {%- endfor %}";
     final Node tree = new TreeParser(interpreter, expression).buildTree();
@@ -64,7 +64,7 @@ public class TreeParserTest extends BaseInterpretingTest {
   }
 
   @Test
-  public void itPreservesInnerWhiteSpace() throws Exception {
+  public void itPreservesInnerWhiteSpace() {
     String expression =
       "{% for foo in [1,2,3] -%}\nL{% if true %}\n{{ foo }}\n{% endif %}R\n{%- endfor %}";
     final Node tree = new TreeParser(interpreter, expression).buildTree();
@@ -72,7 +72,7 @@ public class TreeParserTest extends BaseInterpretingTest {
   }
 
   @Test
-  public void itPreservesInnerWhiteSpaceWithComment() throws Exception {
+  public void itPreservesInnerWhiteSpaceWithComment() {
     String expression =
       "{% for foo in [1,2,3] -%}\n {#- comment -#} \n {#- comment -#}L{% if true %}\n{{ foo }}\n{% endif %}R\n {#- comment -#} \n {#- comment -#}{%- endfor %}";
     final Node tree = new TreeParser(interpreter, expression).buildTree();
@@ -80,14 +80,14 @@ public class TreeParserTest extends BaseInterpretingTest {
   }
 
   @Test
-  public void itStripsLeftWhiteSpaceBeforeTag() throws Exception {
+  public void itStripsLeftWhiteSpaceBeforeTag() {
     String expression = ".\n {%- for foo in [1,2,3] %} {{ foo }} {% endfor %} \n.";
     final Node tree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(tree)).isEqualTo(". 1  2  3  \n.");
   }
 
   @Test
-  public void itStripsLeftWhiteSpaceBeforeTagWithComment() throws Exception {
+  public void itStripsLeftWhiteSpaceBeforeTagWithComment() {
     String expression =
       ".\n {#- comment -#} \n {#- comment -#} {%- for foo in [1,2,3] %} {{ foo }} {% endfor %} \n.";
     final Node tree = new TreeParser(interpreter, expression).buildTree();
@@ -95,14 +95,14 @@ public class TreeParserTest extends BaseInterpretingTest {
   }
 
   @Test
-  public void itStripsRightWhiteSpaceAfterTag() throws Exception {
+  public void itStripsRightWhiteSpaceAfterTag() {
     String expression = ".\n {% for foo in [1,2,3] %} {{ foo }} {% endfor -%} \n.";
     final Node tree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(tree)).isEqualTo(".\n  1  2  3 .");
   }
 
   @Test
-  public void itStripsRightWhiteSpaceAfterTagWithComment() throws Exception {
+  public void itStripsRightWhiteSpaceAfterTagWithComment() {
     String expression =
       ".\n {% for foo in [1,2,3] %} {{ foo }} {% endfor -%} \n {#- comment -#} \n {#- comment -#}.";
     final Node tree = new TreeParser(interpreter, expression).buildTree();
@@ -110,21 +110,21 @@ public class TreeParserTest extends BaseInterpretingTest {
   }
 
   @Test
-  public void itStripsAllOuterWhiteSpace() throws Exception {
+  public void itStripsAllOuterWhiteSpace() {
     String expression = ".\n {%- for foo in [1,2,3] -%} {{ foo }} {%- endfor -%} \n.";
     final Node tree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(tree)).isEqualTo(".123.");
   }
 
   @Test
-  public void itStripsAllOuterWhiteSpaceForInlineTags() throws Exception {
+  public void itStripsAllOuterWhiteSpaceForInlineTags() {
     String expression = "1\n\n{%- print 2 -%}\n\n3\n\n{%- set x = 1 -%}\n\n4";
     final Node tree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(tree)).isEqualTo("1234");
   }
 
   @Test
-  public void itStripsAllOuterWhiteSpaceWithComment() throws Exception {
+  public void itStripsAllOuterWhiteSpaceWithComment() {
     String expression =
       ".\n {#- comment -#} \n {#- comment -#} {%- for foo in [1,2,3] -%} {{ foo }} {%- endfor -%} \n {#- comment -#} \n {#- comment -#}.";
     final Node tree = new TreeParser(interpreter, expression).buildTree();


### PR DESCRIPTION
There isn't a systematic way to collect timings of various methods in Jinjava. This will be useful in finding performance bottlenecks from real user code.

The `Timings` object lives on the `Context` and allows adding "blocks" which represent the time it takes to execute a section of code. 

Typically it will be used like this:
```java
    Timings timings = context.getTimings();
    TimingBlock block = timings.start(
      new TimingBlock("{% do stuff %}", "file.jinja", 1, 10, TimingLevel.LOW)
    );
	try {
	  // do stuff
    } finally {
	  timings.end(block);
    }
```
This creates a timing block with a name of `{% do stuff %}` from the file `file.jinja` at line and position 1:10 and with a level of `LOW`.

It's recommended to wrap your code in a `try` block so it's impossible to forget to end the timing. An alternative is calling `timings.record` with a `Supplier` or `Runnable` which wraps the code for you.

Arbitrary data can be associated with a timing block using `TimingBlock:addData(key, val)`

`JinjavaConfig` now has a `maxTiming` level which limits the level of timings are recorded, defaulting to `NONE`.