### PR TITLE
Handle trailing note without end

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/parse/NoteToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/NoteToken.java
@@ -15,8 +15,6 @@ limitations under the License.
  **********************************************************************/
 package com.hubspot.jinjava.tree.parse;
 
-import org.apache.commons.lang3.StringUtils;
-
 public class NoteToken extends Token {
   private static final long serialVersionUID = -3859011447900311329L;
 
@@ -39,7 +37,7 @@ public class NoteToken extends Token {
    */
   @Override
   protected void parse() {
-    if (StringUtils.isNotEmpty(image)) {
+    if (image.length() > 4) { // {# #}
       handleTrim(image.substring(2, image.length() - 2));
     }
     content = "";

--- a/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
@@ -248,6 +248,72 @@ public class TreeParserTest extends BaseInterpretingTest {
   }
 
   @Test
+  public void itAllowsTrailingNote() {
+    String expression = "A\n{# ";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo("A\n");
+    interpreter =
+      new Jinjava(
+        JinjavaConfig
+          .newBuilder()
+          .withLegacyOverrides(
+            LegacyOverrides
+              .newBuilder()
+              .withUseTrimmingForNotesAndExpressions(true)
+              .build()
+          )
+          .build()
+      )
+      .newInterpreter();
+    final Node newTree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(newTree)).isEqualTo("A\n");
+  }
+
+  @Test
+  public void itAllowsTrailingExpression() {
+    String expression = "A\n{{ ";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo("A\n{{ ");
+    interpreter =
+      new Jinjava(
+        JinjavaConfig
+          .newBuilder()
+          .withLegacyOverrides(
+            LegacyOverrides
+              .newBuilder()
+              .withUseTrimmingForNotesAndExpressions(true)
+              .build()
+          )
+          .build()
+      )
+      .newInterpreter();
+    final Node newTree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(newTree)).isEqualTo("A\n{{ ");
+  }
+
+  @Test
+  public void itAllowsTrailingTag() {
+    String expression = "A\n{% ";
+    final Node tree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(tree)).isEqualTo("A\n{% ");
+    interpreter =
+      new Jinjava(
+        JinjavaConfig
+          .newBuilder()
+          .withLegacyOverrides(
+            LegacyOverrides
+              .newBuilder()
+              .withUseTrimmingForNotesAndExpressions(true)
+              .build()
+          )
+          .build()
+      )
+      .newInterpreter();
+    final Node newTree = new TreeParser(interpreter, expression).buildTree();
+    assertThat(interpreter.render(newTree)).isEqualTo("A\n{% ");
+  }
+
+  @Test
   public void itMergesTextNodesWhileRespectingTrim() {
     String expression = "{% print 'A' -%}\n{#- note -#}\nB\n{%- print 'C' %}";
     final Node tree = new TreeParser(interpreter, expression).buildTree();


### PR DESCRIPTION
Avoids a StringIndexOutOfBoundsException when a template ends in `{# ` by checking that the note length is greater than 4. This is a very quick way to check it because I'm not trying to introduce any performance degradation in the processing of notes (aka comments).