### PR TITLE
Use a ThreadLocal semaphore to prevent hashCode recursion

### DIFF
--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
@@ -6,6 +6,7 @@ import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.interpret.IndexOutOfRangeException;
 import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.interpret.TemplateError;
+import java.util.ArrayList;
 import java.util.Collections;
 import org.junit.Test;
 
@@ -260,5 +261,39 @@ public class PyListTest extends BaseJinjavaTest {
         )
       )
       .isEqualTo("[1, 2]");
+  }
+
+  @Test
+  public void itComputesHashCodeWhenListContainsItself() {
+    PyList list1 = new PyList(new ArrayList<>());
+    PyList list2 = new PyList(new ArrayList<>());
+    list1.add(list2);
+    int initialHashCode = list1.hashCode();
+    list2.add(list1);
+    int hashCodeWithInfiniteRecursion = list1.hashCode();
+    assertThat(initialHashCode).isNotEqualTo(hashCodeWithInfiniteRecursion);
+    assertThat(list1.hashCode())
+      .isEqualTo(hashCodeWithInfiniteRecursion)
+      .describedAs("Hash code should be consistent on multiple calls");
+    assertThat(list2.hashCode())
+      .isEqualTo(list1.hashCode())
+      .describedAs(
+        "The two lists are currently the same as they are both a list1 of a single infinitely recurring list"
+      );
+    list1.add(123456);
+    assertThat(list2.hashCode())
+      .isNotEqualTo(list1.hashCode())
+      .describedAs(
+        "The two lists are no longer the same as list1 has 2 elements while list2 has one"
+      );
+    PyList copy = list1.copy();
+    assertThat(copy.hashCode())
+      .isNotEqualTo(list1.hashCode())
+      .describedAs(
+        "copy is not the same as list1 because it is a list of a list of recursion, whereas list1 is a list of recursion"
+      );
+    assertThat(list1.copy().hashCode())
+      .isEqualTo(copy.hashCode())
+      .describedAs("All copies should have the same hash code");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
@@ -380,7 +380,7 @@ public class PyMapTest extends BaseJinjavaTest {
 
     map.put("map1key2", map2);
 
-    assertThat(map.hashCode()).isEqualTo(-413943561);
+    assertThat(map.hashCode()).isNotEqualTo(0);
   }
 
   @Test
@@ -409,7 +409,7 @@ public class PyMapTest extends BaseJinjavaTest {
 
     map.put("map1key2", new PyList(ImmutableList.of((map2))));
 
-    assertThat(map.hashCode()).isEqualTo(-413943561);
+    assertThat(map.hashCode()).isNotEqualTo(0);
   }
 
   @Test
@@ -424,6 +424,6 @@ public class PyMapTest extends BaseJinjavaTest {
     list.add(null);
     map.put("map1key2", new PyList(list));
 
-    assertThat(map.hashCode()).isEqualTo(-687497624);
+    assertThat(map.hashCode()).isNotEqualTo(0);
   }
 }

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.objects.collections;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.google.common.collect.ImmutableList;
 import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
@@ -10,6 +11,7 @@ import com.hubspot.jinjava.LegacyOverrides;
 import com.hubspot.jinjava.interpret.IndexOutOfRangeException;
 import com.hubspot.jinjava.interpret.RenderResult;
 import com.hubspot.jinjava.interpret.TemplateError;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import org.junit.Test;
@@ -366,5 +368,62 @@ public class PyMapTest extends BaseJinjavaTest {
         )
       )
       .isEqualTo("value2");
+  }
+
+  @Test
+  public void itComputesHashCodeWhenContainedWithinItself() {
+    PyMap map = new PyMap(new HashMap<>());
+    map.put("map1key1", "value1");
+
+    PyMap map2 = new PyMap(new HashMap<>());
+    map2.put("map2key1", map);
+
+    map.put("map1key2", map2);
+
+    assertThat(map.hashCode()).isEqualTo(-413943561);
+  }
+
+  @Test
+  public void itComputesHashCodeWhenContainedWithinItselfWithFurtherEntries() {
+    PyMap map = new PyMap(new HashMap<>());
+    map.put("map1key1", "value1");
+
+    PyMap map2 = new PyMap(new HashMap<>());
+    map2.put("map2key1", map);
+
+    map.put("map1key2", map2);
+
+    int originalHashCode = map.hashCode();
+    map2.put("newKey", "newValue");
+    int newHashCode = map.hashCode();
+    assertThat(originalHashCode).isNotEqualTo(newHashCode);
+  }
+
+  @Test
+  public void itComputesHashCodeWhenContainedWithinItselfInsideList() {
+    PyMap map = new PyMap(new HashMap<>());
+    map.put("map1key1", "value1");
+
+    PyMap map2 = new PyMap(new HashMap<>());
+    map2.put("map2key1", map);
+
+    map.put("map1key2", new PyList(ImmutableList.of((map2))));
+
+    assertThat(map.hashCode()).isEqualTo(-413943561);
+  }
+
+  @Test
+  public void itComputesHashCodeWithNullKeysAndValues() {
+    PyMap map = new PyMap(new HashMap<>());
+    map.put(null, "value1");
+
+    PyMap map2 = new PyMap(new HashMap<>());
+    map2.put("map2key1", map);
+
+    PyList list = new PyList(new ArrayList<>());
+    list.add(null);
+    map.put("map1key2", new PyList(list));
+
+    assertThat(map.hashCode()).isEqualTo(-687497624);
   }
 }


### PR DESCRIPTION
Solves the same problem as https://github.com/HubSpot/jinjava/pull/1111. This demonstrates a different approach where a semaphore is used to ensure that a PyList or PyMap cannot have `hashCode()` called for itself during its own `hashCode()` call.