### PR TITLE
avoid StringIndexOutOfBoundsException while adding interpreter error

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -141,7 +141,10 @@ public class ExpressionResolver {
         TemplateError.fromException(
           new TemplateSyntaxException(
             expression.substring(
-              Math.min(expression.length(), Math.max(e.getPosition() - EXPRESSION_START_TOKEN.length(), 0))
+              Math.min(
+                expression.length(),
+                Math.max(e.getPosition() - EXPRESSION_START_TOKEN.length(), 0)
+              )
             ),
             "Error parsing '" + expression + "': " + errorMessage,
             interpreter.getLineNumber(),

--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -141,7 +141,7 @@ public class ExpressionResolver {
         TemplateError.fromException(
           new TemplateSyntaxException(
             expression.substring(
-              Math.max(e.getPosition() - EXPRESSION_START_TOKEN.length(), 0)
+              Math.min(expression.length(), Math.max(e.getPosition() - EXPRESSION_START_TOKEN.length(), 0))
             ),
             "Error parsing '" + expression + "': " + errorMessage,
             interpreter.getLineNumber(),

--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
@@ -639,7 +639,10 @@ public class ExpressionResolverTest {
   @Test
   public void itAddsErrorRenderingUnclosedExpression() {
     interpreter.resolveELExpression("{", 1);
-    assertThat(interpreter.getErrors().get(0).getMessage()).contains("Error parsing '{': syntax error at position 4, encountered 'null', expected '}'");
+    assertThat(interpreter.getErrors().get(0).getMessage())
+      .contains(
+        "Error parsing '{': syntax error at position 4, encountered 'null', expected '}'"
+      );
   }
 
   public String result(String value, TestClass testClass) {

--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
@@ -636,6 +636,12 @@ public class ExpressionResolverTest {
       .isEqualTo("yes");
   }
 
+  @Test
+  public void itAddsErrorRenderingUnclosedExpression() {
+    interpreter.resolveELExpression("{", 1);
+    assertThat(interpreter.getErrors().get(0).getMessage()).contains("Error parsing '{': syntax error at position 4, encountered 'null', expected '}'");
+  }
+
   public String result(String value, TestClass testClass) {
     testClass.touch();
     return value;


### PR DESCRIPTION
StringIndexOutOfBoundsException happening for cases where expression is like `{` 