### PR TITLE
Legacy text merging

### DIFF
--- a/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
+++ b/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
@@ -13,6 +13,7 @@ public class LegacyOverrides {
   private final boolean whitespaceRequiredWithinTokens;
   private final boolean useNaturalOperatorPrecedence;
   private final boolean parseWhitespaceControlStrictly;
+  private final boolean allowAdjacentTextNodes;
 
   private LegacyOverrides(Builder builder) {
     evaluateMapKeys = builder.evaluateMapKeys;
@@ -22,6 +23,7 @@ public class LegacyOverrides {
     whitespaceRequiredWithinTokens = builder.whitespaceRequiredWithinTokens;
     useNaturalOperatorPrecedence = builder.useNaturalOperatorPrecedence;
     parseWhitespaceControlStrictly = builder.parseWhitespaceControlStrictly;
+    allowAdjacentTextNodes = builder.allowAdjacentTextNodes;
   }
 
   public static Builder newBuilder() {
@@ -56,6 +58,10 @@ public class LegacyOverrides {
     return parseWhitespaceControlStrictly;
   }
 
+  public boolean isAllowAdjacentTextNodes() {
+    return allowAdjacentTextNodes;
+  }
+
   public static class Builder {
     private boolean evaluateMapKeys = false;
     private boolean iterateOverMapKeys = false;
@@ -64,6 +70,7 @@ public class LegacyOverrides {
     private boolean whitespaceRequiredWithinTokens = false;
     private boolean useNaturalOperatorPrecedence = false;
     private boolean parseWhitespaceControlStrictly = false;
+    private boolean allowAdjacentTextNodes = false;
 
     private Builder() {}
 
@@ -83,7 +90,8 @@ public class LegacyOverrides {
         .withUseNaturalOperatorPrecedence(legacyOverrides.useNaturalOperatorPrecedence)
         .withParseWhitespaceControlStrictly(
           legacyOverrides.parseWhitespaceControlStrictly
-        );
+        )
+        .withAllowAdjacentTextNodes(legacyOverrides.allowAdjacentTextNodes);
     }
 
     public Builder withEvaluateMapKeys(boolean evaluateMapKeys) {
@@ -124,6 +132,11 @@ public class LegacyOverrides {
       boolean parseWhitespaceControlStrictly
     ) {
       this.parseWhitespaceControlStrictly = parseWhitespaceControlStrictly;
+      return this;
+    }
+
+    public Builder withAllowAdjacentTextNodes(boolean allowAdjacentTextNodes) {
+      this.allowAdjacentTextNodes = allowAdjacentTextNodes;
       return this;
     }
   }

--- a/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
+++ b/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
@@ -3,9 +3,20 @@ package com.hubspot.jinjava;
 /**
  * This class allows Jinjava to be configured to override legacy behaviour.
  * LegacyOverrides.NONE signifies that none of the legacy functionality will be overridden.
+ * LegacyOverrides.ALL signifies that all new functionality will be used; avoid legacy "bugs".
  */
 public class LegacyOverrides {
   public static final LegacyOverrides NONE = new LegacyOverrides.Builder().build();
+  public static final LegacyOverrides ALL = new LegacyOverrides.Builder()
+    .withEvaluateMapKeys(true)
+    .withIterateOverMapKeys(true)
+    .withUsePyishObjectMapper(true)
+    .withUseSnakeCasePropertyNaming(true)
+    .withWhitespaceRequiredWithinTokens(true)
+    .withUseNaturalOperatorPrecedence(true)
+    .withParseWhitespaceControlStrictly(true)
+    .withAllowAdjacentTextNodes(true)
+    .build();
   private final boolean evaluateMapKeys;
   private final boolean iterateOverMapKeys;
   private final boolean usePyishObjectMapper;

--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -62,7 +62,16 @@ public class TreeParser {
       Node node = nextNode();
 
       if (node != null) {
-        parent.getChildren().add(node);
+        if (
+          node instanceof TextNode &&
+          getLastSibling() instanceof TextNode &&
+          !interpreter.getConfig().getLegacyOverrides().isAllowAdjacentTextNodes()
+        ) {
+          // merge adjacent text nodes so whitespace control properly applies
+          getLastSibling().getMaster().mergeImageAndContent(node.getMaster());
+        } else {
+          parent.getChildren().add(node);
+        }
       }
     }
 

--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -68,7 +68,9 @@ public class TreeParser {
           !interpreter.getConfig().getLegacyOverrides().isAllowAdjacentTextNodes()
         ) {
           // merge adjacent text nodes so whitespace control properly applies
-          getLastSibling().getMaster().mergeImageAndContent(node.getMaster());
+          ((TextToken) getLastSibling().getMaster()).mergeImageAndContent(
+              (TextToken) node.getMaster()
+            );
         } else {
           parent.getChildren().add(node);
         }

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TextToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TextToken.java
@@ -29,6 +29,13 @@ public class TextToken extends Token {
     super(image, lineNumber, startPosition, symbols);
   }
 
+  public void mergeImageAndContent(TextToken otherToken) {
+    String thisOutput = output();
+    String otherTokenOutput = otherToken.output();
+    this.image = thisOutput + otherTokenOutput;
+    this.content = image;
+  }
+
   @Override
   public int getType() {
     return getSymbols().getFixed();

--- a/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
@@ -53,11 +53,6 @@ public abstract class Token implements Serializable {
     return image;
   }
 
-  public void mergeImageAndContent(Token otherToken) {
-    this.image = image + otherToken.image;
-    this.content = content + otherToken.content;
-  }
-
   public int getLineNumber() {
     return lineNumber;
   }

--- a/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
@@ -53,6 +53,11 @@ public abstract class Token implements Serializable {
     return image;
   }
 
+  public void mergeImageAndContent(Token otherToken) {
+    this.image = image + otherToken.image;
+    this.content = content + otherToken.content;
+  }
+
   public int getLineNumber() {
     return lineNumber;
   }

--- a/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
@@ -233,6 +233,13 @@ public class TreeParserTest extends BaseInterpretingTest {
   }
 
   @Test
+  public void itMergesTextNodesWhileRespectingTrim() {
+    String expression = "{% print 'A' -%}\n{#- note -#}\nB\n{%- print 'C' %}";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo("ABC");
+  }
+
+  @Test
   public void itTrimsExpressions() {
     String expression = "A\n{{- 'B' -}}\nC";
     final Node tree = new TreeParser(interpreter, expression).buildTree();


### PR DESCRIPTION
I broke the legacy behaviour in https://github.com/HubSpot/jinjava/pull/1122. This legacy behaviour was added in https://github.com/HubSpot/jinjava/pull/599.

With `trimBlocks` and `lstripBlocks` turned off, the legacy behaviour for handling notes is different than for Jinja:
```
123
{%- if true -%}
{#
     Some comment
    #}
{% print '123' %}
{% endif %}
```
Which is output differently in Jinjava vs jinja:
Legacy Jinjava output:
```
123123
```
Jinja ouptut:
```
123
123
```

Setting the legacy override to `true` will yield the proper output:
```java
JinjavaConfig
  .newBuilder()
  .withLegacyOverrides(
    LegacyOverrides.newBuilder().withAllowAdjacentTextNodes(true).build()
  )
  .build()
```