### PR TITLE
limit coerced string length

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/TruthyTypeConverter.java
+++ b/src/main/java/com/hubspot/jinjava/el/TruthyTypeConverter.java
@@ -115,14 +115,18 @@ public class TruthyTypeConverter extends TypeConverterImpl {
 
   private String coerceCollection(Collection value) {
     Iterator<?> it = value.iterator();
-    if (!it.hasNext()) return "[]";
+    if (!it.hasNext()) {
+      return "[]";
+    }
 
     LengthLimitingStringBuilder sb = new LengthLimitingStringBuilder(1_000_000L);
     sb.append('[');
     for (;;) {
       Object e = it.next();
       sb.append(e == this ? "(this Collection)" : e);
-      if (!it.hasNext()) return sb.append(']').toString();
+      if (!it.hasNext()) {
+        return sb.append(']').toString();
+      }
       sb.append(',');
       sb.append(' ');
     }

--- a/src/main/java/com/hubspot/jinjava/el/TruthyTypeConverter.java
+++ b/src/main/java/com/hubspot/jinjava/el/TruthyTypeConverter.java
@@ -1,7 +1,6 @@
 package com.hubspot.jinjava.el;
 
 import com.hubspot.jinjava.objects.DummyObject;
-import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
 import com.hubspot.jinjava.util.ObjectTruthValue;
 import de.odysseus.el.misc.TypeConverterImpl;
 import java.math.BigDecimal;
@@ -13,6 +12,7 @@ import javax.el.ELException;
 
 public class TruthyTypeConverter extends TypeConverterImpl {
   private static final long serialVersionUID = 1L;
+  public static final int MAX_COLLECTION_STRING_LENGTH = 1_000_000;
 
   @Override
   protected Boolean coerceToBoolean(Object value) {
@@ -119,11 +119,15 @@ public class TruthyTypeConverter extends TypeConverterImpl {
       return "[]";
     }
 
-    LengthLimitingStringBuilder sb = new LengthLimitingStringBuilder(1_000_000L);
+    StringBuilder sb = new StringBuilder();
+
     sb.append('[');
     for (;;) {
       Object e = it.next();
       sb.append(e == this ? "(this Collection)" : e);
+      if (sb.length() > MAX_COLLECTION_STRING_LENGTH) {
+        return sb.append(", ...]").toString();
+      }
       if (!it.hasNext()) {
         return sb.append(']').toString();
       }

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTestTest.java
@@ -3,7 +3,9 @@ package com.hubspot.jinjava.lib.exptest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hubspot.jinjava.BaseJinjavaTest;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import org.junit.Test;
 
 public class IsEqualToExpTestTest extends BaseJinjavaTest {
@@ -33,6 +35,50 @@ public class IsEqualToExpTestTest extends BaseJinjavaTest {
         )
       )
       .isEqualTo("false");
+  }
+
+  @Test
+  public void itEquatesCollectionsToStrings() {
+    assertThat(
+        jinjava.render(
+          String.format(EQUAL_TEMPLATE, "\"[1, 2, 3]\"", "[1, 2, 3]"),
+          new HashMap<>()
+        )
+      )
+      .isEqualTo("true");
+
+    assertThat(
+        jinjava.render(
+          String.format(EQUAL_TEMPLATE, "\"[1, 2, 3]\"", "[1, 2, 4]"),
+          new HashMap<>()
+        )
+      )
+      .isEqualTo("false");
+  }
+
+  @Test
+  public void itEquatesLargeCollectionsAndStrings() {
+    assertThat(compareStringAndCollection(100_000)).isEqualTo("true");
+  }
+
+  @Test
+  public void itDoesNotEquateHugeCollectionsAndStrings() {
+    assertThat(compareStringAndCollection(500_000)).isEqualTo("false");
+  }
+
+  private String compareStringAndCollection(int size) {
+    List<Integer> bigList = new ArrayList<>();
+
+    for (int i = 0; i < size; i++) {
+      bigList.add(1);
+    }
+
+    String bigString = bigList.toString();
+
+    return jinjava.render(
+      String.format(EQUAL_TEMPLATE, "\"" + bigString + "\"", bigString),
+      new HashMap<>()
+    );
   }
 
   @Test


### PR DESCRIPTION
When comparing expression values, JUEL will attempt to compare the values as strings if either of the values are strings. If one of those values is a huge collection, it will try to convert that collection to an even larger string, leading to OOMs.

One way to solve this problem is to limit the size of these compared strings the same way that we limit the output. This will throw an `OutputTooBigException` which is not quite right since it's not output. 

I decided to not throw the exception but just limit the length of the string and allow the comparison to fail assuming the first 1M bytes of the string are not the same as the `toString()` value of the collection.

This doesn't immediately solve the problem of a collection that has a huge collection nested inside it, but it should help in most cases.