### PR TITLE
render back unresolved tokens

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -65,6 +65,7 @@ public class JinjavaConfig {
 
   private final Map<Context.Library, Set<String>> disabled;
   private final boolean failOnUnknownTokens;
+  private final boolean renderBackUnknownTokens;
   private final boolean nestedInterpretationEnabled;
   private final RandomNumberGeneratorStrategy randomNumberGenerator;
   private final boolean validationMode;
@@ -125,6 +126,7 @@ public class JinjavaConfig {
     enableRecursiveMacroCalls = builder.enableRecursiveMacroCalls;
     maxMacroRecursionDepth = builder.maxMacroRecursionDepth;
     failOnUnknownTokens = builder.failOnUnknownTokens;
+    renderBackUnknownTokens = builder.renderBackUnknownTokens;
     maxOutputSize = builder.maxOutputSize;
     nestedInterpretationEnabled = builder.nestedInterpretationEnabled;
     randomNumberGenerator = builder.randomNumberGeneratorStrategy;
@@ -221,6 +223,10 @@ public class JinjavaConfig {
     return failOnUnknownTokens;
   }
 
+  public boolean isRenderBackUnknownTokens() {
+    return renderBackUnknownTokens;
+  }
+
   public boolean isNestedInterpretationEnabled() {
     return nestedInterpretationEnabled;
   }
@@ -311,6 +317,7 @@ public class JinjavaConfig {
     private boolean enableRecursiveMacroCalls;
     private int maxMacroRecursionDepth;
     private boolean failOnUnknownTokens;
+    private boolean renderBackUnknownTokens;
     private boolean nestedInterpretationEnabled = true;
     private RandomNumberGeneratorStrategy randomNumberGeneratorStrategy =
       RandomNumberGeneratorStrategy.THREAD_LOCAL;
@@ -407,6 +414,11 @@ public class JinjavaConfig {
 
     public Builder withFailOnUnknownTokens(boolean failOnUnknownTokens) {
       this.failOnUnknownTokens = failOnUnknownTokens;
+      return this;
+    }
+
+    public Builder withRenderBackUnknownTokens(boolean renderBackUnknownTokens) {
+      this.renderBackUnknownTokens = renderBackUnknownTokens;
       return this;
     }
 

--- a/src/main/java/com/hubspot/jinjava/lib/expression/DefaultExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/DefaultExpressionStrategy.java
@@ -41,6 +41,10 @@ public class DefaultExpressionStrategy implements ExpressionStrategy {
       result = EscapeFilter.escapeHtmlEntities(result);
     }
 
+    if (result.isEmpty() && interpreter.getConfig().isRenderBackUnknownTokens()) {
+      result = master.getImage();
+    }
+
     return new RenderedOutputNode(result);
   }
 }

--- a/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
@@ -138,10 +138,10 @@ public class ExpressionNodeTest extends BaseInterpretingTest {
     JinjavaInterpreter jinjavaInterpreter = new Jinjava(config).newInterpreter();
     jinjavaInterpreter.getContext().put("subject", "this");
 
-    String template = "{{ subject }} expression has an {{ unknown }} token";
+    String template = "{{ subject | capitalize() }} expression has an {{ unknown | lower() }} token";
     Node node = new TreeParser(jinjavaInterpreter, template).buildTree();
     assertThat(jinjavaInterpreter.render(node))
-      .isEqualTo("this expression has an {{ unknown }} token");
+      .isEqualTo("This expression has an {{ unknown | lower() }} token");
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
@@ -138,10 +138,10 @@ public class ExpressionNodeTest extends BaseInterpretingTest {
     JinjavaInterpreter jinjavaInterpreter = new Jinjava(config).newInterpreter();
     jinjavaInterpreter.getContext().put("subject", "this");
 
-    String template = "{{ subject | capitalize() }} expression has an {{ unknown | lower() }} token";
+    String template = "{{ subject | capitalize() }} expression has a {{ unknown | lower() }} token but {{ unknown | default(\"replaced\") }}";
     Node node = new TreeParser(jinjavaInterpreter, template).buildTree();
     assertThat(jinjavaInterpreter.render(node))
-      .isEqualTo("This expression has an {{ unknown | lower() }} token");
+      .isEqualTo("This expression has a {{ unknown | lower() }} token but replaced");
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
@@ -130,6 +130,21 @@ public class ExpressionNodeTest extends BaseInterpretingTest {
   }
 
   @Test
+  public void itRenderBackUnknownTokensAsIsForMissingBinding() {
+    final JinjavaConfig config = JinjavaConfig
+      .newBuilder()
+      .withRenderBackUnknownTokens(true)
+      .build();
+    JinjavaInterpreter jinjavaInterpreter = new Jinjava(config).newInterpreter();
+    jinjavaInterpreter.getContext().put("subject", "this");
+
+    String template = "{{ subject }} expression has an {{ unknown }} token";
+    Node node = new TreeParser(jinjavaInterpreter, template).buildTree();
+    assertThat(jinjavaInterpreter.render(node))
+      .isEqualTo("this expression has an {{ unknown }} token");
+  }
+
+  @Test
   public void itFailsOnUnknownTokensVariables() throws Exception {
     final JinjavaConfig config = JinjavaConfig
       .newBuilder()


### PR DESCRIPTION
This change allow to render back tokens which are unresolved. 

Default behaviour is:
- context `key = "resolved"`
- template `this is {{ key }} but this is {{ missing }}`
- with output `this is resolved but this is `

Enabling configuration `.withRenderBackUnknownTokens(true)` the behaviour is:
- context `key = "resolved"`
- template `this is {{ key }} but this is {{ missing }}`
- with output `this is resolved but this is {{ missing }}`
