### PR TITLE
A builder pattern to DeferredToken

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -79,14 +79,7 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
       EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
         interpreter,
         DeferredToken
-          .builderFromToken(
-            new ExpressionToken(
-              deferredExpressionImage,
-              master.getLineNumber(),
-              master.getStartPosition(),
-              master.getSymbols()
-            )
-          )
+          .builderFromImage(deferredExpressionImage, master)
           .addUsedDeferredWords(eagerExecutionResult.getResult().getDeferredWords())
           .build()
       )

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
@@ -1,7 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
 import com.google.common.annotations.Beta;
-import com.google.common.collect.Sets;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.SetTag;
@@ -12,8 +11,8 @@ import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
 import com.hubspot.jinjava.util.PrefixToPreserveState;
-import java.util.Collections;
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Triple;
 
 @Beta
@@ -125,16 +124,17 @@ public class EagerBlockSetTagStrategy extends EagerSetTagStrategy {
       .withAllInFront(
         EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
           interpreter,
-          new DeferredToken(
-            new TagToken(
-              joiner.toString(),
-              tagNode.getLineNumber(),
-              tagNode.getStartPosition(),
-              tagNode.getSymbols()
-            ),
-            Collections.emptySet(),
-            Sets.newHashSet(variables)
-          )
+          DeferredToken
+            .builderFromToken(
+              new TagToken(
+                joiner.toString(),
+                tagNode.getLineNumber(),
+                tagNode.getStartPosition(),
+                tagNode.getSymbols()
+              )
+            )
+            .addSetDeferredWords(Stream.of(variables))
+            .build()
         )
       );
     String suffixToPreserveState = getSuffixToPreserveState(variables[0], interpreter);

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
@@ -125,14 +125,7 @@ public class EagerBlockSetTagStrategy extends EagerSetTagStrategy {
         EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
           interpreter,
           DeferredToken
-            .builderFromToken(
-              new TagToken(
-                joiner.toString(),
-                tagNode.getLineNumber(),
-                tagNode.getStartPosition(),
-                tagNode.getSymbols()
-              )
-            )
+            .builderFromImage(joiner.toString(), tagNode.getMaster())
             .addSetDeferredWords(Stream.of(variables))
             .build()
         )

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCallTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCallTag.java
@@ -1,7 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
 import com.google.common.annotations.Beta;
-import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -20,7 +19,6 @@ import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
 import com.hubspot.jinjava.util.PrefixToPreserveState;
 import java.util.LinkedHashMap;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 @Beta
@@ -114,23 +112,17 @@ public class EagerCallTag extends EagerStateChangingTag<CallTag> {
       prefixToPreserveState.withAllInFront(
         EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
           interpreter,
-          new DeferredToken(
-            new TagToken(
-              joiner.toString(),
-              tagNode.getLineNumber(),
-              tagNode.getStartPosition(),
-              tagNode.getSymbols()
-            ),
-            eagerExecutionResult
-              .getResult()
-              .getDeferredWords()
-              .stream()
-              .filter(
-                word ->
-                  !(interpreter.getContext().get(word) instanceof DeferredMacroValueImpl)
+          DeferredToken
+            .builderFromToken(
+              new TagToken(
+                joiner.toString(),
+                tagNode.getLineNumber(),
+                tagNode.getStartPosition(),
+                tagNode.getSymbols()
               )
-              .collect(Collectors.toSet())
-          )
+            )
+            .addUsedDeferredWords(eagerExecutionResult.getResult().getDeferredWords())
+            .build()
         )
       );
       StringBuilder result = new StringBuilder(prefixToPreserveState + joiner.toString());

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCallTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCallTag.java
@@ -113,14 +113,7 @@ public class EagerCallTag extends EagerStateChangingTag<CallTag> {
         EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
           interpreter,
           DeferredToken
-            .builderFromToken(
-              new TagToken(
-                joiner.toString(),
-                tagNode.getLineNumber(),
-                tagNode.getStartPosition(),
-                tagNode.getSymbols()
-              )
-            )
+            .builderFromImage(joiner.toString(), tagNode.getMaster())
             .addUsedDeferredWords(eagerExecutionResult.getResult().getDeferredWords())
             .build()
         )

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
@@ -192,14 +192,7 @@ public class EagerCycleTag extends EagerStateChangingTag<CycleTag> {
           EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
             interpreter,
             DeferredToken
-              .builderFromToken(
-                new TagToken(
-                  reconstructedTag,
-                  tagToken.getLineNumber(),
-                  tagToken.getStartPosition(),
-                  tagToken.getSymbols()
-                )
-              )
+              .builderFromImage(reconstructedTag, tagToken)
               .addUsedDeferredWords(eagerExpressionResult.getDeferredWords())
               .build()
           )

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -243,14 +243,7 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
       EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
         interpreter,
         DeferredToken
-          .builderFromToken(
-            new TagToken(
-              joiner.toString(),
-              tagToken.getLineNumber(),
-              tagToken.getStartPosition(),
-              tagToken.getSymbols()
-            )
-          )
+          .builderFromImage(joiner.toString(), tagToken)
           .addUsedDeferredWords(eagerExpressionResult.getDeferredWords())
           .build()
       )

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -19,7 +19,6 @@ import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
 import com.hubspot.jinjava.util.PrefixToPreserveState;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -259,8 +258,7 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
                 word ->
                   !(interpreter.getContext().get(word) instanceof DeferredMacroValueImpl)
               )
-              .collect(Collectors.toSet()),
-            Collections.emptySet()
+              .collect(Collectors.toSet())
           )
         )
       );

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 
 @Beta
@@ -63,11 +64,11 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
         new PrefixToPreserveState(
           EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
             interpreter,
-            new DeferredToken(
-              tagToken,
-              Collections.singleton(helper.get(0)),
-              Collections.singleton(currentImportAlias)
-            )
+            DeferredToken
+              .builderFromToken(tagToken)
+              .addUsedDeferredWords(Stream.of(helper.get(0)))
+              .addSetDeferredWords(Stream.of(currentImportAlias))
+              .build()
           )
         ) +
         tagToken.getImage()

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
@@ -94,14 +94,7 @@ public class EagerInlineSetTagStrategy extends EagerSetTagStrategy {
       EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
         interpreter,
         DeferredToken
-          .builderFromToken(
-            new TagToken(
-              joiner.toString(),
-              tagNode.getLineNumber(),
-              tagNode.getStartPosition(),
-              tagNode.getSymbols()
-            )
-          )
+          .builderFromImage(joiner.toString(), tagNode.getMaster())
           .addUsedDeferredWords(eagerExecutionResult.getResult().getDeferredWords())
           .addSetDeferredWords(Arrays.stream(variables).map(String::trim))
           .build()

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
@@ -1,7 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
 import com.google.common.annotations.Beta;
-import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.SetTag;
@@ -15,7 +14,6 @@ import com.hubspot.jinjava.util.PrefixToPreserveState;
 import com.hubspot.jinjava.util.WhitespaceUtils;
 import java.util.Arrays;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Triple;
 
 @Beta
@@ -88,33 +86,27 @@ public class EagerInlineSetTagStrategy extends EagerSetTagStrategy {
       .add(deferredResult)
       .add(tagNode.getSymbols().getExpressionEndWithTag());
     PrefixToPreserveState prefixToPreserveState = getPrefixToPreserveState(
-        eagerExecutionResult,
-        variables,
-        interpreter
-      )
-      .withAllInFront(
-        EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
-          interpreter,
-          new DeferredToken(
+      eagerExecutionResult,
+      variables,
+      interpreter
+    );
+    prefixToPreserveState.withAllInFront(
+      EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
+        interpreter,
+        DeferredToken
+          .builderFromToken(
             new TagToken(
               joiner.toString(),
               tagNode.getLineNumber(),
               tagNode.getStartPosition(),
               tagNode.getSymbols()
-            ),
-            eagerExecutionResult
-              .getResult()
-              .getDeferredWords()
-              .stream()
-              .filter(
-                word ->
-                  !(interpreter.getContext().get(word) instanceof DeferredMacroValueImpl)
-              )
-              .collect(Collectors.toSet()),
-            Arrays.stream(variables).map(String::trim).collect(Collectors.toSet())
+            )
           )
-        )
-      );
+          .addUsedDeferredWords(eagerExecutionResult.getResult().getDeferredWords())
+          .addSetDeferredWords(Arrays.stream(variables).map(String::trim))
+          .build()
+      )
+    );
     String suffixToPreserveState = getSuffixToPreserveState(
       String.join(",", Arrays.asList(variables)),
       interpreter

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
@@ -1,7 +1,6 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
 import com.google.common.annotations.Beta;
-import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.lib.tag.PrintTag;
@@ -11,7 +10,6 @@ import com.hubspot.jinjava.util.EagerExpressionResolver;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
 import com.hubspot.jinjava.util.PrefixToPreserveState;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 @Beta
@@ -108,23 +106,17 @@ public class EagerPrintTag extends EagerStateChangingTag<PrintTag> {
     prefixToPreserveState.withAllInFront(
       EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
         interpreter,
-        new DeferredToken(
-          new TagToken(
-            joiner.toString(),
-            tagToken.getLineNumber(),
-            tagToken.getStartPosition(),
-            tagToken.getSymbols()
-          ),
-          eagerExecutionResult
-            .getResult()
-            .getDeferredWords()
-            .stream()
-            .filter(
-              word ->
-                !(interpreter.getContext().get(word) instanceof DeferredMacroValueImpl)
+        DeferredToken
+          .builderFromToken(
+            new TagToken(
+              joiner.toString(),
+              tagToken.getLineNumber(),
+              tagToken.getStartPosition(),
+              tagToken.getSymbols()
             )
-            .collect(Collectors.toSet())
-        )
+          )
+          .addUsedDeferredWords(eagerExecutionResult.getResult().getDeferredWords())
+          .build()
       )
     );
     // Possible set tag in front of this one.

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
@@ -107,14 +107,7 @@ public class EagerPrintTag extends EagerStateChangingTag<PrintTag> {
       EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
         interpreter,
         DeferredToken
-          .builderFromToken(
-            new TagToken(
-              joiner.toString(),
-              tagToken.getLineNumber(),
-              tagToken.getStartPosition(),
-              tagToken.getSymbols()
-            )
-          )
+          .builderFromImage(joiner.toString(), tagToken)
           .addUsedDeferredWords(eagerExecutionResult.getResult().getDeferredWords())
           .build()
       )

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -236,14 +236,7 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
       EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
         interpreter,
         DeferredToken
-          .builderFromToken(
-            new TagToken(
-              joiner.toString(),
-              tagToken.getLineNumber(),
-              tagToken.getStartPosition(),
-              tagToken.getSymbols()
-            )
-          )
+          .builderFromImage(joiner.toString(), tagToken)
           .addUsedDeferredWords(eagerExpressionResult.getDeferredWords())
           .build()
       )

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -2,7 +2,6 @@ package com.hubspot.jinjava.lib.tag.eager;
 
 import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
-import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -20,7 +19,6 @@ import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import com.hubspot.jinjava.util.LengthLimitingStringJoiner;
 import com.hubspot.jinjava.util.PrefixToPreserveState;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 @Beta
@@ -237,22 +235,17 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
     prefixToPreserveState.withAllInFront(
       EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
         interpreter,
-        new DeferredToken(
-          new TagToken(
-            joiner.toString(),
-            tagToken.getLineNumber(),
-            tagToken.getStartPosition(),
-            tagToken.getSymbols()
-          ),
-          eagerExpressionResult
-            .getDeferredWords()
-            .stream()
-            .filter(
-              word ->
-                !(interpreter.getContext().get(word) instanceof DeferredMacroValueImpl)
+        DeferredToken
+          .builderFromToken(
+            new TagToken(
+              joiner.toString(),
+              tagToken.getLineNumber(),
+              tagToken.getStartPosition(),
+              tagToken.getSymbols()
             )
-            .collect(Collectors.toSet())
-        )
+          )
+          .addUsedDeferredWords(eagerExpressionResult.getDeferredWords())
+          .build()
       )
     );
 

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -500,15 +500,7 @@ public class EagerReconstructionUtils {
           EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
             interpreter,
             DeferredToken
-              .builderFromToken(
-                new TagToken(
-                  image,
-                  // TODO this line number won't be accurate, currently doesn't matter.
-                  interpreter.getLineNumber(),
-                  interpreter.getPosition(),
-                  interpreter.getConfig().getTokenScannerSymbols()
-                )
-              )
+              .builderFromImage(image, TagToken.class, interpreter)
               .addSetDeferredWords(deferredValuesToSet.keySet())
               .build()
           )
@@ -566,13 +558,10 @@ public class EagerReconstructionUtils {
           EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
             interpreter,
             DeferredToken
-              .builderFromToken(
-                new TagToken(
-                  blockSetTokenBuilder.toString(),
-                  interpreter.getLineNumber(),
-                  interpreter.getPosition(),
-                  interpreter.getConfig().getTokenScannerSymbols()
-                )
+              .builderFromImage(
+                blockSetTokenBuilder.toString(),
+                TagToken.class,
+                interpreter
               )
               .addSetDeferredWords(Stream.of(name))
               .build()
@@ -688,14 +677,7 @@ public class EagerReconstructionUtils {
       EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
         interpreter,
         DeferredToken
-          .builderFromToken(
-            new TagToken(
-              startTokenBuilder.toString(),
-              interpreter.getLineNumber(),
-              interpreter.getPosition(),
-              interpreter.getConfig().getTokenScannerSymbols()
-            )
-          )
+          .builderFromImage(startTokenBuilder.toString(), TagToken.class, interpreter)
           .build()
       );
     }
@@ -799,14 +781,7 @@ public class EagerReconstructionUtils {
           handleDeferredTokenAndReconstructReferences(
             interpreter,
             DeferredToken
-              .builderFromToken(
-                new NoteToken(
-                  "",
-                  interpreter.getLineNumber(),
-                  interpreter.getPosition(),
-                  interpreter.getConfig().getTokenScannerSymbols()
-                )
-              )
+              .builderFromImage("", NoteToken.class, interpreter)
               .addUsedDeferredWords(wordsToDefer)
               .build()
           )

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -499,17 +499,18 @@ public class EagerReconstructionUtils {
         new PrefixToPreserveState(
           EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
             interpreter,
-            new DeferredToken(
-              new TagToken(
-                image,
-                // TODO this line number won't be accurate, currently doesn't matter.
-                interpreter.getLineNumber(),
-                interpreter.getPosition(),
-                interpreter.getConfig().getTokenScannerSymbols()
-              ),
-              Collections.emptySet(),
-              deferredValuesToSet.keySet()
-            )
+            DeferredToken
+              .builderFromToken(
+                new TagToken(
+                  image,
+                  // TODO this line number won't be accurate, currently doesn't matter.
+                  interpreter.getLineNumber(),
+                  interpreter.getPosition(),
+                  interpreter.getConfig().getTokenScannerSymbols()
+                )
+              )
+              .addSetDeferredWords(deferredValuesToSet.keySet())
+              .build()
           )
         ) +
         image
@@ -564,16 +565,17 @@ public class EagerReconstructionUtils {
         new PrefixToPreserveState(
           EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
             interpreter,
-            new DeferredToken(
-              new TagToken(
-                blockSetTokenBuilder.toString(),
-                interpreter.getLineNumber(),
-                interpreter.getPosition(),
-                interpreter.getConfig().getTokenScannerSymbols()
-              ),
-              Collections.emptySet(),
-              Collections.singleton(name)
-            )
+            DeferredToken
+              .builderFromToken(
+                new TagToken(
+                  blockSetTokenBuilder.toString(),
+                  interpreter.getLineNumber(),
+                  interpreter.getPosition(),
+                  interpreter.getConfig().getTokenScannerSymbols()
+                )
+              )
+              .addSetDeferredWords(Stream.of(name))
+              .build()
           )
         ) +
         image
@@ -685,15 +687,16 @@ public class EagerReconstructionUtils {
     if (registerDeferredToken) {
       EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
         interpreter,
-        new DeferredToken(
-          new TagToken(
-            startTokenBuilder.toString(),
-            interpreter.getLineNumber(),
-            interpreter.getPosition(),
-            interpreter.getConfig().getTokenScannerSymbols()
-          ),
-          Collections.emptySet()
-        )
+        DeferredToken
+          .builderFromToken(
+            new TagToken(
+              startTokenBuilder.toString(),
+              interpreter.getLineNumber(),
+              interpreter.getPosition(),
+              interpreter.getConfig().getTokenScannerSymbols()
+            )
+          )
+          .build()
       );
     }
     return image;
@@ -795,15 +798,17 @@ public class EagerReconstructionUtils {
         prefixToPreserveState.withAllInFront(
           handleDeferredTokenAndReconstructReferences(
             interpreter,
-            new DeferredToken(
-              new NoteToken(
-                "",
-                interpreter.getLineNumber(),
-                interpreter.getPosition(),
-                interpreter.getConfig().getTokenScannerSymbols()
-              ),
-              wordsToDefer
-            )
+            DeferredToken
+              .builderFromToken(
+                new NoteToken(
+                  "",
+                  interpreter.getLineNumber(),
+                  interpreter.getPosition(),
+                  interpreter.getConfig().getTokenScannerSymbols()
+                )
+              )
+              .addUsedDeferredWords(wordsToDefer)
+              .build()
           )
         );
       }

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -692,7 +692,6 @@ public class EagerReconstructionUtils {
             interpreter.getPosition(),
             interpreter.getConfig().getTokenScannerSymbols()
           ),
-          Collections.emptySet(),
           Collections.emptySet()
         )
       );

--- a/src/test/java/com/hubspot/jinjava/lib/filter/StripTagsFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/StripTagsFilterTest.java
@@ -11,7 +11,6 @@ import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.eager.DeferredToken;
-import com.hubspot.jinjava.tree.parse.DefaultTokenScannerSymbols;
 import com.hubspot.jinjava.tree.parse.ExpressionToken;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -130,13 +129,10 @@ public class StripTagsFilterTest {
             ? Collections.emptySet()
             : Collections.singleton(
               DeferredToken
-                .builderFromToken(
-                  new ExpressionToken(
-                    "{{ deferred && other }}",
-                    0,
-                    0,
-                    new DefaultTokenScannerSymbols()
-                  )
+                .builderFromImage(
+                  "{{ deferred && other }}",
+                  ExpressionToken.class,
+                  interpreter
                 )
                 .build()
             )

--- a/src/test/java/com/hubspot/jinjava/lib/filter/StripTagsFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/StripTagsFilterTest.java
@@ -129,15 +129,16 @@ public class StripTagsFilterTest {
           counter.getAndIncrement() == 0
             ? Collections.emptySet()
             : Collections.singleton(
-              new DeferredToken(
-                new ExpressionToken(
-                  "{{ deferred && other }}",
-                  0,
-                  0,
-                  new DefaultTokenScannerSymbols()
-                ),
-                Collections.emptySet()
-              )
+              DeferredToken
+                .builderFromToken(
+                  new ExpressionToken(
+                    "{{ deferred && other }}",
+                    0,
+                    0,
+                    new DefaultTokenScannerSymbols()
+                  )
+                )
+                .build()
             )
       );
     assertThatThrownBy(() -> filter.filter("{{ deferred && other }}", mockedInterpreter))

--- a/src/test/java/com/hubspot/jinjava/util/DeferredValueUtilsTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/DeferredValueUtilsTest.java
@@ -212,16 +212,17 @@ public class DeferredValueUtilsTest {
   public void itDefersSetWordsInDeferredTokens() {
     Context context = new Context();
     context.put("var_a", "a");
-    DeferredToken deferredToken = new DeferredToken(
-      new TagToken(
-        "{% set var_a, var_b = deferred, deferred %}",
-        1,
-        1,
-        new DefaultTokenScannerSymbols()
-      ),
-      ImmutableSet.of(),
-      ImmutableSet.of("var_a", "var_b")
-    );
+    DeferredToken deferredToken = DeferredToken
+      .builderFromToken(
+        new TagToken(
+          "{% set var_a, var_b = deferred, deferred %}",
+          1,
+          1,
+          new DefaultTokenScannerSymbols()
+        )
+      )
+      .addSetDeferredWords(ImmutableSet.of("var_a", "var_b"))
+      .build();
     context.handleDeferredToken(deferredToken);
     assertThat(context.get("var_a")).isInstanceOf(DeferredValue.class);
     assertThat(context.get("var_b")).isInstanceOf(DeferredValue.class);
@@ -231,15 +232,18 @@ public class DeferredValueUtilsTest {
   public void itDefersUsedWordsInDeferredTokens() {
     Context context = new Context();
     context.put("var_a", "a");
-    DeferredToken deferredToken = new DeferredToken(
-      new ExpressionToken(
-        "{{ var_a.append(deferred|int)}}",
-        1,
-        1,
-        new DefaultTokenScannerSymbols()
-      ),
-      ImmutableSet.of("var_a", "int")
-    );
+    DeferredToken deferredToken = DeferredToken
+      .builderFromToken(
+        new ExpressionToken(
+          "{{ var_a.append(deferred|int)}}",
+          1,
+          1,
+          new DefaultTokenScannerSymbols()
+        )
+      )
+      .addUsedDeferredWords(ImmutableSet.of("var_a", "int"))
+      .build();
+
     context.handleDeferredToken(deferredToken);
     assertThat(context.get("var_a")).isInstanceOf(DeferredValue.class);
     assertThat(context.containsKey("int")).isFalse();

--- a/src/test/java/com/hubspot/jinjava/util/EagerReconstructionUtilsTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerReconstructionUtilsTest.java
@@ -2,7 +2,8 @@ package com.hubspot.jinjava.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;


### PR DESCRIPTION
Adds the builder pattern for a much simpler, and more readable construction of a `DeferredToken`.
Creating a DeferredToken for a SetTag previously looked like:
```java
new DeferredToken(
  new TagToken(
    joiner.toString(),
    tagNode.getLineNumber(),
    tagNode.getStartPosition(),
    tagNode.getSymbols()
  ),
  eagerExecutionResult
    .getResult()
    .getDeferredWords()
    .stream()
    .filter(
      word ->
        !(interpreter.getContext().get(word) instanceof DeferredMacroValueImpl)
    )
    .collect(Collectors.toSet()),
  Arrays.stream(variables).map(String::trim).collect(Collectors.toSet())
)
```

Now looks like:
```java
DeferredToken
  .builderFromImage(joiner.toString(), tagNode.getMaster())
  .addUsedDeferredWords(eagerExecutionResult.getResult().getDeferredWords())
  .addSetDeferredWords(Arrays.stream(variables).map(String::trim))
  .build()
```
An inline `{% set foo = bar %}` tag was the most unwieldy because it could have set variables `['foo']` and used variables `['bar']` to add which get handled differently. This builder pattern cleans that up and makes it obvious which types of deferred words are being added.