### PR TITLE
Limit string length input for replacement filters

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -246,7 +246,7 @@ public class JinjavaConfig {
   }
 
   public long getMaxStringLength() {
-    return maxStringLength;
+    return maxStringLength == 0 ? getMaxOutputSize() : maxStringLength;
   }
 
   public InterpreterFactory getInterpreterFactory() {

--- a/src/main/java/com/hubspot/jinjava/interpret/InvalidReason.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/InvalidReason.java
@@ -18,7 +18,7 @@ public enum InvalidReason {
   ),
   ENUM("with value '%s' must be one of: %s"),
   CIDR("with value '%s' must be a valid CIDR address"),
-  LENGTH("with length '%s' exceeds maximum allowed length of");
+  LENGTH("with length '%s' exceeds maximum allowed length of '%s'");
 
   private final String errorMessage;
 

--- a/src/main/java/com/hubspot/jinjava/interpret/InvalidReason.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/InvalidReason.java
@@ -17,7 +17,8 @@ public enum InvalidReason {
     "with value '%s' must be a valid attribute of every item in the list"
   ),
   ENUM("with value '%s' must be one of: %s"),
-  CIDR("with value '%s' must be a valid CIDR address");
+  CIDR("with value '%s' must be a valid CIDR address"),
+  LENGTH("with length '%s' exceeds maximum allowed length of");
 
   private final String errorMessage;
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilter.java
@@ -71,6 +71,16 @@ public class RegexReplaceFilter implements Filter {
 
     if (var instanceof String) {
       String s = (String) var;
+      long maxStringLength = interpreter.getConfig().getMaxStringLength();
+      if (maxStringLength > 0 && s.length() > maxStringLength) {
+        throw new InvalidInputException(
+          interpreter,
+          this,
+          InvalidReason.LENGTH,
+          s.length(),
+          maxStringLength
+        );
+      }
       String toReplace = args[0];
       String replaceWith = args[1];
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilter.java
@@ -1,5 +1,7 @@
 package com.hubspot.jinjava.lib.filter;
 
+import static com.hubspot.jinjava.lib.filter.ReplaceFilter.checkLength;
+
 import com.google.re2j.Matcher;
 import com.google.re2j.Pattern;
 import com.google.re2j.PatternSyntaxException;
@@ -71,15 +73,9 @@ public class RegexReplaceFilter implements Filter {
 
     if (var instanceof String) {
       String s = (String) var;
-      long maxStringLength = interpreter.getConfig().getMaxStringLength();
-      if (maxStringLength > 0 && s.length() > maxStringLength) {
-        throw new InvalidInputException(
-          interpreter,
-          this,
-          InvalidReason.LENGTH,
-          s.length(),
-          maxStringLength
-        );
+      // Minor optimization, avoid checking short strings
+      if (s.length() > 100) {
+        checkLength(interpreter, s, this);
       }
       String toReplace = args[0];
       String replaceWith = args[1];

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ReplaceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ReplaceFilter.java
@@ -7,6 +7,7 @@ import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
+import com.hubspot.jinjava.lib.Importable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 
@@ -68,15 +69,9 @@ public class ReplaceFilter implements Filter {
     }
 
     String s = var.toString();
-    long maxStringLength = interpreter.getConfig().getMaxStringLength();
-    if (maxStringLength > 0 && s.length() > maxStringLength) {
-      throw new InvalidInputException(
-        interpreter,
-        this,
-        InvalidReason.LENGTH,
-        s.length(),
-        maxStringLength
-      );
+    // Minor optimization, avoid checking short strings
+    if (s.length() > 100) {
+      checkLength(interpreter, s, this);
     }
 
     String toReplace = args[0];
@@ -91,6 +86,23 @@ public class ReplaceFilter implements Filter {
       return StringUtils.replace(s, toReplace, replaceWith);
     } else {
       return StringUtils.replace(s, toReplace, replaceWith, count);
+    }
+  }
+
+  static void checkLength(
+    JinjavaInterpreter interpreter,
+    String s,
+    Importable importable
+  ) {
+    long maxStringLength = interpreter.getConfig().getMaxStringLength();
+    if (maxStringLength > 0 && s.length() > maxStringLength) {
+      throw new InvalidInputException(
+        interpreter,
+        importable,
+        InvalidReason.LENGTH,
+        s.length(),
+        maxStringLength
+      );
     }
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ReplaceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ReplaceFilter.java
@@ -3,6 +3,8 @@ package com.hubspot.jinjava.lib.filter;
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.interpret.InvalidInputException;
+import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import org.apache.commons.lang3.StringUtils;
@@ -66,6 +68,17 @@ public class ReplaceFilter implements Filter {
     }
 
     String s = var.toString();
+    long maxStringLength = interpreter.getConfig().getMaxStringLength();
+    if (maxStringLength > 0 && s.length() > maxStringLength) {
+      throw new InvalidInputException(
+        interpreter,
+        this,
+        InvalidReason.LENGTH,
+        s.length(),
+        maxStringLength
+      );
+    }
+
     String toReplace = args[0];
     String replaceWith = args[1];
     Integer count = null;

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilterTest.java
@@ -61,10 +61,14 @@ public class RegexReplaceFilterTest extends BaseInterpretingTest {
 
   @Test
   public void itLimitsLongInput() {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 101; i++) {
+      sb.append('a');
+    }
     assertThatThrownBy(
         () ->
           filter.filter(
-            "123456789OO",
+            sb.toString(),
             new Jinjava(JinjavaConfig.newBuilder().withMaxStringLength(10).build())
             .newInterpreter(),
             "O",
@@ -73,7 +77,7 @@ public class RegexReplaceFilterTest extends BaseInterpretingTest {
       )
       .isInstanceOf(InvalidInputException.class)
       .hasMessageContaining(
-        "Invalid input for 'regex_replace': input with length '11' exceeds maximum allowed length of '10'"
+        "Invalid input for 'regex_replace': input with length '101' exceeds maximum allowed length of '10'"
       );
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilterTest.java
@@ -4,7 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.hubspot.jinjava.BaseInterpretingTest;
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.InvalidArgumentException;
+import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.objects.SafeString;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,5 +57,23 @@ public class RegexReplaceFilterTest extends BaseInterpretingTest {
           .toString()
       )
       .isEqualTo("Itcosts");
+  }
+
+  @Test
+  public void itLimitsLongInput() {
+    assertThatThrownBy(
+        () ->
+          filter.filter(
+            "123456789OO",
+            new Jinjava(JinjavaConfig.newBuilder().withMaxStringLength(10).build())
+            .newInterpreter(),
+            "O",
+            "0"
+          )
+      )
+      .isInstanceOf(InvalidInputException.class)
+      .hasMessageContaining(
+        "Invalid input for 'regex_replace': input with length '11' exceeds maximum allowed length of '10'"
+      );
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/ReplaceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/ReplaceFilterTest.java
@@ -59,10 +59,14 @@ public class ReplaceFilterTest extends BaseInterpretingTest {
 
   @Test
   public void itLimitsLongInput() {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 101; i++) {
+      sb.append('a');
+    }
     assertThatThrownBy(
         () ->
           filter.filter(
-            "123456789OO",
+            sb.toString(),
             new Jinjava(JinjavaConfig.newBuilder().withMaxStringLength(10).build())
             .newInterpreter(),
             "O",
@@ -71,7 +75,7 @@ public class ReplaceFilterTest extends BaseInterpretingTest {
       )
       .isInstanceOf(InvalidInputException.class)
       .hasMessageContaining(
-        "Invalid input for 'replace': input with length '11' exceeds maximum allowed length of '10'"
+        "Invalid input for 'replace': input with length '101' exceeds maximum allowed length of '10'"
       );
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/ReplaceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/ReplaceFilterTest.java
@@ -1,9 +1,13 @@
 package com.hubspot.jinjava.lib.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.hubspot.jinjava.BaseInterpretingTest;
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.InterpretException;
+import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.objects.SafeString;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,5 +55,23 @@ public class ReplaceFilterTest extends BaseInterpretingTest {
   public void replaceBoolean() {
     assertThat(filter.filter(true, interpreter, "true", "TRUEEE").toString())
       .isEqualTo("TRUEEE");
+  }
+
+  @Test
+  public void itLimitsLongInput() {
+    assertThatThrownBy(
+        () ->
+          filter.filter(
+            "123456789OO",
+            new Jinjava(JinjavaConfig.newBuilder().withMaxStringLength(10).build())
+            .newInterpreter(),
+            "O",
+            "0"
+          )
+      )
+      .isInstanceOf(InvalidInputException.class)
+      .hasMessageContaining(
+        "Invalid input for 'replace': input with length '11' exceeds maximum allowed length of '10'"
+      );
   }
 }


### PR DESCRIPTION
If `maxStringLength` is set (or defaulting to `maxOutputSize` now), then don't process strings that are longer than that maximum length.
This means that strings that are too long will no longer be considered valid inputs for `|regex_replace` or `replace`.