### PR TITLE
Use a pre-built PropertyNotFoundException

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/BeanELResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/BeanELResolver.java
@@ -55,6 +55,9 @@ import javax.el.PropertyNotWritableException;
  * @see ELResolver
  */
 public class BeanELResolver extends ELResolver {
+  private static PropertyNotFoundException propertyNotFoundException = new PropertyNotFoundException(
+    "Could not find property"
+  );
 
   protected static final class BeanProperties {
     private final Map<String, BeanProperty> map = new HashMap<String, BeanProperty>();
@@ -700,9 +703,7 @@ public class BeanELResolver extends ELResolver {
       ? null
       : beanProperties.getBeanProperty(property.toString());
     if (beanProperty == null) {
-      throw new PropertyNotFoundException(
-        "Could not find property " + property + " in " + base.getClass()
-      );
+      throw propertyNotFoundException;
     }
     return beanProperty;
   }


### PR DESCRIPTION
The `toBeanProperty` function may be called very frequently, and the `propertyNotFoundException` is often thrown. For normal case, this is OK. However, with a very high volume calls and high exception throwing, the construction of the exception itself is the bottleneck.  This pre-built exception does not have the missing property name and base class name. If they are needed, the caller of this function should be able to get them in other ways.