### PR TITLE
Update guava to 31.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <dep.javassist.version>3.24.1-GA</dep.javassist.version>
     <dep.plugin.jacoco.version>0.8.3</dep.plugin.jacoco.version>
     <dep.guava.version>31.1-jre</dep.guava.version>
+    <dep.error-prone.version>2.19.1</dep.error-prone.version>
 
     <basepom.test.add.opens>
       --add-opens=java.base/java.lang=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 
     <dep.javassist.version>3.24.1-GA</dep.javassist.version>
     <dep.plugin.jacoco.version>0.8.3</dep.plugin.jacoco.version>
+    <dep.guava.version>31.1-jre</dep.guava.version>
 
     <basepom.test.add.opens>
       --add-opens=java.base/java.lang=ALL-UNNAMED

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactory.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactory.java
@@ -63,9 +63,11 @@ public class EagerTagFactory {
       if (TAG_CLASSES_TO_SKIP.contains(clazz)) {
         return Optional.empty();
       }
-      if (EAGER_TAG_OVERRIDES.containsKey(clazz)) {
-        EagerTagDecorator<?> decorator = EAGER_TAG_OVERRIDES
-          .get(clazz)
+      Class<? extends EagerTagDecorator<? extends Tag>> eagerOverrideClass = EAGER_TAG_OVERRIDES.get(
+        clazz
+      );
+      if (eagerOverrideClass != null) {
+        EagerTagDecorator<?> decorator = eagerOverrideClass
           .getDeclaredConstructor(clazz)
           .newInstance(tag);
         if (decorator.getTag().getClass() == clazz) {


### PR DESCRIPTION
Upgrades from 25.0-31.1
Addressed 2 CVEs: https://mvnrepository.com/artifact/com.google.guava/guava/25.0-jre

This also requires at least error-prone 2.11.0, pushing it to 2.19.1.

That new version found a potential bug so changing the code to store the map result to avoid a possible null defererence