### PR TITLE
Add warnings for unclosed tokens

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -36,6 +36,7 @@ import com.hubspot.jinjava.tree.parse.TextToken;
 import com.hubspot.jinjava.tree.parse.Token;
 import com.hubspot.jinjava.tree.parse.TokenScanner;
 import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
+import com.hubspot.jinjava.tree.parse.UnclosedToken;
 import org.apache.commons.lang3.StringUtils;
 
 public class TreeParser {
@@ -97,6 +98,20 @@ public class TreeParser {
     Token token = scanner.next();
 
     if (token.getType() == symbols.getFixed()) {
+      if (token instanceof UnclosedToken) {
+        interpreter.addError(
+          new TemplateError(
+            ErrorType.WARNING,
+            ErrorReason.SYNTAX_ERROR,
+            ErrorItem.TAG,
+            "Unclosed token",
+            "token",
+            token.getLineNumber(),
+            token.getStartPosition(),
+            null
+          )
+        );
+      }
       return text((TextToken) token);
     } else if (token.getType() == symbols.getExprStart()) {
       return expression((ExpressionToken) token);

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TokenScanner.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TokenScanner.java
@@ -228,6 +228,13 @@ public class TokenScanner extends AbstractIterator<Token> {
     int type = symbols.getFixed();
     if (inComment > 0) {
       type = symbols.getNote();
+    } else if (inBlock > 0) {
+      return new UnclosedToken(
+        String.valueOf(is, tokenStart, tokenLength),
+        currLine,
+        tokenStart - lastNewlinePos + 1,
+        symbols
+      );
     }
     return Token.newToken(
       type,

--- a/src/main/java/com/hubspot/jinjava/tree/parse/UnclosedToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/UnclosedToken.java
@@ -1,0 +1,13 @@
+package com.hubspot.jinjava.tree.parse;
+
+public class UnclosedToken extends TextToken {
+
+  public UnclosedToken(
+    String image,
+    int lineNumber,
+    int startPosition,
+    TokenScannerSymbols symbols
+  ) {
+    super(image, lineNumber, startPosition, symbols);
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
@@ -165,6 +165,29 @@ public class TreeParserTest extends BaseInterpretingTest {
   }
 
   @Test
+  public void itWarnsAgainstUnclosedExpression() {
+    String expression = "foo {{ this is an unclosed expression %}";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.getErrors()).hasSize(1);
+    assertThat(interpreter.getErrors().get(0).getSeverity()).isEqualTo(ErrorType.WARNING);
+    assertThat(interpreter.getErrors().get(0).getMessage()).isEqualTo("Unclosed token");
+    assertThat(interpreter.getErrors().get(0).getFieldName()).isEqualTo("token");
+    assertThat(interpreter.render(tree))
+      .isEqualTo("foo {{ this is an unclosed expression %}");
+  }
+
+  @Test
+  public void itWarnsAgainstUnclosedTag() {
+    String expression = "foo {% this is an unclosed tag }}";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.getErrors()).hasSize(1);
+    assertThat(interpreter.getErrors().get(0).getSeverity()).isEqualTo(ErrorType.WARNING);
+    assertThat(interpreter.getErrors().get(0).getMessage()).isEqualTo("Unclosed token");
+    assertThat(interpreter.getErrors().get(0).getFieldName()).isEqualTo("token");
+    assertThat(interpreter.render(tree)).isEqualTo("foo {% this is an unclosed tag }}");
+  }
+
+  @Test
   public void itWarnsTwiceAgainstUnclosedForTag() {
     String expression = "{% for item in list %}\n{% for elem in items %}";
     final Node tree = new TreeParser(interpreter, expression).buildTree();


### PR DESCRIPTION
Fixes https://github.com/HubSpot/jinjava/issues/1038 and https://github.com/HubSpot/jinjava/issues/373 by adding a warning when an expression or tag isn't closed.
It will continue to interpret as text, but will now include an interpreter warning for cases such as these:
- `{{ 'foo }}`
- `{{ 'foo' }`
- `{% print 'foo' }}`