### PR TITLE
Fix bad tag token.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/parse/TagToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TagToken.java
@@ -44,6 +44,13 @@ public class TagToken extends Token {
   @Override
   protected void parse() {
     if (image.length() < 4) {
+      if (image.equals("{%}")) {
+        tagName = "";
+        rawTagName = "";
+        helpers = "";
+        content = "";
+        return;
+      }
       throw new TemplateSyntaxException(
         image,
         "Malformed tag token",

--- a/src/test/java/com/hubspot/jinjava/tree/parse/TagTokenTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/parse/TagTokenTest.java
@@ -38,4 +38,11 @@ public class TagTokenTest {
       assertThat(e).hasMessageContaining("Malformed");
     }
   }
+
+  @Test
+  public void testParseEmptyTagWithHelpers() {
+    TagToken t = new TagToken("{%}", 1, 2, SYMBOLS);
+    assertThat(t.getTagName()).isEqualTo("");
+    assertThat(t.getHelpers().trim()).isEqualTo("");
+  }
 }


### PR DESCRIPTION
When the tag is `{%}`, instead of throwing an exception, we can just treat it as empty.