### PR TITLE
Preserve the setting of a variable when calling eager macro function.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -15,8 +15,6 @@
  **********************************************************************/
 package com.hubspot.jinjava.lib.tag;
 
-import static com.hubspot.jinjava.util.Logging.ENGINE_LOG;
-
 import com.google.common.collect.Lists;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaHasCodeBody;
@@ -167,7 +165,6 @@ public class ForTag implements Tag {
     Object collection
   ) {
     ForLoop loop = ObjectIterator.getLoop(collection);
-    int loopCount = 0;
 
     try (InterpreterScopeClosable c = interpreter.enterScope()) {
       if (interpreter.isValidationMode() && !loop.hasNext()) {
@@ -181,7 +178,6 @@ public class ForTag implements Tag {
         interpreter.getConfig().getMaxOutputSize()
       );
       while (loop.hasNext()) {
-        ++loopCount;
         Object val;
         try {
           val = interpreter.wrap(loop.next());
@@ -278,8 +274,6 @@ public class ForTag implements Tag {
         }
       }
       return checkLoopVariable(interpreter, buff);
-    } finally {
-      ENGINE_LOG.error("Loop count {}", loopCount);
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -15,6 +15,8 @@
  **********************************************************************/
 package com.hubspot.jinjava.lib.tag;
 
+import static com.hubspot.jinjava.util.Logging.ENGINE_LOG;
+
 import com.google.common.collect.Lists;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaHasCodeBody;
@@ -165,6 +167,7 @@ public class ForTag implements Tag {
     Object collection
   ) {
     ForLoop loop = ObjectIterator.getLoop(collection);
+    int loopCount = 0;
 
     try (InterpreterScopeClosable c = interpreter.enterScope()) {
       if (interpreter.isValidationMode() && !loop.hasNext()) {
@@ -178,6 +181,7 @@ public class ForTag implements Tag {
         interpreter.getConfig().getMaxOutputSize()
       );
       while (loop.hasNext()) {
+        ++loopCount;
         Object val;
         try {
           val = interpreter.wrap(loop.next());
@@ -274,6 +278,8 @@ public class ForTag implements Tag {
         }
       }
       return checkLoopVariable(interpreter, buff);
+    } finally {
+      ENGINE_LOG.error("Loop count {}", loopCount);
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCallTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCallTag.java
@@ -41,7 +41,7 @@ public class EagerCallTag extends EagerStateChangingTag<CallTag> {
     InterpretException e
   ) {
     interpreter.getContext().checkNumberOfDeferredTokens();
-    try (InterpreterScopeClosable c = interpreter.enterScope()) {
+    try (InterpreterScopeClosable c = interpreter.enterNonStackingScope()) {
       MacroFunction caller = new MacroFunction(
         tagNode.getChildren(),
         "caller",

--- a/src/test/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunctionTest.java
@@ -78,6 +78,20 @@ public class EagerMacroFunctionTest extends BaseInterpretingTest {
   }
 
   @Test
+  public void itResolvesFromSet() {
+    String template =
+      "{% macro foo(foobar, other) %}" +
+      " {% do foobar.update({'a': 'b'} ) %} " +
+      " {{ foobar }}  and {{ other }}" +
+      "{% endmacro %}" +
+      "{% set bar = {}  %}" +
+      "{% call foo(bar, deferred) %} {% endcall %}" +
+      "{{ bar }}";
+    String firstPass = interpreter.render(template);
+    assertThat(firstPass).isEqualTo(template);
+  }
+
+  @Test
   public void itReconstructsImageWithNamedParams() {
     String name = "foo";
     String code = "{% macro foo(bar, baz=0) %}It's: {{ bar }}, {{ baz }}{% endmacro %}";


### PR DESCRIPTION
When running the EagerCallTag, we need to use the `enterNonStackingScope` instead of `enterScope` as the variables are in the same scope. They would have been removed if using a stacked scope. E.g.,
```
org.junit.ComparisonFailure: 
Expected :"{% set bar={} %}{% macro foo(bar, foobar, other) %} {% do bar.update({'a': 'b'}) %}  {{ foobar }}  {{ bar }} and {{ other }}{% endmacro %}{% call foo(bar, foobar, deferred) %} {% endcall %}{{ bar }}"
Actual   :"{% macro foo(bar, foobar, other) %} {% do bar.update({'a': 'b'} ) %}  {{ foobar }}  {{ bar }} and {{ other }}{% endmacro %}{% call foo(bar, null, deferred) %} {% endcall %}{{ bar }}"
```