### PR TITLE
Treat BigDecimal and other Numbers as a serializable object type

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
@@ -340,7 +340,10 @@ public class EagerExpressionResolver {
 
   public static boolean isPrimitive(Object val) {
     return (
-      val == null || Primitives.isWrapperType(val.getClass()) || val instanceof String
+      val == null ||
+      Primitives.isWrapperType(val.getClass()) ||
+      val instanceof String ||
+      val instanceof Number
     );
   }
 

--- a/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
@@ -25,6 +25,7 @@ import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -913,5 +914,11 @@ public class EagerExpressionResolverTest {
       throws IOException {
       throw new DeferredValueException("Can't serialize");
     }
+  }
+
+  @Test
+  public void itCountsBigDecimalAsPrimitive() {
+    assertThat(EagerExpressionResolver.isResolvableObject(new BigDecimal("2.1E7")))
+      .isTrue();
   }
 }


### PR DESCRIPTION
These `Number` implementations are serializable, however since they aren't primitive wrappers of implementations of `PyishSerializable`, we weren't serializing them.
We can check if `val instanceof String || val instanceof Number`