### PR TITLE
Re-add note/expression whitespace control behind legacy override

### DIFF
--- a/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
+++ b/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
@@ -3,9 +3,20 @@ package com.hubspot.jinjava;
 /**
  * This class allows Jinjava to be configured to override legacy behaviour.
  * LegacyOverrides.NONE signifies that none of the legacy functionality will be overridden.
+ * LegacyOverrides.ALL signifies that all new functionality will be used; avoid legacy "bugs".
  */
 public class LegacyOverrides {
   public static final LegacyOverrides NONE = new LegacyOverrides.Builder().build();
+  public static final LegacyOverrides ALL = new LegacyOverrides.Builder()
+    .withEvaluateMapKeys(true)
+    .withIterateOverMapKeys(true)
+    .withUsePyishObjectMapper(true)
+    .withUseSnakeCasePropertyNaming(true)
+    .withWhitespaceRequiredWithinTokens(true)
+    .withUseNaturalOperatorPrecedence(true)
+    .withParseWhitespaceControlStrictly(true)
+    .withAllowAdjacentTextNodes(true)
+    .build();
   private final boolean evaluateMapKeys;
   private final boolean iterateOverMapKeys;
   private final boolean usePyishObjectMapper;
@@ -13,6 +24,7 @@ public class LegacyOverrides {
   private final boolean whitespaceRequiredWithinTokens;
   private final boolean useNaturalOperatorPrecedence;
   private final boolean parseWhitespaceControlStrictly;
+  private final boolean allowAdjacentTextNodes;
 
   private LegacyOverrides(Builder builder) {
     evaluateMapKeys = builder.evaluateMapKeys;
@@ -22,6 +34,7 @@ public class LegacyOverrides {
     whitespaceRequiredWithinTokens = builder.whitespaceRequiredWithinTokens;
     useNaturalOperatorPrecedence = builder.useNaturalOperatorPrecedence;
     parseWhitespaceControlStrictly = builder.parseWhitespaceControlStrictly;
+    allowAdjacentTextNodes = builder.allowAdjacentTextNodes;
   }
 
   public static Builder newBuilder() {
@@ -56,6 +69,10 @@ public class LegacyOverrides {
     return parseWhitespaceControlStrictly;
   }
 
+  public boolean isAllowAdjacentTextNodes() {
+    return allowAdjacentTextNodes;
+  }
+
   public static class Builder {
     private boolean evaluateMapKeys = false;
     private boolean iterateOverMapKeys = false;
@@ -64,6 +81,7 @@ public class LegacyOverrides {
     private boolean whitespaceRequiredWithinTokens = false;
     private boolean useNaturalOperatorPrecedence = false;
     private boolean parseWhitespaceControlStrictly = false;
+    private boolean allowAdjacentTextNodes = false;
 
     private Builder() {}
 
@@ -83,7 +101,8 @@ public class LegacyOverrides {
         .withUseNaturalOperatorPrecedence(legacyOverrides.useNaturalOperatorPrecedence)
         .withParseWhitespaceControlStrictly(
           legacyOverrides.parseWhitespaceControlStrictly
-        );
+        )
+        .withAllowAdjacentTextNodes(legacyOverrides.allowAdjacentTextNodes);
     }
 
     public Builder withEvaluateMapKeys(boolean evaluateMapKeys) {
@@ -124,6 +143,11 @@ public class LegacyOverrides {
       boolean parseWhitespaceControlStrictly
     ) {
       this.parseWhitespaceControlStrictly = parseWhitespaceControlStrictly;
+      return this;
+    }
+
+    public Builder withAllowAdjacentTextNodes(boolean allowAdjacentTextNodes) {
+      this.allowAdjacentTextNodes = allowAdjacentTextNodes;
       return this;
     }
   }

--- a/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
+++ b/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
@@ -16,6 +16,7 @@ public class LegacyOverrides {
     .withUseNaturalOperatorPrecedence(true)
     .withParseWhitespaceControlStrictly(true)
     .withAllowAdjacentTextNodes(true)
+    .withUseTrimmingForNotesAndExpressions(true)
     .build();
   private final boolean evaluateMapKeys;
   private final boolean iterateOverMapKeys;
@@ -25,6 +26,7 @@ public class LegacyOverrides {
   private final boolean useNaturalOperatorPrecedence;
   private final boolean parseWhitespaceControlStrictly;
   private final boolean allowAdjacentTextNodes;
+  private final boolean useTrimmingForNotesAndExpressions;
 
   private LegacyOverrides(Builder builder) {
     evaluateMapKeys = builder.evaluateMapKeys;
@@ -35,6 +37,7 @@ public class LegacyOverrides {
     useNaturalOperatorPrecedence = builder.useNaturalOperatorPrecedence;
     parseWhitespaceControlStrictly = builder.parseWhitespaceControlStrictly;
     allowAdjacentTextNodes = builder.allowAdjacentTextNodes;
+    useTrimmingForNotesAndExpressions = builder.useTrimmingForNotesAndExpressions;
   }
 
   public static Builder newBuilder() {
@@ -73,6 +76,10 @@ public class LegacyOverrides {
     return allowAdjacentTextNodes;
   }
 
+  public boolean isUseTrimmingForNotesAndExpressions() {
+    return useTrimmingForNotesAndExpressions;
+  }
+
   public static class Builder {
     private boolean evaluateMapKeys = false;
     private boolean iterateOverMapKeys = false;
@@ -82,6 +89,7 @@ public class LegacyOverrides {
     private boolean useNaturalOperatorPrecedence = false;
     private boolean parseWhitespaceControlStrictly = false;
     private boolean allowAdjacentTextNodes = false;
+    private boolean useTrimmingForNotesAndExpressions = false;
 
     private Builder() {}
 
@@ -102,7 +110,10 @@ public class LegacyOverrides {
         .withParseWhitespaceControlStrictly(
           legacyOverrides.parseWhitespaceControlStrictly
         )
-        .withAllowAdjacentTextNodes(legacyOverrides.allowAdjacentTextNodes);
+        .withAllowAdjacentTextNodes(legacyOverrides.allowAdjacentTextNodes)
+        .withUseTrimmingForNotesAndExpressions(
+          legacyOverrides.useTrimmingForNotesAndExpressions
+        );
     }
 
     public Builder withEvaluateMapKeys(boolean evaluateMapKeys) {
@@ -148,6 +159,13 @@ public class LegacyOverrides {
 
     public Builder withAllowAdjacentTextNodes(boolean allowAdjacentTextNodes) {
       this.allowAdjacentTextNodes = allowAdjacentTextNodes;
+      return this;
+    }
+
+    public Builder withUseTrimmingForNotesAndExpressions(
+      boolean useTrimmingForNotesAndExpressions
+    ) {
+      this.useTrimmingForNotesAndExpressions = useTrimmingForNotesAndExpressions;
       return this;
     }
   }

--- a/src/main/java/com/hubspot/jinjava/tree/output/OutputList.java
+++ b/src/main/java/com/hubspot/jinjava/tree/output/OutputList.java
@@ -3,11 +3,14 @@ package com.hubspot.jinjava.tree.output;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.OutputTooBigException;
 import com.hubspot.jinjava.interpret.TemplateError;
+import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import java.util.LinkedList;
 import java.util.List;
 
 public class OutputList {
+  public static final String PREVENT_ACCIDENTAL_EXPRESSIONS =
+    "PREVENT_ACCIDENTAL_EXPRESSIONS";
   private final List<OutputNode> nodes = new LinkedList<>();
   private final List<BlockPlaceholderOutputNode> blocks = new LinkedList<>();
   private final long maxOutputSize;
@@ -48,6 +51,72 @@ public class OutputList {
   public String getValue() {
     LengthLimitingStringBuilder val = new LengthLimitingStringBuilder(maxOutputSize);
 
+    return JinjavaInterpreter
+      .getCurrentMaybe()
+      .map(JinjavaInterpreter::getConfig)
+      .filter(
+        config ->
+          config
+            .getFeatures()
+            .getActivationStrategy(PREVENT_ACCIDENTAL_EXPRESSIONS)
+            .isActive(null)
+      )
+      .map(
+        config -> joinNodesWithoutAddingExpressions(val, config.getTokenScannerSymbols())
+      )
+      .orElseGet(() -> joinNodes(val));
+  }
+
+  private String joinNodesWithoutAddingExpressions(
+    LengthLimitingStringBuilder val,
+    TokenScannerSymbols tokenScannerSymbols
+  ) {
+    String separator = getWhitespaceSeparator(tokenScannerSymbols);
+    String prev = null;
+    String cur;
+    for (OutputNode node : nodes) {
+      try {
+        cur = node.getValue();
+        if (
+          prev != null &&
+          prev.length() > 0 &&
+          prev.charAt(prev.length() - 1) == tokenScannerSymbols.getExprStartChar()
+        ) {
+          if (
+            cur.length() > 0 &&
+            TokenScannerSymbols.isNoteTagOrExprChar(tokenScannerSymbols, cur.charAt(0))
+          ) {
+            val.append(separator);
+          }
+        }
+        prev = cur;
+        val.append(node.getValue());
+      } catch (OutputTooBigException e) {
+        JinjavaInterpreter
+          .getCurrent()
+          .addError(TemplateError.fromOutputTooBigException(e));
+        return val.toString();
+      }
+    }
+
+    return val.toString();
+  }
+
+  private static String getWhitespaceSeparator(TokenScannerSymbols tokenScannerSymbols) {
+    @SuppressWarnings("StringBufferReplaceableByString")
+    String separator = new StringBuilder()
+      .append('\n')
+      .append(tokenScannerSymbols.getPrefixChar())
+      .append(tokenScannerSymbols.getNoteChar())
+      .append(tokenScannerSymbols.getTrimChar())
+      .append(' ')
+      .append(tokenScannerSymbols.getNoteChar())
+      .append(tokenScannerSymbols.getExprEndChar())
+      .toString();
+    return separator;
+  }
+
+  private String joinNodes(LengthLimitingStringBuilder val) {
     for (OutputNode node : nodes) {
       try {
         val.append(node.getValue());

--- a/src/main/java/com/hubspot/jinjava/tree/parse/NoteToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/NoteToken.java
@@ -15,6 +15,8 @@ limitations under the License.
  **********************************************************************/
 package com.hubspot.jinjava.tree.parse;
 
+import org.apache.commons.lang3.StringUtils;
+
 public class NoteToken extends Token {
   private static final long serialVersionUID = -3859011447900311329L;
 
@@ -37,6 +39,9 @@ public class NoteToken extends Token {
    */
   @Override
   protected void parse() {
+    if (StringUtils.isNotEmpty(image)) {
+      handleTrim(image.substring(2, image.length() - 2));
+    }
     content = "";
   }
 

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TextToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TextToken.java
@@ -29,6 +29,13 @@ public class TextToken extends Token {
     super(image, lineNumber, startPosition, symbols);
   }
 
+  public void mergeImageAndContent(TextToken otherToken) {
+    String thisOutput = output();
+    String otherTokenOutput = otherToken.output();
+    this.image = thisOutput + otherTokenOutput;
+    this.content = image;
+  }
+
   @Override
   public int getType() {
     return getSymbols().getFixed();

--- a/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
@@ -53,11 +53,6 @@ public abstract class Token implements Serializable {
     return image;
   }
 
-  public void mergeImageAndContent(Token otherToken) {
-    this.image = image + otherToken.image;
-    this.content = content + otherToken.content;
-  }
-
   public int getLineNumber() {
     return lineNumber;
   }

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TokenScannerSymbols.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TokenScannerSymbols.java
@@ -122,4 +122,10 @@ public abstract class TokenScannerSymbols implements Serializable {
     }
     return closingComment;
   }
+
+  public static boolean isNoteTagOrExprChar(TokenScannerSymbols symbols, char c) {
+    return (
+      c == symbols.getNote() || c == symbols.getTag() || c == symbols.getExprStartChar()
+    );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -8,15 +8,19 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.features.FeatureConfig;
+import com.hubspot.jinjava.features.FeatureStrategies;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorItem;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorReason;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
+import com.hubspot.jinjava.mode.EagerExecutionMode;
 import com.hubspot.jinjava.mode.PreserveRawExecutionMode;
 import com.hubspot.jinjava.objects.date.FormattedDate;
 import com.hubspot.jinjava.objects.date.StrftimeFormatter;
 import com.hubspot.jinjava.tree.TextNode;
 import com.hubspot.jinjava.tree.output.BlockInfo;
+import com.hubspot.jinjava.tree.output.OutputList;
 import com.hubspot.jinjava.tree.parse.TextToken;
 import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
 import java.time.ZoneId;
@@ -502,5 +506,54 @@ public class JinjavaInterpreterTest {
     interpreter.addError(copiedError1);
 
     assertThat(interpreter.getErrors()).containsExactly(error1, error2);
+  }
+
+  @Test
+  public void itPreventsAccidentalExpressions() {
+    String makeExpression = "if (true) {\n{%- print deferred -%}\n}";
+    String makeTag = "if (true) {\n{%- print '% print 123 %' -%}\n}";
+    String makeNote = "if (true) {\n{%- print '# note #' -%}\n}";
+    jinjava.getGlobalContext().put("deferred", DeferredValue.instance());
+
+    JinjavaInterpreter normalInterpreter = new JinjavaInterpreter(
+      jinjava,
+      jinjava.getGlobalContext(),
+      JinjavaConfig.newBuilder().withExecutionMode(EagerExecutionMode.instance()).build()
+    );
+    JinjavaInterpreter preventingInterpreter = new JinjavaInterpreter(
+      jinjava,
+      jinjava.getGlobalContext(),
+      JinjavaConfig
+        .newBuilder()
+        .withFeatureConfig(
+          FeatureConfig
+            .newBuilder()
+            .add(OutputList.PREVENT_ACCIDENTAL_EXPRESSIONS, FeatureStrategies.ACTIVE)
+            .build()
+        )
+        .withExecutionMode(EagerExecutionMode.instance())
+        .build()
+    );
+    JinjavaInterpreter.pushCurrent(normalInterpreter);
+    try {
+      assertThat(normalInterpreter.render(makeExpression))
+        .isEqualTo("if (true) {{% print deferred %}}");
+      assertThat(normalInterpreter.render(makeTag))
+        .isEqualTo("if (true) {% print 123 %}");
+      assertThat(normalInterpreter.render(makeNote)).isEqualTo("if (true) {# note #}");
+    } finally {
+      JinjavaInterpreter.popCurrent();
+    }
+    JinjavaInterpreter.pushCurrent(preventingInterpreter);
+    try {
+      assertThat(preventingInterpreter.render(makeExpression))
+        .isEqualTo("if (true) {\n" + "{#- #}{% print deferred %}}");
+      assertThat(preventingInterpreter.render(makeTag))
+        .isEqualTo("if (true) {\n" + "{#- #}% print 123 %}");
+      assertThat(preventingInterpreter.render(makeNote))
+        .isEqualTo("if (true) {\n" + "{#- #}# note #}");
+    } finally {
+      JinjavaInterpreter.popCurrent();
+    }
   }
 }

--- a/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
@@ -6,6 +6,7 @@ import com.google.common.io.Resources;
 import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.LegacyOverrides;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import java.nio.charset.StandardCharsets;
 import org.junit.Test;
@@ -222,6 +223,46 @@ public class TreeParserTest extends BaseInterpretingTest {
     assertThat(interpreter.getErrors().get(1).getFieldName())
       .isEqualTo("{% block first %}");
     assertThat(interpreter.getErrors().get(1).getLineno()).isEqualTo(1);
+  }
+
+  @Test
+  public void itTrimsNotes() {
+    String expression = "A\n{#- note -#}\nB";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo("AB");
+  }
+
+  @Test
+  public void itMergesTextNodesWhileRespectingTrim() {
+    String expression = "{% print 'A' -%}\n{#- note -#}\nB\n{%- print 'C' %}";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo("ABC");
+  }
+
+  @Test
+  public void itTrimsExpressions() {
+    String expression = "A\n{{- 'B' -}}\nC";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo("ABC");
+  }
+
+  @Test
+  public void itDoesNotMergeAdjacentTextNodesWhenLegacyOverrideIsApplied() {
+    String expression = "A\n{%- if true -%}\n{# comment #}\nB{% endif %}";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo("AB");
+    interpreter =
+      new Jinjava(
+        JinjavaConfig
+          .newBuilder()
+          .withLegacyOverrides(
+            LegacyOverrides.newBuilder().withAllowAdjacentTextNodes(true).build()
+          )
+          .build()
+      )
+      .newInterpreter();
+    final Node overriddenTree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(overriddenTree)).isEqualTo("A\nB");
   }
 
   Node parse(String fixture) {

--- a/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
@@ -229,7 +229,22 @@ public class TreeParserTest extends BaseInterpretingTest {
   public void itTrimsNotes() {
     String expression = "A\n{#- note -#}\nB";
     final Node tree = new TreeParser(interpreter, expression).buildTree();
-    assertThat(interpreter.render(tree)).isEqualTo("AB");
+    assertThat(interpreter.render(tree)).isEqualTo("A\n\nB");
+    interpreter =
+      new Jinjava(
+        JinjavaConfig
+          .newBuilder()
+          .withLegacyOverrides(
+            LegacyOverrides
+              .newBuilder()
+              .withUseTrimmingForNotesAndExpressions(true)
+              .build()
+          )
+          .build()
+      )
+      .newInterpreter();
+    final Node newTree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(newTree)).isEqualTo("AB");
   }
 
   @Test
@@ -243,7 +258,22 @@ public class TreeParserTest extends BaseInterpretingTest {
   public void itTrimsExpressions() {
     String expression = "A\n{{- 'B' -}}\nC";
     final Node tree = new TreeParser(interpreter, expression).buildTree();
-    assertThat(interpreter.render(tree)).isEqualTo("ABC");
+    assertThat(interpreter.render(tree)).isEqualTo("A\nB\nC");
+    interpreter =
+      new Jinjava(
+        JinjavaConfig
+          .newBuilder()
+          .withLegacyOverrides(
+            LegacyOverrides
+              .newBuilder()
+              .withUseTrimmingForNotesAndExpressions(true)
+              .build()
+          )
+          .build()
+      )
+      .newInterpreter();
+    final Node newTree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(newTree)).isEqualTo("ABC");
   }
 
   @Test


### PR DESCRIPTION
Re-adds trimming for notes and expressions, but behind a legacy override `withUseTrimmingForNotesAndExpressions`