### PR TITLE
add warnings when datetime-related filters called with null arguments

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -134,6 +134,19 @@ public class TemplateError {
     );
   }
 
+  public static TemplateError fromMissingFilterArgException(InvalidArgumentException ex) {
+    return new TemplateError(
+      ErrorType.WARNING,
+      ErrorReason.INVALID_ARGUMENT,
+      ErrorItem.FILTER,
+      ex.getMessage(),
+      ex.getName(),
+      ex.getLineNumber(),
+      ex.getStartPosition(),
+      ex
+    );
+  }
+
   public static TemplateError fromException(Exception ex) {
     int lineNumber = -1;
     int startPosition = -1;

--- a/src/main/java/com/hubspot/jinjava/lib/filter/time/DateTimeFormatHelper.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/time/DateTimeFormatHelper.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.lib.filter.time;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.lib.fn.Functions;
 import com.hubspot.jinjava.objects.date.InvalidDateFormatException;
 import java.time.DateTimeException;
@@ -90,6 +91,22 @@ final class DateTimeFormatHelper {
         } catch (IllegalArgumentException e) {
           throw new InvalidDateFormatException(format, e);
         }
+    }
+  }
+
+  public void checkForNullVar(Object var, String name) {
+    if (var == null) {
+      JinjavaInterpreter
+        .getCurrent()
+        .addError(
+          TemplateError.fromMissingFilterArgException(
+            new InvalidArgumentException(
+              JinjavaInterpreter.getCurrent(),
+              name,
+              name + " filter called with null value"
+            )
+          )
+        );
     }
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/time/FormatDateFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/time/FormatDateFilter.java
@@ -48,6 +48,7 @@ public class FormatDateFilter implements Filter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+    HELPER.checkForNullVar(var, NAME);
     return format(var, args);
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/time/FormatDatetimeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/time/FormatDatetimeFilter.java
@@ -54,6 +54,7 @@ public class FormatDatetimeFilter implements Filter {
   }
 
   public static Object format(Object var, String... args) {
+    HELPER.checkForNullVar(var, NAME);
     return HELPER.format(var, args);
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/time/FormatTimeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/time/FormatTimeFilter.java
@@ -52,6 +52,7 @@ public class FormatTimeFilter implements Filter {
   }
 
   public static Object format(Object var, String... args) {
+    HELPER.checkForNullVar(var, NAME);
     return HELPER.format(var, args);
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -204,6 +204,20 @@ public class Functions {
       zoneOffset = ((PyishDate) var).toDateTime().getZone();
     }
 
+    if (var == null) {
+      JinjavaInterpreter
+        .getCurrent()
+        .addError(
+          TemplateError.fromMissingFilterArgException(
+            new InvalidArgumentException(
+              JinjavaInterpreter.getCurrent(),
+              "datetimeformat",
+              "datetimeformat filter called with null datetime"
+            )
+          )
+        );
+    }
+
     ZonedDateTime d = getDateTimeArg(var, zoneOffset);
     if (d == null) {
       return "";
@@ -283,10 +297,22 @@ public class Functions {
     }
   )
   public static long unixtimestamp(Object... var) {
-    ZonedDateTime d = getDateTimeArg(
-      var == null || var.length == 0 ? null : var[0],
-      ZoneOffset.UTC
-    );
+    Object filterVar = var == null || var.length == 0 ? null : var[0];
+
+    if (filterVar == null) {
+      JinjavaInterpreter
+        .getCurrent()
+        .addError(
+          TemplateError.fromInvalidArgumentException(
+            new InvalidArgumentException(
+              JinjavaInterpreter.getCurrent(),
+              "unixtimestamp",
+              "unixtimestamp filter called with null value"
+            )
+          )
+        );
+    }
+    ZonedDateTime d = getDateTimeArg(filterVar, ZoneOffset.UTC);
 
     if (d == null) {
       return 0;

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -303,7 +303,7 @@ public class Functions {
       JinjavaInterpreter
         .getCurrent()
         .addError(
-          TemplateError.fromInvalidArgumentException(
+          TemplateError.fromMissingFilterArgException(
             new InvalidArgumentException(
               JinjavaInterpreter.getCurrent(),
               "unixtimestamp",

--- a/src/test/java/com/hubspot/jinjava/lib/filter/BetweenTimesFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/BetweenTimesFilterTest.java
@@ -9,15 +9,9 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Map;
-import org.junit.Before;
 import org.junit.Test;
 
 public class BetweenTimesFilterTest extends BaseJinjavaTest {
-
-  @Before
-  public void setup() {
-    jinjava.getGlobalContext().registerClasses(EscapeJsFilter.class);
-  }
 
   @Test
   public void itGetsDurationBetweenTimes() {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
@@ -30,29 +30,31 @@ public class DateTimeFormatFilterTest extends BaseInterpretingTest {
   }
 
   @Test
-  public void itUsesTodayIfNoDateProvided() throws Exception {
+  public void itUsesTodayIfNoDateProvided() {
     assertThat(filter.filter(null, interpreter))
       .isEqualTo(StrftimeFormatter.format(ZonedDateTime.now(ZoneOffset.UTC)));
+    assertThat(interpreter.getErrors().get(0).getMessage())
+      .contains("datetimeformat filter called with null datetime");
   }
 
   @Test
-  public void itSupportsLongAsInput() throws Exception {
+  public void itSupportsLongAsInput() {
     assertThat(filter.filter(d, interpreter)).isEqualTo(StrftimeFormatter.format(d));
   }
 
   @Test
-  public void itUsesDefaultFormatStringIfNoneSpecified() throws Exception {
+  public void itUsesDefaultFormatStringIfNoneSpecified() {
     assertThat(filter.filter(d, interpreter)).isEqualTo("14:22 / 06-11-2013");
   }
 
   @Test
-  public void itUsesSpecifiedFormatString() throws Exception {
+  public void itUsesSpecifiedFormatString() {
     assertThat(filter.filter(d, interpreter, "%B %d, %Y, at %I:%M %p"))
       .isEqualTo("November 06, 2013, at 02:22 PM");
   }
 
   @Test
-  public void itHandlesVarsAndLiterals() throws Exception {
+  public void itHandlesVarsAndLiterals() {
     interpreter.getContext().put("d", d);
     interpreter.getContext().put("foo", "%Y-%m");
 
@@ -64,7 +66,7 @@ public class DateTimeFormatFilterTest extends BaseInterpretingTest {
   }
 
   @Test
-  public void itSupportsTimezones() throws Exception {
+  public void itSupportsTimezones() {
     assertThat(filter.filter(1539277785000L, interpreter, "%B %d, %Y, at %I:%M %p"))
       .isEqualTo("October 11, 2018, at 05:09 PM");
     assertThat(
@@ -83,7 +85,7 @@ public class DateTimeFormatFilterTest extends BaseInterpretingTest {
   }
 
   @Test(expected = InvalidArgumentException.class)
-  public void itThrowsExceptionOnInvalidTimezone() throws Exception {
+  public void itThrowsExceptionOnInvalidTimezone() {
     filter.filter(
       1539277785000L,
       interpreter,
@@ -93,7 +95,7 @@ public class DateTimeFormatFilterTest extends BaseInterpretingTest {
   }
 
   @Test(expected = InvalidDateFormatException.class)
-  public void itThrowsExceptionOnInvalidDateformat() throws Exception {
+  public void itThrowsExceptionOnInvalidDateformat() {
     filter.filter(1539277785000L, interpreter, "Not a format");
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/MinusTimeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/MinusTimeFilterTest.java
@@ -10,15 +10,9 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Map;
-import org.junit.Before;
 import org.junit.Test;
 
 public class MinusTimeFilterTest extends BaseJinjavaTest {
-
-  @Before
-  public void setup() {
-    jinjava.getGlobalContext().registerClasses(EscapeJsFilter.class);
-  }
 
   @Test
   public void itSubtractsTime() {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/PlusTimeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/PlusTimeFilterTest.java
@@ -10,15 +10,9 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Map;
-import org.junit.Before;
 import org.junit.Test;
 
 public class PlusTimeFilterTest extends BaseJinjavaTest {
-
-  @Before
-  public void setup() {
-    jinjava.getGlobalContext().registerClasses(EscapeJsFilter.class);
-  }
 
   @Test
   public void itAddsTime() {

--- a/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
@@ -11,6 +11,7 @@ import com.hubspot.jinjava.mode.EagerExecutionMode;
 import com.hubspot.jinjava.objects.date.FixedDateTimeProvider;
 import java.time.ZonedDateTime;
 import org.assertj.core.data.Offset;
+import org.junit.After;
 import org.junit.Test;
 
 public class UnixTimestampFunctionTest {
@@ -19,8 +20,20 @@ public class UnixTimestampFunctionTest {
   );
   private final long epochMilliseconds = d.toEpochSecond() * 1000 + 345;
 
+  @After
+  public void tearDown() {
+    JinjavaInterpreter.popCurrent();
+  }
+
   @Test
   public void itGetsUnixTimestamps() {
+    JinjavaInterpreter.pushCurrent(
+      new JinjavaInterpreter(
+        new Jinjava(),
+        new Context(),
+        JinjavaConfig.newBuilder().build()
+      )
+    );
     assertThat(Functions.unixtimestamp())
       .isGreaterThan(0)
       .isLessThanOrEqualTo(System.currentTimeMillis());
@@ -44,11 +57,7 @@ public class UnixTimestampFunctionTest {
           .build()
       )
     );
-    try {
-      assertThat(Functions.unixtimestamp((Object) null)).isEqualTo(ts);
-    } finally {
-      JinjavaInterpreter.popCurrent();
-    }
+    assertThat(Functions.unixtimestamp((Object) null)).isEqualTo(ts);
   }
 
   @Test(expected = DeferredValueException.class)
@@ -63,10 +72,6 @@ public class UnixTimestampFunctionTest {
           .build()
       )
     );
-    try {
-      Functions.unixtimestamp((Object) null);
-    } finally {
-      JinjavaInterpreter.popCurrent();
-    }
+    Functions.unixtimestamp((Object) null);
   }
 }


### PR DESCRIPTION
In the future we may change this behavior so null args do not default to the current time. I suspect many users didn't know this was happening since there was no warning.