### PR TITLE
Unwrap JsonMappingException if cause is LengthLimitingJsonProcessingException

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -132,14 +132,21 @@ public class JinjavaInterpreter implements PyishSerializable {
   }
 
   public static void checkOutputSize(String string) {
+    if (isOutputTooLarge(string)) {
+      throw new OutputTooBigException(
+        getCurrent().getConfig().getMaxOutputSize(),
+        string.length()
+      );
+    }
+  }
+
+  public static boolean isOutputTooLarge(String string) {
     Optional<Long> maxStringLength = getCurrentMaybe()
       .map(interpreter -> interpreter.getConfig().getMaxOutputSize())
       .filter(max -> max > 0);
-    if (
+    return (
       maxStringLength.map(max -> string != null && string.length() > max).orElse(false)
-    ) {
-      throw new OutputTooBigException(maxStringLength.get(), string.length());
-    }
+    );
   }
 
   /**

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -66,10 +66,14 @@ public class PyishObjectMapper {
     try {
       return getAsPyishStringOrThrow(val, forOutput);
     } catch (IOException e) {
-      if (e instanceof LengthLimitingJsonProcessingException) {
+      IOException unwrapped = e;
+      if (unwrapped.getCause() instanceof LengthLimitingJsonProcessingException) {
+        unwrapped = (LengthLimitingJsonProcessingException) unwrapped.getCause();
+      }
+      if (unwrapped instanceof LengthLimitingJsonProcessingException) {
         throw new OutputTooBigException(
-          ((LengthLimitingJsonProcessingException) e).getMaxSize(),
-          ((LengthLimitingJsonProcessingException) e).getAttemptedSize()
+          ((LengthLimitingJsonProcessingException) unwrapped).getMaxSize(),
+          ((LengthLimitingJsonProcessingException) unwrapped).getAttemptedSize()
         );
       }
       return Objects.toString(val, "");

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.objects.serialization;
 
 import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -66,15 +67,17 @@ public class PyishObjectMapper {
     try {
       return getAsPyishStringOrThrow(val, forOutput);
     } catch (IOException e) {
-      IOException unwrapped = e;
-      if (unwrapped.getCause() instanceof LengthLimitingJsonProcessingException) {
-        unwrapped = (LengthLimitingJsonProcessingException) unwrapped.getCause();
+      Throwable unwrapped = e;
+      if (e instanceof JsonMappingException) {
+        unwrapped = unwrapped.getCause();
       }
       if (unwrapped instanceof LengthLimitingJsonProcessingException) {
         throw new OutputTooBigException(
           ((LengthLimitingJsonProcessingException) unwrapped).getMaxSize(),
           ((LengthLimitingJsonProcessingException) unwrapped).getAttemptedSize()
         );
+      } else if (unwrapped instanceof OutputTooBigException) {
+        throw (OutputTooBigException) unwrapped;
       }
       return Objects.toString(val, "");
     }

--- a/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
@@ -88,7 +88,10 @@ public class PyishObjectMapperTest {
       assertThatThrownBy(() -> PyishObjectMapper.getAsPyishStringOrThrow(original))
         .as("The string to be serialized is larger than the max output size")
         .isInstanceOf(JsonMappingException.class)
+        .hasCauseInstanceOf(LengthLimitingJsonProcessingException.class)
         .hasMessageContaining("Max length of 10000 chars reached");
+      assertThatThrownBy(() -> PyishObjectMapper.getAsPyishString(original))
+        .isInstanceOf(OutputTooBigException.class);
     } finally {
       JinjavaInterpreter.popCurrent();
     }


### PR DESCRIPTION
As a follow up to https://github.com/HubSpot/jinjava/pull/1051, since these exceptions are now wrapped in `JsonMappingException`, we can unwrap them to see if they are caused by `LengthLimitingJsonProcessingException` so that we'll convert it to an `OutputTooBigException`