### PR TITLE
Make null values loop-able.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
+++ b/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
@@ -17,6 +17,7 @@ public class LegacyOverrides {
     .withParseWhitespaceControlStrictly(true)
     .withAllowAdjacentTextNodes(true)
     .withUseTrimmingForNotesAndExpressions(true)
+    .withKeepNullableLoopValues(true)
     .build();
   private final boolean evaluateMapKeys;
   private final boolean iterateOverMapKeys;
@@ -27,6 +28,7 @@ public class LegacyOverrides {
   private final boolean parseWhitespaceControlStrictly;
   private final boolean allowAdjacentTextNodes;
   private final boolean useTrimmingForNotesAndExpressions;
+  private final boolean keepNullableLoopValues;
 
   private LegacyOverrides(Builder builder) {
     evaluateMapKeys = builder.evaluateMapKeys;
@@ -38,6 +40,7 @@ public class LegacyOverrides {
     parseWhitespaceControlStrictly = builder.parseWhitespaceControlStrictly;
     allowAdjacentTextNodes = builder.allowAdjacentTextNodes;
     useTrimmingForNotesAndExpressions = builder.useTrimmingForNotesAndExpressions;
+    keepNullableLoopValues = builder.keepNullableLoopValues;
   }
 
   public static Builder newBuilder() {
@@ -80,6 +83,10 @@ public class LegacyOverrides {
     return useTrimmingForNotesAndExpressions;
   }
 
+  public boolean isKeepNullableLoopValues() {
+    return keepNullableLoopValues;
+  }
+
   public static class Builder {
     private boolean evaluateMapKeys = false;
     private boolean iterateOverMapKeys = false;
@@ -90,6 +97,7 @@ public class LegacyOverrides {
     private boolean parseWhitespaceControlStrictly = false;
     private boolean allowAdjacentTextNodes = false;
     private boolean useTrimmingForNotesAndExpressions = false;
+    private boolean keepNullableLoopValues = false;
 
     private Builder() {}
 
@@ -166,6 +174,11 @@ public class LegacyOverrides {
       boolean useTrimmingForNotesAndExpressions
     ) {
       this.useTrimmingForNotesAndExpressions = useTrimmingForNotesAndExpressions;
+      return this;
+    }
+
+    public Builder withKeepNullableLoopValues(boolean keepNullableLoopValues) {
+      this.keepNullableLoopValues = keepNullableLoopValues;
       return this;
     }
   }

--- a/src/main/java/com/hubspot/jinjava/interpret/NullValue.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/NullValue.java
@@ -1,0 +1,19 @@
+package com.hubspot.jinjava.interpret;
+
+/**
+ * Marker object of a `null` value. A null value in the map is usually considered
+ * the key does not exist. For example map = {"a": null}, if map.get("a") == null,
+ * we treat it as the there is not key "a" in the map.
+ */
+public final class NullValue {
+  public static final NullValue INSTANCE = new NullValue();
+
+  static NullValue instance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public String toString() {
+    return "null";
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/interpret/NullValue.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/NullValue.java
@@ -8,7 +8,9 @@ package com.hubspot.jinjava.interpret;
 public final class NullValue {
   public static final NullValue INSTANCE = new NullValue();
 
-  static NullValue instance() {
+  private NullValue() {}
+
+  public static NullValue instance() {
     return INSTANCE;
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -27,6 +27,7 @@ import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
+import com.hubspot.jinjava.interpret.NullValue;
 import com.hubspot.jinjava.interpret.OutputTooBigException;
 import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
@@ -200,7 +201,11 @@ public class ForTag implements Tag {
 
         // set item variables
         if (loopVars.size() == 1) {
-          interpreter.getContext().put(loopVars.get(0), val);
+          if (val == null && interpreter.getContext().get(loopVars.get(0)) != null) {
+            interpreter.getContext().put(loopVars.get(0), NullValue.INSTANCE);
+          } else {
+            interpreter.getContext().put(loopVars.get(0), val);
+          }
         } else {
           for (int loopVarIndex = 0; loopVarIndex < loopVars.size(); loopVarIndex++) {
             String loopVar = loopVars.get(loopVarIndex);

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -201,7 +201,11 @@ public class ForTag implements Tag {
 
         // set item variables
         if (loopVars.size() == 1) {
-          if (val == null && interpreter.getContext().get(loopVars.get(0)) != null) {
+          if (
+            val == null &&
+            interpreter.getContext().get(loopVars.get(0)) != null &&
+            interpreter.getConfig().getLegacyOverrides().isKeepNullableLoopValues()
+          ) {
             interpreter.getContext().put(loopVars.get(0), NullValue.INSTANCE);
           } else {
             interpreter.getContext().put(loopVars.get(0), val);

--- a/src/test/java/com/hubspot/jinjava/BaseJinjavaTest.java
+++ b/src/test/java/com/hubspot/jinjava/BaseJinjavaTest.java
@@ -12,7 +12,11 @@ public abstract class BaseJinjavaTest {
         JinjavaConfig
           .newBuilder()
           .withLegacyOverrides(
-            LegacyOverrides.newBuilder().withUsePyishObjectMapper(true).build()
+            LegacyOverrides
+              .newBuilder()
+              .withUsePyishObjectMapper(true)
+              .withKeepNullableLoopValues(true)
+              .build()
           )
           .build()
       );

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
@@ -381,12 +381,13 @@ public class ForTagTest extends BaseInterpretingTest {
   public void forLoopWithNullValues() {
     context.put("number", -1);
     context.put("the_list", Lists.newArrayList(1L, 2L, null, null, null));
-    TagNode tagNode = (TagNode) fixture("loop-last-var");
-    Document dom = Jsoup.parseBodyFragment(tag.interpret(tagNode, interpreter));
-
-    assertThat(dom.select("h3")).hasSize(4);
-    dom.outputSettings().prettyPrint(true).indentAmount(4);
-    assertThat(dom.html()).contains("seven: null");
+    String template = "{% for number in the_list %} {{ number }} {% endfor %}";
+    TagNode tagNode = (TagNode) new TreeParser(interpreter, template)
+      .buildTree()
+      .getChildren()
+      .getFirst();
+    String result = tag.interpret(tagNode, interpreter);
+    assertThat(result).isEqualTo(" 1  2  null  null  null ");
   }
 
   public static boolean inForLoop() {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
@@ -377,6 +377,18 @@ public class ForTagTest extends BaseInterpretingTest {
     assertThat(rendered.getOutput()).isEqualTo("false true true false");
   }
 
+  @Test
+  public void forLoopWithNullValues() {
+    context.put("number", -1);
+    context.put("the_list", Lists.newArrayList(1L, 2L, null, null, null));
+    TagNode tagNode = (TagNode) fixture("loop-last-var");
+    Document dom = Jsoup.parseBodyFragment(tag.interpret(tagNode, interpreter));
+
+    assertThat(dom.select("h3")).hasSize(4);
+    dom.outputSettings().prettyPrint(true).indentAmount(4);
+    assertThat(dom.html()).contains("seven: null");
+  }
+
   public static boolean inForLoop() {
     JinjavaInterpreter interpreter = JinjavaInterpreter.getCurrent();
     return interpreter.getContext().isInForLoop();

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
@@ -32,7 +32,11 @@ public class EagerForTagTest extends ForTagTest {
           .withMaxOutputSize(MAX_OUTPUT_SIZE)
           .withExecutionMode(EagerExecutionMode.instance())
           .withLegacyOverrides(
-            LegacyOverrides.newBuilder().withUsePyishObjectMapper(true).build()
+            LegacyOverrides
+              .newBuilder()
+              .withUsePyishObjectMapper(true)
+              .withKeepNullableLoopValues(true)
+              .build()
           )
           .build()
       );


### PR DESCRIPTION
When the loop collection contains `null`, the loop var will be searching the outer scope of the value instead of just use the `null` value. For example,

```
context.put("number", -1);
context.put("the_list", Lists.newArrayList(1L, 2L, null, null, null));
String template = "{% for number in the_list %} {{ number }} {% endfor %}";
```

When rendering the above for tag, because the 3rd and later values are `null`, the loop var is `number`, and it will find the value of it from outside of the forTag scope. It will result in the following

```
Expected :" 1  2  null  null  null "
Actual   :" 1  2  -1  -1  -1 "
```

With this special `NullValue` instance,  the loopVar value will stay inside the loop.
