### PR TITLE
Simplify deferred node adding logic

### DIFF
--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -482,7 +482,11 @@ public class EagerTest {
     String output = interpreter.render(template);
     assertThat(localContext).containsKey("deferredValue2");
     Object deferredValue2 = localContext.get("deferredValue2");
-    DeferredValueUtils.findAndMarkDeferredProperties(localContext);
+    localContext
+      .getDeferredNodes()
+      .forEach(
+        node -> DeferredValueUtils.findAndMarkDeferredProperties(localContext, node)
+      );
     assertThat(deferredValue2).isInstanceOf(DeferredValue.class);
     assertThat(output)
       .contains(

--- a/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
@@ -357,7 +357,11 @@ public class DeferredTest {
     String output = interpreter.render(template);
     assertThat(localContext).containsKey("deferredValue2");
     Object deferredValue2 = localContext.get("deferredValue2");
-    DeferredValueUtils.findAndMarkDeferredProperties(localContext);
+    localContext
+      .getDeferredNodes()
+      .forEach(
+        node -> DeferredValueUtils.findAndMarkDeferredProperties(localContext, node)
+      );
     assertThat(deferredValue2).isInstanceOf(DeferredValue.class);
     assertThat(output)
       .contains("{% set varSetInside = imported.map[deferredValue2.nonexistentprop] %}");


### PR DESCRIPTION
This deferred node logic is incredibly slow as more deferred nodes get added.
Because everytime one deferred node gets added, it will reconstruct a string of all the deferred nodes and look for variables in that string to defer. So if there are 1000 deferred nodes, it will take a very long time to keep adding more deferred nodes.
It's essentially `O(n^2)` currently, this PR makes it `O(n)`
Also, the logic of deferring variables inside deferred nodes is not useful for eager execution because it's logic-to-be-deprecated as it was added before eager execution and doesn't properly handle all Jinjava tags anyway. In eager execution, we just use Deferred Nodes as a way to track that something not-handleable in eager execution was encountered.
So we also just don't run this value-deferring logic when running in eager execution. This is just a performance boost as eager pre-renders with Deferred Nodes in them are considered rubbish anyway.