### PR TITLE
Add new DeferredInvocationResolutionException which extends DeferredParsingException

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/DeferredInvocationResolutionException.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/DeferredInvocationResolutionException.java
@@ -1,0 +1,8 @@
+package com.hubspot.jinjava.el.ext;
+
+public class DeferredInvocationResolutionException extends DeferredParsingException {
+
+  public DeferredInvocationResolutionException(String invocationResultString) {
+    super(DeferredInvocationResolutionException.class, invocationResultString);
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
@@ -1,13 +1,13 @@
 package com.hubspot.jinjava.el.ext.eager;
 
 import com.hubspot.jinjava.el.ext.AstMacroFunction;
+import com.hubspot.jinjava.el.ext.DeferredInvocationResolutionException;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.el.ext.ExtendedParser;
 import com.hubspot.jinjava.el.ext.IdentifierPreservationStrategy;
 import com.hubspot.jinjava.interpret.Context.TemporaryValueClosable;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.lib.fn.MacroFunction;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstParameters;
 import java.lang.reflect.Array;
@@ -154,10 +154,7 @@ public class EagerAstMacroFunction extends AstMacroFunction implements EvalResul
     DeferredParsingException deferredParsingException,
     IdentifierPreservationStrategy identifierPreservationStrategy
   ) {
-    if (
-      deferredParsingException != null &&
-      deferredParsingException.getSourceNode() instanceof MacroFunction
-    ) {
+    if (deferredParsingException instanceof DeferredInvocationResolutionException) {
       return deferredParsingException.getDeferredEvalResult();
     }
     String paramString;

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.el.ext.eager;
 
+import com.hubspot.jinjava.el.ext.DeferredInvocationResolutionException;
 import com.hubspot.jinjava.el.ext.DeferredParsingException;
 import com.hubspot.jinjava.el.ext.IdentifierPreservationStrategy;
 import com.hubspot.jinjava.interpret.DeferredValueException;
@@ -80,6 +81,9 @@ public class EagerAstMethod extends AstMethod implements EvalResultHolder {
     DeferredParsingException deferredParsingException,
     IdentifierPreservationStrategy identifierPreservationStrategy
   ) {
+    if (deferredParsingException instanceof DeferredInvocationResolutionException) {
+      return deferredParsingException.getDeferredEvalResult();
+    }
     String propertyResult;
     propertyResult =
       (property).getPartiallyResolved(

--- a/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
@@ -2,7 +2,7 @@ package com.hubspot.jinjava.lib.fn.eager;
 
 import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.el.ext.AstMacroFunction;
-import com.hubspot.jinjava.el.ext.DeferredParsingException;
+import com.hubspot.jinjava.el.ext.DeferredInvocationResolutionException;
 import com.hubspot.jinjava.el.ext.eager.MacroFunctionTempVariable;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
@@ -122,7 +122,7 @@ public class EagerMacroFunction extends MacroFunction {
             prefixToPreserveState + eagerExecutionResult.asTemplateString()
           )
         );
-      throw new DeferredParsingException(this, tempVarName);
+      throw new DeferredInvocationResolutionException(tempVarName);
     }
     return eagerExecutionResult.getResult().toString(true);
   }

--- a/src/test/resources/eager/puts-deferred-imported-macro-in-output.expected.jinja
+++ b/src/test/resources/eager/puts-deferred-imported-macro-in-output.expected.jinja
@@ -1,1 +1,1 @@
-{% set myname = deferred + 3 %}{% set deferred_import_resource_path = 'simple-with-call.jinja' %}{% macro simple.getPath() %}Hello {{ myname }}{% endmacro %}{% set deferred_import_resource_path = null %}{% print simple.getPath() %}
+{% set myname = deferred + 3 %}{% set __macro_getPath_331491059_temp_variable_1__ %}Hello {{ myname }}{% endset %}{% print __macro_getPath_331491059_temp_variable_1__ %}


### PR DESCRIPTION
This is used in an EagerMacroFunction which will convert its output into a temporary variable so that the macro function's call will be replaced with that variable name. This same process should be usable within custom defined functions as well so this converts that functionality into a new type of exception which will allow custom functions to define what the partial resolution of their invocation is. Additionally, this check wasn't applied to EagerAstMethod, so aliased macro functions weren't being converted to temporary macro variables as they should have been.