### PR TITLE
Support aliasing macro function names in {% from %} tag

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/FromTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/FromTag.java
@@ -167,7 +167,11 @@ public class FromTag implements Tag {
       Object val = child.getContext().getGlobalMacro(importMapping.getKey());
 
       if (val != null) {
-        interpreter.getContext().addGlobalMacro((MacroFunction) val);
+        MacroFunction toImport = (MacroFunction) val;
+        if (!importMapping.getKey().equals(importMapping.getValue())) {
+          toImport = new MacroFunction(toImport, importMapping.getValue());
+        }
+        interpreter.getContext().addGlobalMacro(toImport);
       } else {
         val = child.getContext().get(importMapping.getKey());
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/FromTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/FromTagTest.java
@@ -59,6 +59,14 @@ public class FromTagTest extends BaseInterpretingTest {
   }
 
   @Test
+  public void itImportsAliasedMacroName() {
+    assertThat(fixture("from-alias-macro"))
+      .contains("wrap-spacer:")
+      .contains("<td height=\"42\">")
+      .contains("wrap-padding: padding-left:42px;padding-right:42px");
+  }
+
+  @Test
   public void importedCycleDected() {
     fixture("from-recursion");
     assertTrue(

--- a/src/test/resources/tags/macrotag/from-alias-macro.jinja
+++ b/src/test/resources/tags/macrotag/from-alias-macro.jinja
@@ -1,0 +1,4 @@
+{% from "pegasus-importable.jinja" import wrap_padding as wp, spacer as sp %}
+
+wrap-padding: {{ wp }}
+wrap-spacer: {{ sp() }}


### PR DESCRIPTION
I just realised that this is something that I supported when implementing eager execution, but it was never supported in default execution. This is allowed in jinja, and we allow aliasing variables, so we should also allow aliasing macro functions:

[From jinja docs:](https://jinja.palletsprojects.com/en/3.1.x/templates/#:~:text=Alternatively%2C%20you%20can%20import%20specific%20names%20from%20a%20template%20into%20the%20current%20namespace%3A)
> Alternatively, you can import specific names from a template into the current namespace:
```
{% from 'forms.html' import input as input_field, textarea %}
<dl>
    <dt>Username</dt>
    <dd>{{ input_field('username') }}</dd>
    <dt>Password</dt>
    <dd>{{ input_field('password', type='password') }}</dd>
</dl>
<p>{{ textarea('comment') }}</p>
```