### PR TITLE
Allow imported files to have variables sharing alias of import name

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -1,36 +1,21 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
 import com.google.common.annotations.Beta;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Strings;
 import com.hubspot.jinjava.interpret.Context;
-import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import com.hubspot.jinjava.lib.fn.MacroFunction;
 import com.hubspot.jinjava.lib.tag.DoTag;
 import com.hubspot.jinjava.lib.tag.ImportTag;
-import com.hubspot.jinjava.loader.RelativePathResolver;
-import com.hubspot.jinjava.objects.collections.PyMap;
-import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
+import com.hubspot.jinjava.lib.tag.eager.importing.EagerImportingStrategy;
+import com.hubspot.jinjava.lib.tag.eager.importing.EagerImportingStrategyFactory;
+import com.hubspot.jinjava.lib.tag.eager.importing.ImportingData;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
-import com.hubspot.jinjava.util.PrefixToPreserveState;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.Set;
-import java.util.StringJoiner;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import org.apache.commons.lang3.StringUtils;
 
 @Beta
 public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
@@ -45,34 +30,22 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
 
   @Override
   public String getEagerTagImage(TagToken tagToken, JinjavaInterpreter interpreter) {
-    List<String> helper = ImportTag.getHelpers(tagToken);
+    ImportingData importingData = EagerImportingStrategyFactory.getImportingData(
+      tagToken,
+      interpreter
+    );
+    EagerImportingStrategy eagerImportingStrategy = EagerImportingStrategyFactory.create(
+      importingData
+    );
 
-    String currentImportAlias = ImportTag.getContextVar(helper);
-
-    final String initialPathSetter = getSetTagForCurrentPath(interpreter);
     final String newPathSetter;
 
     Optional<String> maybeTemplateFile;
     try {
-      maybeTemplateFile = ImportTag.getTemplateFile(helper, tagToken, interpreter);
+      maybeTemplateFile =
+        ImportTag.getTemplateFile(importingData.getHelpers(), tagToken, interpreter);
     } catch (DeferredValueException e) {
-      if (currentImportAlias.isEmpty()) {
-        throw e;
-      }
-      return (
-        initialPathSetter +
-        new PrefixToPreserveState(
-          EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
-            interpreter,
-            DeferredToken
-              .builderFromToken(tagToken)
-              .addUsedDeferredWords(Stream.of(helper.get(0)))
-              .addSetDeferredWords(Stream.of(currentImportAlias))
-              .build()
-          )
-        ) +
-        tagToken.getImage()
-      );
+      return eagerImportingStrategy.handleDeferredTemplateFile(e);
     }
     if (!maybeTemplateFile.isPresent()) {
       return "";
@@ -80,7 +53,7 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
     String templateFile = maybeTemplateFile.get();
     try {
       Node node = ImportTag.parseTemplateAsNode(interpreter, templateFile);
-      newPathSetter = getSetTagForCurrentPath(interpreter);
+      newPathSetter = EagerImportingStrategyFactory.getSetTagForCurrentPath(interpreter);
 
       JinjavaInterpreter child = interpreter
         .getConfig()
@@ -90,7 +63,7 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
       JinjavaInterpreter.pushCurrent(child);
       String output;
       try {
-        setupImportAlias(currentImportAlias, child, interpreter);
+        eagerImportingStrategy.setup(child);
         output = child.render(node);
       } finally {
         JinjavaInterpreter.popCurrent();
@@ -109,7 +82,7 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
       ) {
         ImportTag.handleDeferredNodesDuringImport(
           node,
-          currentImportAlias,
+          ImportTag.getContextVar(importingData.getHelpers()),
           childBindings,
           child,
           interpreter
@@ -120,34 +93,12 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
           tagToken.getStartPosition()
         );
       }
-      integrateChild(currentImportAlias, childBindings, child, interpreter);
-      String finalOutput;
+      eagerImportingStrategy.integrateChild(child);
       if (child.getContext().getDeferredTokens().isEmpty() || output == null) {
         return "";
-      } else if (!Strings.isNullOrEmpty(currentImportAlias)) {
-        // Since some values got deferred, output a DoTag that will load the currentImportAlias on the context.
-        finalOutput =
-          getFinalOutputWithAlias(
-            interpreter,
-            currentImportAlias,
-            initialPathSetter,
-            newPathSetter,
-            output,
-            childBindings
-          );
-      } else {
-        finalOutput =
-          getFinalOutputWithoutAlias(
-            interpreter,
-            currentImportAlias,
-            initialPathSetter,
-            newPathSetter,
-            output,
-            childBindings
-          );
       }
       return EagerReconstructionUtils.wrapInTag(
-        finalOutput,
+        eagerImportingStrategy.getFinalOutput(newPathSetter, output, childBindings),
         DoTag.TAG_NAME,
         interpreter,
         true
@@ -162,345 +113,6 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
     } finally {
       interpreter.getContext().getCurrentPathStack().pop();
       interpreter.getContext().getImportPathStack().pop();
-    }
-  }
-
-  private String getFinalOutputWithoutAlias(
-    JinjavaInterpreter interpreter,
-    String currentImportAlias,
-    String initialPathSetter,
-    String newPathSetter,
-    String output,
-    Map<String, Object> childBindings
-  ) {
-    return (
-      newPathSetter +
-      getSetTagForDeferredChildBindings(interpreter, currentImportAlias, childBindings) +
-      output +
-      initialPathSetter
-    );
-  }
-
-  private String getFinalOutputWithAlias(
-    JinjavaInterpreter interpreter,
-    String currentImportAlias,
-    String initialPathSetter,
-    String newPathSetter,
-    String output,
-    Map<String, Object> childBindings
-  ) {
-    return (
-      newPathSetter +
-      EagerReconstructionUtils.buildBlockOrInlineSetTagAndRegisterDeferredToken(
-        currentImportAlias,
-        Collections.emptyMap(),
-        interpreter
-      ) +
-      wrapInChildScope(
-        interpreter,
-        getSetTagForDeferredChildBindings(
-          interpreter,
-          currentImportAlias,
-          childBindings
-        ) +
-        output,
-        currentImportAlias
-      ) +
-      initialPathSetter
-    );
-  }
-
-  private static String wrapInChildScope(
-    JinjavaInterpreter interpreter,
-    String output,
-    String currentImportAlias
-  ) {
-    String combined = output + getDoTagToPreserve(interpreter, currentImportAlias);
-    // So that any set variables other than the alias won't exist outside the child's scope
-    return EagerReconstructionUtils.wrapInChildScope(combined, interpreter);
-  }
-
-  private String getSetTagForDeferredChildBindings(
-    JinjavaInterpreter interpreter,
-    String currentImportAlias,
-    Map<String, Object> childBindings
-  ) {
-    if (
-      Strings.isNullOrEmpty(currentImportAlias) &&
-      interpreter.getContext().isDeferredExecutionMode()
-    ) {
-      Set<String> metaContextVariables = interpreter
-        .getContext()
-        .getMetaContextVariables();
-      // defer imported variables
-      EagerReconstructionUtils.buildSetTag(
-        childBindings
-          .entrySet()
-          .stream()
-          .filter(
-            entry ->
-              !(entry.getValue() instanceof DeferredValue) && entry.getValue() != null
-          )
-          .filter(entry -> !metaContextVariables.contains(entry.getKey()))
-          .collect(Collectors.toMap(Entry::getKey, entry -> "")),
-        interpreter,
-        true
-      );
-    }
-    return childBindings
-      .entrySet()
-      .stream()
-      .filter(
-        entry ->
-          entry.getValue() instanceof DeferredValue &&
-          ((DeferredValue) entry.getValue()).getOriginalValue() != null
-      )
-      .filter(entry -> !interpreter.getContext().containsKey(entry.getKey()))
-      .filter(entry -> !entry.getKey().equals(currentImportAlias))
-      .map(
-        entry ->
-          EagerReconstructionUtils.buildBlockOrInlineSetTag( // don't register deferred token so that we don't defer them on higher context scopes; they only exist in the child scope
-            entry.getKey(),
-            ((DeferredValue) entry.getValue()).getOriginalValue(),
-            interpreter
-          )
-      )
-      .collect(Collectors.joining());
-  }
-
-  public static String getSetTagForCurrentPath(JinjavaInterpreter interpreter) {
-    return EagerReconstructionUtils.buildBlockOrInlineSetTag(
-      RelativePathResolver.CURRENT_PATH_CONTEXT_KEY,
-      interpreter
-        .getContext()
-        .getCurrentPathStack()
-        .peek()
-        .orElseGet(
-          () ->
-            (String) interpreter
-              .getContext()
-              .getOrDefault(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY, "")
-        ),
-      interpreter
-    );
-  }
-
-  @SuppressWarnings("unchecked")
-  private static String getDoTagToPreserve(
-    JinjavaInterpreter interpreter,
-    String currentImportAlias
-  ) {
-    StringJoiner keyValueJoiner = new StringJoiner(",");
-    Object currentAliasMap = interpreter
-      .getContext()
-      .getSessionBindings()
-      .get(currentImportAlias);
-    for (Map.Entry<String, Object> entry : (
-      (Map<String, Object>) ((DeferredValue) currentAliasMap).getOriginalValue()
-    ).entrySet()) {
-      if (entry.getKey().equals(currentImportAlias)) {
-        continue;
-      }
-      if (entry.getValue() instanceof DeferredValue) {
-        keyValueJoiner.add(String.format("'%s': %s", entry.getKey(), entry.getKey()));
-      } else if (!(entry.getValue() instanceof MacroFunction)) {
-        keyValueJoiner.add(
-          String.format(
-            "'%s': %s",
-            entry.getKey(),
-            PyishObjectMapper.getAsPyishString(entry.getValue())
-          )
-        );
-      }
-    }
-    if (keyValueJoiner.length() > 0) {
-      return EagerReconstructionUtils.buildDoUpdateTag(
-        currentImportAlias,
-        "{" + keyValueJoiner.toString() + "}",
-        interpreter
-      );
-    }
-    return "";
-  }
-
-  @VisibleForTesting
-  public static void setupImportAlias(
-    String currentImportAlias,
-    JinjavaInterpreter child,
-    JinjavaInterpreter parent
-  ) {
-    if (!Strings.isNullOrEmpty(currentImportAlias)) {
-      Optional<String> maybeParentImportAlias = parent
-        .getContext()
-        .getImportResourceAlias();
-      if (maybeParentImportAlias.isPresent()) {
-        child
-          .getContext()
-          .getScope()
-          .put(
-            Context.IMPORT_RESOURCE_ALIAS_KEY,
-            String.format("%s.%s", maybeParentImportAlias.get(), currentImportAlias)
-          );
-      } else {
-        child
-          .getContext()
-          .getScope()
-          .put(Context.IMPORT_RESOURCE_ALIAS_KEY, currentImportAlias);
-      }
-      constructFullAliasPathMap(currentImportAlias, child);
-      getMapForCurrentContextAlias(currentImportAlias, child);
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  private static void constructFullAliasPathMap(
-    String currentImportAlias,
-    JinjavaInterpreter child
-  ) {
-    String fullImportAlias = child
-      .getContext()
-      .getImportResourceAlias()
-      .orElse(currentImportAlias);
-    String[] allAliases = fullImportAlias.split("\\.");
-    Map<String, Object> currentMap = child.getContext().getParent();
-    for (int i = 0; i < allAliases.length - 1; i++) {
-      Object maybeNextMap = currentMap.get(allAliases[i]);
-      if (maybeNextMap instanceof Map) {
-        currentMap = (Map<String, Object>) maybeNextMap;
-      } else if (
-        maybeNextMap instanceof DeferredValue &&
-        ((DeferredValue) maybeNextMap).getOriginalValue() instanceof Map
-      ) {
-        currentMap =
-          (Map<String, Object>) ((DeferredValue) maybeNextMap).getOriginalValue();
-      } else {
-        throw new InterpretException("Encountered a problem with import alias maps");
-      }
-    }
-    currentMap.put(
-      allAliases[allAliases.length - 1],
-      child.getContext().isDeferredExecutionMode()
-        ? DeferredValue.instance(new PyMap(new HashMap<>()))
-        : new PyMap(new HashMap<>())
-    );
-  }
-
-  @SuppressWarnings("unchecked")
-  private static Map<String, Object> getMapForCurrentContextAlias(
-    String currentImportAlias,
-    JinjavaInterpreter child
-  ) {
-    Object parentValueForChild = child
-      .getContext()
-      .getParent()
-      .getSessionBindings()
-      .get(currentImportAlias);
-    if (parentValueForChild instanceof Map) {
-      return (Map<String, Object>) parentValueForChild;
-    } else if (parentValueForChild instanceof DeferredValue) {
-      if (((DeferredValue) parentValueForChild).getOriginalValue() instanceof Map) {
-        return (Map<String, Object>) (
-          (DeferredValue) parentValueForChild
-        ).getOriginalValue();
-      }
-      Map<String, Object> newMap = new PyMap(new HashMap<>());
-      child
-        .getContext()
-        .getParent()
-        .put(currentImportAlias, DeferredValue.instance(newMap));
-      return newMap;
-    } else {
-      Map<String, Object> newMap = new PyMap(new HashMap<>());
-      child
-        .getContext()
-        .getParent()
-        .put(
-          currentImportAlias,
-          child.getContext().isDeferredExecutionMode()
-            ? DeferredValue.instance(newMap)
-            : newMap
-        );
-      return newMap;
-    }
-  }
-
-  @VisibleForTesting
-  public static void integrateChild(
-    String currentImportAlias,
-    Map<String, Object> childBindings,
-    JinjavaInterpreter child,
-    JinjavaInterpreter parent
-  ) {
-    for (MacroFunction macro : child.getContext().getGlobalMacros().values()) {
-      if (parent.getContext().isDeferredExecutionMode()) {
-        macro.setDeferred(true);
-      }
-    }
-    if (StringUtils.isBlank(currentImportAlias)) {
-      for (MacroFunction macro : child.getContext().getGlobalMacros().values()) {
-        parent.getContext().addGlobalMacro(macro);
-      }
-      childBindings.remove(Context.GLOBAL_MACROS_SCOPE_KEY);
-      childBindings.remove(Context.IMPORT_RESOURCE_ALIAS_KEY);
-      Map<String, Object> childBindingsWithoutImportResourcePath = ImportTag.getChildBindingsWithoutImportResourcePath(
-        childBindings
-      );
-      if (parent.getContext().isDeferredExecutionMode()) {
-        childBindingsWithoutImportResourcePath
-          .keySet()
-          .forEach(
-            key ->
-              parent
-                .getContext()
-                .put(key, DeferredValue.instance(parent.getContext().get(key)))
-          );
-      } else {
-        parent.getContext().putAll(childBindingsWithoutImportResourcePath);
-      }
-    } else {
-      if (
-        child.getContext().isDeferredExecutionMode() &&
-        child
-          .getContext()
-          .getDeferredTokens()
-          .stream()
-          .flatMap(deferredToken -> deferredToken.getSetDeferredWords().stream())
-          .collect(Collectors.toSet())
-          .contains(currentImportAlias)
-      ) {
-        // since a child scope will be used, the import alias would not be properly reconstructed
-        throw new DeferredValueException(
-          "Same-named variable as import alias: " + currentImportAlias
-        );
-      }
-      childBindings.putAll(child.getContext().getGlobalMacros());
-      Map<String, Object> mapForCurrentContextAlias = getMapForCurrentContextAlias(
-        currentImportAlias,
-        child
-      );
-      // Remove layers from self down to original import alias to prevent reference loops
-      Arrays
-        .stream(
-          child
-            .getContext()
-            .getImportResourceAlias()
-            .orElse(currentImportAlias)
-            .split("\\.")
-        )
-        .filter(
-          key ->
-            mapForCurrentContextAlias ==
-            (
-              childBindings.get(key) instanceof DeferredValue
-                ? ((DeferredValue) childBindings.get(key)).getOriginalValue()
-                : childBindings.get(key)
-            )
-        )
-        .forEach(childBindings::remove);
-      // Remove meta keys
-      childBindings.remove(Context.GLOBAL_MACROS_SCOPE_KEY);
-      childBindings.remove(Context.IMPORT_RESOURCE_ALIAS_KEY);
-      mapForCurrentContextAlias.putAll(childBindings);
     }
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -98,7 +98,7 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
         return "";
       }
       return EagerReconstructionUtils.wrapInTag(
-        eagerImportingStrategy.getFinalOutput(newPathSetter, output, childBindings),
+        eagerImportingStrategy.getFinalOutput(newPathSetter, output, child),
         DoTag.TAG_NAME,
         interpreter,
         true

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.lib.tag.eager;
 import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.IncludeTag;
+import com.hubspot.jinjava.lib.tag.eager.importing.EagerImportingStrategyFactory;
 import com.hubspot.jinjava.loader.RelativePathResolver;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
@@ -29,7 +30,7 @@ public class EagerIncludeTag extends EagerTagDecorator<IncludeTag> {
         tagNode.getStartPosition()
       );
       templateFile = interpreter.resolveResourceLocation(templateFile);
-      final String initialPathSetter = EagerImportTag.getSetTagForCurrentPath(
+      final String initialPathSetter = EagerImportingStrategyFactory.getSetTagForCurrentPath(
         interpreter
       );
       final String newPathSetter = EagerReconstructionUtils.buildBlockOrInlineSetTag(

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
@@ -150,23 +150,30 @@ public abstract class EagerSetTagStrategy {
     return prefixToPreserveState;
   }
 
-  protected String getSuffixToPreserveState(
+  public static String getSuffixToPreserveState(
     String variables,
     JinjavaInterpreter interpreter
   ) {
+    if (variables.isEmpty()) {
+      return "";
+    }
     StringBuilder suffixToPreserveState = new StringBuilder();
     Optional<String> maybeTemporaryImportAlias = AliasedEagerImportingStrategy.getTemporaryImportAlias(
       interpreter.getContext()
     );
-    if (maybeTemporaryImportAlias.isPresent()) {
+    if (
+      maybeTemporaryImportAlias.isPresent() &&
+      !AliasedEagerImportingStrategy.isTemporaryImportAlias(variables) &&
+      !interpreter.getContext().getMetaContextVariables().contains(variables)
+    ) {
       String updateString = getUpdateString(variables);
+
+      // Don't need to render because the temporary import alias's value is always deferred, and rendering will do nothing
       suffixToPreserveState.append(
-        interpreter.render(
-          EagerReconstructionUtils.buildDoUpdateTag(
-            maybeTemporaryImportAlias.get(),
-            updateString,
-            interpreter
-          )
+        EagerReconstructionUtils.buildDoUpdateTag(
+          maybeTemporaryImportAlias.get(),
+          updateString,
+          interpreter
         )
       );
     }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.lib.tag.eager;
 import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.SetTag;
+import com.hubspot.jinjava.lib.tag.eager.importing.AliasedEagerImportingStrategy;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.PrefixToPreserveState;
@@ -154,30 +155,22 @@ public abstract class EagerSetTagStrategy {
     JinjavaInterpreter interpreter
   ) {
     StringBuilder suffixToPreserveState = new StringBuilder();
-    Optional<String> maybeFullImportAlias = interpreter
-      .getContext()
-      .getImportResourceAlias();
-    if (maybeFullImportAlias.isPresent()) {
-      String currentImportAlias = maybeFullImportAlias
-        .get()
-        .substring(maybeFullImportAlias.get().lastIndexOf(".") + 1);
-      String filteredVariables = Arrays
-        .stream(variables.split(","))
-        .filter(var -> !var.equals(currentImportAlias))
-        .collect(Collectors.joining(","));
-      if (!filteredVariables.isEmpty()) {
-        String updateString = getUpdateString(filteredVariables);
-        suffixToPreserveState.append(
-          interpreter.render(
-            EagerReconstructionUtils.buildDoUpdateTag(
-              currentImportAlias,
-              updateString,
-              interpreter
-            )
+    Optional<String> maybeTemporaryImportAlias = AliasedEagerImportingStrategy.getTemporaryImportAlias(
+      interpreter.getContext()
+    );
+    if (maybeTemporaryImportAlias.isPresent()) {
+      String updateString = getUpdateString(variables);
+      suffixToPreserveState.append(
+        interpreter.render(
+          EagerReconstructionUtils.buildDoUpdateTag(
+            maybeTemporaryImportAlias.get(),
+            updateString,
+            interpreter
           )
-        );
-      }
+        )
+      );
     }
+
     return suffixToPreserveState.toString();
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/AliasedEagerImportingStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/AliasedEagerImportingStrategy.java
@@ -22,12 +22,19 @@ import java.util.StringJoiner;
 import java.util.stream.Stream;
 
 public class AliasedEagerImportingStrategy implements EagerImportingStrategy {
-  private static final String TEMPORARY_IMPORT_ALIAS_FORMAT = "__temp_import_alias_%d__";
+  private static final String TEMPORARY_IMPORT_ALIAS_PREFIX = "__temp_import_alias_";
+  private static final String TEMPORARY_IMPORT_ALIAS_FORMAT =
+    TEMPORARY_IMPORT_ALIAS_PREFIX + "%d__";
 
   public static Optional<String> getTemporaryImportAlias(Context context) {
     return context
       .getImportResourceAlias()
       .map(AliasedEagerImportingStrategy::getTemporaryImportAlias);
+  }
+
+  public static boolean isTemporaryImportAlias(String varName) {
+    // This is just faster than checking a regex
+    return varName.startsWith(TEMPORARY_IMPORT_ALIAS_PREFIX);
   }
 
   private static String getTemporaryImportAlias(String fullAlias) {
@@ -83,10 +90,7 @@ public class AliasedEagerImportingStrategy implements EagerImportingStrategy {
     child.getContext().getScope().put(Context.IMPORT_RESOURCE_ALIAS_KEY, fullImportAlias);
     child.getContext().put(Context.IMPORT_RESOURCE_ALIAS_KEY, fullImportAlias);
     constructFullAliasPathMap(currentImportAlias, child);
-    Map<String, Object> currentContextAliasMap = getMapForCurrentContextAlias(
-      currentImportAlias,
-      child
-    );
+    getMapForCurrentContextAlias(currentImportAlias, child);
     importingData
       .getOriginalInterpreter()
       .getContext()
@@ -133,7 +137,7 @@ public class AliasedEagerImportingStrategy implements EagerImportingStrategy {
       ) +
       wrapInChildScope(
         EagerImportingStrategy.getSetTagForDeferredChildBindings(
-          importingData.getOriginalInterpreter(),
+          child,
           currentImportAlias,
           child.getContext()
         ) +

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/AliasedEagerImportingStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/AliasedEagerImportingStrategy.java
@@ -1,0 +1,279 @@
+package com.hubspot.jinjava.lib.tag.eager.importing;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.hubspot.jinjava.interpret.Context;
+import com.hubspot.jinjava.interpret.DeferredValue;
+import com.hubspot.jinjava.interpret.DeferredValueException;
+import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.lib.fn.MacroFunction;
+import com.hubspot.jinjava.lib.tag.eager.DeferredToken;
+import com.hubspot.jinjava.objects.collections.PyMap;
+import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
+import com.hubspot.jinjava.util.EagerReconstructionUtils;
+import com.hubspot.jinjava.util.PrefixToPreserveState;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class AliasedEagerImportingStrategy implements EagerImportingStrategy {
+  private final ImportingData importingData;
+  private final String currentImportAlias;
+
+  @VisibleForTesting
+  public AliasedEagerImportingStrategy(
+    ImportingData importingData,
+    String currentImportAlias
+  ) {
+    this.importingData = importingData;
+    this.currentImportAlias = currentImportAlias;
+  }
+
+  @Override
+  public String handleDeferredTemplateFile(DeferredValueException e) {
+    return (
+      importingData.getInitialPathSetter() +
+      new PrefixToPreserveState(
+        EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
+          importingData.getOriginalInterpreter(),
+          DeferredToken
+            .builderFromToken(importingData.getTagToken())
+            .addUsedDeferredWords(Stream.of(importingData.getHelpers().get(0)))
+            .addSetDeferredWords(Stream.of(currentImportAlias))
+            .build()
+        )
+      ) +
+      importingData.getTagToken().getImage()
+    );
+  }
+
+  @Override
+  public void setup(JinjavaInterpreter child) {
+    Optional<String> maybeParentImportAlias = importingData
+      .getOriginalInterpreter()
+      .getContext()
+      .getImportResourceAlias();
+    if (maybeParentImportAlias.isPresent()) {
+      child
+        .getContext()
+        .getScope()
+        .put(
+          Context.IMPORT_RESOURCE_ALIAS_KEY,
+          String.format("%s.%s", maybeParentImportAlias.get(), currentImportAlias)
+        );
+    } else {
+      child
+        .getContext()
+        .getScope()
+        .put(Context.IMPORT_RESOURCE_ALIAS_KEY, currentImportAlias);
+    }
+    constructFullAliasPathMap(currentImportAlias, child);
+    getMapForCurrentContextAlias(currentImportAlias, child);
+  }
+
+  @Override
+  public void integrateChild(JinjavaInterpreter child) {
+    JinjavaInterpreter parent = importingData.getOriginalInterpreter();
+    for (MacroFunction macro : child.getContext().getGlobalMacros().values()) {
+      if (parent.getContext().isDeferredExecutionMode()) {
+        macro.setDeferred(true);
+      }
+    }
+    if (
+      child.getContext().isDeferredExecutionMode() &&
+      child
+        .getContext()
+        .getDeferredTokens()
+        .stream()
+        .flatMap(deferredToken -> deferredToken.getSetDeferredWords().stream())
+        .collect(Collectors.toSet())
+        .contains(currentImportAlias)
+    ) {
+      // since a child scope will be used, the import alias would not be properly reconstructed
+      throw new DeferredValueException(
+        "Same-named variable as import alias: " + currentImportAlias
+      );
+    }
+    Map<String, Object> childBindings = child.getContext().getSessionBindings();
+    childBindings.putAll(child.getContext().getGlobalMacros());
+    Map<String, Object> mapForCurrentContextAlias = getMapForCurrentContextAlias(
+      currentImportAlias,
+      child
+    );
+    // Remove layers from self down to original import alias to prevent reference loops
+    Arrays
+      .stream(
+        child
+          .getContext()
+          .getImportResourceAlias()
+          .orElse(currentImportAlias)
+          .split("\\.")
+      )
+      .filter(
+        key ->
+          mapForCurrentContextAlias ==
+          (
+            childBindings.get(key) instanceof DeferredValue
+              ? ((DeferredValue) childBindings.get(key)).getOriginalValue()
+              : childBindings.get(key)
+          )
+      )
+      .forEach(childBindings::remove);
+    // Remove meta keys
+    childBindings.remove(Context.GLOBAL_MACROS_SCOPE_KEY);
+    childBindings.remove(Context.IMPORT_RESOURCE_ALIAS_KEY);
+    mapForCurrentContextAlias.putAll(childBindings);
+  }
+
+  @Override
+  public String getFinalOutput(
+    String newPathSetter,
+    String output,
+    Map<String, Object> childBindings
+  ) {
+    return (
+      newPathSetter +
+      EagerReconstructionUtils.buildBlockOrInlineSetTagAndRegisterDeferredToken(
+        currentImportAlias,
+        Collections.emptyMap(),
+        importingData.getOriginalInterpreter()
+      ) +
+      wrapInChildScope(
+        importingData.getOriginalInterpreter(),
+        EagerImportingStrategy.getSetTagForDeferredChildBindings(
+          importingData.getOriginalInterpreter(),
+          currentImportAlias,
+          childBindings
+        ) +
+        output,
+        currentImportAlias
+      ) +
+      importingData.getInitialPathSetter()
+    );
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void constructFullAliasPathMap(
+    String currentImportAlias,
+    JinjavaInterpreter child
+  ) {
+    String fullImportAlias = child
+      .getContext()
+      .getImportResourceAlias()
+      .orElse(currentImportAlias);
+    String[] allAliases = fullImportAlias.split("\\.");
+    Map<String, Object> currentMap = child.getContext().getParent();
+    for (int i = 0; i < allAliases.length - 1; i++) {
+      Object maybeNextMap = currentMap.get(allAliases[i]);
+      if (maybeNextMap instanceof Map) {
+        currentMap = (Map<String, Object>) maybeNextMap;
+      } else if (
+        maybeNextMap instanceof DeferredValue &&
+        ((DeferredValue) maybeNextMap).getOriginalValue() instanceof Map
+      ) {
+        currentMap =
+          (Map<String, Object>) ((DeferredValue) maybeNextMap).getOriginalValue();
+      } else {
+        throw new InterpretException("Encountered a problem with import alias maps");
+      }
+    }
+    currentMap.put(
+      allAliases[allAliases.length - 1],
+      child.getContext().isDeferredExecutionMode()
+        ? DeferredValue.instance(new PyMap(new HashMap<>()))
+        : new PyMap(new HashMap<>())
+    );
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> getMapForCurrentContextAlias(
+    String currentImportAlias,
+    JinjavaInterpreter child
+  ) {
+    Object parentValueForChild = child
+      .getContext()
+      .getParent()
+      .getSessionBindings()
+      .get(currentImportAlias);
+    if (parentValueForChild instanceof Map) {
+      return (Map<String, Object>) parentValueForChild;
+    } else if (parentValueForChild instanceof DeferredValue) {
+      if (((DeferredValue) parentValueForChild).getOriginalValue() instanceof Map) {
+        return (Map<String, Object>) (
+          (DeferredValue) parentValueForChild
+        ).getOriginalValue();
+      }
+      Map<String, Object> newMap = new PyMap(new HashMap<>());
+      child
+        .getContext()
+        .getParent()
+        .put(currentImportAlias, DeferredValue.instance(newMap));
+      return newMap;
+    } else {
+      Map<String, Object> newMap = new PyMap(new HashMap<>());
+      child
+        .getContext()
+        .getParent()
+        .put(
+          currentImportAlias,
+          child.getContext().isDeferredExecutionMode()
+            ? DeferredValue.instance(newMap)
+            : newMap
+        );
+      return newMap;
+    }
+  }
+
+  private static String wrapInChildScope(
+    JinjavaInterpreter interpreter,
+    String output,
+    String currentImportAlias
+  ) {
+    String combined = output + getDoTagToPreserve(interpreter, currentImportAlias);
+    // So that any set variables other than the alias won't exist outside the child's scope
+    return EagerReconstructionUtils.wrapInChildScope(combined, interpreter);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static String getDoTagToPreserve(
+    JinjavaInterpreter interpreter,
+    String currentImportAlias
+  ) {
+    StringJoiner keyValueJoiner = new StringJoiner(",");
+    Object currentAliasMap = interpreter
+      .getContext()
+      .getSessionBindings()
+      .get(currentImportAlias);
+    for (Map.Entry<String, Object> entry : (
+      (Map<String, Object>) ((DeferredValue) currentAliasMap).getOriginalValue()
+    ).entrySet()) {
+      if (entry.getKey().equals(currentImportAlias)) {
+        continue;
+      }
+      if (entry.getValue() instanceof DeferredValue) {
+        keyValueJoiner.add(String.format("'%s': %s", entry.getKey(), entry.getKey()));
+      } else if (!(entry.getValue() instanceof MacroFunction)) {
+        keyValueJoiner.add(
+          String.format(
+            "'%s': %s",
+            entry.getKey(),
+            PyishObjectMapper.getAsPyishString(entry.getValue())
+          )
+        );
+      }
+    }
+    if (keyValueJoiner.length() > 0) {
+      return EagerReconstructionUtils.buildDoUpdateTag(
+        currentImportAlias,
+        "{" + keyValueJoiner.toString() + "}",
+        interpreter
+      );
+    }
+    return "";
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/AliasedEagerImportingStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/AliasedEagerImportingStrategy.java
@@ -112,7 +112,6 @@ public class AliasedEagerImportingStrategy implements EagerImportingStrategy {
       currentImportAlias,
       child
     );
-    // Remove layers from self down to original import alias to prevent reference loops
     childBindings.remove(temporaryImportAlias);
     importingData.getOriginalInterpreter().getContext().remove(temporaryImportAlias);
     // Remove meta keys

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/EagerImportingStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/EagerImportingStrategy.java
@@ -12,11 +12,7 @@ public interface EagerImportingStrategy {
   void setup(JinjavaInterpreter child);
 
   void integrateChild(JinjavaInterpreter child);
-  String getFinalOutput(
-    String newPathSetter,
-    String output,
-    Map<String, Object> childBindings
-  );
+  String getFinalOutput(String newPathSetter, String output, JinjavaInterpreter child);
 
   static String getSetTagForDeferredChildBindings(
     JinjavaInterpreter interpreter,

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/EagerImportingStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/EagerImportingStrategy.java
@@ -1,0 +1,46 @@
+package com.hubspot.jinjava.lib.tag.eager.importing;
+
+import com.hubspot.jinjava.interpret.DeferredValue;
+import com.hubspot.jinjava.interpret.DeferredValueException;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.util.EagerReconstructionUtils;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public interface EagerImportingStrategy {
+  String handleDeferredTemplateFile(DeferredValueException e);
+  void setup(JinjavaInterpreter child);
+
+  void integrateChild(JinjavaInterpreter child);
+  String getFinalOutput(
+    String newPathSetter,
+    String output,
+    Map<String, Object> childBindings
+  );
+
+  static String getSetTagForDeferredChildBindings(
+    JinjavaInterpreter interpreter,
+    String currentImportAlias,
+    Map<String, Object> childBindings
+  ) {
+    return childBindings
+      .entrySet()
+      .stream()
+      .filter(
+        entry ->
+          entry.getValue() instanceof DeferredValue &&
+          ((DeferredValue) entry.getValue()).getOriginalValue() != null
+      )
+      .filter(entry -> !interpreter.getContext().containsKey(entry.getKey()))
+      .filter(entry -> !entry.getKey().equals(currentImportAlias))
+      .map(
+        entry ->
+          EagerReconstructionUtils.buildBlockOrInlineSetTag( // don't register deferred token so that we don't defer them on higher context scopes; they only exist in the child scope
+            entry.getKey(),
+            ((DeferredValue) entry.getValue()).getOriginalValue(),
+            interpreter
+          )
+      )
+      .collect(Collectors.joining());
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/EagerImportingStrategyFactory.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/EagerImportingStrategyFactory.java
@@ -1,0 +1,46 @@
+package com.hubspot.jinjava.lib.tag.eager.importing;
+
+import com.google.common.base.Strings;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.lib.tag.ImportTag;
+import com.hubspot.jinjava.loader.RelativePathResolver;
+import com.hubspot.jinjava.tree.parse.TagToken;
+import com.hubspot.jinjava.util.EagerReconstructionUtils;
+import java.util.List;
+
+public class EagerImportingStrategyFactory {
+
+  public static ImportingData getImportingData(
+    TagToken tagToken,
+    JinjavaInterpreter interpreter
+  ) {
+    List<String> helpers = ImportTag.getHelpers(tagToken);
+    String initialPathSetter = getSetTagForCurrentPath(interpreter);
+    return new ImportingData(interpreter, tagToken, helpers, initialPathSetter);
+  }
+
+  public static EagerImportingStrategy create(ImportingData importingData) {
+    String currentImportAlias = ImportTag.getContextVar(importingData.getHelpers());
+    if (Strings.isNullOrEmpty(currentImportAlias)) {
+      return new FlatEagerImportingStrategy(importingData);
+    }
+    return new AliasedEagerImportingStrategy(importingData, currentImportAlias);
+  }
+
+  public static String getSetTagForCurrentPath(JinjavaInterpreter interpreter) {
+    return EagerReconstructionUtils.buildBlockOrInlineSetTag(
+      RelativePathResolver.CURRENT_PATH_CONTEXT_KEY,
+      interpreter
+        .getContext()
+        .getCurrentPathStack()
+        .peek()
+        .orElseGet(
+          () ->
+            (String) interpreter
+              .getContext()
+              .getOrDefault(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY, "")
+        ),
+      interpreter
+    );
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/FlatEagerImportingStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/FlatEagerImportingStrategy.java
@@ -67,7 +67,7 @@ public class FlatEagerImportingStrategy implements EagerImportingStrategy {
   public String getFinalOutput(
     String newPathSetter,
     String output,
-    Map<String, Object> childBindings
+    JinjavaInterpreter child
   ) {
     if (importingData.getOriginalInterpreter().getContext().isDeferredExecutionMode()) {
       Set<String> metaContextVariables = importingData
@@ -76,7 +76,9 @@ public class FlatEagerImportingStrategy implements EagerImportingStrategy {
         .getMetaContextVariables();
       // defer imported variables
       EagerReconstructionUtils.buildSetTag(
-        childBindings
+        child
+          .getContext()
+          .getSessionBindings()
           .entrySet()
           .stream()
           .filter(
@@ -94,7 +96,7 @@ public class FlatEagerImportingStrategy implements EagerImportingStrategy {
       EagerImportingStrategy.getSetTagForDeferredChildBindings(
         importingData.getOriginalInterpreter(),
         null,
-        childBindings
+        child.getContext().getSessionBindings()
       ) +
       output +
       importingData.getInitialPathSetter()

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/FlatEagerImportingStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/FlatEagerImportingStrategy.java
@@ -1,0 +1,103 @@
+package com.hubspot.jinjava.lib.tag.eager.importing;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.hubspot.jinjava.interpret.Context;
+import com.hubspot.jinjava.interpret.DeferredValue;
+import com.hubspot.jinjava.interpret.DeferredValueException;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.lib.fn.MacroFunction;
+import com.hubspot.jinjava.lib.tag.ImportTag;
+import com.hubspot.jinjava.util.EagerReconstructionUtils;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class FlatEagerImportingStrategy implements EagerImportingStrategy {
+  private final ImportingData importingData;
+
+  @VisibleForTesting
+  public FlatEagerImportingStrategy(ImportingData importingData) {
+    this.importingData = importingData;
+  }
+
+  @Override
+  public String handleDeferredTemplateFile(DeferredValueException e) {
+    throw e;
+  }
+
+  @Override
+  public void setup(JinjavaInterpreter child) {
+    // Do nothing
+  }
+
+  @Override
+  public void integrateChild(JinjavaInterpreter child) {
+    JinjavaInterpreter parent = importingData.getOriginalInterpreter();
+    for (MacroFunction macro : child.getContext().getGlobalMacros().values()) {
+      if (parent.getContext().isDeferredExecutionMode()) {
+        macro.setDeferred(true);
+      }
+    }
+    for (MacroFunction macro : child.getContext().getGlobalMacros().values()) {
+      parent.getContext().addGlobalMacro(macro);
+    }
+    Map<String, Object> childBindings = child.getContext().getSessionBindings();
+
+    childBindings.remove(Context.GLOBAL_MACROS_SCOPE_KEY);
+    childBindings.remove(Context.IMPORT_RESOURCE_ALIAS_KEY);
+    Map<String, Object> childBindingsWithoutImportResourcePath = ImportTag.getChildBindingsWithoutImportResourcePath(
+      childBindings
+    );
+    if (parent.getContext().isDeferredExecutionMode()) {
+      childBindingsWithoutImportResourcePath
+        .keySet()
+        .forEach(
+          key ->
+            parent
+              .getContext()
+              .put(key, DeferredValue.instance(parent.getContext().get(key)))
+        );
+    } else {
+      parent.getContext().putAll(childBindingsWithoutImportResourcePath);
+    }
+  }
+
+  @Override
+  public String getFinalOutput(
+    String newPathSetter,
+    String output,
+    Map<String, Object> childBindings
+  ) {
+    if (importingData.getOriginalInterpreter().getContext().isDeferredExecutionMode()) {
+      Set<String> metaContextVariables = importingData
+        .getOriginalInterpreter()
+        .getContext()
+        .getMetaContextVariables();
+      // defer imported variables
+      EagerReconstructionUtils.buildSetTag(
+        childBindings
+          .entrySet()
+          .stream()
+          .filter(
+            entry ->
+              !(entry.getValue() instanceof DeferredValue) && entry.getValue() != null
+          )
+          .filter(entry -> !metaContextVariables.contains(entry.getKey()))
+          .collect(Collectors.toMap(Entry::getKey, entry -> "")),
+        importingData.getOriginalInterpreter(),
+        true
+      );
+    }
+    return (
+      newPathSetter +
+      EagerImportingStrategy.getSetTagForDeferredChildBindings(
+        importingData.getOriginalInterpreter(),
+        null,
+        childBindings
+      ) +
+      output +
+      importingData.getInitialPathSetter()
+    );
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/ImportingData.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/ImportingData.java
@@ -1,0 +1,40 @@
+package com.hubspot.jinjava.lib.tag.eager.importing;
+
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.tree.parse.TagToken;
+import java.util.List;
+
+public class ImportingData {
+  private final JinjavaInterpreter originalInterpreter;
+  private final TagToken tagToken;
+  private final List<String> helpers;
+  private final String initialPathSetter;
+
+  public ImportingData(
+    JinjavaInterpreter originalInterpreter,
+    TagToken tagToken,
+    List<String> helpers,
+    String initialPathSetter
+  ) {
+    this.originalInterpreter = originalInterpreter;
+    this.tagToken = tagToken;
+    this.helpers = helpers;
+    this.initialPathSetter = initialPathSetter;
+  }
+
+  public JinjavaInterpreter getOriginalInterpreter() {
+    return originalInterpreter;
+  }
+
+  public TagToken getTagToken() {
+    return tagToken;
+  }
+
+  public List<String> getHelpers() {
+    return helpers;
+  }
+
+  public String getInitialPathSetter() {
+    return initialPathSetter;
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -551,6 +551,9 @@ public class EagerTest {
     expectedTemplateInterpreter.assertExpectedOutput(
       "sets-multiple-vars-deferred-in-child.expected"
     );
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
+      "sets-multiple-vars-deferred-in-child.expected"
+    );
   }
 
   @Test
@@ -657,6 +660,8 @@ public class EagerTest {
 
   @Test
   public void itEagerlyDefersMacroSecondPass() {
+    localContext.put("foo", "I am foo");
+    localContext.put("bar", "I am bar");
     localContext.put("deferred", true);
     expectedTemplateInterpreter.assertExpectedOutput("eagerly-defers-macro.expected");
     expectedTemplateInterpreter.assertExpectedNonEagerOutput(
@@ -801,6 +806,9 @@ public class EagerTest {
     expectedTemplateInterpreter.assertExpectedOutput(
       "handles-deferred-import-vars.expected"
     );
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
+      "handles-deferred-import-vars.expected"
+    );
   }
 
   @Test
@@ -820,6 +828,9 @@ public class EagerTest {
   public void itHandlesDeferredFromImportAsSecondPass() {
     localContext.put("deferred", 1);
     expectedTemplateInterpreter.assertExpectedOutput(
+      "handles-deferred-from-import-as.expected"
+    );
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
       "handles-deferred-from-import-as.expected"
     );
   }
@@ -889,6 +900,9 @@ public class EagerTest {
     expectedTemplateInterpreter.assertExpectedOutput(
       "handles-deferred-in-namespace.expected"
     );
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
+      "handles-deferred-in-namespace.expected"
+    );
   }
 
   @Test
@@ -916,6 +930,9 @@ public class EagerTest {
   public void itHandlesBlockSetInDeferredIfSecondPass() {
     localContext.put("deferred", 1);
     expectedTemplateInterpreter.assertExpectedOutput(
+      "handles-block-set-in-deferred-if.expected"
+    );
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
       "handles-block-set-in-deferred-if.expected"
     );
   }
@@ -1001,6 +1018,9 @@ public class EagerTest {
   @Test
   public void itHandlesDoubleImportModificationSecondPass() {
     interpreter.getContext().put("deferred", false);
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "handles-double-import-modification.expected"
+    );
     expectedTemplateInterpreter.assertExpectedNonEagerOutput(
       "handles-double-import-modification.expected"
     );
@@ -1016,6 +1036,9 @@ public class EagerTest {
   @Test
   public void itHandlesSameNameImportVarSecondPass() {
     interpreter.getContext().put("deferred", "resolved");
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "handles-same-name-import-var.expected"
+    );
     expectedTemplateInterpreter.assertExpectedNonEagerOutput(
       "handles-same-name-import-var.expected"
     );
@@ -1069,6 +1092,9 @@ public class EagerTest {
     expectedTemplateInterpreter.assertExpectedOutput(
       "fully-defers-filtered-macro.expected"
     );
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
+      "fully-defers-filtered-macro.expected"
+    );
   }
 
   @Test
@@ -1103,6 +1129,7 @@ public class EagerTest {
   @Test
   public void itReconstructsMapNodeSecondPass() {
     interpreter.getContext().put("deferred", "resolved");
+    expectedTemplateInterpreter.assertExpectedOutput("reconstructs-map-node.expected");
     expectedTemplateInterpreter.assertExpectedNonEagerOutput(
       "reconstructs-map-node.expected"
     );
@@ -1123,6 +1150,9 @@ public class EagerTest {
   @Test
   public void itDefersCallTagWithDeferredArgumentSecondPass() {
     interpreter.getContext().put("deferred", "resolved");
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "defers-call-tag-with-deferred-argument.expected"
+    );
     expectedTemplateInterpreter.assertExpectedNonEagerOutput(
       "defers-call-tag-with-deferred-argument.expected"
     );
@@ -1145,6 +1175,9 @@ public class EagerTest {
   @Test
   public void itHandlesHigherScopeReferenceModificationSecondPass() {
     interpreter.getContext().put("deferred", "b");
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "handles-higher-scope-reference-modification.expected"
+    );
     expectedTemplateInterpreter.assertExpectedNonEagerOutput(
       "handles-higher-scope-reference-modification.expected"
     );
@@ -1181,6 +1214,9 @@ public class EagerTest {
   @Test
   public void itDoesNotOverrideImportModificationInForSecondPass() {
     interpreter.getContext().put("deferred", "resolved");
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "does-not-override-import-modification-in-for.expected"
+    );
     expectedTemplateInterpreter.assertExpectedNonEagerOutput(
       "does-not-override-import-modification-in-for.expected"
     );
@@ -1196,6 +1232,9 @@ public class EagerTest {
   @Test
   public void itHandlesDeferredForLoopVarFromMacroSecondPass() {
     interpreter.getContext().put("deferred", "resolved");
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "handles-deferred-for-loop-var-from-macro.expected"
+    );
     expectedTemplateInterpreter.assertExpectedNonEagerOutput(
       "handles-deferred-for-loop-var-from-macro.expected"
     );
@@ -1225,6 +1264,9 @@ public class EagerTest {
   @Test
   public void itReconstructsNamespaceForSetTagsUsingPeriodSecondPass() {
     interpreter.getContext().put("deferred", "resolved");
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "reconstructs-namespace-for-set-tags-using-period.expected"
+    );
     expectedTemplateInterpreter.assertExpectedNonEagerOutput(
       "reconstructs-namespace-for-set-tags-using-period.expected"
     );
@@ -1241,6 +1283,9 @@ public class EagerTest {
   public void itUsesUniqueMacroNamesSecondPass() {
     interpreter.getContext().put("deferred", "resolved");
     expectedTemplateInterpreter.assertExpectedOutput("uses-unique-macro-names.expected");
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
+      "uses-unique-macro-names.expected"
+    );
   }
 
   @Test
@@ -1298,6 +1343,9 @@ public class EagerTest {
     expectedTemplateInterpreter.assertExpectedOutput(
       "keeps-macro-modifications-in-scope.expected"
     );
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
+      "keeps-macro-modifications-in-scope.expected"
+    );
   }
 
   @Test
@@ -1310,6 +1358,9 @@ public class EagerTest {
   @Test
   public void itDoesNotReconstructVariableInWrongScopeSecondPass() {
     interpreter.getContext().put("deferred", true);
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "does-not-reconstruct-variable-in-wrong-scope.expected"
+    );
     expectedTemplateInterpreter.assertExpectedNonEagerOutput(
       "does-not-reconstruct-variable-in-wrong-scope.expected"
     );
@@ -1356,6 +1407,9 @@ public class EagerTest {
     expectedTemplateInterpreter.assertExpectedOutput(
       "reconstructs-value-used-in-deferred-imported-macro.expected"
     );
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
+      "reconstructs-value-used-in-deferred-imported-macro.expected"
+    );
   }
 
   @Test
@@ -1369,6 +1423,9 @@ public class EagerTest {
   public void itAllowsDeferredLazyReferenceToGetOverriddenSecondPass() {
     interpreter.getContext().put("deferred", "resolved");
     expectedTemplateInterpreter.assertExpectedOutput(
+      "allows-deferred-lazy-reference-to-get-overridden.expected"
+    );
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
       "allows-deferred-lazy-reference-to-get-overridden.expected"
     );
   }
@@ -1411,6 +1468,9 @@ public class EagerTest {
     expectedTemplateInterpreter.assertExpectedOutput(
       "reconstructs-nested-value-in-string-representation.expected"
     );
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
+      "reconstructs-nested-value-in-string-representation.expected"
+    );
   }
 
   @Test
@@ -1425,6 +1485,9 @@ public class EagerTest {
   public void itDefersLoopSettingMetaContextVarSecondPass() {
     interpreter.getContext().put("deferred", "resolved");
     interpreter.getContext().getMetaContextVariables().add("content");
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "defers-loop-setting-meta-context-var.expected"
+    );
     expectedTemplateInterpreter.assertExpectedNonEagerOutput(
       "defers-loop-setting-meta-context-var.expected"
     );

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1008,13 +1008,17 @@ public class EagerTest {
 
   @Test
   public void itHandlesSameNameImportVar() {
-    String template = expectedTemplateInterpreter.getFixtureTemplate(
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
       "handles-same-name-import-var"
     );
-    JinjavaInterpreter.getCurrent().render(template);
-    // No longer allows importing a file that uses the same alias as a variable declared in the import file
-    assertThat(JinjavaInterpreter.getCurrent().getContext().getDeferredNodes())
-      .isNotEmpty();
+  }
+
+  @Test
+  public void itHandlesSameNameImportVarSecondPass() {
+    interpreter.getContext().put("deferred", "resolved");
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
+      "handles-same-name-import-var.expected"
+    );
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1428,7 +1428,7 @@ public class EagerTest {
 
   @Test
   public void itAllowsVariableSharingAliasName() {
-    expectedTemplateInterpreter.assertExpectedOutput(
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
       "allows-variable-sharing-alias-name"
     );
   }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1425,4 +1425,11 @@ public class EagerTest {
       "defers-loop-setting-meta-context-var.expected"
     );
   }
+
+  @Test
+  public void itAllowsVariableSharingAliasName() {
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "allows-variable-sharing-alias-name"
+    );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerExtendsTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerExtendsTagTest.java
@@ -54,6 +54,9 @@ public class EagerExtendsTagTest extends ExtendsTagTest {
     expectedTemplateInterpreter.assertExpectedOutput(
       "defers-block-in-extends-child.expected"
     );
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
+      "defers-block-in-extends-child.expected"
+    );
   }
 
   @Test
@@ -65,6 +68,9 @@ public class EagerExtendsTagTest extends ExtendsTagTest {
   public void itDefersSuperBlockWithDeferredSecondPass() {
     context.put("deferred", "Resolved now");
     expectedTemplateInterpreter.assertExpectedOutput(
+      "defers-super-block-with-deferred.expected"
+    );
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
       "defers-super-block-with-deferred.expected"
     );
   }
@@ -81,6 +87,9 @@ public class EagerExtendsTagTest extends ExtendsTagTest {
     context.put("deferred", "Resolved now");
 
     expectedTemplateInterpreter.assertExpectedOutput(
+      "reconstructs-deferred-outside-block.expected"
+    );
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
       "reconstructs-deferred-outside-block.expected"
     );
   }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -426,11 +426,11 @@ public class EagerImportTagTest extends ImportTagTest {
     );
     assertThat(result)
       .isEqualTo(
-        "{% if deferred %}{% do %}{% set current_path = 'import-tree-b.jinja' %}{% set b = {}  %}{% for __ignored__ in [0] %}{% set a = {'foo_a': 'a', 'import_resource_path': 'import-tree-a.jinja', 'something': 'somn'}  %}{% do %}{% set current_path = 'import-tree-a.jinja' %}{% set a = {}  %}{% for __ignored__ in [0] %}{% set something = 'somn' %}{% do a.update({'something': something}) %}\n" +
-        "{% set foo_a = 'a' %}{% do a.update({'foo_a': foo_a}) %}\n" +
-        "{% do a.update({'foo_a': 'a','import_resource_path': 'import-tree-a.jinja','something': 'somn'}) %}{% endfor %}{% set current_path = 'import-tree-b.jinja' %}{% enddo %}\n" +
-        "{% set foo_b = 'b' + a.foo_a %}{% do b.update({'foo_b': foo_b}) %}\n" +
-        "{% do b.update({'a': a,'foo_b': foo_b,'import_resource_path': 'import-tree-b.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}{% endif %}"
+        "{% if deferred %}{% do %}{% set current_path = 'import-tree-b.jinja' %}{% set __temp_import_alias_98__ = {}  %}{% for __ignored__ in [0] %}{% set a = {'foo_a': 'a', 'import_resource_path': 'import-tree-a.jinja', 'something': 'somn'}  %}{% do %}{% set current_path = 'import-tree-a.jinja' %}{% set __temp_import_alias_95701__ = {}  %}{% for __ignored__ in [0] %}{% set something = 'somn' %}{% do __temp_import_alias_95701__.update({'something': something}) %}\n" +
+        "{% set foo_a = 'a' %}{% do __temp_import_alias_95701__.update({'foo_a': foo_a}) %}\n" +
+        "{% do __temp_import_alias_95701__.update({'foo_a': 'a','import_resource_path': 'import-tree-a.jinja','something': 'somn'}) %}{% endfor %}{% set a = __temp_import_alias_95701__ %}{% set current_path = 'import-tree-b.jinja' %}{% enddo %}\n" +
+        "{% set foo_b = 'b' + a.foo_a %}{% do __temp_import_alias_98__.update({'foo_b': foo_b}) %}\n" +
+        "{% do __temp_import_alias_98__.update({'a': a,'foo_b': foo_b,'import_resource_path': 'import-tree-b.jinja'}) %}{% endfor %}{% set b = __temp_import_alias_98__ %}{% set current_path = '' %}{% enddo %}{% endif %}"
       );
 
     removeDeferredContextKeys();
@@ -671,8 +671,8 @@ public class EagerImportTagTest extends ImportTagTest {
       .isEqualTo(
         "a" +
         "{% set vars = {'foo': 'a', 'import_resource_path': 'var-a.jinja'}  %}{% if deferred %}" +
-        "{% do %}{% set current_path = 'var-b.jinja' %}{% set vars = {}  %}{% for __ignored__ in [0] %}{% set foo = 'b' %}{% do vars.update({'foo': foo}) %}\n" +
-        "{% do vars.update({'foo': 'b','import_resource_path': 'var-b.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}" +
+        "{% do %}{% set current_path = 'var-b.jinja' %}{% set __temp_import_alias_3612204__ = {}  %}{% for __ignored__ in [0] %}{% set foo = 'b' %}{% do __temp_import_alias_3612204__.update({'foo': foo}) %}\n" +
+        "{% do __temp_import_alias_3612204__.update({'foo': 'b','import_resource_path': 'var-b.jinja'}) %}{% endfor %}{% set vars = __temp_import_alias_3612204__ %}{% set current_path = '' %}{% enddo %}" +
         "{% endif %}" +
         "{{ vars.foo }}"
       );

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -397,7 +397,7 @@ public class EagerImportTagTest extends ImportTagTest {
     );
     assertThat(result)
       .isEqualTo(
-        "{% if deferred %}{% do %}{% set current_path = 'import-tree-b.jinja' %}{% set __temp_import_alias_98__ = {}  %}{% for __ignored__ in [0] %}{% set a = {'foo_a': 'a', 'import_resource_path': 'import-tree-a.jinja', 'something': 'somn'}  %}{% do %}{% set current_path = 'import-tree-a.jinja' %}{% set __temp_import_alias_95701__ = {}  %}{% for __ignored__ in [0] %}{% set something = 'somn' %}{% do __temp_import_alias_95701__.update({'something': something}) %}\n" +
+        "{% if deferred %}{% do %}{% set current_path = 'import-tree-b.jinja' %}{% set __temp_import_alias_98__ = {}  %}{% for __ignored__ in [0] %}{% do %}{% set current_path = 'import-tree-a.jinja' %}{% set __temp_import_alias_95701__ = {}  %}{% for __ignored__ in [0] %}{% set something = 'somn' %}{% do __temp_import_alias_95701__.update({'something': something}) %}\n" +
         "{% set foo_a = 'a' %}{% do __temp_import_alias_95701__.update({'foo_a': foo_a}) %}\n" +
         "{% do __temp_import_alias_95701__.update({'foo_a': 'a','import_resource_path': 'import-tree-a.jinja','something': 'somn'}) %}{% endfor %}{% set a = __temp_import_alias_95701__ %}{% set current_path = 'import-tree-b.jinja' %}{% enddo %}\n" +
         "{% set foo_b = 'b' + a.foo_a %}{% do __temp_import_alias_98__.update({'foo_b': foo_b}) %}\n" +

--- a/src/test/resources/eager/allows-variable-sharing-alias-name.expected.jinja
+++ b/src/test/resources/eager/allows-variable-sharing-alias-name.expected.jinja
@@ -1,4 +1,7 @@
-{% import 'filters.jinja' as filters %}
+{% do %}{% set current_path = 'filters.jinja' %}{% set __temp_import_alias_854547461__ = {}  %}{% for __ignored__ in [0] %}
+{% set bar = deferred %}{% do __temp_import_alias_854547461__.update({'bar': bar}) %}
+
+{% set filters = {}  %}{% do filters.update(deferred) %}
+{% do __temp_import_alias_854547461__.update({'bar': bar,'import_resource_path': 'filters.jinja','filters': filters,'foo': 123}) %}{% endfor %}{% set filters = __temp_import_alias_854547461__ %}{% set current_path = '' %}{% enddo %}
 
 {{ filters }}
-

--- a/src/test/resources/eager/allows-variable-sharing-alias-name.expected.jinja
+++ b/src/test/resources/eager/allows-variable-sharing-alias-name.expected.jinja
@@ -1,7 +1,7 @@
 {% do %}{% set current_path = 'filters.jinja' %}{% set __temp_import_alias_854547461__ = {}  %}{% for __ignored__ in [0] %}
 {% set bar = deferred %}{% do __temp_import_alias_854547461__.update({'bar': bar}) %}
 
-{% set filters = {}  %}{% do filters.update(deferred) %}
+{% set filters = {}  %}{% do __temp_import_alias_854547461__.update({'filters': filters}) %}{% do filters.update(deferred) %}
 {% do __temp_import_alias_854547461__.update({'bar': bar,'import_resource_path': 'filters.jinja','filters': filters,'foo': 123}) %}{% endfor %}{% set filters = __temp_import_alias_854547461__ %}{% set current_path = '' %}{% enddo %}
 
 {{ filters }}

--- a/src/test/resources/eager/allows-variable-sharing-alias-name.expected.jinja
+++ b/src/test/resources/eager/allows-variable-sharing-alias-name.expected.jinja
@@ -1,0 +1,4 @@
+{% import 'filters.jinja' as filters %}
+
+{{ filters }}
+

--- a/src/test/resources/eager/allows-variable-sharing-alias-name.jinja
+++ b/src/test/resources/eager/allows-variable-sharing-alias-name.jinja
@@ -1,0 +1,3 @@
+{% import 'filters.jinja' as filters %}
+
+{{ filters }}

--- a/src/test/resources/eager/does-not-override-import-modification-in-for.expected.jinja
+++ b/src/test/resources/eager/does-not-override-import-modification-in-for.expected.jinja
@@ -1,40 +1,40 @@
 {% set foo = 'start' %}{% for __ignored__ in [0] %}
-{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set bar1 = {}  %}{% for __ignored__ in [0] %}{% if deferred %}
+{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set __temp_import_alias_3016318__ = {}  %}{% for __ignored__ in [0] %}{% if deferred %}
 
-{% set foo = 'starta' %}{% do bar1.update({'foo': foo}) %}
+{% set foo = 'starta' %}{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
 
 {% endif %}
 
-{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar1.update({'foo': foo}) %}
-{% do bar1.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
+{% do __temp_import_alias_3016318__.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set bar1 = __temp_import_alias_3016318__ %}{% set current_path = '' %}{% enddo %}
 {{ bar1.foo }}
-{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set bar2 = {}  %}{% for __ignored__ in [0] %}{% if deferred %}
+{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set __temp_import_alias_3016319__ = {}  %}{% for __ignored__ in [0] %}{% if deferred %}
 
-{% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}{% do bar2.update({'foo': foo}) %}
+{% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
 
 {% endif %}
 
-{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar2.update({'foo': foo}) %}
-{% do bar2.update({'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
+{% do __temp_import_alias_3016319__.update({'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set bar2 = __temp_import_alias_3016319__ %}{% set current_path = '' %}{% enddo %}
 {{ bar2.foo }}
 
-{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set bar1 = {}  %}{% for __ignored__ in [0] %}{% if deferred %}
+{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set __temp_import_alias_3016318__ = {}  %}{% for __ignored__ in [0] %}{% if deferred %}
 
-{% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}{% do bar1.update({'foo': foo}) %}
+{% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
 
 {% endif %}
 
-{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar1.update({'foo': foo}) %}
-{% do bar1.update({'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
+{% do __temp_import_alias_3016318__.update({'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set bar1 = __temp_import_alias_3016318__ %}{% set current_path = '' %}{% enddo %}
 {{ bar1.foo }}
-{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set bar2 = {}  %}{% for __ignored__ in [0] %}{% if deferred %}
+{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set __temp_import_alias_3016319__ = {}  %}{% for __ignored__ in [0] %}{% if deferred %}
 
-{% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}{% do bar2.update({'foo': foo}) %}
+{% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
 
 {% endif %}
 
-{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar2.update({'foo': foo}) %}
-{% do bar2.update({'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
+{% do __temp_import_alias_3016319__.update({'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set bar2 = __temp_import_alias_3016319__ %}{% set current_path = '' %}{% enddo %}
 {{ bar2.foo }}
 {% endfor %}
 {{ foo }}

--- a/src/test/resources/eager/handles-cycle-in-deferred-for.jinja
+++ b/src/test/resources/eager/handles-cycle-in-deferred-for.jinja
@@ -1,5 +1,8 @@
 {% set foo = ['1','2','3'] %}
+{% set one = '1' %}
+{% set two = '2' %}
+{% set three = '3' %}
 {%- for item in deferred %}
 {% cycle foo %}
-{% cycle foo[0],foo[1],foo[2] %}
+{% cycle one,two,three %}
 {%- endfor -%}

--- a/src/test/resources/eager/handles-deferred-import-vars.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-import-vars.expected.jinja
@@ -4,8 +4,8 @@ Hello {{ myname }}
 {% enddo %}foo: Hello {{ myname }}
 bar: {{ bar }}
 ---
-{% set myname = deferred + 7 %}{% do %}{% set current_path = 'macro-and-set.jinja' %}{% set simple = {}  %}{% for __ignored__ in [0] %}
-{% set bar = myname + 19 %}{% do simple.update({'bar': bar}) %}
+{% set myname = deferred + 7 %}{% do %}{% set current_path = 'macro-and-set.jinja' %}{% set __temp_import_alias_902286926__ = {}  %}{% for __ignored__ in [0] %}
+{% set bar = myname + 19 %}{% do __temp_import_alias_902286926__.update({'bar': bar}) %}
 Hello {{ myname }}
-{% do simple.update({'import_resource_path': 'macro-and-set.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}simple.foo: {% set deferred_import_resource_path = 'macro-and-set.jinja' %}{% macro simple.foo() %}Hello {{ myname }}{% endmacro %}{% set deferred_import_resource_path = null %}{{ simple.foo() }}
+{% do __temp_import_alias_902286926__.update({'import_resource_path': 'macro-and-set.jinja'}) %}{% endfor %}{% set simple = __temp_import_alias_902286926__ %}{% set current_path = '' %}{% enddo %}simple.foo: {% set deferred_import_resource_path = 'macro-and-set.jinja' %}{% macro simple.foo() %}Hello {{ myname }}{% endmacro %}{% set deferred_import_resource_path = null %}{{ simple.foo() }}
 simple.bar: {{ simple.bar }}

--- a/src/test/resources/eager/handles-double-import-modification.expected.jinja
+++ b/src/test/resources/eager/handles-double-import-modification.expected.jinja
@@ -1,20 +1,20 @@
-{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set bar1 = {}  %}{% for __ignored__ in [0] %}{% if deferred %}
+{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set __temp_import_alias_3016318__ = {}  %}{% for __ignored__ in [0] %}{% if deferred %}
 
-{% set foo = 'a' %}{% do bar1.update({'foo': foo}) %}
+{% set foo = 'a' %}{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
 
 {% endif %}
 
-{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar1.update({'foo': foo}) %}
-{% do bar1.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
+{% do __temp_import_alias_3016318__.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set bar1 = __temp_import_alias_3016318__ %}{% set current_path = '' %}{% enddo %}
 ---
-{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set bar2 = {}  %}{% for __ignored__ in [0] %}{% if deferred %}
+{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set __temp_import_alias_3016319__ = {}  %}{% for __ignored__ in [0] %}{% if deferred %}
 
-{% set foo = 'a' %}{% do bar2.update({'foo': foo}) %}
+{% set foo = 'a' %}{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
 
 {% endif %}
 
-{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do bar2.update({'foo': foo}) %}
-{% do bar2.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
+{% do __temp_import_alias_3016319__.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set bar2 = __temp_import_alias_3016319__ %}{% set current_path = '' %}{% enddo %}
 ---
 {{ bar1.foo }}
 {{ bar2.foo }}

--- a/src/test/resources/eager/handles-import-in-deferred-if.expected.jinja
+++ b/src/test/resources/eager/handles-import-in-deferred-if.expected.jinja
@@ -1,5 +1,5 @@
 {% set primary_line_height = 100 %}{% if deferred %}
-{% do %}{% set current_path = '../settag/set-val.jinja' %}{% set simple = {}  %}{% for __ignored__ in [0] %}{% set primary_line_height = 42 %}{% do simple.update({'primary_line_height': primary_line_height}) %}{% do simple.update({'primary_line_height': 42,'import_resource_path': '../settag/set-val.jinja'}) %}{% endfor %}{% set current_path = '' %}{% enddo %}
+{% do %}{% set current_path = '../settag/set-val.jinja' %}{% set __temp_import_alias_902286926__ = {}  %}{% for __ignored__ in [0] %}{% set primary_line_height = 42 %}{% do __temp_import_alias_902286926__.update({'primary_line_height': primary_line_height}) %}{% do __temp_import_alias_902286926__.update({'primary_line_height': 42,'import_resource_path': '../settag/set-val.jinja'}) %}{% endfor %}{% set simple = __temp_import_alias_902286926__ %}{% set current_path = '' %}{% enddo %}
 {% else %}
 {% do %}{% set current_path = '../settag/set-val.jinja' %}{% set primary_line_height = 42 %}{% set current_path = '' %}{% enddo %}
 {% endif %}

--- a/src/test/resources/eager/handles-same-name-import-var.expected.expected.jinja
+++ b/src/test/resources/eager/handles-same-name-import-var.expected.expected.jinja
@@ -1,0 +1,1 @@
+[fn:map_entry('import_resource_path', '../settag/set-var-and-deferred.jinja'), fn:map_entry('my_var', {'my_var': {'foo': 'bar'} , 'value': 'resolved', 'import_resource_path': '../settag/set-var-and-deferred.jinja'} ), fn:map_entry('path', ''), fn:map_entry('value', 'resolved')]

--- a/src/test/resources/eager/handles-same-name-import-var.expected.jinja
+++ b/src/test/resources/eager/handles-same-name-import-var.expected.jinja
@@ -1,0 +1,10 @@
+{% if deferred %}
+{% do %}{% set current_path = '../settag/set-var-and-deferred.jinja' %}{% set __temp_import_alias_1059697132__ = {}  %}{% for __ignored__ in [0] %}{% if deferred %}
+{% do %}{% set path = '' %}{% do __temp_import_alias_1059697132__.update({'path': path}) %}{% set my_var = {'my_var': {'foo': 'bar'} }  %}{% do __temp_import_alias_1059697132__.update({'my_var': my_var}) %}{% set path = '../settag/set-var-and-deferred.jinja' %}{% do __temp_import_alias_1059697132__.update({'path': path}) %}{% set value = null %}{% do __temp_import_alias_1059697132__.update({'value': value}) %}{% set my_var = {}  %}{% do __temp_import_alias_1059697132__.update({'my_var': my_var}) %}{% set my_var = {'foo': 'bar'}  %}{% do __temp_import_alias_1059697132__.update({'my_var': my_var}) %}{% set my_var = {'my_var': {'foo': 'bar'} }  %}{% do __temp_import_alias_1059697132__.update({'my_var': my_var}) %}
+{% set value = deferred %}{% do __temp_import_alias_1059697132__.update({'value': value}) %}{% set my_var = {'my_var': {'foo': 'bar'} }  %}{% do __temp_import_alias_1059697132__.update({'my_var': my_var}) %}{% do my_var.update({'value': value}) %}
+{% do my_var.update({'import_resource_path': '../settag/set-var-and-deferred.jinja', 'value': value}) %}{% set path = '' %}{% do __temp_import_alias_1059697132__.update({'path': path}) %}{% enddo %}
+{{ my_var }}
+{% endif %}
+{% do __temp_import_alias_1059697132__.update({'path': path,'import_resource_path': '../settag/set-var-and-deferred.jinja','value': value}) %}{% endfor %}{% set my_var = __temp_import_alias_1059697132__ %}{% set current_path = '' %}{% enddo %}
+{{ filter:dictsort.filter(my_var, ____int3rpr3t3r____, false, 'key') }}
+{% endif %}

--- a/src/test/resources/eager/handles-same-name-import-var.jinja
+++ b/src/test/resources/eager/handles-same-name-import-var.jinja
@@ -1,4 +1,4 @@
 {% if deferred %}
 {% import '../settag/set-var-and-deferred.jinja' as my_var %}
-{{ my_var }}
+{{ my_var|dictsort(false, 'key') }}
 {% endif %}

--- a/src/test/resources/eager/reconstructs-map-node.expected.expected.jinja
+++ b/src/test/resources/eager/reconstructs-map-node.expected.expected.jinja
@@ -1,5 +1,3 @@
-First key is foo.
-
 foo ff
 bar bb
 ['resolved', 'resolved']

--- a/src/test/resources/eager/reconstructs-map-node.expected.jinja
+++ b/src/test/resources/eager/reconstructs-map-node.expected.jinja
@@ -1,10 +1,8 @@
 {% if deferred %}
 {% set foo = [fn:map_entry('foo', 'ff'), fn:map_entry('bar', 'bb')] %}
 {% endif %}
-First key is {{ foo[0].key }}.
-{% set my_list = [] %}{% for __ignored__ in [0] %}{% do my_list.append(deferred) %}
-foo ff{% do my_list.append(deferred) %}
-bar bb{% endfor %}
+{% set my_list = [] %}{% for key, val in foo %}{% do my_list.append(deferred) %}
+{{ key ~ ' ' ~ val }}{% endfor %}
 {{ my_list }}
 
 {% set my_list = [] %}{% for __ignored__ in [0] %}{% do my_list.append(deferred) %}

--- a/src/test/resources/eager/reconstructs-map-node.jinja
+++ b/src/test/resources/eager/reconstructs-map-node.jinja
@@ -2,8 +2,7 @@
 {% if deferred %}
 {% set foo = {'foo': 'ff', 'bar': 'bb'}.items() %}
 {% endif %}
-First key is {{ foo[0].key }}.
-{% for key, val in {'foo': 'ff', 'bar': 'bb'}.items() -%}
+{% for key, val in foo -%}
 {% do my_list.append(deferred) %}
 {{ key ~ ' ' ~ val }}
 {%- endfor %}

--- a/src/test/resources/eager/reconstructs-value-used-in-deferred-imported-macro.expected.jinja
+++ b/src/test/resources/eager/reconstructs-value-used-in-deferred-imported-macro.expected.jinja
@@ -1,6 +1,6 @@
-{% do %}{% set current_path = 'uses-deferred-value-in-macro.jinja' %}{% set macros = {}  %}{% for __ignored__ in [0] %}{% set value = deferred %}{% do macros.update({'value': value}) %}
+{% do %}{% set current_path = 'uses-deferred-value-in-macro.jinja' %}{% set __temp_import_alias_1081745881__ = {}  %}{% for __ignored__ in [0] %}{% set value = deferred %}{% do __temp_import_alias_1081745881__.update({'value': value}) %}
 
-{% do macros.update({'import_resource_path': 'uses-deferred-value-in-macro.jinja','value': value}) %}{% endfor %}{% set current_path = '' %}{% enddo %}
+{% do __temp_import_alias_1081745881__.update({'import_resource_path': 'uses-deferred-value-in-macro.jinja','value': value}) %}{% endfor %}{% set macros = __temp_import_alias_1081745881__ %}{% set current_path = '' %}{% enddo %}
 
 {% set deferred_import_resource_path = 'uses-deferred-value-in-macro.jinja' %}{% macro macros.getValueAnd(other) %}{% set value = macros.value %}
 {{ value ~ ' ' ~ other }}

--- a/src/test/resources/tags/eager/importtag/layer-one.jinja
+++ b/src/test/resources/tags/eager/importtag/layer-one.jinja
@@ -1,0 +1,2 @@
+{% set bar = 'bar val' %}
+{% import 'layer-two.jinja' as double_child %}

--- a/src/test/resources/tags/eager/importtag/layer-two.jinja
+++ b/src/test/resources/tags/eager/importtag/layer-two.jinja
@@ -1,0 +1,2 @@
+{% set foo = 'foo val' %}
+{% set foo_d = deferred %}

--- a/src/test/resources/tags/macrotag/filters.jinja
+++ b/src/test/resources/tags/macrotag/filters.jinja
@@ -1,0 +1,4 @@
+{% set foo = 123 %}
+{% set bar = deferred %}
+{% set filters = {} %}
+{% do filters.update(deferred) %}


### PR DESCRIPTION
There's a bug where if you use a variable that shares the same name as the alias which you're importing the current file, eager execution will not reconstruct the output properly. 



This was attempted to be handled in a graceful failure way, but it didn't catch all cases:
https://github.com/HubSpot/jinjava/blob/15f33ad9a3b97f3e1aa86e9f9bc7aa6547feecb1/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java#L461-L475
This PR handles it in a successful way instead, including handling additional cases.

The issue is easily explained through an example.

```
{# child.jinja #}
{% set where_am_i = 'here' %}
{% set my_var = {} %}
{% do my_var.update(deferred) %}
```

```
{# main.jinja #}
{% import 'child.jinja' as my_var %}
{{ my_var }}
```

The eager execution output _was_ like (prettified):
```
{% do %}
  {% set current_path = 'child.jinja' %}
  {% set my_var = {}  %}
  {% for __ignored__ in [0] %}
    {% set my_var = {}  %}
    {% do my_var.update(deferred) %}
    {% do my_var.update({'where_am_i': 'here','import_resource_path': 'child.jinja'}) %} // <- We're storing where_am_i on the wrong map!
  {% endfor %}
  {% set current_path = '' %}
{% enddo %}
{{ my_var }}
```
Since `my_var` is declared again inside of the child scope, when we try to add `where_am_i` to the aliased `my_var`, we're actually just adding it to the other dictionary, which will result in the alias ultimately being empty.

Now the output is like (prettified):
```
{% do %}
  {% set current_path = 'child.jinja' %}
  {% set __temp_import_alias_1059697132__ = {}  %}
  {% for __ignored__ in [0] %}
    {% set my_var = {}  %}
    {% do __temp_import_alias_1059697132__.update({'my_var': my_var}) %}
    {% do my_var.update(deferred) %}
    {% do __temp_import_alias_1059697132__.update({'where_am_i': 'here','my_var': my_var,'import_resource_path': 'child.jinja'}) %}
  {% endfor %}
  {% set my_var = __temp_import_alias_1059697132__ %}
  {% set current_path = '' %}
{% enddo %}
{{ my_var }}
```
Now we're using a temporary alias, which uses the hashcode of the full import alias (which in the case of nested importing could look like `x.y.z`) so that we avoid name clashing. The `my_var` is created in the child scope, but it is updated on the temporary alias, which exists in the higher scope, and eventually we set the higher-scoped `my_var` alias to the temporary alias and all is well.

---

In making this change, I also split out the EagerImportTag's logic into two separate strategies:
- AliasedEagerImportingStrategy
- FlatEagerImportingStrategy

because there were so many places where we'd check if the alias is empty, do this otherwise do that. There's enough of a distinction between the way that `{% import 'child.jinja' %}` and `{% import 'child.jinja' as child %}` function that using the strategy pattern is beneficial.
Here is the diff, omitting that refactor: https://github.com/HubSpot/jinjava/pull/1118/files/504e96bc1c2893e1a04f923fb5c5beeb62163047..c9a11652064dd05c0ed78174298f5211bba4760c

The changes really boil down to two commits:
- https://github.com/HubSpot/jinjava/commit/2ae6f73abfb5ab2a59ce0630f5a13afeac13c229
- https://github.com/HubSpot/jinjava/commit/8b313d573e4ffd444193ff2b5661e09d8b48da5b