### PR TITLE
Improve for loop explosion success with deferred tokens

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -44,7 +44,6 @@ import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.util.ConcurrentModificationException;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -151,6 +150,20 @@ public class ForTag implements Tag {
         String.format("%s in %s", String.join(", ", loopVars), e.getDeferredEvalResult())
       );
     }
+    return renderForCollection(
+      tagNode,
+      interpreter,
+      loopVarsAndExpression.getLeft(),
+      collection
+    );
+  }
+
+  public String renderForCollection(
+    TagNode tagNode,
+    JinjavaInterpreter interpreter,
+    List<String> loopVars,
+    Object collection
+  ) {
     ForLoop loop = ObjectIterator.getLoop(collection);
 
     try (InterpreterScopeClosable c = interpreter.enterScope()) {
@@ -190,8 +203,8 @@ public class ForTag implements Tag {
         } else {
           for (int loopVarIndex = 0; loopVarIndex < loopVars.size(); loopVarIndex++) {
             String loopVar = loopVars.get(loopVarIndex);
-            if (Map.Entry.class.isAssignableFrom(val.getClass())) {
-              Map.Entry<String, Object> entry = (Entry<String, Object>) val;
+            if (Entry.class.isAssignableFrom(val.getClass())) {
+              Entry<String, Object> entry = (Entry<String, Object>) val;
               Object entryVal = null;
 
               if (loopVars.indexOf(loopVar) == 0) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerDoTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerDoTag.java
@@ -40,7 +40,6 @@ public class EagerDoTag extends EagerStateChangingTag<DoTag> implements Flexible
         EagerContextWatcher
           .EagerChildContextConfig.newBuilder()
           .withTakeNewValue(true)
-          .withCheckForContextChanges(!interpreter.getContext().isDeferredExecutionMode())
           .build()
       );
       PrefixToPreserveState prefixToPreserveState = new PrefixToPreserveState();

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerExecutionResult.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerExecutionResult.java
@@ -4,6 +4,7 @@ import static com.hubspot.jinjava.util.EagerReconstructionUtils.buildBlockSetTag
 import static com.hubspot.jinjava.util.EagerReconstructionUtils.buildSetTag;
 
 import com.google.common.annotations.Beta;
+import com.hubspot.jinjava.interpret.DeferredLazyReferenceSource;
 import com.hubspot.jinjava.interpret.DeferredValueShadow;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.LazyReference;
@@ -55,8 +56,13 @@ public class EagerExecutionResult {
       .entrySet()
       .stream()
       .filter(
-        entry ->
-          !(interpreter.getContext().get(entry.getKey()) instanceof DeferredValueShadow)
+        entry -> {
+          Object contextValue = interpreter.getContext().get(entry.getKey());
+          if (contextValue instanceof DeferredLazyReferenceSource) {
+            ((DeferredLazyReferenceSource) contextValue).setReconstructed(true);
+          }
+          return (contextValue != null && !(contextValue instanceof DeferredValueShadow));
+        }
       )
       .collect(Collectors.toList());
     prefixToPreserveState.putAll(

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -72,11 +72,7 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
           return expressionResult;
         },
         interpreter,
-        EagerContextWatcher
-          .EagerChildContextConfig.newBuilder()
-          .withCheckForContextChanges(!interpreter.getContext().isDeferredExecutionMode())
-          .withTakeNewValue(true)
-          .build()
+        EagerContextWatcher.EagerChildContextConfig.newBuilder().build()
       );
       if (result.getResult().getResolutionState() == ResolutionState.NONE) {
         EagerReconstructionUtils.resetSpeculativeBindings(interpreter, collectionResult);

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -39,45 +39,67 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
 
   @Override
   public String innerInterpret(TagNode tagNode, JinjavaInterpreter interpreter) {
-    Set<DeferredToken> addedTokens = new HashSet<>();
-    EagerExecutionResult result = EagerContextWatcher.executeInChildContext(
-      eagerInterpreter -> {
-        EagerExpressionResult expressionResult = EagerExpressionResult.fromSupplier(
-          () -> getTag().interpretUnchecked(tagNode, eagerInterpreter),
-          eagerInterpreter
-        );
-        addedTokens.addAll(eagerInterpreter.getContext().getDeferredTokens());
-        return expressionResult;
-      },
+    Pair<List<String>, String> loopVarsAndExpression = getTag()
+      .getLoopVarsAndExpression((TagToken) tagNode.getMaster());
+    EagerExecutionResult collectionResult = EagerContextWatcher.executeInChildContext(
+      eagerInterpreter ->
+        EagerExpressionResolver.resolveExpression(
+          '[' + loopVarsAndExpression.getRight() + ']',
+          interpreter
+        ),
       interpreter,
       EagerContextWatcher
         .EagerChildContextConfig.newBuilder()
         .withCheckForContextChanges(!interpreter.getContext().isDeferredExecutionMode())
         .build()
     );
-    if (
-      result.getResult().getResolutionState() == ResolutionState.NONE ||
-      (
-        !result.getResult().isFullyResolved() &&
-        !result.getSpeculativeBindings().isEmpty()
-      )
-    ) {
-      EagerReconstructionUtils.resetSpeculativeBindings(interpreter, result);
-      interpreter.getContext().removeDeferredTokens(addedTokens);
-      throw new DeferredValueException(
-        result.getResult().getResolutionState() == ResolutionState.NONE
-          ? result.getResult().toString()
-          : "Modification inside partially evaluated for loop"
+    if (collectionResult.getResult().isFullyResolved()) {
+      Set<DeferredToken> addedTokens = new HashSet<>();
+      EagerExecutionResult result = EagerContextWatcher.executeInChildContext(
+        eagerInterpreter -> {
+          EagerExpressionResult expressionResult = EagerExpressionResult.fromSupplier(
+            () ->
+              getTag()
+                .renderForCollection(
+                  tagNode,
+                  eagerInterpreter,
+                  loopVarsAndExpression.getLeft(),
+                  collectionResult.getResult().toList().get(0)
+                ),
+            eagerInterpreter
+          );
+          addedTokens.addAll(eagerInterpreter.getContext().getDeferredTokens());
+          return expressionResult;
+        },
+        interpreter,
+        EagerContextWatcher
+          .EagerChildContextConfig.newBuilder()
+          .withCheckForContextChanges(!interpreter.getContext().isDeferredExecutionMode())
+          .withTakeNewValue(true)
+          .build()
       );
+      if (result.getResult().getResolutionState() == ResolutionState.NONE) {
+        EagerReconstructionUtils.resetSpeculativeBindings(interpreter, collectionResult);
+        EagerReconstructionUtils.resetSpeculativeBindings(interpreter, result);
+        interpreter.getContext().removeDeferredTokens(addedTokens);
+        throw new DeferredValueException(result.getResult().toString());
+      }
+      if (result.getResult().isFullyResolved()) {
+        return result.getResult().toString(true);
+      } else {
+        return (
+          result
+            .getPrefixToPreserveState()
+            .withAllInFront(collectionResult.getPrefixToPreserveState()) +
+          EagerReconstructionUtils.wrapInChildScope(
+            result.getResult().toString(true),
+            interpreter
+          )
+        );
+      }
     }
-    if (result.getResult().isFullyResolved()) {
-      return result.getResult().toString(true);
-    } else {
-      return EagerReconstructionUtils.wrapInChildScope(
-        result.getResult().toString(true),
-        interpreter
-      );
-    }
+    EagerReconstructionUtils.resetSpeculativeBindings(interpreter, collectionResult);
+    throw new DeferredValueException(collectionResult.getResult().toString());
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -197,22 +197,19 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
         interpreter,
         true
       ) +
-      wrapInChildScopeIfNecessary(interpreter, output, currentImportAlias) +
+      wrapInChildScope(interpreter, output, currentImportAlias) +
       initialPathSetter
     );
   }
 
-  private static String wrapInChildScopeIfNecessary(
+  private static String wrapInChildScope(
     JinjavaInterpreter interpreter,
     String output,
     String currentImportAlias
   ) {
     String combined = output + getDoTagToPreserve(interpreter, currentImportAlias);
     // So that any set variables other than the alias won't exist outside the child's scope
-    //    if (interpreter.getContext().isDeferredExecutionMode()) {
     return EagerReconstructionUtils.wrapInChildScope(combined, interpreter);
-    //    }
-    //    return combined;
   }
 
   private String getSetTagForDeferredChildBindings(

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -209,10 +209,10 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
   ) {
     String combined = output + getDoTagToPreserve(interpreter, currentImportAlias);
     // So that any set variables other than the alias won't exist outside the child's scope
-    if (interpreter.getContext().isDeferredExecutionMode()) {
-      return EagerReconstructionUtils.wrapInChildScope(combined, interpreter);
-    }
-    return combined;
+    //    if (interpreter.getContext().isDeferredExecutionMode()) {
+    return EagerReconstructionUtils.wrapInChildScope(combined, interpreter);
+    //    }
+    //    return combined;
   }
 
   private String getSetTagForDeferredChildBindings(

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -790,7 +790,8 @@ public class EagerReconstructionUtils {
    *   * When doing some eager execution and then needing to repeat the same execution in deferred execution mode.
    *   <p>
    *   * When rendering logic which takes place in its own child scope (for tag, macro function, set block) and there
-   *   speculative bindings. These must be deferred and the execution must run again so they don't get reconstructed
+   *   are speculative bindings.
+   *   These must be deferred and the execution must run again, so they don't get reconstructed
    *   within the child scope, and can instead be reconstructed in their original scopes.
    * @param interpreter The JinjavaInterpreter
    * @param eagerExecutionResult The execution result which contains information about which bindings were modified

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1141,7 +1141,7 @@ public class EagerTest {
 
   @Test
   public void itHandlesReferenceModificationWhenSourceIsLost() {
-    expectedTemplateInterpreter.assertExpectedOutput(
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
       "handles-reference-modification-when-source-is-lost"
     );
   }

--- a/src/test/resources/eager/correctly-defers-with-multiple-loops.expected.jinja
+++ b/src/test/resources/eager/correctly-defers-with-multiple-loops.expected.jinja
@@ -1,6 +1,6 @@
 {% set my_list = [] %}{% for __ignored__ in [0] %}
 {% for j in deferred %}
-{% do my_list.append(1) %}
+{% do my_list.append(0) %}
 {% endfor %}
 
 {% for j in deferred %}

--- a/src/test/resources/eager/correctly-defers-with-multiple-loops.expected.jinja
+++ b/src/test/resources/eager/correctly-defers-with-multiple-loops.expected.jinja
@@ -1,4 +1,8 @@
-{% set my_list = [] %}{% for i in [0, 1] %}
+{% set my_list = [] %}{% for __ignored__ in [0] %}
+{% for j in deferred %}
+{% do my_list.append(1) %}
+{% endfor %}
+
 {% for j in deferred %}
 {% do my_list.append(1) %}
 {% endfor %}

--- a/src/test/resources/eager/correctly-defers-with-multiple-loops.jinja
+++ b/src/test/resources/eager/correctly-defers-with-multiple-loops.jinja
@@ -1,7 +1,7 @@
 {% set my_list = [] %}
 {% for i in range(2) %}
 {% for j in deferred %}
-{% do my_list.append(1) %}
+{% do my_list.append(i) %}
 {% endfor %}
 {% endfor %}
 {{ my_list }}

--- a/src/test/resources/eager/does-not-override-import-modification-in-for.expected.jinja
+++ b/src/test/resources/eager/does-not-override-import-modification-in-for.expected.jinja
@@ -1,4 +1,23 @@
-{% set foo = 'start' %}{% for i in [0, 1] %}
+{% set foo = 'start' %}{% for __ignored__ in [0] %}
+{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set bar1 = {} %}{% for __ignored__ in [0] %}{% if deferred %}
+
+{% set foo = 'starta' %}{% do bar1.update({'foo': foo}) %}
+
+{% endif %}
+
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar1.update({'foo': foo}) %}
+{% do bar1.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}
+{{ bar1.foo }}
+{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set bar2 = {} %}{% for __ignored__ in [0] %}{% if deferred %}
+
+{% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}{% do bar2.update({'foo': foo}) %}
+
+{% endif %}
+
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar2.update({'foo': foo}) %}
+{% do bar2.update({'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}
+{{ bar2.foo }}
+
 {% do %}{% set current_path = 'deferred-modification.jinja' %}{% set bar1 = {} %}{% for __ignored__ in [0] %}{% if deferred %}
 
 {% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}{% do bar1.update({'foo': foo}) %}

--- a/src/test/resources/eager/handles-deferred-import-vars.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-import-vars.expected.jinja
@@ -4,8 +4,8 @@ Hello {{ myname }}
 {% enddo %}foo: Hello {{ myname }}
 bar: {{ bar }}
 ---
-{% set myname = deferred + 7 %}{% do %}{% set current_path = 'macro-and-set.jinja' %}{% set simple = {} %}
+{% set myname = deferred + 7 %}{% do %}{% set current_path = 'macro-and-set.jinja' %}{% set simple = {} %}{% for __ignored__ in [0] %}
 {% set bar = myname + 19 %}{% do simple.update({'bar': bar}) %}
 Hello {{ myname }}
-{% do simple.update({'import_resource_path': 'macro-and-set.jinja'}) %}{% set current_path = '' %}{% enddo %}simple.foo: {% set deferred_import_resource_path = 'macro-and-set.jinja' %}{% macro simple.foo() %}Hello {{ myname }}{% endmacro %}{% set deferred_import_resource_path = null %}{{ simple.foo() }}
+{% do simple.update({'import_resource_path': 'macro-and-set.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}simple.foo: {% set deferred_import_resource_path = 'macro-and-set.jinja' %}{% macro simple.foo() %}Hello {{ myname }}{% endmacro %}{% set deferred_import_resource_path = null %}{{ simple.foo() }}
 simple.bar: {{ simple.bar }}

--- a/src/test/resources/eager/handles-double-import-modification.expected.jinja
+++ b/src/test/resources/eager/handles-double-import-modification.expected.jinja
@@ -1,20 +1,20 @@
-{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set foo = null %}{% set bar1 = {} %}{% if deferred %}
+{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set foo = null %}{% set bar1 = {} %}{% for __ignored__ in [0] %}{% if deferred %}
 
 {% set foo = 'a' %}{% do bar1.update({'foo': foo}) %}
 
 {% endif %}
 
 {% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar1.update({'foo': foo}) %}
-{% do bar1.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}{% enddo %}
+{% do bar1.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}
 ---
-{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set foo = null %}{% set bar2 = {} %}{% if deferred %}
+{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set foo = null %}{% set bar2 = {} %}{% for __ignored__ in [0] %}{% if deferred %}
 
 {% set foo = 'a' %}{% do bar2.update({'foo': foo}) %}
 
 {% endif %}
 
 {% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar2.update({'foo': foo}) %}
-{% do bar2.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}{% enddo %}
+{% do bar2.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}
 ---
 {{ bar1.foo }}
 {{ bar2.foo }}

--- a/src/test/resources/eager/handles-higher-scope-reference-modification.expected.jinja
+++ b/src/test/resources/eager/handles-higher-scope-reference-modification.expected.jinja
@@ -4,7 +4,7 @@ C: {{ c_list }}.{% endmacro %}{{ c(b_list) }}{% set b_list = a_list %}{% do b_li
 B: {% set b_list = a_list %}{{ b_list }}.{% endset %}{{ __macro_b_125206_temp_variable_0__ }}{% do a_list.append(deferred ? 'A' : '') %}
 A: {{ a_list }}.
 ---
-{% set a_list = ['a'] %}{% for i in [0] %}{% set b_list = a_list %}{% do b_list.append('b') %}{% for __ignored__ in [0] %}{% set c_list = b_list %}{% do c_list.append(deferred ? 'c' : '') %}
-C: {{ c_list }}.{% endfor %}{% do b_list.append(deferred ? 'B' : '') %}
-B: {{ b_list }}.{% endfor %}{% do a_list.append(deferred ? 'A' : '') %}
+{% set a_list = ['a', 'b'] %}{% for __ignored__ in [0] %}{% set b_list = a_list %}{% for __ignored__ in [0] %}{% set c_list = a_list %}{% do c_list.append(deferred ? 'c' : '') %}
+C: {% set c_list = a_list %}{{ c_list }}.{% endfor %}{% set b_list = a_list %}{% do b_list.append(deferred ? 'B' : '') %}
+B: {% set b_list = a_list %}{{ b_list }}.{% endfor %}{% do a_list.append(deferred ? 'A' : '') %}
 A: {{ a_list }}.

--- a/src/test/resources/eager/handles-higher-scope-reference-modification.expected.jinja
+++ b/src/test/resources/eager/handles-higher-scope-reference-modification.expected.jinja
@@ -4,7 +4,7 @@ C: {{ c_list }}.{% endmacro %}{{ c(b_list) }}{% set b_list = a_list %}{% do b_li
 B: {% set b_list = a_list %}{{ b_list }}.{% endset %}{{ __macro_b_125206_temp_variable_0__ }}{% do a_list.append(deferred ? 'A' : '') %}
 A: {{ a_list }}.
 ---
-{% set a_list = ['a', 'b'] %}{% for __ignored__ in [0] %}{% set b_list = a_list %}{% for __ignored__ in [0] %}{% set c_list = a_list %}{% do c_list.append(deferred ? 'c' : '') %}
+{% set a_list = ['a', 'b'] %}{% for __ignored__ in [0] %}{% for __ignored__ in [0] %}{% set c_list = a_list %}{% do c_list.append(deferred ? 'c' : '') %}
 C: {% set c_list = a_list %}{{ c_list }}.{% endfor %}{% set b_list = a_list %}{% do b_list.append(deferred ? 'B' : '') %}
 B: {% set b_list = a_list %}{{ b_list }}.{% endfor %}{% do a_list.append(deferred ? 'A' : '') %}
 A: {{ a_list }}.

--- a/src/test/resources/eager/handles-reference-modification-when-source-is-lost.expected.jinja
+++ b/src/test/resources/eager/handles-reference-modification-when-source-is-lost.expected.jinja
@@ -1,13 +1,13 @@
-{% set a_list = ['a'] %}{% for i in [0] %}{% set b_list = a_list %}{% do b_list.append(deferred) %}
+{% set a_list = ['a'] %}{% for __ignored__ in [0] %}{% set b_list = a_list %}{% do b_list.append(deferred) %}
 {% endfor %}
 {{ a_list }}
 ---
 {% for __ignored__ in [0] %}
 
-{% set a_list = [] %}{% for i in [0] %}
+{% set a_list = [] %}{% for __ignored__ in [0] %}
 {% if deferred %}
-{% set b_list = a_list %}
-{% do b_list.append(1) %}
+{% set b_list = [] %}
+{% set b_list = a_list %}{% do b_list.append(1) %}
 {% endif %}
 {% endfor %}
 {{ a_list }}

--- a/src/test/resources/eager/reconstructs-map-node.expected.expected.jinja
+++ b/src/test/resources/eager/reconstructs-map-node.expected.expected.jinja
@@ -1,3 +1,5 @@
+First key is foo.
+
 foo ff
 bar bb
 ['resolved', 'resolved']

--- a/src/test/resources/eager/reconstructs-map-node.expected.jinja
+++ b/src/test/resources/eager/reconstructs-map-node.expected.jinja
@@ -1,7 +1,13 @@
-{% set my_list = [] %}{% for key, val in [fn:map_entry('foo', 'ff'), fn:map_entry('bar', 'bb')] %}{% do my_list.append(deferred) %}
-{{ key ~ ' ' ~ val }}{% endfor %}
+{% if deferred %}
+{% set foo = [fn:map_entry('foo', 'ff'), fn:map_entry('bar', 'bb')] %}
+{% endif %}
+First key is {{ foo[0].key }}.
+{% set my_list = [] %}{% for __ignored__ in [0] %}{% do my_list.append(deferred) %}
+foo ff{% do my_list.append(deferred) %}
+bar bb{% endfor %}
 {{ my_list }}
 
-{% set my_list = [] %}{% for i in [fn:map_entry('foo', 'ff'), fn:map_entry('bar', 'bb')] %}{% do my_list.append(deferred) %}
-{{ i.key }}{% endfor %}
+{% set my_list = [] %}{% for __ignored__ in [0] %}{% do my_list.append(deferred) %}
+foo{% do my_list.append(deferred) %}
+bar{% endfor %}
 {{ my_list }}

--- a/src/test/resources/eager/reconstructs-map-node.jinja
+++ b/src/test/resources/eager/reconstructs-map-node.jinja
@@ -1,4 +1,8 @@
 {% set my_list = [] %}
+{% if deferred %}
+{% set foo = {'foo': 'ff', 'bar': 'bb'}.items() %}
+{% endif %}
+First key is {{ foo[0].key }}.
 {% for key, val in {'foo': 'ff', 'bar': 'bb'}.items() -%}
 {% do my_list.append(deferred) %}
 {{ key ~ ' ' ~ val }}

--- a/src/test/resources/eager/reverts-modification-with-deferred-loop.expected.jinja
+++ b/src/test/resources/eager/reverts-modification-with-deferred-loop.expected.jinja
@@ -1,4 +1,10 @@
-{% set my_list = [] %}{% for i in [0, 1] %}
+{% set my_list = [] %}{% for __ignored__ in [0] %}
+{% for j in deferred %}
+{% if loop.first %}
+{% do my_list.append(1) %}
+{% endif %}
+{% endfor %}
+
 {% for j in deferred %}
 {% if loop.first %}
 {% do my_list.append(1) %}


### PR DESCRIPTION
Now that we [have better tracking of the PrefixToPreserveState](https://github.com/HubSpot/jinjava/pull/1032), we can separate the collection expression execution from the iterating of the for loop.
This leads to better explosion success where we can now support exploding for loops even when there are modifications inside for loops with deferred tokens
Additionally, for loop evaluation will be faster as we don't need to re-run the for loop.

For this input:
```
{% set my_list = [] %}
{% for i in range(2) %}
{% for j in deferred %}
{% do my_list.append(i) %}
{% endfor %}
{% endfor %}
{{ my_list }}
```
Previously, we'd have this output:
```
{% set my_list = [] %}{% for i in [0, 1] %}
{% for j in deferred %}
{% do my_list.append(i) %}
{% endfor %}
{% endfor %}
{{ my_list }}
```
But now we can get this exploded output:
```
{% set my_list = [] %}{% for __ignored__ in [0] %}
{% for j in deferred %}
{% do my_list.append(0) %}
{% endfor %}

{% for j in deferred %}
{% do my_list.append(1) %}
{% endfor %}
{% endfor %}
{{ my_list }}
```