### PR TITLE
Prevent accidental expressions from being output

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/output/OutputList.java
+++ b/src/main/java/com/hubspot/jinjava/tree/output/OutputList.java
@@ -71,16 +71,7 @@ public class OutputList {
     LengthLimitingStringBuilder val,
     TokenScannerSymbols tokenScannerSymbols
   ) {
-    @SuppressWarnings("StringBufferReplaceableByString")
-    String separator = new StringBuilder()
-      .append('\n')
-      .append(tokenScannerSymbols.getPrefixChar())
-      .append(tokenScannerSymbols.getNoteChar())
-      .append(tokenScannerSymbols.getTrimChar())
-      .append(' ')
-      .append(tokenScannerSymbols.getNoteChar())
-      .append(tokenScannerSymbols.getExprEndChar())
-      .toString();
+    String separator = getWhitespaceSeparator(tokenScannerSymbols);
     String prev = null;
     String cur;
     for (OutputNode node : nodes) {
@@ -93,11 +84,7 @@ public class OutputList {
         ) {
           if (
             cur.length() > 0 &&
-            (
-              cur.charAt(0) == tokenScannerSymbols.getTag() ||
-              cur.charAt(0) == tokenScannerSymbols.getExprStartChar() ||
-              cur.charAt(0) == tokenScannerSymbols.getNoteChar()
-            )
+            TokenScannerSymbols.isNoteTagOrExprChar(tokenScannerSymbols, cur.charAt(0))
           ) {
             val.append(separator);
           }
@@ -113,6 +100,20 @@ public class OutputList {
     }
 
     return val.toString();
+  }
+
+  private static String getWhitespaceSeparator(TokenScannerSymbols tokenScannerSymbols) {
+    @SuppressWarnings("StringBufferReplaceableByString")
+    String separator = new StringBuilder()
+      .append('\n')
+      .append(tokenScannerSymbols.getPrefixChar())
+      .append(tokenScannerSymbols.getNoteChar())
+      .append(tokenScannerSymbols.getTrimChar())
+      .append(' ')
+      .append(tokenScannerSymbols.getNoteChar())
+      .append(tokenScannerSymbols.getExprEndChar())
+      .toString();
+    return separator;
   }
 
   private String joinNodes(LengthLimitingStringBuilder val) {

--- a/src/main/java/com/hubspot/jinjava/tree/output/OutputList.java
+++ b/src/main/java/com/hubspot/jinjava/tree/output/OutputList.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.tree.output;
 
+import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.OutputTooBigException;
 import com.hubspot.jinjava.interpret.TemplateError;
@@ -8,6 +9,8 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class OutputList {
+  public static final String PREVENT_ACCIDENTAL_EXPRESSIONS =
+    "PREVENT_ACCIDENTAL_EXPRESSIONS";
   private final List<OutputNode> nodes = new LinkedList<>();
   private final List<BlockPlaceholderOutputNode> blocks = new LinkedList<>();
   private final long maxOutputSize;
@@ -46,6 +49,16 @@ public class OutputList {
   }
 
   public String getValue() {
+    boolean preventAccidentalExpressions = JinjavaInterpreter
+      .getCurrentMaybe()
+      .map(JinjavaInterpreter::getConfig)
+      .map(JinjavaConfig::getFeatures)
+      .map(
+        features ->
+          features.getActivationStrategy(PREVENT_ACCIDENTAL_EXPRESSIONS).isActive(null)
+      )
+      .orElse(false);
+
     LengthLimitingStringBuilder val = new LengthLimitingStringBuilder(maxOutputSize);
 
     for (OutputNode node : nodes) {

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TokenScannerSymbols.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TokenScannerSymbols.java
@@ -122,4 +122,10 @@ public abstract class TokenScannerSymbols implements Serializable {
     }
     return closingComment;
   }
+
+  public static boolean isNoteTagOrExprChar(TokenScannerSymbols symbols, char c) {
+    return (
+      c == symbols.getNote() || c == symbols.getTag() || c == symbols.getExprStartChar()
+    );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -8,15 +8,19 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.features.FeatureConfig;
+import com.hubspot.jinjava.features.FeatureStrategies;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
+import com.hubspot.jinjava.mode.EagerExecutionMode;
 import com.hubspot.jinjava.mode.PreserveRawExecutionMode;
 import com.hubspot.jinjava.objects.date.FormattedDate;
 import com.hubspot.jinjava.objects.date.StrftimeFormatter;
 import com.hubspot.jinjava.tree.TextNode;
 import com.hubspot.jinjava.tree.output.BlockInfo;
+import com.hubspot.jinjava.tree.output.OutputList;
 import com.hubspot.jinjava.tree.parse.TextToken;
 import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
 import java.time.ZoneId;
@@ -502,5 +506,54 @@ public class JinjavaInterpreterTest {
     interpreter.addError(copiedError1);
 
     assertThat(interpreter.getErrors()).containsExactly(error1, error2);
+  }
+
+  @Test
+  public void itPreventsAccidentalExpressions() {
+    String makeExpression = "if (true) {\n{%- print deferred -%}\n}";
+    String makeTag = "if (true) {\n{%- print '% print 123 %' -%}\n}";
+    String makeNote = "if (true) {\n{%- print '# note #' -%}\n}";
+    jinjava.getGlobalContext().put("deferred", DeferredValue.instance());
+
+    JinjavaInterpreter normalInterpreter = new JinjavaInterpreter(
+      jinjava,
+      jinjava.getGlobalContext(),
+      JinjavaConfig.newBuilder().withExecutionMode(EagerExecutionMode.instance()).build()
+    );
+    JinjavaInterpreter preventingInterpreter = new JinjavaInterpreter(
+      jinjava,
+      jinjava.getGlobalContext(),
+      JinjavaConfig
+        .newBuilder()
+        .withFeatureConfig(
+          FeatureConfig
+            .newBuilder()
+            .add(OutputList.PREVENT_ACCIDENTAL_EXPRESSIONS, FeatureStrategies.ACTIVE)
+            .build()
+        )
+        .withExecutionMode(EagerExecutionMode.instance())
+        .build()
+    );
+    JinjavaInterpreter.pushCurrent(normalInterpreter);
+    try {
+      assertThat(normalInterpreter.render(makeExpression))
+        .isEqualTo("if (true) {{% print deferred %}}");
+      assertThat(normalInterpreter.render(makeTag))
+        .isEqualTo("if (true) {% print 123 %}");
+      assertThat(normalInterpreter.render(makeNote)).isEqualTo("if (true) {# note #}");
+    } finally {
+      JinjavaInterpreter.popCurrent();
+    }
+    JinjavaInterpreter.pushCurrent(preventingInterpreter);
+    try {
+      assertThat(preventingInterpreter.render(makeExpression))
+        .isEqualTo("if (true) {\n" + "{#- #}{% print deferred %}}");
+      assertThat(preventingInterpreter.render(makeTag))
+        .isEqualTo("if (true) {\n" + "{#- #}% print 123 %}");
+      assertThat(preventingInterpreter.render(makeNote))
+        .isEqualTo("if (true) {\n" + "{#- #}# note #}");
+    } finally {
+      JinjavaInterpreter.popCurrent();
+    }
   }
 }


### PR DESCRIPTION
This adds a feature flag for `PREVENT_ACCIDENTAL_EXPRESSIONS` where, when combining output, it will check if the last character of the previous node and the first character of the current node create a tag/expression/note start string. If so, it will add a `\n{#- #}` spacer, which, if the entire output is passed back to jinjava, will tokensise properly, and maintain the correct whitespace due to the left-trim of the note.

Note/expression trimming is added in https://github.com/HubSpot/jinjava/pull/1122

For example:
```
if (true) {
{%- print '% print 123 %' -%}
}
```
Would normally output as:
```
if (true) {% print 123 %}
```
But with this feature enabled, it will output as:
```
if (true) {
{#- #}% print 123 %}
```
Which will prevent a `PrintTag` from being in it, if it were to be passed back into the interpreter.