### PR TITLE
More gracefully handle null keys/values in map resolver

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/TypeConvertingMapELResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/TypeConvertingMapELResolver.java
@@ -23,8 +23,18 @@ public class TypeConvertingMapELResolver extends MapELResolver {
 
     if (base instanceof Map && !((Map) base).isEmpty()) {
       Iterator<?> iterator = ((Map) base).keySet().iterator();
-      if (iterator.hasNext()) {
-        Class<?> keyClass = iterator.next().getClass();
+      Class<?> keyClass = null;
+      while (iterator.hasNext()) {
+        Object nextObject = iterator.next();
+        if (nextObject != null) {
+          keyClass = nextObject.getClass();
+          break;
+        }
+      }
+
+      if (keyClass == null) {
+        value = ((Map) base).get(property);
+      } else {
         try {
           value = ((Map) base).get(TYPE_CONVERTER.convert(property, keyClass));
           if (value != null) {

--- a/src/test/java/com/hubspot/jinjava/el/TypeConvertingMapELResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/TypeConvertingMapELResolverTest.java
@@ -1,0 +1,60 @@
+package com.hubspot.jinjava.el;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TypeConvertingMapELResolverTest {
+  private TypeConvertingMapELResolver typeConvertingMapELResolver;
+
+  @Before
+  public void setup() {
+    typeConvertingMapELResolver = new TypeConvertingMapELResolver(false);
+  }
+
+  @Test
+  public void itResolvesProperties() {
+    Map<String, String> values = ImmutableMap.of("1", "value1", "2", "value2");
+    assertThat(typeConvertingMapELResolver.getValue(new JinjavaELContext(), values, "2"))
+      .isEqualTo("value2");
+  }
+
+  @Test
+  public void itConvertsPropertyClassWhenResolvingProperty() {
+    Map<String, String> values = ImmutableMap.of("1", "value1", "2", "value2");
+    assertThat(typeConvertingMapELResolver.getValue(new JinjavaELContext(), values, 1))
+      .isEqualTo("value1");
+  }
+
+  @Test
+  public void itHandlesNullKeyValuesWhenResolvingProperty() {
+    Map<String, String> values = new HashMap<>();
+    values.put(null, "nullValue");
+    values.put("1", "value1");
+    values.put("2", "value2");
+    assertThat(typeConvertingMapELResolver.getValue(new JinjavaELContext(), values, 1))
+      .isEqualTo("value1");
+  }
+
+  @Test
+  public void itHandlesMapWithOnlyNullKey() {
+    Map<String, String> values = new HashMap<>();
+    values.put(null, "nullValue");
+    assertThat(typeConvertingMapELResolver.getValue(new JinjavaELContext(), values, 1))
+      .isEqualTo(null);
+  }
+
+  @Test
+  public void itResolvesNullPropertyValue() {
+    Map<String, String> values = new HashMap<>();
+    values.put(null, "nullValue");
+    values.put("1", "value1");
+    values.put("2", "value2");
+    assertThat(typeConvertingMapELResolver.getValue(new JinjavaELContext(), values, null))
+      .isEqualTo("nullValue");
+  }
+}


### PR DESCRIPTION
There are some issues with this method when the property values are null or there exists null keys in the map causing NPE.

Just some updates and more thorough unit testing here to ensure these NPE's don't crop up again.