### PR TITLE
Revert "Improve for loop explosion success with deferred tokens"

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -44,6 +44,7 @@ import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.util.ConcurrentModificationException;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -150,20 +151,6 @@ public class ForTag implements Tag {
         String.format("%s in %s", String.join(", ", loopVars), e.getDeferredEvalResult())
       );
     }
-    return renderForCollection(
-      tagNode,
-      interpreter,
-      loopVarsAndExpression.getLeft(),
-      collection
-    );
-  }
-
-  public String renderForCollection(
-    TagNode tagNode,
-    JinjavaInterpreter interpreter,
-    List<String> loopVars,
-    Object collection
-  ) {
     ForLoop loop = ObjectIterator.getLoop(collection);
 
     try (InterpreterScopeClosable c = interpreter.enterScope()) {
@@ -203,8 +190,8 @@ public class ForTag implements Tag {
         } else {
           for (int loopVarIndex = 0; loopVarIndex < loopVars.size(); loopVarIndex++) {
             String loopVar = loopVars.get(loopVarIndex);
-            if (Entry.class.isAssignableFrom(val.getClass())) {
-              Entry<String, Object> entry = (Entry<String, Object>) val;
+            if (Map.Entry.class.isAssignableFrom(val.getClass())) {
+              Map.Entry<String, Object> entry = (Entry<String, Object>) val;
               Object entryVal = null;
 
               if (loopVars.indexOf(loopVar) == 0) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerDoTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerDoTag.java
@@ -40,6 +40,7 @@ public class EagerDoTag extends EagerStateChangingTag<DoTag> implements Flexible
         EagerContextWatcher
           .EagerChildContextConfig.newBuilder()
           .withTakeNewValue(true)
+          .withCheckForContextChanges(!interpreter.getContext().isDeferredExecutionMode())
           .build()
       );
       PrefixToPreserveState prefixToPreserveState = new PrefixToPreserveState();

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerExecutionResult.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerExecutionResult.java
@@ -4,7 +4,6 @@ import static com.hubspot.jinjava.util.EagerReconstructionUtils.buildBlockSetTag
 import static com.hubspot.jinjava.util.EagerReconstructionUtils.buildSetTag;
 
 import com.google.common.annotations.Beta;
-import com.hubspot.jinjava.interpret.DeferredLazyReferenceSource;
 import com.hubspot.jinjava.interpret.DeferredValueShadow;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.LazyReference;
@@ -56,13 +55,8 @@ public class EagerExecutionResult {
       .entrySet()
       .stream()
       .filter(
-        entry -> {
-          Object contextValue = interpreter.getContext().get(entry.getKey());
-          if (contextValue instanceof DeferredLazyReferenceSource) {
-            ((DeferredLazyReferenceSource) contextValue).setReconstructed(true);
-          }
-          return (contextValue != null && !(contextValue instanceof DeferredValueShadow));
-        }
+        entry ->
+          !(interpreter.getContext().get(entry.getKey()) instanceof DeferredValueShadow)
       )
       .collect(Collectors.toList());
     prefixToPreserveState.putAll(

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -197,19 +197,22 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
         interpreter,
         true
       ) +
-      wrapInChildScope(interpreter, output, currentImportAlias) +
+      wrapInChildScopeIfNecessary(interpreter, output, currentImportAlias) +
       initialPathSetter
     );
   }
 
-  private static String wrapInChildScope(
+  private static String wrapInChildScopeIfNecessary(
     JinjavaInterpreter interpreter,
     String output,
     String currentImportAlias
   ) {
     String combined = output + getDoTagToPreserve(interpreter, currentImportAlias);
     // So that any set variables other than the alias won't exist outside the child's scope
-    return EagerReconstructionUtils.wrapInChildScope(combined, interpreter);
+    if (interpreter.getContext().isDeferredExecutionMode()) {
+      return EagerReconstructionUtils.wrapInChildScope(combined, interpreter);
+    }
+    return combined;
   }
 
   private String getSetTagForDeferredChildBindings(

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -790,8 +790,7 @@ public class EagerReconstructionUtils {
    *   * When doing some eager execution and then needing to repeat the same execution in deferred execution mode.
    *   <p>
    *   * When rendering logic which takes place in its own child scope (for tag, macro function, set block) and there
-   *   are speculative bindings.
-   *   These must be deferred and the execution must run again, so they don't get reconstructed
+   *   speculative bindings. These must be deferred and the execution must run again so they don't get reconstructed
    *   within the child scope, and can instead be reconstructed in their original scopes.
    * @param interpreter The JinjavaInterpreter
    * @param eagerExecutionResult The execution result which contains information about which bindings were modified

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1141,7 +1141,7 @@ public class EagerTest {
 
   @Test
   public void itHandlesReferenceModificationWhenSourceIsLost() {
-    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
+    expectedTemplateInterpreter.assertExpectedOutput(
       "handles-reference-modification-when-source-is-lost"
     );
   }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
@@ -11,7 +11,6 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.ForTagTest;
 import com.hubspot.jinjava.mode.EagerExecutionMode;
 import com.hubspot.jinjava.tree.parse.TagToken;
-import java.util.List;
 import java.util.Optional;
 import org.junit.After;
 import org.junit.Before;
@@ -216,7 +215,7 @@ public class EagerForTagTest extends ForTagTest {
   }
 
   @Test
-  public void itCanNowHandleModificationInPartiallyDeferredLoop() {
+  public void itDoesNotSwallowDeferredValueException() {
     interpreter.getContext().registerTag(new EagerDoTag());
     interpreter.getContext().registerTag(new EagerIfTag());
     interpreter.getContext().registerTag(new EagerSetTag());
@@ -224,29 +223,18 @@ public class EagerForTagTest extends ForTagTest {
     String input =
       "{% set my_list = [] %}" +
       "{% for i in range(401) %}" +
-      "{% do my_list.append(i) %}" +
+      "{{ my_list.append(i) }}" +
       "{% endfor %}" +
-      "{% for i in my_list.append(-1) ? [0, 1] : [0] %}" +
+      "{% for i in my_list.append(1) ? [0, 1] : [0] %}" +
       "{% for j in deferred %}" +
       "{% if loop.first %}" +
-      "{% do my_list.append(i) %}" +
+      "{% do my_list.append(1) %}" +
       "{% endif %}" +
       "{% endfor %}" +
       "{% endfor %}" +
       "{{ my_list }}";
-    String initialResult = interpreter.render(input);
-    assertThat(interpreter.getContext().getDeferredNodes()).isEmpty();
-    interpreter.getContext().put("deferred", ImmutableList.of(1, 2));
-    interpreter.render(initialResult);
-    assertThat(interpreter.getContext().get("my_list")).isInstanceOf(List.class);
-    assertThat((List<Long>) interpreter.getContext().get("my_list"))
-      .as(
-        "Appends 401 numbers and then appends '-1', running the 'i' loop twice," +
-        "which runs the 'j' loop, the first time appending the value of 'i', which will be '0', then '1'"
-      )
-      .hasSize(404)
-      .containsSequence(400L, -1L, 0L, 1L);
-    assertThat(interpreter.getContext().getDeferredNodes()).isEmpty();
+    interpreter.render(input);
+    assertThat(interpreter.getContext().getDeferredNodes()).isNotEmpty();
   }
 
   public static boolean inForLoop() {

--- a/src/test/resources/eager/correctly-defers-with-multiple-loops.expected.jinja
+++ b/src/test/resources/eager/correctly-defers-with-multiple-loops.expected.jinja
@@ -1,8 +1,4 @@
-{% set my_list = [] %}{% for __ignored__ in [0] %}
-{% for j in deferred %}
-{% do my_list.append(0) %}
-{% endfor %}
-
+{% set my_list = [] %}{% for i in [0, 1] %}
 {% for j in deferred %}
 {% do my_list.append(1) %}
 {% endfor %}

--- a/src/test/resources/eager/correctly-defers-with-multiple-loops.jinja
+++ b/src/test/resources/eager/correctly-defers-with-multiple-loops.jinja
@@ -1,7 +1,7 @@
 {% set my_list = [] %}
 {% for i in range(2) %}
 {% for j in deferred %}
-{% do my_list.append(i) %}
+{% do my_list.append(1) %}
 {% endfor %}
 {% endfor %}
 {{ my_list }}

--- a/src/test/resources/eager/does-not-override-import-modification-in-for.expected.jinja
+++ b/src/test/resources/eager/does-not-override-import-modification-in-for.expected.jinja
@@ -1,23 +1,4 @@
-{% set foo = 'start' %}{% for __ignored__ in [0] %}
-{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set bar1 = {} %}{% for __ignored__ in [0] %}{% if deferred %}
-
-{% set foo = 'starta' %}{% do bar1.update({'foo': foo}) %}
-
-{% endif %}
-
-{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar1.update({'foo': foo}) %}
-{% do bar1.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}
-{{ bar1.foo }}
-{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set bar2 = {} %}{% for __ignored__ in [0] %}{% if deferred %}
-
-{% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}{% do bar2.update({'foo': foo}) %}
-
-{% endif %}
-
-{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar2.update({'foo': foo}) %}
-{% do bar2.update({'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}
-{{ bar2.foo }}
-
+{% set foo = 'start' %}{% for i in [0, 1] %}
 {% do %}{% set current_path = 'deferred-modification.jinja' %}{% set bar1 = {} %}{% for __ignored__ in [0] %}{% if deferred %}
 
 {% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}{% do bar1.update({'foo': foo}) %}

--- a/src/test/resources/eager/handles-deferred-import-vars.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-import-vars.expected.jinja
@@ -4,8 +4,8 @@ Hello {{ myname }}
 {% enddo %}foo: Hello {{ myname }}
 bar: {{ bar }}
 ---
-{% set myname = deferred + 7 %}{% do %}{% set current_path = 'macro-and-set.jinja' %}{% set simple = {} %}{% for __ignored__ in [0] %}
+{% set myname = deferred + 7 %}{% do %}{% set current_path = 'macro-and-set.jinja' %}{% set simple = {} %}
 {% set bar = myname + 19 %}{% do simple.update({'bar': bar}) %}
 Hello {{ myname }}
-{% do simple.update({'import_resource_path': 'macro-and-set.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}simple.foo: {% set deferred_import_resource_path = 'macro-and-set.jinja' %}{% macro simple.foo() %}Hello {{ myname }}{% endmacro %}{% set deferred_import_resource_path = null %}{{ simple.foo() }}
+{% do simple.update({'import_resource_path': 'macro-and-set.jinja'}) %}{% set current_path = '' %}{% enddo %}simple.foo: {% set deferred_import_resource_path = 'macro-and-set.jinja' %}{% macro simple.foo() %}Hello {{ myname }}{% endmacro %}{% set deferred_import_resource_path = null %}{{ simple.foo() }}
 simple.bar: {{ simple.bar }}

--- a/src/test/resources/eager/handles-double-import-modification.expected.jinja
+++ b/src/test/resources/eager/handles-double-import-modification.expected.jinja
@@ -1,20 +1,20 @@
-{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set foo = null %}{% set bar1 = {} %}{% for __ignored__ in [0] %}{% if deferred %}
+{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set foo = null %}{% set bar1 = {} %}{% if deferred %}
 
 {% set foo = 'a' %}{% do bar1.update({'foo': foo}) %}
 
 {% endif %}
 
 {% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar1.update({'foo': foo}) %}
-{% do bar1.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}
+{% do bar1.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}{% enddo %}
 ---
-{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set foo = null %}{% set bar2 = {} %}{% for __ignored__ in [0] %}{% if deferred %}
+{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set foo = null %}{% set bar2 = {} %}{% if deferred %}
 
 {% set foo = 'a' %}{% do bar2.update({'foo': foo}) %}
 
 {% endif %}
 
 {% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar2.update({'foo': foo}) %}
-{% do bar2.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}
+{% do bar2.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% set current_path = '' %}{% enddo %}
 ---
 {{ bar1.foo }}
 {{ bar2.foo }}

--- a/src/test/resources/eager/handles-higher-scope-reference-modification.expected.jinja
+++ b/src/test/resources/eager/handles-higher-scope-reference-modification.expected.jinja
@@ -4,7 +4,7 @@ C: {{ c_list }}.{% endmacro %}{{ c(b_list) }}{% set b_list = a_list %}{% do b_li
 B: {% set b_list = a_list %}{{ b_list }}.{% endset %}{{ __macro_b_125206_temp_variable_0__ }}{% do a_list.append(deferred ? 'A' : '') %}
 A: {{ a_list }}.
 ---
-{% set a_list = ['a', 'b'] %}{% for __ignored__ in [0] %}{% for __ignored__ in [0] %}{% set c_list = a_list %}{% do c_list.append(deferred ? 'c' : '') %}
-C: {% set c_list = a_list %}{{ c_list }}.{% endfor %}{% set b_list = a_list %}{% do b_list.append(deferred ? 'B' : '') %}
-B: {% set b_list = a_list %}{{ b_list }}.{% endfor %}{% do a_list.append(deferred ? 'A' : '') %}
+{% set a_list = ['a'] %}{% for i in [0] %}{% set b_list = a_list %}{% do b_list.append('b') %}{% for __ignored__ in [0] %}{% set c_list = b_list %}{% do c_list.append(deferred ? 'c' : '') %}
+C: {{ c_list }}.{% endfor %}{% do b_list.append(deferred ? 'B' : '') %}
+B: {{ b_list }}.{% endfor %}{% do a_list.append(deferred ? 'A' : '') %}
 A: {{ a_list }}.

--- a/src/test/resources/eager/handles-reference-modification-when-source-is-lost.expected.jinja
+++ b/src/test/resources/eager/handles-reference-modification-when-source-is-lost.expected.jinja
@@ -1,13 +1,13 @@
-{% set a_list = ['a'] %}{% for __ignored__ in [0] %}{% set b_list = a_list %}{% do b_list.append(deferred) %}
+{% set a_list = ['a'] %}{% for i in [0] %}{% set b_list = a_list %}{% do b_list.append(deferred) %}
 {% endfor %}
 {{ a_list }}
 ---
 {% for __ignored__ in [0] %}
 
-{% set a_list = [] %}{% for __ignored__ in [0] %}
+{% set a_list = [] %}{% for i in [0] %}
 {% if deferred %}
-{% set b_list = [] %}
-{% set b_list = a_list %}{% do b_list.append(1) %}
+{% set b_list = a_list %}
+{% do b_list.append(1) %}
 {% endif %}
 {% endfor %}
 {{ a_list }}

--- a/src/test/resources/eager/reconstructs-map-node.expected.expected.jinja
+++ b/src/test/resources/eager/reconstructs-map-node.expected.expected.jinja
@@ -1,5 +1,3 @@
-First key is foo.
-
 foo ff
 bar bb
 ['resolved', 'resolved']

--- a/src/test/resources/eager/reconstructs-map-node.expected.jinja
+++ b/src/test/resources/eager/reconstructs-map-node.expected.jinja
@@ -1,13 +1,7 @@
-{% if deferred %}
-{% set foo = [fn:map_entry('foo', 'ff'), fn:map_entry('bar', 'bb')] %}
-{% endif %}
-First key is {{ foo[0].key }}.
-{% set my_list = [] %}{% for __ignored__ in [0] %}{% do my_list.append(deferred) %}
-foo ff{% do my_list.append(deferred) %}
-bar bb{% endfor %}
+{% set my_list = [] %}{% for key, val in [fn:map_entry('foo', 'ff'), fn:map_entry('bar', 'bb')] %}{% do my_list.append(deferred) %}
+{{ key ~ ' ' ~ val }}{% endfor %}
 {{ my_list }}
 
-{% set my_list = [] %}{% for __ignored__ in [0] %}{% do my_list.append(deferred) %}
-foo{% do my_list.append(deferred) %}
-bar{% endfor %}
+{% set my_list = [] %}{% for i in [fn:map_entry('foo', 'ff'), fn:map_entry('bar', 'bb')] %}{% do my_list.append(deferred) %}
+{{ i.key }}{% endfor %}
 {{ my_list }}

--- a/src/test/resources/eager/reconstructs-map-node.jinja
+++ b/src/test/resources/eager/reconstructs-map-node.jinja
@@ -1,8 +1,4 @@
 {% set my_list = [] %}
-{% if deferred %}
-{% set foo = {'foo': 'ff', 'bar': 'bb'}.items() %}
-{% endif %}
-First key is {{ foo[0].key }}.
 {% for key, val in {'foo': 'ff', 'bar': 'bb'}.items() -%}
 {% do my_list.append(deferred) %}
 {{ key ~ ' ' ~ val }}

--- a/src/test/resources/eager/reverts-modification-with-deferred-loop.expected.jinja
+++ b/src/test/resources/eager/reverts-modification-with-deferred-loop.expected.jinja
@@ -1,10 +1,4 @@
-{% set my_list = [] %}{% for __ignored__ in [0] %}
-{% for j in deferred %}
-{% if loop.first %}
-{% do my_list.append(1) %}
-{% endif %}
-{% endfor %}
-
+{% set my_list = [] %}{% for i in [0, 1] %}
 {% for j in deferred %}
 {% if loop.first %}
 {% do my_list.append(1) %}


### PR DESCRIPTION
Reverts HubSpot/jinjava#1048

It seems that https://github.com/HubSpot/jinjava/pull/1048/files#diff-2369c43da9f2c20b984a379e8e693fecdbc42526d24259a073c7653af9c950e6L212-L215 is not backwards compatible. I'll need to do more investigation into that, but reverting for now