### PR TITLE
Handle nested representations inside of fully evaluated objects

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
@@ -393,6 +393,23 @@ public class EagerExpressionResolver {
       } else {
         asString = PyishObjectMapper.getAsPyishString(resolvedObject);
       }
+      if (
+        !forOutput &&
+        interpreter != null &&
+        interpreter.getConfig().isNestedInterpretationEnabled() &&
+        asString.contains(
+          interpreter.getConfig().getTokenScannerSymbols().getExpressionStart()
+        )
+      ) {
+        Set<String> dependentWords = EagerExpressionResolver.findDeferredWords(
+          asString,
+          interpreter
+        );
+        if (!dependentWords.isEmpty()) {
+          deferredWords.addAll(dependentWords);
+          return asString;
+        }
+      }
       return asString;
     }
 

--- a/src/test/resources/eager/reconstructs-nested-value-in-string-representation.expected.expected.jinja
+++ b/src/test/resources/eager/reconstructs-nested-value-in-string-representation.expected.expected.jinja
@@ -1,2 +1,11 @@
 map.foo: Foo is I am foo.
 map.bar: Bar is I am bar.
+
+
+
+a
+
+
+
+
+{'b': 'b'}

--- a/src/test/resources/eager/reconstructs-nested-value-in-string-representation.expected.jinja
+++ b/src/test/resources/eager/reconstructs-nested-value-in-string-representation.expected.jinja
@@ -3,3 +3,13 @@
 {% endif %}
 map.foo: {{ map_with_vals.foo }}
 map.bar: {{ map_with_vals.bar }}
+
+{% set a = 'a' %}{% set aa = '{{ a }}' %}{% if deferred %}
+{% set aaa = '{{ aa }}' %}
+{{ aa }}
+{% endif %}
+
+{% set b = 'b' %}{% set bb = '{{ b }}' %}{% if deferred %}
+{% set bbb = {'b': '{{ bb }}'}  %}
+{'b': '{{ bb }}'}
+{% endif %}

--- a/src/test/resources/eager/reconstructs-nested-value-in-string-representation.jinja
+++ b/src/test/resources/eager/reconstructs-nested-value-in-string-representation.jinja
@@ -7,3 +7,18 @@
 {% endif %}
 map.foo: {{ map_with_vals.foo }}
 map.bar: {{ map_with_vals.bar }}
+
+{%- set a = 'a' %}
+{% set aa = '{{ a }}' %}
+{% if deferred %}
+{% set aaa = '{{ aa }}' %}
+{{ aaa }}
+{% endif -%}
+
+{%- set b = 'b' %}
+{% set bb = '{{ b }}' %}
+{% if deferred %}
+{% set bbb = {'b': '{{ bb }}'} %}
+{{ bbb }}
+{% endif -%}
+


### PR DESCRIPTION
Follow up on https://github.com/HubSpot/jinjava/pull/1088, there are a couple cases that weren't handled.

Those cases are ones which stem from a fully evaluated object which we are then converting to a string representation directly. This can be from a `{% set %}` tag which we aren't sure we'll commit the results of, for example:

```
{%- set a = 'a' %}
{% set aa = '{{ a }}' %}
{% if deferred %}
{% set aaa = '{{ aa }}' %}
{{ aaa }}
{% endif -%}
```

We need to ensure that `a` and `aa` are reconstructed when `aaa` gets reconstructed.