### PR TITLE
Handle alternate `is in` exptest syntax

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -284,7 +284,7 @@ public class ExtendedParser extends Parser {
         if (getToken().getSymbol() == COLON) {
           Symbol lookahead = lookahead(0).getSymbol();
           if (
-            (lookahead == IDENTIFIER || lookahead == FALSE || lookahead == TRUE) &&
+            (isPossibleExpTest(lookahead)) &&
             (lookahead(1).getSymbol() == LPAREN || (isPossibleExpTestOrFilter(name)))
           ) { // ns:f(...)
             consumeToken();

--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -284,7 +284,7 @@ public class ExtendedParser extends Parser {
         if (getToken().getSymbol() == COLON) {
           Symbol lookahead = lookahead(0).getSymbol();
           if (
-            (isPossibleExpTest(lookahead)) &&
+            isPossibleExpTest(lookahead) &&
             (lookahead(1).getSymbol() == LPAREN || (isPossibleExpTestOrFilter(name)))
           ) { // ns:f(...)
             consumeToken();

--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
@@ -637,6 +637,22 @@ public class ExpressionResolverTest {
   }
 
   @Test
+  public void itResolvesAlternateExpTestSyntaxForInExpTests() {
+    assertThat(
+        interpreter.render(
+          "{% if exptest:in.evaluate(1, ____int3rpr3t3r____, [1]) %}yes{% endif %}"
+        )
+      )
+      .isEqualTo("yes");
+    assertThat(
+        interpreter.render(
+          "{% if exptest:in.evaluate(2, ____int3rpr3t3r____, [1]) %}yes{% else %}no{% endif %}"
+        )
+      )
+      .isEqualTo("no");
+  }
+
+  @Test
   public void itAddsErrorRenderingUnclosedExpression() {
     interpreter.resolveELExpression("{", 1);
     assertThat(interpreter.getErrors().get(0).getMessage())

--- a/src/test/java/com/hubspot/jinjava/el/ext/ExtendedParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/ExtendedParserTest.java
@@ -3,9 +3,6 @@ package com.hubspot.jinjava.el.ext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-import com.hubspot.jinjava.lib.exptest.IsEvenExpTest;
-import com.hubspot.jinjava.lib.exptest.IsFalseExpTest;
-import com.hubspot.jinjava.lib.exptest.IsTrueExpTest;
 import de.odysseus.el.tree.impl.Builder;
 import de.odysseus.el.tree.impl.Builder.Feature;
 import de.odysseus.el.tree.impl.ast.AstBinary;
@@ -163,6 +160,16 @@ public class ExtendedParserTest {
     assertThat(trueExpTest).isInstanceOf(AstMethod.class);
     assertThat(trueExpTest.getChild(0)).isInstanceOf(AstDot.class);
     assertThat(trueExpTest.getChild(1)).isInstanceOf(AstParameters.class);
+  }
+
+  @Test
+  public void itResolvesAlternateExpTestSyntaxForInExpTest() {
+    AstNode inExpTest = buildExpressionNodes(
+      "#{exptest:in.evaluate(2, ____int3rpr3t3r____, [])}"
+    );
+    assertThat(inExpTest).isInstanceOf(AstMethod.class);
+    assertThat(inExpTest.getChild(0)).isInstanceOf(AstDot.class);
+    assertThat(inExpTest.getChild(1)).isInstanceOf(AstParameters.class);
   }
 
   private void assertForExpression(


### PR DESCRIPTION
Similar to https://github.com/HubSpot/jinjava/pull/973, there are several tokens which can be both operators and exptests.

This means you could do both: `1 in [1]` or `1 is in [1]`, with the former being an operator and the latter being parsed as an exptest. We were not handling all of these with the alternate exptest syntax, which looks like `exptest:in.evaluate(1, ____int3rpr3t3r____, [1])`. We can use the same method to check if a symbol is a valid exptest symbol so that there is consistency.