### PR TITLE
Make ELFunction proxies distinct on injected instance class name and package 

### DIFF
--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
@@ -26,8 +26,6 @@ public class JinjavaDocFactory {
   private static final Class JINJAVA_DOC_CLASS =
     com.hubspot.jinjava.doc.annotations.JinjavaDoc.class;
 
-  private static final String GUICE_CLASS_INDICATOR = "$$EnhancerByGuice$$";
-
   private final Jinjava jinjava;
 
   public JinjavaDocFactory(Jinjava jinjava) {
@@ -320,11 +318,7 @@ public class JinjavaDocFactory {
   private com.hubspot.jinjava.doc.annotations.JinjavaDoc getJinjavaDocAnnotation(
     Class<?> clazz
   ) {
-    if (
-      clazz.getName().contains(GUICE_CLASS_INDICATOR) && clazz.getSuperclass() != null
-    ) {
-      clazz = clazz.getSuperclass();
-    }
+    clazz = InjectedContextFunctionProxy.removeGuiceWrapping(clazz);
 
     return clazz.getAnnotation(com.hubspot.jinjava.doc.annotations.JinjavaDoc.class);
   }

--- a/src/test/java/com/hubspot/jinjava/lib/fn/InjectedContextFunctionProxyTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/InjectedContextFunctionProxyTest.java
@@ -19,6 +19,18 @@ public class InjectedContextFunctionProxyTest {
     }
   }
 
+  public static class OtherClass {
+    private String state;
+
+    public OtherClass(String state) {
+      this.state = state;
+    }
+
+    public String prependState(String in) {
+      return state + in;
+    }
+  }
+
   @Test
   public void testDefineProxy() throws Exception {
     Method m = MyClass.class.getDeclaredMethod("concatState", String.class);
@@ -31,9 +43,56 @@ public class InjectedContextFunctionProxyTest {
       instance
     );
     assertThat(proxy.getName()).isEqualTo("ns:fooproxy");
-    assertThat(proxy.getMethod().getDeclaringClass().getSimpleName())
-      .isEqualTo(InjectedContextFunctionProxy.class.getSimpleName() + "$$ns$$fooproxy");
+    assertThat(proxy.getMethod().getDeclaringClass().getName())
+      .isEqualTo(
+        MyClass.class.getName() +
+        "$$" +
+        InjectedContextFunctionProxy.class.getSimpleName() +
+        "$$ns$$fooproxy"
+      );
 
     assertThat(proxy.getMethod().invoke(null, "foo")).isEqualTo("foobar");
+  }
+
+  @Test
+  public void testDefineMultipleProxies() throws Exception {
+    Method concat = MyClass.class.getDeclaredMethod("concatState", String.class);
+    MyClass myClassInstance = new MyClass("bar");
+
+    ELFunctionDefinition myClassProxy = InjectedContextFunctionProxy.defineProxy(
+      "ns",
+      "fooproxy",
+      concat,
+      myClassInstance
+    );
+    Method prepend = OtherClass.class.getDeclaredMethod("prependState", String.class);
+    OtherClass otherClassInstance = new OtherClass("bar");
+
+    ELFunctionDefinition otherClassProxy = InjectedContextFunctionProxy.defineProxy(
+      "ns",
+      "fooproxy",
+      prepend,
+      otherClassInstance
+    );
+    assertThat(myClassProxy.getName()).isEqualTo("ns:fooproxy");
+    assertThat(myClassProxy.getMethod().getDeclaringClass().getName())
+      .isEqualTo(
+        MyClass.class.getName() +
+        "$$" +
+        InjectedContextFunctionProxy.class.getSimpleName() +
+        "$$ns$$fooproxy"
+      );
+
+    assertThat(myClassProxy.getMethod().invoke(null, "foo")).isEqualTo("foobar");
+    assertThat(otherClassProxy.getName()).isEqualTo("ns:fooproxy");
+    assertThat(otherClassProxy.getMethod().getDeclaringClass().getName())
+      .isEqualTo(
+        OtherClass.class.getName() +
+        "$$" +
+        InjectedContextFunctionProxy.class.getSimpleName() +
+        "$$ns$$fooproxy"
+      );
+
+    assertThat(otherClassProxy.getMethod().invoke(null, "foo")).isEqualTo("barfoo");
   }
 }


### PR DESCRIPTION
This allows for multiple jinjava instances to exist in the same JVM, with some ELFunctions which function differently but have the same namespace and name.
This PR adds the package and class name of injectedInstance so that ELFunctions with different internals can be defined in the same ClassPool.