### PR TITLE
Use interpreter locale as default for strftime functions

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
@@ -4,6 +4,8 @@ import static com.hubspot.jinjava.objects.date.StrftimeFormatter.ConversionCompo
 import static com.hubspot.jinjava.objects.date.StrftimeFormatter.ConversionComponent.pattern;
 
 import com.google.common.collect.ImmutableMap;
+import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -158,7 +160,15 @@ public class StrftimeFormatter {
   }
 
   public static String format(ZonedDateTime d, String strftime) {
-    return format(d, strftime, Locale.ENGLISH);
+    return format(
+      d,
+      strftime,
+      JinjavaInterpreter
+        .getCurrentMaybe()
+        .map(JinjavaInterpreter::getConfig)
+        .map(JinjavaConfig::getLocale)
+        .orElse(Locale.ENGLISH)
+    );
   }
 
   public static String format(ZonedDateTime d, String strftime, Locale locale) {

--- a/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
@@ -3,6 +3,9 @@ package com.hubspot.jinjava.objects.date;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Locale;
@@ -145,5 +148,18 @@ public class StrftimeFormatterTest {
   public void itAllowsLiteralCharacters() {
     assertThat(StrftimeFormatter.format(d, "1: day %d month %B"))
       .isEqualTo("1: day 06 month November");
+  }
+
+  @Test
+  public void itUsesInterpreterLocaleAsDefault() {
+    try {
+      Jinjava jinjava = new Jinjava(
+        JinjavaConfig.newBuilder().withLocale(Locale.FRENCH).build()
+      );
+      JinjavaInterpreter.pushCurrent(jinjava.newInterpreter());
+      assertThat(StrftimeFormatter.format(d, "%B %-d, %Y")).isEqualTo("novembre 6, 2013");
+    } finally {
+      JinjavaInterpreter.popCurrent();
+    }
   }
 }


### PR DESCRIPTION
There is a mismatch utilizing one of these strftime functions vs the datetimeformat filters. The datetimeformat filters will default to the locale set in the config if none is passed to the functions, however these functions will just default to English. This just updates the logic to be unified between the two functions/filters.