### PR TITLE
Test case demonstrating bug: empty string equals zero

### DIFF
--- a/src/test/java/com/hubspot/jinjava/lib/exptest/ComparisonExpTestsTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/ComparisonExpTestsTest.java
@@ -55,6 +55,11 @@ public class ComparisonExpTestsTest extends BaseJinjavaTest {
   }
 
   @Test
+  public void itDoesntCompare() {
+    assertThat(jinjava.render("{{ '' == 0 }}", new HashMap<>())).isEqualTo("false");
+  }
+
+  @Test
   public void testAliases() {
     assertThat(jinjava.render("{{ 4 is lessthan 5 }}", new HashMap<>()))
       .isEqualTo("true");


### PR DESCRIPTION
I ran into some unexpected template behavior recently with some date comparison logic.
We have to convert `null` values to empty strings (due to a Jinjava issue removing keys with `null` values).

Comparing the empty string to `0` evaluates to `true`. The expected result is `false`, as they are different types.