### PR TITLE
Preserve identifiers when reconstructing AstMethod

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/DeferredParsingException.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/DeferredParsingException.java
@@ -5,11 +5,13 @@ import com.hubspot.jinjava.interpret.DeferredValueException;
 public class DeferredParsingException extends DeferredValueException {
   private final String deferredEvalResult;
   private final Object sourceNode;
+  private final IdentifierPreservationStrategy identifierPreservationStrategy;
 
   public DeferredParsingException(String message) {
     super(message);
     this.deferredEvalResult = message;
     this.sourceNode = null;
+    this.identifierPreservationStrategy = IdentifierPreservationStrategy.RESOLVING;
   }
 
   public DeferredParsingException(Object sourceNode, String deferredEvalResult) {
@@ -22,6 +24,24 @@ public class DeferredParsingException extends DeferredValueException {
     );
     this.deferredEvalResult = deferredEvalResult;
     this.sourceNode = sourceNode;
+    this.identifierPreservationStrategy = IdentifierPreservationStrategy.RESOLVING;
+  }
+
+  public DeferredParsingException(
+    Object sourceNode,
+    String deferredEvalResult,
+    IdentifierPreservationStrategy identifierPreservationStrategy
+  ) {
+    super(
+      String.format(
+        "%s could not be parsed more than: %s",
+        sourceNode.getClass(),
+        deferredEvalResult
+      )
+    );
+    this.deferredEvalResult = deferredEvalResult;
+    this.sourceNode = sourceNode;
+    this.identifierPreservationStrategy = identifierPreservationStrategy;
   }
 
   public String getDeferredEvalResult() {
@@ -30,5 +50,9 @@ public class DeferredParsingException extends DeferredValueException {
 
   public Object getSourceNode() {
     return sourceNode;
+  }
+
+  public IdentifierPreservationStrategy getIdentifierPreservationStrategy() {
+    return identifierPreservationStrategy;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/el/ext/IdentifierPreservationStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/IdentifierPreservationStrategy.java
@@ -1,0 +1,20 @@
+package com.hubspot.jinjava.el.ext;
+
+public enum IdentifierPreservationStrategy {
+  PRESERVING(true),
+  RESOLVING(false);
+
+  public static IdentifierPreservationStrategy preserving(boolean preserveIdentifier) {
+    return preserveIdentifier ? PRESERVING : RESOLVING;
+  }
+
+  private final boolean preserving;
+
+  IdentifierPreservationStrategy(boolean preserving) {
+    this.preserving = preserving;
+  }
+
+  public boolean isPreserving() {
+    return preserving;
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBinary.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBinary.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.NoInvokeELContext;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.el.ext.IdentifierPreservationStrategy;
 import com.hubspot.jinjava.el.ext.OrOperator;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstBinary;
@@ -48,7 +49,7 @@ public class EagerAstBinary extends AstBinary implements EvalResultHolder {
     Bindings bindings,
     ELContext context,
     DeferredParsingException deferredParsingException,
-    boolean preserveIdentifier
+    IdentifierPreservationStrategy identifierPreservationStrategy
   ) {
     return (
       EvalResultHolder.reconstructNode(
@@ -56,7 +57,7 @@ public class EagerAstBinary extends AstBinary implements EvalResultHolder {
         context,
         left,
         deferredParsingException,
-        false
+        IdentifierPreservationStrategy.RESOLVING
       ) +
       String.format(" %s ", operator.toString()) +
       EvalResultHolder.reconstructNode(
@@ -66,7 +67,7 @@ public class EagerAstBinary extends AstBinary implements EvalResultHolder {
           : context,
         right,
         deferredParsingException,
-        false
+        IdentifierPreservationStrategy.RESOLVING
       )
     );
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBracket.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.el.ext.IdentifierPreservationStrategy;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstBracket;
 import de.odysseus.el.tree.impl.ast.AstNode;
@@ -63,7 +64,7 @@ public class EagerAstBracket extends AstBracket implements EvalResultHolder {
     Bindings bindings,
     ELContext context,
     DeferredParsingException deferredParsingException,
-    boolean preserveIdentifier
+    IdentifierPreservationStrategy identifierPreservationStrategy
   ) {
     return String.format(
       "%s[%s]",
@@ -72,14 +73,14 @@ public class EagerAstBracket extends AstBracket implements EvalResultHolder {
         context,
         (EvalResultHolder) prefix,
         deferredParsingException,
-        preserveIdentifier
+        identifierPreservationStrategy
       ),
       EvalResultHolder.reconstructNode(
         bindings,
         context,
         (EvalResultHolder) property,
         deferredParsingException,
-        false
+        IdentifierPreservationStrategy.RESOLVING
       )
     );
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoice.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoice.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.NoInvokeELContext;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.el.ext.IdentifierPreservationStrategy;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstChoice;
 import de.odysseus.el.tree.impl.ast.AstNode;
@@ -46,7 +47,12 @@ public class EagerAstChoice extends AstChoice implements EvalResultHolder {
       }
       throw new DeferredParsingException(
         this,
-        getPartiallyResolved(bindings, context, e, false)
+        getPartiallyResolved(
+          bindings,
+          context,
+          e,
+          IdentifierPreservationStrategy.RESOLVING
+        )
       );
     }
   }
@@ -72,7 +78,7 @@ public class EagerAstChoice extends AstChoice implements EvalResultHolder {
     Bindings bindings,
     ELContext context,
     DeferredParsingException deferredParsingException,
-    boolean preserveIdentifier
+    IdentifierPreservationStrategy identifierPreservationStrategy
   ) {
     return (
       EvalResultHolder.reconstructNode(
@@ -80,7 +86,7 @@ public class EagerAstChoice extends AstChoice implements EvalResultHolder {
         context,
         question,
         deferredParsingException,
-        false
+        IdentifierPreservationStrategy.RESOLVING
       ) +
       " ? " +
       EvalResultHolder.reconstructNode(
@@ -88,7 +94,7 @@ public class EagerAstChoice extends AstChoice implements EvalResultHolder {
         new NoInvokeELContext(context),
         yes,
         deferredParsingException,
-        preserveIdentifier
+        identifierPreservationStrategy
       ) +
       " : " +
       EvalResultHolder.reconstructNode(
@@ -96,7 +102,7 @@ public class EagerAstChoice extends AstChoice implements EvalResultHolder {
         new NoInvokeELContext(context),
         no,
         deferredParsingException,
-        preserveIdentifier
+        identifierPreservationStrategy
       )
     );
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDict.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDict.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.el.ext.eager;
 import com.hubspot.jinjava.el.ext.AstDict;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.el.ext.ExtendedParser;
+import com.hubspot.jinjava.el.ext.IdentifierPreservationStrategy;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
 import de.odysseus.el.tree.Bindings;
@@ -34,7 +35,7 @@ public class EagerAstDict extends AstDict implements EvalResultHolder {
     Bindings bindings,
     ELContext context,
     DeferredParsingException deferredParsingException,
-    boolean preserveIdentifier
+    IdentifierPreservationStrategy identifierPreservationStrategy
   ) {
     JinjavaInterpreter interpreter = (JinjavaInterpreter) context
       .getELResolver()
@@ -52,7 +53,9 @@ public class EagerAstDict extends AstDict implements EvalResultHolder {
               context,
               (EvalResultHolder) key,
               deferredParsingException,
-              !interpreter.getConfig().getLegacyOverrides().isEvaluateMapKeys()
+              IdentifierPreservationStrategy.preserving(
+                !interpreter.getConfig().getLegacyOverrides().isEvaluateMapKeys()
+              )
             )
           );
         } else {
@@ -69,7 +72,7 @@ public class EagerAstDict extends AstDict implements EvalResultHolder {
               context,
               (EvalResultHolder) value,
               deferredParsingException,
-              preserveIdentifier
+              identifierPreservationStrategy
             )
           );
         } else {

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDot.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDot.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.el.ext.IdentifierPreservationStrategy;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstDot;
 import de.odysseus.el.tree.impl.ast.AstNode;
@@ -52,11 +53,17 @@ public class EagerAstDot extends AstDot implements EvalResultHolder {
     Bindings bindings,
     ELContext context,
     DeferredParsingException e,
-    boolean preserveIdentifier
+    IdentifierPreservationStrategy identifierPreservationStrategy
   ) {
     return String.format(
       "%s.%s",
-      EvalResultHolder.reconstructNode(bindings, context, base, e, preserveIdentifier),
+      EvalResultHolder.reconstructNode(
+        bindings,
+        context,
+        base,
+        e,
+        identifierPreservationStrategy
+      ),
       property
     );
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifier.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifier.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.el.ext.IdentifierPreservationStrategy;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstIdentifier;
 import javax.el.ELContext;
@@ -43,7 +44,7 @@ public class EagerAstIdentifier extends AstIdentifier implements EvalResultHolde
     Bindings bindings,
     ELContext context,
     DeferredParsingException deferredParsingException,
-    boolean preserveIdentifier
+    IdentifierPreservationStrategy identifierPreservationStrategy
   ) {
     return getName();
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstList.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstList.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.AstList;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.el.ext.IdentifierPreservationStrategy;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstParameters;
 import java.util.StringJoiner;
@@ -45,7 +46,7 @@ public class EagerAstList extends AstList implements EvalResultHolder {
     Bindings bindings,
     ELContext context,
     DeferredParsingException deferredParsingException,
-    boolean preserveIdentifier
+    IdentifierPreservationStrategy identifierPreservationStrategy
   ) {
     StringJoiner joiner = new StringJoiner(", ");
     for (int i = 0; i < elements.getCardinality(); i++) {
@@ -55,7 +56,7 @@ public class EagerAstList extends AstList implements EvalResultHolder {
           context,
           (EvalResultHolder) elements.getChild(i),
           deferredParsingException,
-          preserveIdentifier
+          identifierPreservationStrategy
         )
       );
     }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.el.ext.eager;
 import com.hubspot.jinjava.el.ext.AstMacroFunction;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.el.ext.ExtendedParser;
+import com.hubspot.jinjava.el.ext.IdentifierPreservationStrategy;
 import com.hubspot.jinjava.interpret.Context.TemporaryValueClosable;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -53,7 +54,13 @@ public class EagerAstMacroFunction extends AstMacroFunction implements EvalResul
       );
       throw new DeferredParsingException(
         this,
-        getPartiallyResolved(bindings, context, e, true) // Need this to always be true because the macro function may modify the identifier
+        getPartiallyResolved(
+          bindings,
+          context,
+          e,
+          IdentifierPreservationStrategy.PRESERVING
+        ), // Need this to always be true because the macro function may modify the identifier
+        IdentifierPreservationStrategy.PRESERVING
       );
     }
   }
@@ -145,7 +152,7 @@ public class EagerAstMacroFunction extends AstMacroFunction implements EvalResul
     Bindings bindings,
     ELContext context,
     DeferredParsingException deferredParsingException,
-    boolean preserveIdentifier
+    IdentifierPreservationStrategy identifierPreservationStrategy
   ) {
     if (
       deferredParsingException != null &&
@@ -154,10 +161,7 @@ public class EagerAstMacroFunction extends AstMacroFunction implements EvalResul
       return deferredParsingException.getDeferredEvalResult();
     }
     String paramString;
-    if (
-      deferredParsingException != null &&
-      deferredParsingException.getSourceNode() == params
-    ) {
+    if (EvalResultHolder.exceptionMatchesNode(deferredParsingException, params)) {
       paramString = deferredParsingException.getDeferredEvalResult();
     } else {
       paramString =
@@ -165,7 +169,7 @@ public class EagerAstMacroFunction extends AstMacroFunction implements EvalResul
           bindings,
           context,
           deferredParsingException,
-          preserveIdentifier
+          identifierPreservationStrategy
         );
     }
 

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
@@ -12,7 +12,6 @@ import de.odysseus.el.tree.impl.ast.AstParameters;
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.StringJoiner;
 import javax.el.ELContext;
 import javax.el.ELException;
 
@@ -154,26 +153,23 @@ public class EagerAstMacroFunction extends AstMacroFunction implements EvalResul
     ) {
       return deferredParsingException.getDeferredEvalResult();
     }
-    StringBuilder sb = new StringBuilder();
-    sb.append(getName());
-    try {
-      StringJoiner paramString = new StringJoiner(", ");
-      for (int i = 0; i < ((AstParameters) params).getCardinality(); i++) {
-        paramString.add(
-          EvalResultHolder.reconstructNode(
-            bindings,
-            context,
-            (EvalResultHolder) ((AstParameters) params).getChild(i),
-            deferredParsingException,
-            preserveIdentifier
-          )
+    String paramString;
+    if (
+      deferredParsingException != null &&
+      deferredParsingException.getSourceNode() == params
+    ) {
+      paramString = deferredParsingException.getDeferredEvalResult();
+    } else {
+      paramString =
+        params.getPartiallyResolved(
+          bindings,
+          context,
+          deferredParsingException,
+          preserveIdentifier
         );
-      }
-      sb.append(String.format("(%s)", paramString));
-    } catch (DeferredParsingException dpe) {
-      sb.append(String.format("(%s)", dpe.getDeferredEvalResult()));
     }
-    return sb.toString();
+
+    return (getName() + String.format("(%s)", paramString));
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.el.ext.IdentifierPreservationStrategy;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstMethod;
@@ -41,7 +42,13 @@ public class EagerAstMethod extends AstMethod implements EvalResultHolder {
       );
       throw new DeferredParsingException(
         this,
-        getPartiallyResolved(bindings, context, e, true) // Need this to always be true because the method may modify the identifier
+        getPartiallyResolved(
+          bindings,
+          context,
+          e,
+          IdentifierPreservationStrategy.PRESERVING
+        ), // Need this to always be true because the method may modify the identifier
+        IdentifierPreservationStrategy.PRESERVING
       );
     }
   }
@@ -71,7 +78,7 @@ public class EagerAstMethod extends AstMethod implements EvalResultHolder {
     Bindings bindings,
     ELContext context,
     DeferredParsingException deferredParsingException,
-    boolean preserveIdentifier
+    IdentifierPreservationStrategy identifierPreservationStrategy
   ) {
     String propertyResult;
     propertyResult =
@@ -79,13 +86,10 @@ public class EagerAstMethod extends AstMethod implements EvalResultHolder {
           bindings,
           context,
           deferredParsingException,
-          preserveIdentifier
+          identifierPreservationStrategy
         );
     String paramString;
-    if (
-      deferredParsingException != null &&
-      deferredParsingException.getSourceNode() == params
-    ) {
+    if (EvalResultHolder.exceptionMatchesNode(deferredParsingException, params)) {
       paramString = deferredParsingException.getDeferredEvalResult();
     } else {
       paramString =
@@ -93,7 +97,7 @@ public class EagerAstMethod extends AstMethod implements EvalResultHolder {
           bindings,
           context,
           deferredParsingException,
-          preserveIdentifier
+          identifierPreservationStrategy
         );
     }
 

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
@@ -2,10 +2,8 @@ package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.interpret.DeferredValueException;
-import com.hubspot.jinjava.util.EagerExpressionResolver;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstMethod;
-import de.odysseus.el.tree.impl.ast.AstNode;
 import de.odysseus.el.tree.impl.ast.AstParameters;
 import de.odysseus.el.tree.impl.ast.AstProperty;
 import javax.el.ELContext;
@@ -90,16 +88,13 @@ public class EagerAstMethod extends AstMethod implements EvalResultHolder {
     ) {
       paramString = deferredParsingException.getDeferredEvalResult();
     } else {
-      try {
-        paramString =
-          EagerExpressionResolver.getValueAsJinjavaStringSafe(
-            ((AstNode) params).eval(bindings, context)
-          );
-        // remove brackets so they can get replaced with parentheses
-        paramString = paramString.substring(1, paramString.length() - 1);
-      } catch (DeferredParsingException e) {
-        paramString = e.getDeferredEvalResult();
-      }
+      paramString =
+        params.getPartiallyResolved(
+          bindings,
+          context,
+          deferredParsingException,
+          preserveIdentifier
+        );
     }
 
     return (propertyResult + String.format("(%s)", paramString));

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNamedParameter.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNamedParameter.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.AstNamedParameter;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.el.ext.IdentifierPreservationStrategy;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstIdentifier;
 import de.odysseus.el.tree.impl.ast.AstNode;
@@ -39,7 +40,7 @@ public class EagerAstNamedParameter
     Bindings bindings,
     ELContext context,
     DeferredParsingException deferredParsingException,
-    boolean preserveIdentifier
+    IdentifierPreservationStrategy identifierPreservationStrategy
   ) {
     return String.format(
       "%s=%s",
@@ -49,7 +50,7 @@ public class EagerAstNamedParameter
         context,
         value,
         deferredParsingException,
-        false
+        IdentifierPreservationStrategy.RESOLVING
       )
     );
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNested.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNested.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.el.ext.IdentifierPreservationStrategy;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.Node;
 import de.odysseus.el.tree.impl.ast.AstNode;
@@ -71,7 +72,7 @@ public class EagerAstNested extends AstRightValue implements EvalResultHolder {
     Bindings bindings,
     ELContext context,
     DeferredParsingException deferredParsingException,
-    boolean preserveIdentifier
+    IdentifierPreservationStrategy identifierPreservationStrategy
   ) {
     return String.format(
       "(%s)",
@@ -80,7 +81,7 @@ public class EagerAstNested extends AstRightValue implements EvalResultHolder {
         context,
         (EvalResultHolder) child,
         deferredParsingException,
-        preserveIdentifier
+        identifierPreservationStrategy
       )
     );
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNodeDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNodeDecorator.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.el.ext.IdentifierPreservationStrategy;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.Node;
 import de.odysseus.el.tree.impl.ast.AstNode;
@@ -64,7 +65,7 @@ public class EagerAstNodeDecorator extends AstNode implements EvalResultHolder {
     Bindings bindings,
     ELContext context,
     DeferredParsingException deferredParsingException,
-    boolean preserveIdentifier
+    IdentifierPreservationStrategy identifierPreservationStrategy
   ) {
     return astNode.toString();
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstParameters.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstParameters.java
@@ -70,7 +70,7 @@ public class EagerAstParameters extends AstParameters implements EvalResultHolde
               context,
               node,
               deferredParsingException,
-              false
+              preserveIdentifier
             )
           )
       );

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstParameters.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstParameters.java
@@ -2,7 +2,9 @@ package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.el.ext.ExtendedParser;
+import com.hubspot.jinjava.el.ext.IdentifierPreservationStrategy;
 import com.hubspot.jinjava.interpret.Context.TemporaryValueClosable;
+import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstNode;
@@ -11,6 +13,7 @@ import java.util.List;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
 import javax.el.ELContext;
+import javax.el.ELException;
 
 public class EagerAstParameters extends AstParameters implements EvalResultHolder {
   protected Object evalResult;
@@ -43,11 +46,24 @@ public class EagerAstParameters extends AstParameters implements EvalResultHolde
       ).getContext()
         .withPartialMacroEvaluation(false)
     ) {
-      return (Object[]) EvalResultHolder.super.eval(
-        () -> super.eval(bindings, context),
-        bindings,
-        context
-      );
+      try {
+        setEvalResult(super.eval(bindings, context));
+        return (Object[]) checkEvalResultSize(context);
+      } catch (DeferredValueException | ELException originalException) {
+        DeferredParsingException e = EvalResultHolder.convertToDeferredParsingException(
+          originalException
+        );
+        throw new DeferredParsingException(
+          this,
+          getPartiallyResolved(
+            bindings,
+            context,
+            e,
+            IdentifierPreservationStrategy.PRESERVING
+          ), // Need this to always be true because a function may modify the identifier
+          IdentifierPreservationStrategy.PRESERVING
+        );
+      }
     }
   }
 
@@ -56,7 +72,7 @@ public class EagerAstParameters extends AstParameters implements EvalResultHolde
     Bindings bindings,
     ELContext context,
     DeferredParsingException deferredParsingException,
-    boolean preserveIdentifier
+    IdentifierPreservationStrategy identifierPreservationStrategy
   ) {
     StringJoiner joiner = new StringJoiner(", ");
     nodes
@@ -70,7 +86,7 @@ public class EagerAstParameters extends AstParameters implements EvalResultHolde
               context,
               node,
               deferredParsingException,
-              preserveIdentifier
+              identifierPreservationStrategy
             )
           )
       );

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstRangeBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstRangeBracket.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.AstRangeBracket;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.el.ext.IdentifierPreservationStrategy;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstNode;
 import javax.el.ELContext;
@@ -42,7 +43,7 @@ public class EagerAstRangeBracket extends AstRangeBracket implements EvalResultH
     Bindings bindings,
     ELContext context,
     DeferredParsingException deferredParsingException,
-    boolean preserveIdentifier
+    IdentifierPreservationStrategy identifierPreservationStrategy
   ) {
     return (
       EvalResultHolder.reconstructNode(
@@ -50,7 +51,7 @@ public class EagerAstRangeBracket extends AstRangeBracket implements EvalResultH
         context,
         (EvalResultHolder) prefix,
         deferredParsingException,
-        preserveIdentifier
+        identifierPreservationStrategy
       ) +
       "[" +
       EvalResultHolder.reconstructNode(
@@ -58,7 +59,7 @@ public class EagerAstRangeBracket extends AstRangeBracket implements EvalResultH
         context,
         (EvalResultHolder) property,
         deferredParsingException,
-        false
+        IdentifierPreservationStrategy.RESOLVING
       ) +
       ":" +
       EvalResultHolder.reconstructNode(
@@ -66,7 +67,7 @@ public class EagerAstRangeBracket extends AstRangeBracket implements EvalResultH
         context,
         (EvalResultHolder) rangeMax,
         deferredParsingException,
-        false
+        IdentifierPreservationStrategy.RESOLVING
       ) +
       "]"
     );

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstTuple.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstTuple.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.AstTuple;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.el.ext.IdentifierPreservationStrategy;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstParameters;
 import java.util.StringJoiner;
@@ -29,7 +30,7 @@ public class EagerAstTuple extends AstTuple implements EvalResultHolder {
     Bindings bindings,
     ELContext context,
     DeferredParsingException deferredParsingException,
-    boolean preserveIdentifier
+    IdentifierPreservationStrategy identifierPreservationStrategy
   ) {
     StringJoiner joiner = new StringJoiner(", ");
     for (int i = 0; i < elements.getCardinality(); i++) {
@@ -39,7 +40,7 @@ public class EagerAstTuple extends AstTuple implements EvalResultHolder {
           context,
           (EvalResultHolder) elements.getChild(i),
           deferredParsingException,
-          preserveIdentifier
+          identifierPreservationStrategy
         )
       );
     }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstUnary.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstUnary.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.el.ext.IdentifierPreservationStrategy;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstNode;
 import de.odysseus.el.tree.impl.ast.AstUnary;
@@ -36,7 +37,7 @@ public class EagerAstUnary extends AstUnary implements EvalResultHolder {
     Bindings bindings,
     ELContext context,
     DeferredParsingException deferredParsingException,
-    boolean preserveIdentifier
+    IdentifierPreservationStrategy identifierPreservationStrategy
   ) {
     return (
       operator.toString() +
@@ -45,7 +46,7 @@ public class EagerAstUnary extends AstUnary implements EvalResultHolder {
         context,
         child,
         deferredParsingException,
-        false
+        IdentifierPreservationStrategy.RESOLVING
       )
     );
   }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1053,7 +1053,10 @@ public class EagerTest {
 
   @Test
   public void itFullyDefersFilteredMacro() {
-    expectedTemplateInterpreter.assertExpectedOutput("fully-defers-filtered-macro");
+    // Macro and set tag reconstruction are flipped so not exactly idempotent, but functionally identical
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
+      "fully-defers-filtered-macro"
+    );
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethodTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethodTest.java
@@ -70,6 +70,16 @@ public class EagerAstMethodTest extends BaseInterpretingTest {
   }
 
   @Test
+  public void itPreservesNonDeferredIdentifier() {
+    try {
+      interpreter.resolveELExpression("deferred.append(foo_map)", -1);
+      fail("Should throw DeferredParsingException");
+    } catch (DeferredParsingException e) {
+      assertThat(e.getDeferredEvalResult()).isEqualTo("deferred.append(foo_map)");
+    }
+  }
+
+  @Test
   public void itPreservesAstDot() {
     try {
       interpreter.resolveELExpression("foo_map.foo_list.append(deferred)", -1);

--- a/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethodTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethodTest.java
@@ -80,6 +80,17 @@ public class EagerAstMethodTest extends BaseInterpretingTest {
   }
 
   @Test
+  public void itPreservesNonDeferredIdentifierWhenSecondParamIsDeferred() {
+    try {
+      interpreter.resolveELExpression("foo_list.append(foo_map, deferred)", -1);
+      fail("Should throw DeferredParsingException");
+    } catch (DeferredParsingException e) {
+      assertThat(e.getDeferredEvalResult())
+        .isEqualTo("foo_list.append(foo_map, deferred)");
+    }
+  }
+
+  @Test
   public void itPreservesAstDot() {
     try {
       interpreter.resolveELExpression("foo_map.foo_list.append(deferred)", -1);

--- a/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethodTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethodTest.java
@@ -72,21 +72,21 @@ public class EagerAstMethodTest extends BaseInterpretingTest {
   @Test
   public void itPreservesNonDeferredIdentifier() {
     try {
-      interpreter.resolveELExpression("deferred.append(foo_map)", -1);
+      interpreter.resolveELExpression("deferred.modify(foo_map)", -1);
       fail("Should throw DeferredParsingException");
     } catch (DeferredParsingException e) {
-      assertThat(e.getDeferredEvalResult()).isEqualTo("deferred.append(foo_map)");
+      assertThat(e.getDeferredEvalResult()).isEqualTo("deferred.modify(foo_map)");
     }
   }
 
   @Test
   public void itPreservesNonDeferredIdentifierWhenSecondParamIsDeferred() {
     try {
-      interpreter.resolveELExpression("foo_list.append(foo_map, deferred)", -1);
+      interpreter.resolveELExpression("foo_list.modify(foo_map, deferred)", -1);
       fail("Should throw DeferredParsingException");
     } catch (DeferredParsingException e) {
       assertThat(e.getDeferredEvalResult())
-        .isEqualTo("foo_list.append(foo_map, deferred)");
+        .isEqualTo("foo_list.modify(foo_map, deferred)");
     }
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunctionTest.java
@@ -81,7 +81,7 @@ public class EagerMacroFunctionTest extends BaseInterpretingTest {
   public void itResolvesFromSet() {
     String template =
       "{% macro foo(foobar, other) %}" +
-      " {% do foobar.update({'a': 'b'} ) %} " +
+      " {% do foobar.update({'a': 'b'}) %} " +
       " {{ foobar }}  and {{ other }}" +
       "{% endmacro %}" +
       "{% set bar = {}  %}" +

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
@@ -173,7 +173,7 @@ public class EagerForTagTest extends ForTagTest {
         "{% set foo = {'a': 'a'}  %}{% for i in range(0, deferred) %}\n" +
         "bar{{ foo }}\n" +
         "{% do foo.clear() %}\n" +
-        "{% do foo.update({'b': 'b'} ) %}\n" +
+        "{% do foo.update({'b': 'b'}) %}\n" +
         "{% endfor %}\n" +
         "{{ foo }}"
       );

--- a/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
@@ -782,7 +782,7 @@ public class EagerExpressionResolverTest {
   @Test
   public void itHandlesRandom() {
     assertThat(eagerResolveExpression("range(1)|random").toString())
-      .isEqualTo("filter:random.filter([0], ____int3rpr3t3r____)");
+      .isEqualTo("filter:random.filter(range(1), ____int3rpr3t3r____)");
   }
 
   @Test

--- a/src/test/resources/eager/fully-defers-filtered-macro.expected.jinja
+++ b/src/test/resources/eager/fully-defers-filtered-macro.expected.jinja
@@ -1,5 +1,6 @@
 {% macro flashy(foo) %}{{ filter:upper.filter(foo, ____int3rpr3t3r____) }}
-  A flashy {{ deferred }}.{% endmacro %}{{ flashy(flashy('bar')) }}
+  A flashy {{ deferred }}.{% endmacro %}{% set __macro_flashy_1625622909_temp_variable_0__ %}BAR
+  A flashy {{ deferred }}.{% endset %}{{ flashy(__macro_flashy_1625622909_temp_variable_0__) }}
 ---
 
 {% set __macro_silly_2092874071_temp_variable_0__ %}A silly {{ deferred }}.{% endset %}{{ filter:upper.filter(__macro_silly_2092874071_temp_variable_0__, ____int3rpr3t3r____) }}


### PR DESCRIPTION
An aliased macro function (aka a local macro function) can be defined which modifies the value of a non-primitive argument. These are parsed by the Ast parser as AstMethod rather than AstMacroFunction. The AstMethod and AstMacroFunction should reconstruct parameters in the same way so I am making that consistent, by actually using the EagerAstParameter's definition of how to reconstruct itself.

Another change I am making is defining a `IdentifierPreservationStrategy` enum which lets a `DeferredParsingException` know if it is thrown by one of these classes which forces preserving identifiers (this is done because of the possibility of modifying a variable. Modifying `[]` is different than modifying `my_list`, which starts as `[]`). By adding this information, we know that the partially resolved value within the `DeferredParsingException` is done such that the necessary identifiers have been preserved. Previously, if `preserveIdentifer == true`, we'd ignore the result of the DeferredParsingException, and remake it which led to duplicate work and with the other change I'm making in this PR, would not allow the [macro function temp variable](https://github.com/HubSpot/jinjava/pull/920) logic to work.

These new tests demonstrate how we need to preserve `foo_map`, imagining that this `.modify` method does some modification on `foo_map`:
```java
@Test
public void itPreservesNonDeferredIdentifier() {
  try {
    interpreter.resolveELExpression("deferred.modify(foo_map)", -1);
    fail("Should throw DeferredParsingException");
  } catch (DeferredParsingException e) {
    assertThat(e.getDeferredEvalResult()).isEqualTo("deferred.modify(foo_map)");
  }
}

@Test
public void itPreservesNonDeferredIdentifierWhenSecondParamIsDeferred() {
  try {
    interpreter.resolveELExpression("foo_list.modify(foo_map, deferred)", -1);
    fail("Should throw DeferredParsingException");
  } catch (DeferredParsingException e) {
    assertThat(e.getDeferredEvalResult())
      .isEqualTo("foo_list.modify(foo_map, deferred)");
  }
}
```