### PR TITLE
Unwrap raw tags when evaluating set blocks

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
@@ -19,6 +19,7 @@ import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.doc.annotations.JinjavaTextMateSnippet;
+import com.hubspot.jinjava.interpret.Context.TemporaryValueClosable;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -167,8 +168,12 @@ public class SetTag implements Tag, FlexibleTag {
   private static String renderChildren(TagNode tagNode, JinjavaInterpreter interpreter) {
     String result;
     StringBuilder sb = new StringBuilder();
-    for (Node child : tagNode.getChildren()) {
-      sb.append(child.render(interpreter));
+    try (
+      TemporaryValueClosable<Boolean> c = interpreter.getContext().withUnwrapRawOverride()
+    ) {
+      for (Node child : tagNode.getChildren()) {
+        sb.append(child.render(interpreter));
+      }
     }
     result = sb.toString();
     return result;

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagTest.java
@@ -219,6 +219,13 @@ public class EagerSetTagTest extends SetTagTest {
   }
 
   @Test
+  public void itUnwrapsRawTags() {
+    String template = "{% set foo %}{% raw %}{%{% endraw %}{% endset %}";
+    interpreter.render(template);
+    assertThat(interpreter.getContext().get("foo")).isEqualTo("{%");
+  }
+
+  @Test
   @Override
   @Ignore
   public void itThrowsAndDefersVarWhenValContainsDeferred() {


### PR DESCRIPTION
We need to unwrap raw tags here, like when evaluating macro functions. Since the nodes inside of the set block aren't output directly, the raw tags should be unwrapped so that the proper value is stored to the variable.
Without unwrapping this:
```
{% set foo %}{% raw %}{{ HELLO }}{% endraw %}{% endset %}
```
foo would be `{% raw %}{{ HELLO }}{% endraw %}` instead of `{{ HELLO }}` when rendering in an execution mode which has `isPreserveRawTags() == true`