### PR TITLE
add features flags to jinjava config

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -23,6 +23,8 @@ import com.hubspot.jinjava.el.JinjavaInterpreterResolver;
 import com.hubspot.jinjava.el.JinjavaObjectUnwrapper;
 import com.hubspot.jinjava.el.JinjavaProcessors;
 import com.hubspot.jinjava.el.ObjectUnwrapper;
+import com.hubspot.jinjava.features.FeatureConfig;
+import com.hubspot.jinjava.features.Features;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.Context.Library;
 import com.hubspot.jinjava.interpret.InterpreterFactory;
@@ -79,6 +81,8 @@ public class JinjavaConfig {
   private final LegacyOverrides legacyOverrides;
   private final boolean enablePreciseDivideFilter;
   private final ObjectMapper objectMapper;
+
+  private final Features features;
 
   private final ObjectUnwrapper objectUnwrapper;
   private final JinjavaProcessors processors;
@@ -140,6 +144,7 @@ public class JinjavaConfig {
     objectMapper = setupObjectMapper(builder.objectMapper);
     objectUnwrapper = builder.objectUnwrapper;
     processors = builder.processors;
+    features = new Features(builder.featureConfig);
   }
 
   private ObjectMapper setupObjectMapper(@Nullable ObjectMapper objectMapper) {
@@ -322,6 +327,7 @@ public class JinjavaConfig {
 
     private ObjectUnwrapper objectUnwrapper = new JinjavaObjectUnwrapper();
     private JinjavaProcessors processors = JinjavaProcessors.newBuilder().build();
+    private FeatureConfig featureConfig = FeatureConfig.newBuilder().build();
 
     private Builder() {}
 
@@ -505,6 +511,11 @@ public class JinjavaConfig {
 
     public Builder withProcessors(JinjavaProcessors jinjavaProcessors) {
       this.processors = jinjavaProcessors;
+      return this;
+    }
+
+    public Builder withFeatureConfig(FeatureConfig featureConfig) {
+      this.featureConfig = featureConfig;
       return this;
     }
 

--- a/src/main/java/com/hubspot/jinjava/features/DateTimeFeatureActivationStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/features/DateTimeFeatureActivationStrategy.java
@@ -1,0 +1,24 @@
+package com.hubspot.jinjava.features;
+
+import java.time.LocalDateTime;
+
+public class DateTimeFeatureActivationStrategy implements FeatureActivationStrategy {
+  private final LocalDateTime activateAt;
+
+  public static DateTimeFeatureActivationStrategy of(LocalDateTime activateAt) {
+    return new DateTimeFeatureActivationStrategy(activateAt);
+  }
+
+  private DateTimeFeatureActivationStrategy(LocalDateTime activateAt) {
+    this.activateAt = activateAt;
+  }
+
+  @Override
+  public boolean isActive() {
+    return LocalDateTime.now().isAfter(activateAt);
+  }
+
+  public LocalDateTime getActivateAt() {
+    return activateAt;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/features/DelegatingFeatureActivationStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/features/DelegatingFeatureActivationStrategy.java
@@ -1,0 +1,20 @@
+package com.hubspot.jinjava.features;
+
+import java.util.function.Supplier;
+
+public class DelegatingFeatureActivationStrategy implements FeatureActivationStrategy {
+  public Supplier<Boolean> delegate;
+
+  public static FeatureActivationStrategy of(Supplier<Boolean> delegate) {
+    return new DelegatingFeatureActivationStrategy(delegate);
+  }
+
+  private DelegatingFeatureActivationStrategy(Supplier<Boolean> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public boolean isActive() {
+    return delegate.get();
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/features/DisabledFeatureActivationStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/features/DisabledFeatureActivationStrategy.java
@@ -1,0 +1,14 @@
+package com.hubspot.jinjava.features;
+
+public class DisabledFeatureActivationStrategy implements FeatureActivationStrategy {
+  private static final DisabledFeatureActivationStrategy INSTANCE = new DisabledFeatureActivationStrategy();
+
+  @Override
+  public boolean isActive() {
+    return false;
+  }
+
+  public static DisabledFeatureActivationStrategy getInstance() {
+    return INSTANCE;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/features/FeatureActivationStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/features/FeatureActivationStrategy.java
@@ -1,0 +1,5 @@
+package com.hubspot.jinjava.features;
+
+public interface FeatureActivationStrategy {
+  boolean isActive();
+}

--- a/src/main/java/com/hubspot/jinjava/features/FeatureConfig.java
+++ b/src/main/java/com/hubspot/jinjava/features/FeatureConfig.java
@@ -1,0 +1,34 @@
+package com.hubspot.jinjava.features;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+
+public class FeatureConfig {
+  Map<String, FeatureActivationStrategy> features;
+
+  private FeatureConfig(Map<String, FeatureActivationStrategy> features) {
+    this.features = ImmutableMap.copyOf(features);
+  }
+
+  public FeatureActivationStrategy getFeature(String name) {
+    return features.getOrDefault(name, DisabledFeatureActivationStrategy.getInstance());
+  }
+
+  public static FeatureConfig.Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private final Map<String, FeatureActivationStrategy> features = new HashMap<>();
+
+    public Builder add(String name, FeatureActivationStrategy strategy) {
+      features.put(name, strategy);
+      return this;
+    }
+
+    public FeatureConfig build() {
+      return new FeatureConfig(features);
+    }
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/features/Features.java
+++ b/src/main/java/com/hubspot/jinjava/features/Features.java
@@ -1,0 +1,17 @@
+package com.hubspot.jinjava.features;
+
+public class Features {
+  private final FeatureConfig featureConfig;
+
+  public Features(FeatureConfig featureConfig) {
+    this.featureConfig = featureConfig;
+  }
+
+  public boolean isActive(String featureName) {
+    return getActivationStrategy(featureName).isActive();
+  }
+
+  public FeatureActivationStrategy getActivationStrategy(String featureName) {
+    return featureConfig.getFeature(featureName);
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/features/StaticFeatureActivationStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/features/StaticFeatureActivationStrategy.java
@@ -1,0 +1,18 @@
+package com.hubspot.jinjava.features;
+
+public class StaticFeatureActivationStrategy implements FeatureActivationStrategy {
+  private final boolean active;
+
+  public static StaticFeatureActivationStrategy of(boolean active) {
+    return new StaticFeatureActivationStrategy(active);
+  }
+
+  private StaticFeatureActivationStrategy(boolean active) {
+    this.active = active;
+  }
+
+  @Override
+  public boolean isActive() {
+    return active;
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/FeaturesTest.java
+++ b/src/test/java/com/hubspot/jinjava/FeaturesTest.java
@@ -1,0 +1,72 @@
+package com.hubspot.jinjava;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hubspot.jinjava.features.DateTimeFeatureActivationStrategy;
+import com.hubspot.jinjava.features.DelegatingFeatureActivationStrategy;
+import com.hubspot.jinjava.features.FeatureConfig;
+import com.hubspot.jinjava.features.Features;
+import com.hubspot.jinjava.features.StaticFeatureActivationStrategy;
+import java.time.LocalDateTime;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FeaturesTest {
+  private static final String ALWAYS_OFF = "alwaysOff";
+  private static final String ALWAYS_ON = "alwaysOn";
+  private static final String DATE_PAST = "datePast";
+  private static final String DATE_FUTURE = "dateFuture";
+  private static final String DELEGATING = "delegating";
+
+  private Features features;
+
+  private boolean delegateActive = false;
+
+  @Before
+  public void setUp() throws Exception {
+    features =
+      new Features(
+        FeatureConfig
+          .newBuilder()
+          .add(ALWAYS_OFF, StaticFeatureActivationStrategy.of(false))
+          .add(ALWAYS_ON, StaticFeatureActivationStrategy.of(true))
+          .add(DATE_PAST, DateTimeFeatureActivationStrategy.of(LocalDateTime.MIN))
+          .add(DATE_FUTURE, DateTimeFeatureActivationStrategy.of(LocalDateTime.MAX))
+          .add(DELEGATING, DelegatingFeatureActivationStrategy.of(() -> delegateActive))
+          .build()
+      );
+  }
+
+  @Test
+  public void itHasEnabledFeature() {
+    assertThat(features.isActive(ALWAYS_ON)).isTrue();
+  }
+
+  @Test
+  public void itHasDisabledFeature() {
+    assertThat(features.isActive(ALWAYS_OFF)).isFalse();
+  }
+
+  @Test
+  public void itHasPastEnabledFeature() {
+    assertThat(features.isActive(DATE_PAST)).isTrue();
+  }
+
+  @Test
+  public void itHasFutureEnabledFeature() {
+    assertThat(features.isActive(DATE_FUTURE)).isFalse();
+  }
+
+  @Test
+  public void itUsesDelegate() {
+    delegateActive = false;
+    assertThat(features.isActive(DELEGATING)).isEqualTo(delegateActive);
+    delegateActive = true;
+    assertThat(features.isActive(DELEGATING)).isEqualTo(delegateActive);
+  }
+
+  @Test
+  public void itDefaultsToFalse() {
+    assertThat(features.isActive("unknown")).isFalse();
+  }
+}


### PR DESCRIPTION
When building https://github.com/HubSpot/jinjava/pull/1065, I didn't like adding yet another property to the JinjavaConfig builder. I figured we could use a simple Feature Flags implementation. 

Partially inspired by https://ff4j.org/ and https://www.togglz.org/ . 

This can replace any boolean configs like enablePreciseDivideFilter, enableRecursiveMacroCalls, failOnUnknownTokens,  nestedInterpretationEnabled and more in the future.