### PR TITLE
Make restricted methods and properties to be configurable in `JinjavaConfig`

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -43,6 +43,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -63,7 +64,13 @@ public class JinjavaConfig {
   private final boolean enableRecursiveMacroCalls;
   private final int maxMacroRecursionDepth;
 
-  private final Map<Context.Library, Set<String>> disabled;
+  private final Map<Library, Set<String>> disabled;
+
+  private final Set<String> restrictedMethods;
+
+  private final Set<String> restrictedProperties;
+  private final Set<String> deferredExecutionRestrictedMethods;
+
   private final boolean failOnUnknownTokens;
   private final boolean nestedInterpretationEnabled;
   private final RandomNumberGeneratorStrategy randomNumberGenerator;
@@ -120,6 +127,9 @@ public class JinjavaConfig {
     timeZone = builder.timeZone;
     maxRenderDepth = builder.maxRenderDepth;
     disabled = builder.disabled;
+    restrictedMethods = builder.restrictedMethods;
+    restrictedProperties = builder.restrictedProperties;
+    deferredExecutionRestrictedMethods = builder.deferredExecutionRestrictedMethods;
     trimBlocks = builder.trimBlocks;
     lstripBlocks = builder.lstripBlocks;
     enableRecursiveMacroCalls = builder.enableRecursiveMacroCalls;
@@ -217,6 +227,18 @@ public class JinjavaConfig {
     return disabled;
   }
 
+  public Set<String> getRestrictedMethods() {
+    return restrictedMethods;
+  }
+
+  public Set<String> getRestrictedProperties() {
+    return restrictedProperties;
+  }
+
+  public Set<String> getDeferredExecutionRestrictedMethods() {
+    return deferredExecutionRestrictedMethods;
+  }
+
   public boolean isFailOnUnknownTokens() {
     return failOnUnknownTokens;
   }
@@ -305,6 +327,10 @@ public class JinjavaConfig {
     private long maxOutputSize = 0; // in bytes
     private Map<Context.Library, Set<String>> disabled = new HashMap<>();
 
+    private Set<String> restrictedMethods = new HashSet<>();
+    private Set<String> restrictedProperties = new HashSet<>();
+    private Set<String> deferredExecutionRestrictedMethods = new HashSet<>();
+
     private boolean trimBlocks;
     private boolean lstripBlocks;
 
@@ -352,6 +378,23 @@ public class JinjavaConfig {
 
     public Builder withDisabled(Map<Context.Library, Set<String>> disabled) {
       this.disabled = disabled;
+      return this;
+    }
+
+    public Builder withRestrictedMethods(Set<String> restrictedMethods) {
+      this.restrictedMethods = restrictedMethods;
+      return this;
+    }
+
+    public Builder withRestrictedProperties(Set<String> restrictedProperties) {
+      this.restrictedProperties = restrictedProperties;
+      return this;
+    }
+
+    public Builder withDeferredExecutionRestrictedMethods(
+      Set<String> deferredExecutionRestrictedMethods
+    ) {
+      this.deferredExecutionRestrictedMethods = deferredExecutionRestrictedMethods;
       return this;
     }
 

--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -19,6 +19,7 @@ import static com.hubspot.jinjava.lib.fn.Functions.DEFAULT_RANGE_LIMIT;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.google.common.collect.ImmutableSet;
 import com.hubspot.jinjava.el.JinjavaInterpreterResolver;
 import com.hubspot.jinjava.el.JinjavaObjectUnwrapper;
 import com.hubspot.jinjava.el.JinjavaProcessors;
@@ -43,7 +44,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -321,8 +321,8 @@ public class JinjavaConfig {
     private long maxOutputSize = 0; // in bytes
     private Map<Context.Library, Set<String>> disabled = new HashMap<>();
 
-    private Set<String> restrictedMethods = new HashSet<>();
-    private Set<String> restrictedProperties = new HashSet<>();
+    private Set<String> restrictedMethods = ImmutableSet.of();
+    private Set<String> restrictedProperties = ImmutableSet.of();
 
     private boolean trimBlocks;
     private boolean lstripBlocks;
@@ -375,12 +375,12 @@ public class JinjavaConfig {
     }
 
     public Builder withRestrictedMethods(Set<String> restrictedMethods) {
-      this.restrictedMethods = restrictedMethods;
+      this.restrictedMethods = ImmutableSet.copyOf(restrictedMethods);
       return this;
     }
 
     public Builder withRestrictedProperties(Set<String> restrictedProperties) {
-      this.restrictedProperties = restrictedProperties;
+      this.restrictedProperties = ImmutableSet.copyOf(restrictedProperties);
       return this;
     }
 

--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -69,7 +69,6 @@ public class JinjavaConfig {
   private final Set<String> restrictedMethods;
 
   private final Set<String> restrictedProperties;
-  private final Set<String> deferredExecutionRestrictedMethods;
 
   private final boolean failOnUnknownTokens;
   private final boolean nestedInterpretationEnabled;
@@ -129,7 +128,6 @@ public class JinjavaConfig {
     disabled = builder.disabled;
     restrictedMethods = builder.restrictedMethods;
     restrictedProperties = builder.restrictedProperties;
-    deferredExecutionRestrictedMethods = builder.deferredExecutionRestrictedMethods;
     trimBlocks = builder.trimBlocks;
     lstripBlocks = builder.lstripBlocks;
     enableRecursiveMacroCalls = builder.enableRecursiveMacroCalls;
@@ -235,10 +233,6 @@ public class JinjavaConfig {
     return restrictedProperties;
   }
 
-  public Set<String> getDeferredExecutionRestrictedMethods() {
-    return deferredExecutionRestrictedMethods;
-  }
-
   public boolean isFailOnUnknownTokens() {
     return failOnUnknownTokens;
   }
@@ -329,7 +323,6 @@ public class JinjavaConfig {
 
     private Set<String> restrictedMethods = new HashSet<>();
     private Set<String> restrictedProperties = new HashSet<>();
-    private Set<String> deferredExecutionRestrictedMethods = new HashSet<>();
 
     private boolean trimBlocks;
     private boolean lstripBlocks;
@@ -388,13 +381,6 @@ public class JinjavaConfig {
 
     public Builder withRestrictedProperties(Set<String> restrictedProperties) {
       this.restrictedProperties = restrictedProperties;
-      return this;
-    }
-
-    public Builder withDeferredExecutionRestrictedMethods(
-      Set<String> deferredExecutionRestrictedMethods
-    ) {
-      this.deferredExecutionRestrictedMethods = deferredExecutionRestrictedMethods;
       return this;
     }
 

--- a/src/main/java/com/hubspot/jinjava/el/ext/JinjavaBeanELResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/JinjavaBeanELResolver.java
@@ -2,7 +2,6 @@ package com.hubspot.jinjava.el.ext;
 
 import com.google.common.base.CaseFormat;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
@@ -109,12 +108,11 @@ public class JinjavaBeanELResolver extends BeanELResolver {
       .getELResolver()
       .getValue(context, null, ExtendedParser.INTERPRETER);
 
-    Set<String> allRestrictedMethods = Sets.union(
-      interpreter.getConfig().getRestrictedMethods(),
-      DEFAULT_RESTRICTED_METHODS
-    );
-
-    if (method == null || allRestrictedMethods.contains(method.toString())) {
+    if (
+      method == null ||
+      DEFAULT_RESTRICTED_METHODS.contains(method.toString()) ||
+      interpreter.getConfig().getRestrictedMethods().contains(method.toString())
+    ) {
       throw new MethodNotFoundException(
         "Cannot find method '" + method + "' in " + base.getClass()
       );
@@ -229,12 +227,10 @@ public class JinjavaBeanELResolver extends BeanELResolver {
       .getELResolver()
       .getValue(context, null, ExtendedParser.INTERPRETER);
 
-    Set<String> allRestrictedProperties = Sets.union(
-      interpreter.getConfig().getRestrictedProperties(),
-      DEFAULT_RESTRICTED_PROPERTIES
-    );
-
-    if (allRestrictedProperties.contains(propertyName)) {
+    if (
+      DEFAULT_RESTRICTED_PROPERTIES.contains(propertyName) ||
+      interpreter.getConfig().getRestrictedProperties().contains(propertyName)
+    ) {
       return null;
     }
 

--- a/src/main/java/com/hubspot/jinjava/el/ext/JinjavaBeanELResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/JinjavaBeanELResolver.java
@@ -73,27 +73,23 @@ public class JinjavaBeanELResolver extends BeanELResolver {
 
   @Override
   public Class<?> getType(ELContext context, Object base, Object property) {
-    return super.getType(context, base, validatePropertyName(context, property));
+    return super.getType(context, base, validatePropertyName(property));
   }
 
   @Override
   public Object getValue(ELContext context, Object base, Object property) {
-    Object result = super.getValue(
-      context,
-      base,
-      validatePropertyName(context, property)
-    );
+    Object result = super.getValue(context, base, validatePropertyName(property));
     return result instanceof Class ? null : result;
   }
 
   @Override
   public boolean isReadOnly(ELContext context, Object base, Object property) {
-    return super.isReadOnly(context, base, validatePropertyName(context, property));
+    return super.isReadOnly(context, base, validatePropertyName(property));
   }
 
   @Override
   public void setValue(ELContext context, Object base, Object property, Object value) {
-    super.setValue(context, base, validatePropertyName(context, property), value);
+    super.setValue(context, base, validatePropertyName(property), value);
   }
 
   @Override
@@ -104,14 +100,15 @@ public class JinjavaBeanELResolver extends BeanELResolver {
     Class<?>[] paramTypes,
     Object[] params
   ) {
-    JinjavaInterpreter interpreter = (JinjavaInterpreter) context
-      .getELResolver()
-      .getValue(context, null, ExtendedParser.INTERPRETER);
+    JinjavaInterpreter interpreter = JinjavaInterpreter.getCurrent();
 
     if (
       method == null ||
       DEFAULT_RESTRICTED_METHODS.contains(method.toString()) ||
-      interpreter.getConfig().getRestrictedMethods().contains(method.toString())
+      (
+        interpreter != null &&
+        interpreter.getConfig().getRestrictedMethods().contains(method.toString())
+      )
     ) {
       throw new MethodNotFoundException(
         "Cannot find method '" + method + "' in " + base.getClass()
@@ -220,16 +217,17 @@ public class JinjavaBeanELResolver extends BeanELResolver {
     return 1;
   }
 
-  private String validatePropertyName(ELContext context, Object property) {
+  private String validatePropertyName(Object property) {
     String propertyName = transformPropertyName(property);
 
-    JinjavaInterpreter interpreter = (JinjavaInterpreter) context
-      .getELResolver()
-      .getValue(context, null, ExtendedParser.INTERPRETER);
+    JinjavaInterpreter interpreter = JinjavaInterpreter.getCurrent();
 
     if (
       DEFAULT_RESTRICTED_PROPERTIES.contains(propertyName) ||
-      interpreter.getConfig().getRestrictedProperties().contains(propertyName)
+      (
+        interpreter != null &&
+        interpreter.getConfig().getRestrictedProperties().contains(propertyName)
+      )
     ) {
       return null;
     }

--- a/src/main/java/com/hubspot/jinjava/el/ext/JinjavaBeanELResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/JinjavaBeanELResolver.java
@@ -38,7 +38,7 @@ public class JinjavaBeanELResolver extends BeanELResolver {
     .add("wait")
     .build();
 
-  private static final Set<String> DEFAULT_DEFERRED_EXECUTION_RESTRICTED_METHODS = ImmutableSet
+  private static final Set<String> DEFERRED_EXECUTION_RESTRICTED_METHODS = ImmutableSet
     .<String>builder()
     .add("put")
     .add("putAll")
@@ -126,13 +126,8 @@ public class JinjavaBeanELResolver extends BeanELResolver {
       );
     }
 
-    Set<String> allDeferredExecutionRestrictedMethods = Sets.union(
-      interpreter.getConfig().getDeferredExecutionRestrictedMethods(),
-      DEFAULT_DEFERRED_EXECUTION_RESTRICTED_METHODS
-    );
-
     if (
-      allDeferredExecutionRestrictedMethods.contains(method.toString()) &&
+      DEFERRED_EXECUTION_RESTRICTED_METHODS.contains(method.toString()) &&
       EagerReconstructionUtils.isDeferredExecutionMode()
     ) {
       throw new DeferredValueException(

--- a/src/test/java/com/hubspot/jinjava/el/ext/JinjavaBeanELResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/JinjavaBeanELResolverTest.java
@@ -26,9 +26,6 @@ public class JinjavaBeanELResolverTest {
   public void setUp() throws Exception {
     jinjavaBeanELResolver = new JinjavaBeanELResolver();
     elContext = new JinjavaELContext();
-    elContext
-      .getELResolver()
-      .setValue(elContext, null, ExtendedParser.INTERPRETER, interpreter);
     when(interpreter.getConfig()).thenReturn(config);
   }
 
@@ -160,6 +157,7 @@ public class JinjavaBeanELResolverTest {
 
   @Test
   public void itThrowsExceptionWhenMethodIsRestrictedFromConfig() {
+    JinjavaInterpreter.pushCurrent(interpreter);
     when(config.getRestrictedMethods()).thenReturn(ImmutableSet.of("foo"));
     assertThatThrownBy(
         () ->
@@ -167,15 +165,18 @@ public class JinjavaBeanELResolverTest {
       )
       .isInstanceOf(MethodNotFoundException.class)
       .hasMessageStartingWith("Cannot find method 'foo'");
+    JinjavaInterpreter.popCurrent();
   }
 
   @Test
   public void itThrowsExceptionWhenPropertyIsRestrictedFromConfig() {
+    JinjavaInterpreter.pushCurrent(interpreter);
     when(config.getRestrictedProperties()).thenReturn(ImmutableSet.of("property1"));
     assertThatThrownBy(
         () -> jinjavaBeanELResolver.getValue(elContext, "abcd", "property1")
       )
       .isInstanceOf(PropertyNotFoundException.class)
       .hasMessageStartingWith("Could not find property");
+    JinjavaInterpreter.popCurrent();
   }
 }

--- a/src/test/java/com/hubspot/jinjava/el/ext/JinjavaBeanELResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/JinjavaBeanELResolverTest.java
@@ -1,8 +1,12 @@
 package com.hubspot.jinjava.el.ext;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.el.JinjavaELContext;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import javax.el.ELContext;
 import org.junit.Before;
 import org.junit.Test;
@@ -11,10 +15,17 @@ public class JinjavaBeanELResolverTest {
   private JinjavaBeanELResolver jinjavaBeanELResolver;
   private ELContext elContext;
 
+  JinjavaInterpreter interpreter = mock(JinjavaInterpreter.class);
+  JinjavaConfig config = mock(JinjavaConfig.class);
+
   @Before
   public void setUp() throws Exception {
     jinjavaBeanELResolver = new JinjavaBeanELResolver();
     elContext = new JinjavaELContext();
+    elContext
+      .getELResolver()
+      .setValue(elContext, null, ExtendedParser.INTERPRETER, interpreter);
+    when(interpreter.getConfig()).thenReturn(config);
   }
 
   @Test


### PR DESCRIPTION
In `JinjavaBeanELResolver`, restrict methods and properties based on the values from `JinjavaConfig` (`restrictedMethods`, `restrictedProperties` and `deferredExecutionRestrictedMethods`.

