### PR TITLE
Bp/configure raw

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -19,6 +19,7 @@ import static com.hubspot.jinjava.lib.fn.Functions.DEFAULT_RANGE_LIMIT;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.jinjava.el.JinjavaInterpreterResolver;
 import com.hubspot.jinjava.el.JinjavaObjectUnwrapper;
@@ -93,6 +94,8 @@ public class JinjavaConfig {
   private final ObjectUnwrapper objectUnwrapper;
   private final JinjavaProcessors processors;
 
+  private final Map<String, String> rawTokens;
+
   public static Builder newBuilder() {
     return new Builder();
   }
@@ -153,6 +156,7 @@ public class JinjavaConfig {
     objectUnwrapper = builder.objectUnwrapper;
     processors = builder.processors;
     features = new Features(builder.featureConfig);
+    rawTokens = builder.rawTokens;
   }
 
   private ObjectMapper setupObjectMapper(@Nullable ObjectMapper objectMapper) {
@@ -313,6 +317,10 @@ public class JinjavaConfig {
     return features;
   }
 
+  public Map<String, String> getRawTokens() {
+    return rawTokens;
+  }
+
   public static class Builder {
     private Charset charset = StandardCharsets.UTF_8;
     private Locale locale = Locale.ENGLISH;
@@ -351,6 +359,8 @@ public class JinjavaConfig {
     private ObjectUnwrapper objectUnwrapper = new JinjavaObjectUnwrapper();
     private JinjavaProcessors processors = JinjavaProcessors.newBuilder().build();
     private FeatureConfig featureConfig = FeatureConfig.newBuilder().build();
+
+    private Map<String, String> rawTokens = ImmutableMap.of();
 
     private Builder() {}
 
@@ -549,6 +559,11 @@ public class JinjavaConfig {
 
     public Builder withFeatureConfig(FeatureConfig featureConfig) {
       this.featureConfig = featureConfig;
+      return this;
+    }
+
+    public Builder withRawTokens(Map<String, String> rawTokens) {
+      this.rawTokens = rawTokens;
       return this;
     }
 


### PR DESCRIPTION
https://git.hubteam.com/HubSpot/Blog/issues/317

Adds the ability to configure what tags our tokenizer treats as raw tags. We need this to support the ability to pass in hubl to module attributes and not have that hubl parsed until the module renders it. At the moment, hubl like

```
{% module_attribute "code_snippet" is_json="true" %}"{% extends \\\"./layouts/base.html\\\" %}\n\n{% block body %}\n\n{% dnd_area \\\"dnd_area\\\" label=\\\"Main section\\\", class=\\\"body-container body-container--blog\\\" %}\n\n {# HERO SECTION #}\n {% dnd_section full_width=true, padding={ 'default': { 'top': 0, 'right': 0, 'bottom': 0, 'left': 0 }} %}\n {% dnd_column padding={'default': { 'top': 0, 'right': 0, 'bottom': 0, 'left': 0 }} %}\n {% dnd_row padding={'default': { 'top': 0, 'right': 0, 'bottom': 0, 'left': 0 }} %}\n {% dnd_module path='../modules/folio-section.module', width=12 %}\n {% end_dnd_module %}\n {% end_dnd_row %}\n {% end_dnd_column %}\n {% end_dnd_section %}\n {# End HERO SECTION #}\n\n {# BLOG POSTS SECTION #}\n {% dnd_section full_width=true, padding={ 'default': { 'top': 0, 'right': 0, 'bottom': 0, 'left': 0 }} %}\n {% dnd_column padding={'default': { 'top': 0, 'right': 0, 'bottom': 0, 'left': 0 }} %}\n {% dnd_row padding={'default': { 'top': 0, 'right': 0, 'bottom': 0, 'left': 0 }} %}\n {% dnd_module path='../modules/resources.module', width=12 %}\n {% end_dnd_module %}\n {% end_dnd_row %}\n {% end_dnd_column %}\n {% end_dnd_section %}\n {# End BLOG POSTS SECTION #}\n\n{% end_dnd_area %}\n\n{% endblock body %}"{% end_module_attribute %}
```

fails to render because the hubl within the attribute is being tokenized and parsed. This causes errors to be thrown as the hubl within the attribute isn't valid for the render context. In the case I'm trying to solve for the hubl isn't actually being rendered by the module and is instead escaped and rendered within a code block so it doesn't need to be valid.

If the module were to use the hubl within the module attribute directly, that hubl should be tokenized and parsed when it's used within the module's template, so I don't believe allowing for this will cause any breaking changes.

before:
<img width="1788" alt="Screenshot 2023-08-10 at 4 32 38 PM" src="https://github.com/HubSpot/jinjava/assets/6777052/5b80abe3-c23b-4440-a80c-803e16b181a2">


after:
<img width="1792" alt="Screenshot 2023-08-10 at 4 32 55 PM" src="https://github.com/HubSpot/jinjava/assets/6777052/d1c8d1c7-5365-493b-ba81-964c9f21d48b">
