### PR TITLE
When there's no current JinjavaInterpreter, don't limit the maximum number of deferred tokens

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -407,15 +407,18 @@ public class Context extends ScopeMap<String, Object> {
         secondToLastContext = secondToLastContext.parent;
       }
     }
-    int maxNumDeferredTokens = JinjavaInterpreter
+    int currentNumDeferredTokens = secondToLastContext.deferredTokens.size();
+    JinjavaInterpreter
       .getCurrentMaybe()
       .map(i -> i.getConfig().getMaxNumDeferredTokens())
-      .orElse(1000);
-    if (secondToLastContext.deferredTokens.size() >= maxNumDeferredTokens) {
-      throw new DeferredValueException(
-        "Too many Deferred Tokens, max is " + maxNumDeferredTokens
+      .filter(maxNumDeferredTokens -> currentNumDeferredTokens >= maxNumDeferredTokens)
+      .ifPresent(
+        maxNumDeferredTokens -> {
+          throw new DeferredValueException(
+            "Too many Deferred Tokens, max is " + maxNumDeferredTokens
+          );
+        }
       );
-    }
   }
 
   @Beta


### PR DESCRIPTION
1000 is an arbitrary number. If there's no JinjavaInterpreter, there's no config to be able to override this value. It would be better to avoid limiting, which throws an unchecked exception.