### PR TITLE
Handle invalid escaped quotes in tags more gracefully

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/parse/TokenScanner.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TokenScanner.java
@@ -68,17 +68,15 @@ public class TokenScanner extends AbstractIterator<Token> {
       }
 
       if (inBlock > 0) {
-        if (inQuote != 0) {
+        if (c == '\\') {
+          ++currPost;
+          continue;
+        } else if (inQuote != 0) {
           if (inQuote == c) {
             inQuote = 0;
-            continue;
-          } else if (c == '\\') {
-            ++currPost;
-            continue;
-          } else {
-            continue;
           }
-        } else if (inQuote == 0 && (c == '\'' || c == '"')) {
+          continue;
+        } else if (c == '\'' || c == '"') {
           inQuote = c;
           continue;
         }

--- a/src/test/java/com/hubspot/jinjava/tree/parse/TokenScannerTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/parse/TokenScannerTest.java
@@ -305,6 +305,23 @@ public class TokenScannerTest {
     assertThat(tokens).isNotEmpty();
   }
 
+  @Test
+  public void itTreatsEscapedQuotesSameWhenNotInQuotes() {
+    List<Token> tokens = tokens("tag-with-all-escaped-quotes");
+    assertThat(tokens).hasSize(8);
+    assertThat(tokens.stream().map(Token::getType).collect(Collectors.toList()))
+      .containsExactly(
+        symbols.getNote(),
+        symbols.getFixed(),
+        symbols.getTag(),
+        symbols.getFixed(),
+        symbols.getTag(),
+        symbols.getFixed(),
+        symbols.getTag(),
+        symbols.getFixed()
+      );
+  }
+
   private List<Token> tokens(String fixture) {
     TokenScanner t = fixture(fixture);
     return Lists.newArrayList(t);

--- a/src/test/resources/parse/tokenizer/tag-with-all-escaped-quotes.jinja
+++ b/src/test/resources/parse/tokenizer/tag-with-all-escaped-quotes.jinja
@@ -1,0 +1,7 @@
+{# This print tag is invalid, but it should not cause the rest of the template to break #}
+{% print \"foo\" %}
+Start
+{% if true %}
+The dog says: "Woof!"
+{% endif %}
+End


### PR DESCRIPTION
Don't break the entire parsing of the template afterwards by treating escaped quotes which aren't already in quotes as not being quotes.
This means that a token like the following would break the rest of the template:
`{% print \"foo\" %}`. This is because the initial slash currently does not get treated as escaping the double quote so the token scanner will think that it is inside of quotes.
In this example:
```
{% print \"foo\" %} I am "hungry" {% print 'x' %} " {% print 'y' %} " {% print 'z' %}
```
The scanner currently will parse tokens like the following:
- `{% print \"foo\" %} I am "hungry" {% print 'x' %} " {% print 'y' %}` <- this token is broken and won't render properly
- ` " `
- `{% print 'z' %}`

But with this change it will parse like:
- `{% print \"foo\" %}` <- this token is broken and won't render properly
- ` I am "hungry" `
- `{% print 'x' %}`
- ` " `
- `{% print 'y' %}`
- ` " `
- `{% print 'z' %}`

Essentially it limits the scope of the broken token down to just affecting the token which is broken.