### PR TITLE
Fix stackoverflow issue related to pymap hashcode computation

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/collections/PyMap.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/PyMap.java
@@ -76,7 +76,14 @@ public class PyMap extends ForwardingMap<String, Object> implements PyWrapper {
         int code = System.identityHashCode(subMap);
         if (!visited.contains(code)) {
           visited.add(code);
-          subMap.entrySet().forEach(valueIterator::add);
+          subMap
+            .entrySet()
+            .forEach(
+              e -> {
+                valueIterator.add(e);
+                valueIterator.previous();
+              }
+            );
         }
       } else {
         h += entry.hashCode();

--- a/src/main/java/com/hubspot/jinjava/objects/collections/PyMap.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/PyMap.java
@@ -2,6 +2,10 @@ package com.hubspot.jinjava.objects.collections;
 
 import com.google.common.collect.ForwardingMap;
 import com.hubspot.jinjava.objects.PyWrapper;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -62,8 +66,19 @@ public class PyMap extends ForwardingMap<String, Object> implements PyWrapper {
   @Override
   public int hashCode() {
     int h = 0;
-    for (Entry<String, Object> entry : map.entrySet()) {
-      if (entry.getValue() != map && entry.getValue() != this) {
+    List<Entry<?, ?>> valueList = new ArrayList<>(map.entrySet());
+    ListIterator<Entry<?, ?>> valueIterator = valueList.listIterator();
+    Set<Integer> visited = new HashSet<>();
+    while (valueIterator.hasNext()) {
+      Entry<?, ?> entry = valueIterator.next();
+      if (entry.getValue() instanceof Map) {
+        Map<?, ?> subMap = (Map<?, ?>) entry.getValue();
+        int code = System.identityHashCode(subMap);
+        if (!visited.contains(code)) {
+          visited.add(code);
+          subMap.entrySet().forEach(valueIterator::add);
+        }
+      } else {
         h += entry.hashCode();
       }
     }

--- a/src/main/java/com/hubspot/jinjava/objects/collections/PyMap.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/PyMap.java
@@ -79,7 +79,9 @@ public class PyMap extends ForwardingMap<String, Object> implements PyWrapper {
       }
       if (next instanceof Entry) {
         Entry nextEntry = (Entry) next;
-        h += nextEntry.getKey().hashCode();
+        if (nextEntry.getKey() != null) {
+          h += nextEntry.getKey().hashCode();
+        }
         valueIterator.add(nextEntry.getValue());
         valueIterator.previous();
       } else if (next instanceof Iterable) {

--- a/src/main/java/com/hubspot/jinjava/objects/collections/PyMap.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/PyMap.java
@@ -95,7 +95,7 @@ public class PyMap extends ForwardingMap<String, Object> implements PyWrapper {
               valueIterator.previous();
             }
           );
-      } else {
+      } else if (next != null) {
         h += next.hashCode();
       }
     }

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
@@ -11,6 +11,7 @@ import com.hubspot.jinjava.LegacyOverrides;
 import com.hubspot.jinjava.interpret.IndexOutOfRangeException;
 import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.interpret.TemplateError;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import org.junit.Test;
@@ -409,5 +410,20 @@ public class PyMapTest extends BaseJinjavaTest {
     map.put("map1key2", new PyList(ImmutableList.of((map2))));
 
     assertThat(map.hashCode()).isEqualTo(-413943561);
+  }
+
+  @Test
+  public void itComputesHashCodeWithNullKeysAndValues() {
+    PyMap map = new PyMap(new HashMap<>());
+    map.put(null, "value1");
+
+    PyMap map2 = new PyMap(new HashMap<>());
+    map2.put("map2key1", map);
+
+    PyList list = new PyList(new ArrayList<>());
+    list.add(null);
+    map.put("map1key2", new PyList(list));
+
+    assertThat(map.hashCode()).isEqualTo(-687497624);
   }
 }

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
@@ -381,6 +381,27 @@ public class PyMapTest extends BaseJinjavaTest {
     PyMap pyMap2 = new PyMap(map2);
 
     pyMap.put("key2", pyMap2);
-    assertThat(pyMap.hashCode()).isEqualTo(-824725166);
+    assertThat(pyMap.hashCode()).isEqualTo(-1649450332);
+  }
+
+  @Test
+  public void itComputesHashCodeWhenContainedWithinItselfWithFurtherEntries() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("key1", "value1");
+    PyMap pyMap = new PyMap(map);
+
+    Map<String, Object> map2 = new HashMap<>();
+    map2.put("key1", pyMap);
+
+    PyMap pyMap2 = new PyMap(map2);
+
+    pyMap.put("key2", pyMap2);
+
+    int originalHashCode = pyMap.hashCode();
+    pyMap2.put("newKey", "newValue");
+    int newHashCode = pyMap.hashCode();
+    assertThat(originalHashCode).isNotEqualTo(newHashCode);
+
+    assertThat(pyMap.hashCode()).isEqualTo(-1649450332);
   }
 }

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
@@ -12,7 +12,6 @@ import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.interpret.TemplateError;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Map;
 import org.junit.Test;
 
 public class PyMapTest extends BaseJinjavaTest {
@@ -371,37 +370,30 @@ public class PyMapTest extends BaseJinjavaTest {
 
   @Test
   public void itComputesHashCodeWhenContainedWithinItself() {
-    Map<String, Object> map = new HashMap<>();
-    map.put("key1", "value1");
-    PyMap pyMap = new PyMap(map);
+    PyMap map = new PyMap(new HashMap<>());
+    map.put("map1key1", "value1");
 
-    Map<String, Object> map2 = new HashMap<>();
-    map2.put("key1", pyMap);
+    PyMap map2 = new PyMap(new HashMap<>());
+    map2.put("map2key1", map);
 
-    PyMap pyMap2 = new PyMap(map2);
+    map.put("map1key2", map2);
 
-    pyMap.put("key2", pyMap2);
-    assertThat(pyMap.hashCode()).isEqualTo(-1649450332);
+    assertThat(map.hashCode()).isEqualTo(-1920255282);
   }
 
   @Test
   public void itComputesHashCodeWhenContainedWithinItselfWithFurtherEntries() {
-    Map<String, Object> map = new HashMap<>();
-    map.put("key1", "value1");
-    PyMap pyMap = new PyMap(map);
+    PyMap map = new PyMap(new HashMap<>());
+    map.put("map1key1", "value1");
 
-    Map<String, Object> map2 = new HashMap<>();
-    map2.put("key1", pyMap);
+    PyMap map2 = new PyMap(new HashMap<>());
+    map2.put("map2key1", map);
 
-    PyMap pyMap2 = new PyMap(map2);
+    map.put("map1key2", map2);
 
-    pyMap.put("key2", pyMap2);
-
-    int originalHashCode = pyMap.hashCode();
-    pyMap2.put("newKey", "newValue");
-    int newHashCode = pyMap.hashCode();
+    int originalHashCode = map.hashCode();
+    map2.put("newKey", "newValue");
+    int newHashCode = map.hashCode();
     assertThat(originalHashCode).isNotEqualTo(newHashCode);
-
-    assertThat(pyMap.hashCode()).isEqualTo(-1649450332);
   }
 }

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.objects.collections;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.google.common.collect.ImmutableList;
 import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
@@ -378,7 +379,7 @@ public class PyMapTest extends BaseJinjavaTest {
 
     map.put("map1key2", map2);
 
-    assertThat(map.hashCode()).isEqualTo(-1920255282);
+    assertThat(map.hashCode()).isEqualTo(-413943561);
   }
 
   @Test
@@ -395,5 +396,18 @@ public class PyMapTest extends BaseJinjavaTest {
     map2.put("newKey", "newValue");
     int newHashCode = map.hashCode();
     assertThat(originalHashCode).isNotEqualTo(newHashCode);
+  }
+
+  @Test
+  public void itComputesHashCodeWhenContainedWithinItselfInsideList() {
+    PyMap map = new PyMap(new HashMap<>());
+    map.put("map1key1", "value1");
+
+    PyMap map2 = new PyMap(new HashMap<>());
+    map2.put("map2key1", map);
+
+    map.put("map1key2", new PyList(ImmutableList.of((map2))));
+
+    assertThat(map.hashCode()).isEqualTo(-413943561);
   }
 }

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
@@ -12,6 +12,7 @@ import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.interpret.TemplateError;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import org.junit.Test;
 
 public class PyMapTest extends BaseJinjavaTest {
@@ -366,5 +367,20 @@ public class PyMapTest extends BaseJinjavaTest {
         )
       )
       .isEqualTo("value2");
+  }
+
+  @Test
+  public void itComputesHashCodeWhenContainedWithinItself() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("key1", "value1");
+    PyMap pyMap = new PyMap(map);
+
+    Map<String, Object> map2 = new HashMap<>();
+    map2.put("key1", pyMap);
+
+    PyMap pyMap2 = new PyMap(map2);
+
+    pyMap.put("key2", pyMap2);
+    assertThat(pyMap.hashCode()).isEqualTo(-824725166);
   }
 }


### PR DESCRIPTION
If a pymap contains itself we would get stackoverflow exceptions since the hashcode method recursively calls the hashcode method for all entrys in the set.

Instead we use an iterator so we can add additional elements from nested Maps. We then keep a HashSet with the `System.identityHashCode()` value so we can tell if we already visited a nested map.