### PR TITLE
Fix flakiness caused by hash map

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/AliasedEagerImportingStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/AliasedEagerImportingStrategy.java
@@ -14,7 +14,7 @@ import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.PrefixToPreserveState;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -188,8 +188,8 @@ public class AliasedEagerImportingStrategy implements EagerImportingStrategy {
     currentMap.put(
       allAliases[allAliases.length - 1],
       child.getContext().isDeferredExecutionMode()
-        ? DeferredValue.instance(new PyMap(new HashMap<>()))
-        : new PyMap(new HashMap<>())
+        ? DeferredValue.instance(new PyMap(new LinkedHashMap<>()))
+        : new PyMap(new LinkedHashMap<>())
     );
   }
 
@@ -211,14 +211,14 @@ public class AliasedEagerImportingStrategy implements EagerImportingStrategy {
           (DeferredValue) parentValueForChild
         ).getOriginalValue();
       }
-      Map<String, Object> newMap = new PyMap(new HashMap<>());
+      Map<String, Object> newMap = new PyMap(new LinkedHashMap<>());
       child
         .getContext()
         .getParent()
         .put(currentImportAlias, DeferredValue.instance(newMap));
       return newMap;
     } else {
-      Map<String, Object> newMap = new PyMap(new HashMap<>());
+      Map<String, Object> newMap = new PyMap(new LinkedHashMap<>());
       child
         .getContext()
         .getParent()

--- a/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
@@ -14,6 +14,7 @@ import com.hubspot.jinjava.objects.collections.SizeLimitingPyMap;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -23,26 +24,26 @@ public class PyishObjectMapperTest {
 
   @Test
   public void itSerializesMapWithNullKeysAsEmptyString() {
-    Map<String, Object> map = new SizeLimitingPyMap(new HashMap<>(), 10);
+    Map<String, Object> map = new SizeLimitingPyMap(new LinkedHashMap<>(), 10);
     map.put("foo", "bar");
     map.put(null, "null");
     assertThat(PyishObjectMapper.getAsPyishString(map))
-      .isEqualTo("{'': 'null', 'foo': 'bar'} ");
+      .isEqualTo("{'foo': 'bar', '': 'null'} ");
   }
 
   @Test
   public void itSerializesMapEntrySet() {
-    SizeLimitingPyMap map = new SizeLimitingPyMap(new HashMap<>(), 10);
+    SizeLimitingPyMap map = new SizeLimitingPyMap(new LinkedHashMap<>(), 10);
     map.put("foo", "bar");
     map.put("bar", ImmutableMap.of("foobar", new ArrayList<>()));
     String result = PyishObjectMapper.getAsPyishString(map.items());
     assertThat(result)
-      .isEqualTo("[fn:map_entry('bar', {'foobar': []} ), fn:map_entry('foo', 'bar')]");
+      .isEqualTo("[fn:map_entry('foo', 'bar'), fn:map_entry('bar', {'foobar': []} )]");
   }
 
   @Test
   public void itSerializesMapEntrySetWithLimit() {
-    SizeLimitingPyMap map = new SizeLimitingPyMap(new HashMap<>(), 10);
+    SizeLimitingPyMap map = new SizeLimitingPyMap(new LinkedHashMap<>(), 10);
     map.put("foo", "bar");
     map.put("bar", ImmutableMap.of("foobar", new ArrayList<>()));
 
@@ -53,7 +54,7 @@ public class PyishObjectMapperTest {
       JinjavaInterpreter.pushCurrent(jinjava.newInterpreter());
       String result = PyishObjectMapper.getAsPyishString(map.items());
       assertThat(result)
-        .isEqualTo("[fn:map_entry('bar', {'foobar': []} ), fn:map_entry('foo', 'bar')]");
+        .isEqualTo("[fn:map_entry('foo', 'bar'), fn:map_entry('bar', {'foobar': []} )]");
     } finally {
       JinjavaInterpreter.popCurrent();
     }
@@ -61,11 +62,11 @@ public class PyishObjectMapperTest {
 
   @Test
   public void itSerializesMapWithNullValues() {
-    Map<String, Object> map = new SizeLimitingPyMap(new HashMap<>(), 10);
+    Map<String, Object> map = new SizeLimitingPyMap(new LinkedHashMap<>(), 10);
     map.put("foo", "bar");
     map.put("foobar", null);
     assertThat(PyishObjectMapper.getAsPyishString(map))
-      .isEqualTo("{'foobar': null, 'foo': 'bar'} ");
+      .isEqualTo("{'foo': 'bar', 'foobar': null} ");
   }
 
   @Test


### PR DESCRIPTION
## Problem
Running maven tests with [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool would discover flaky tests.
[NonDex](https://github.com/TestingResearchIllinois/NonDex) is a tool for detecting wrong assumptions on undeterministic Java APIs. It could help developers fix the assumption before it becomes a problem far in the future and more difficult to fix.

## Reproduce step
* Test Environment
  > Apache Maven: 3.6.3
  > Java: 11.0.21
  > OS: Ubuntu 20.04.6 LTS
  > Linux kernel: 5.4.0-167-generic

```Shell
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex
```

## Root cause
### EagerTest related test
Take [com.hubspot.jinjava.EagerTest#itHandlesImportInDeferredIf](https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/EagerTest.java#L988-L993) as an example, the test fails at assertion in `ExpectedTemplateInterpreter.java` L45

https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/ExpectedTemplateInterpreter.java#L39-L46

The reason why it fails is that the rendered string is determined by the order of `HashMap.entrySet()`, which is called at `AliasedEagerImportingStrategy.java` L255
https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/AliasedEagerImportingStrategy.java#L255

However, the order of `HashMap.entrySet()` is not guaranteed. It might change from time to time.
[NonDex](https://github.com/TestingResearchIllinois/NonDex) would shuffle the map on each invocation of methods.
Therefore, the rendered string might change, and make the tests fail.

### PyishObjectMapperTest
For [PyishObjectMapperTest](https://github.com/HubSpot/jinjava/blob/master/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java) test, it is the similar reason. 
In L25, `HashMap` has been used. However, the assertion in L29 is relied on the order of `HashMap.entrySet()`

https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java#L24-L31

## Code change
To fix the test flakiness, I replaced `HashMap` with `LinkedHashMap` in  [AliasedEagerImportingStrategy.java](https://github.com/HubSpot/jinjava/blob/master/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/AliasedEagerImportingStrategy.java) and [PyishObjectMapperTest.java](https://github.com/HubSpot/jinjava/blob/master/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java), and exchange the order of string to aligned with the order of `LinkedHashMap

## Failed test
[com.hubspot.jinjava.EagerTest#itHandlesImportInDeferredIf](https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/EagerTest.java#L988-L993)
[com.hubspot.jinjava.EagerTest#itHandlesDoubleImportModification](https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/EagerTest.java#L1011-L1016)
[com.hubspot.jinjava.EagerTest#itHandlesSameNameImportVar](https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/EagerTest.java#L1029-L1034)
[com.hubspot.jinjava.EagerTest#itDoesNotOverrideImportModificationInFor](https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/EagerTest.java#L1207-L1212)
[com.hubspot.jinjava.EagerTest#itRreconstructsValueUsedInDeferredImportedMacro](https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/EagerTest.java#L1397-L1402)
[com.hubspot.jinjava.EagerTest#itAllowsVariableSharingAliasName](https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/EagerTest.java#L1496-L1501)
[com.hubspot.jinjava.NonRevertingEagerTest#itHandlesImportInDeferredIf](https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/EagerTest.java#L988-L993)
[com.hubspot.jinjava.NonRevertingEagerTest#itHandlesDoubleImportModification](https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/EagerTest.java#L1011-L1016)
[com.hubspot.jinjava.NonRevertingEagerTest#itHandlesSameNameImportVar](https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/EagerTest.java#L1029-L1034)
[com.hubspot.jinjava.NonRevertingEagerTest#itDoesNotOverrideImportModificationInFor](https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/EagerTest.java#L1207-L1212)
[com.hubspot.jinjava.NonRevertingEagerTest#itRreconstructsValueUsedInDeferredImportedMacro](https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/EagerTest.java#L1397-L1402)
[com.hubspot.jinjava.NonRevertingEagerTest#itAllowsVariableSharingAliasName](https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/EagerTest.java#L1496-L1501)

[com.hubspot.jinjava.lib.tag.eager.EagerImportTagTest#itDefersTripleLayer](https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java#L339-L361)
[com.hubspot.jinjava.lib.tag.eager.EagerImportTagTest#itHandlesQuadLayerInDeferredIf](https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java#L390-L413)
[com.hubspot.jinjava.lib.tag.eager.EagerImportTagTest#itDoesNotSilentlyOverrideVariable](https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java#L627-L652)

[com.hubspot.jinjava.objects.serialization.PyishObjectMapperTest#itSerializesMapWithNullKeysAsEmptyString](https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java#L24-L31)
[com.hubspot.jinjava.objects.serialization.PyishObjectMapperTest#itSerializesMapEntrySet](https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java#L33-L41)
[com.hubspot.jinjava.objects.serialization.PyishObjectMapperTest#itSerializesMapEntrySetWithLimit](https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java#L43-L60)
[com.hubspot.jinjava.objects.serialization.PyishObjectMapperTest#itSerializesMapWithNullValues](https://github.com/HubSpot/jinjava/blob/ddd35c002d52cda2c407f6e6997196c9fcdc72d6/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java#L62-L69)