### PR TITLE
Upgrade basepom and prettier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>56.1</version>
+    <version>56.2</version>
   </parent>
 
   <groupId>com.hubspot.jinjava</groupId>
@@ -14,11 +14,6 @@
   <description>Jinja templating engine implemented in Java</description>
 
   <properties>
-    <basepom.check.skip-prettier>false</basepom.check.skip-prettier>
-
-    <basepom.prettier.prettier-java-version>0.7.0</basepom.prettier.prettier-java-version>
-    <basepom.prettier.extract-to-target-directory>false</basepom.prettier.extract-to-target-directory>
-
     <dep.javassist.version>3.24.1-GA</dep.javassist.version>
     <dep.plugin.jacoco.version>0.8.3</dep.plugin.jacoco.version>
     <dep.guava.version>31.1-jre</dep.guava.version>

--- a/src/main/java/com/hubspot/jinjava/Jinjava.java
+++ b/src/main/java/com/hubspot/jinjava/Jinjava.java
@@ -61,6 +61,7 @@ import javax.el.ExpressionFactory;
  * @author jstehler
  */
 public class Jinjava {
+
   private ExpressionFactory expressionFactory;
   private ExpressionFactory eagerExpressionFactory;
   private ResourceLocator resourceLocator;

--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -52,6 +52,7 @@ import javax.annotation.Nullable;
 import javax.el.ELResolver;
 
 public class JinjavaConfig {
+
   private final Charset charset;
   private final Locale locale;
   private final ZoneId timeZone;
@@ -314,6 +315,7 @@ public class JinjavaConfig {
   }
 
   public static class Builder {
+
     private Charset charset = StandardCharsets.UTF_8;
     private Locale locale = Locale.ENGLISH;
     private ZoneId timeZone = ZoneOffset.UTC;
@@ -495,8 +497,8 @@ public class JinjavaConfig {
     @Deprecated
     public Builder withIterateOverMapKeys(boolean iterateOverMapKeys) {
       return withLegacyOverrides(
-        LegacyOverrides
-          .Builder.from(legacyOverrides)
+        LegacyOverrides.Builder
+          .from(legacyOverrides)
           .withIterateOverMapKeys(iterateOverMapKeys)
           .build()
       );

--- a/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
+++ b/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
@@ -6,6 +6,7 @@ package com.hubspot.jinjava;
  * LegacyOverrides.ALL signifies that all new functionality will be used; avoid legacy "bugs".
  */
 public class LegacyOverrides {
+
   public static final LegacyOverrides NONE = new LegacyOverrides.Builder().build();
   public static final LegacyOverrides ALL = new LegacyOverrides.Builder()
     .withEvaluateMapKeys(true)
@@ -88,6 +89,7 @@ public class LegacyOverrides {
   }
 
   public static class Builder {
+
     private boolean evaluateMapKeys = false;
     private boolean iterateOverMapKeys = false;
     private boolean usePyishObjectMapper = false;

--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDoc.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDoc.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 public class JinjavaDoc {
+
   private final Map<String, JinjavaDocExpTest> expTests = new TreeMap<>();
   private final Map<String, JinjavaDocFilter> filters = new TreeMap<>();
   private final Map<String, JinjavaDocFunction> functions = new TreeMap<>();

--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocFactory.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class JinjavaDocFactory {
+
   private static final Logger LOG = LoggerFactory.getLogger(JinjavaDocFactory.class);
 
   private static final Class JINJAVA_DOC_CLASS =
@@ -61,9 +62,8 @@ public class JinjavaDocFactory {
       if (tag instanceof EndTag) {
         continue;
       }
-      com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation = getJinjavaDocAnnotation(
-        tag.getClass()
-      );
+      com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation =
+        getJinjavaDocAnnotation(tag.getClass());
 
       if (docAnnotation == null) {
         LOG.warn(
@@ -92,9 +92,8 @@ public class JinjavaDocFactory {
 
   private void addExpTests(JinjavaDoc doc) {
     for (ExpTest t : jinjava.getGlobalContextCopy().getAllExpTests()) {
-      com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation = getJinjavaDocAnnotation(
-        t.getClass()
-      );
+      com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation =
+        getJinjavaDocAnnotation(t.getClass());
 
       if (docAnnotation == null) {
         LOG.warn(
@@ -133,9 +132,8 @@ public class JinjavaDocFactory {
 
   private void addFilterDocs(JinjavaDoc doc) {
     for (Filter f : jinjava.getGlobalContextCopy().getAllFilters()) {
-      com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation = getJinjavaDocAnnotation(
-        f.getClass()
-      );
+      com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation =
+        getJinjavaDocAnnotation(f.getClass());
 
       if (docAnnotation == null) {
         LOG.warn(
@@ -190,9 +188,8 @@ public class JinjavaDocFactory {
           }
         }
 
-        com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation = realMethod.getAnnotation(
-          com.hubspot.jinjava.doc.annotations.JinjavaDoc.class
-        );
+        com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation =
+          realMethod.getAnnotation(com.hubspot.jinjava.doc.annotations.JinjavaDoc.class);
 
         if (docAnnotation == null) {
           LOG.warn(
@@ -235,9 +232,8 @@ public class JinjavaDocFactory {
       if (t instanceof EndTag) {
         continue;
       }
-      com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation = getJinjavaDocAnnotation(
-        t.getClass()
-      );
+      com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation =
+        getJinjavaDocAnnotation(t.getClass());
 
       if (docAnnotation == null) {
         LOG.warn(
@@ -330,9 +326,8 @@ public class JinjavaDocFactory {
     if (annotation != null) {
       return annotation.code();
     }
-    com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation = getJinjavaDocAnnotation(
-      tag.getClass()
-    );
+    com.hubspot.jinjava.doc.annotations.JinjavaDoc docAnnotation =
+      getJinjavaDocAnnotation(tag.getClass());
     StringBuilder snippet = new StringBuilder("{% ");
     snippet.append(tag.getName());
     int i = 1;

--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocItem.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocItem.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.doc;
 import java.util.Map;
 
 public abstract class JinjavaDocItem {
+
   private final String name;
   private final String desc;
   private final String aliasOf;

--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocParam.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocParam.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.doc;
 
 public class JinjavaDocParam {
+
   private final String name;
   private final String type;
   private final String desc;

--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocSnippet.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocSnippet.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.doc;
 
 public class JinjavaDocSnippet {
+
   private final String desc;
   private final String code;
   private final String output;

--- a/src/main/java/com/hubspot/jinjava/doc/JinjavaDocTag.java
+++ b/src/main/java/com/hubspot/jinjava/doc/JinjavaDocTag.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.doc;
 import java.util.Map;
 
 public class JinjavaDocTag extends JinjavaDocItem {
+
   private final boolean empty;
 
   public JinjavaDocTag(

--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -36,6 +36,7 @@ import org.apache.commons.lang3.StringUtils;
  * Resolves Jinja expressions.
  */
 public class ExpressionResolver {
+
   private final JinjavaInterpreter interpreter;
   private final ExpressionFactory expressionFactory;
   private final JinjavaInterpreterResolver resolver;
@@ -92,8 +93,8 @@ public class ExpressionResolver {
     if (WhitespaceUtils.isWrappedWith(expression, "[", "]")) {
       Arrays
         .stream(expression.substring(1, expression.length() - 1).split(","))
-        .forEach(
-          substring -> interpreter.getContext().addResolvedExpression(substring.trim())
+        .forEach(substring ->
+          interpreter.getContext().addResolvedExpression(substring.trim())
         );
     }
     try {

--- a/src/main/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilder.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilder.java
@@ -12,6 +12,7 @@ import de.odysseus.el.tree.impl.Parser;
  *
  */
 public class ExtendedSyntaxBuilder extends Builder {
+
   private static final long serialVersionUID = 1L;
 
   public ExtendedSyntaxBuilder() {

--- a/src/main/java/com/hubspot/jinjava/el/JinjavaELContext.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaELContext.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Method;
 import javax.el.ELResolver;
 
 public class JinjavaELContext extends SimpleContext {
+
   private JinjavaInterpreter interpreter;
   private MacroFunctionMapper functionMapper;
 

--- a/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaInterpreterResolver.java
@@ -49,8 +49,8 @@ import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
 
 public class JinjavaInterpreterResolver extends SimpleResolver {
-  public static final ELResolver DEFAULT_RESOLVER_READ_ONLY = new CompositeELResolver() {
 
+  public static final ELResolver DEFAULT_RESOLVER_READ_ONLY = new CompositeELResolver() {
     {
       add(new ArrayELResolver(true));
       add(new JinjavaListELResolver(true));
@@ -61,7 +61,6 @@ public class JinjavaInterpreterResolver extends SimpleResolver {
   };
 
   public static final ELResolver DEFAULT_RESOLVER_READ_WRITE = new CompositeELResolver() {
-
     {
       add(new ArrayELResolver(false));
       add(new JinjavaListELResolver(false));

--- a/src/main/java/com/hubspot/jinjava/el/JinjavaProcessors.java
+++ b/src/main/java/com/hubspot/jinjava/el/JinjavaProcessors.java
@@ -5,6 +5,7 @@ import com.hubspot.jinjava.tree.Node;
 import java.util.function.BiConsumer;
 
 public class JinjavaProcessors {
+
   private final BiConsumer<Node, JinjavaInterpreter> nodePreProcessor;
   private final BiConsumer<Node, JinjavaInterpreter> nodePostProcessor;
 
@@ -30,6 +31,7 @@ public class JinjavaProcessors {
   }
 
   public static class Builder {
+
     private BiConsumer<Node, JinjavaInterpreter> nodePreProcessor = (n, i) -> {};
     private BiConsumer<Node, JinjavaInterpreter> nodePostProcessor = (n, i) -> {};
 

--- a/src/main/java/com/hubspot/jinjava/el/MacroFunctionMapper.java
+++ b/src/main/java/com/hubspot/jinjava/el/MacroFunctionMapper.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import javax.el.FunctionMapper;
 
 public class MacroFunctionMapper extends FunctionMapper {
+
   private final JinjavaInterpreter interpreter;
   private Map<String, Method> map = Collections.emptyMap();
 

--- a/src/main/java/com/hubspot/jinjava/el/NoInvokeELContext.java
+++ b/src/main/java/com/hubspot/jinjava/el/NoInvokeELContext.java
@@ -6,6 +6,7 @@ import javax.el.FunctionMapper;
 import javax.el.VariableMapper;
 
 public class NoInvokeELContext extends ELContext {
+
   private ELContext delegate;
   private NoInvokeELResolver elResolver;
 

--- a/src/main/java/com/hubspot/jinjava/el/NoInvokeELResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/NoInvokeELResolver.java
@@ -12,6 +12,7 @@ import javax.el.ELResolver;
  * so disallows modification and invocation which may result in modification of values.
  */
 public class NoInvokeELResolver extends ELResolver {
+
   private ELResolver delegate;
 
   public NoInvokeELResolver(ELResolver delegate) {

--- a/src/main/java/com/hubspot/jinjava/el/TruthyTypeConverter.java
+++ b/src/main/java/com/hubspot/jinjava/el/TruthyTypeConverter.java
@@ -11,6 +11,7 @@ import java.util.Iterator;
 import javax.el.ELException;
 
 public class TruthyTypeConverter extends TypeConverterImpl {
+
   private static final long serialVersionUID = 1L;
   public static final int MAX_COLLECTION_STRING_LENGTH = 1_000_000;
 

--- a/src/main/java/com/hubspot/jinjava/el/TypeConvertingMapELResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/TypeConvertingMapELResolver.java
@@ -7,6 +7,7 @@ import javax.el.ELException;
 import javax.el.MapELResolver;
 
 public class TypeConvertingMapELResolver extends MapELResolver {
+
   private static final TruthyTypeConverter TYPE_CONVERTER = new TruthyTypeConverter();
 
   public TypeConvertingMapELResolver(boolean readOnly) {

--- a/src/main/java/com/hubspot/jinjava/el/ext/AbsOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AbsOperator.java
@@ -11,6 +11,7 @@ import de.odysseus.el.tree.impl.ast.AstUnary;
 import de.odysseus.el.tree.impl.ast.AstUnary.SimpleOperator;
 
 public class AbsOperator extends SimpleOperator {
+
   public static final ExtensionToken TOKEN = new Scanner.ExtensionToken("+");
   public static final AbsOperator OP = new AbsOperator();
 
@@ -47,7 +48,6 @@ public class AbsOperator extends SimpleOperator {
 
   public static ExtensionHandler getHandler(boolean eager) {
     return new ExtensionHandler(ExtensionPoint.UNARY) {
-
       @Override
       public AstNode createAstNode(AstNode... children) {
         return eager ? new EagerAstUnary(children[0], OP) : new AstUnary(children[0], OP);

--- a/src/main/java/com/hubspot/jinjava/el/ext/AbstractCallableMethod.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AbstractCallableMethod.java
@@ -14,6 +14,7 @@ import java.util.Map;
  *
  */
 public abstract class AbstractCallableMethod {
+
   public static final Method EVAL_METHOD;
 
   static {

--- a/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
@@ -14,6 +14,7 @@ import java.util.Objects;
 import javax.el.ELContext;
 
 public class AstDict extends AstLiteral {
+
   protected final Map<AstNode, AstNode> dict;
 
   public AstDict(Map<AstNode, AstNode> dict) {

--- a/src/main/java/com/hubspot/jinjava/el/ext/AstList.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstList.java
@@ -11,6 +11,7 @@ import javax.el.ELContext;
 import org.apache.commons.lang3.StringUtils;
 
 public class AstList extends AstLiteral {
+
   protected final AstParameters elements;
 
   public AstList(AstParameters elements) {

--- a/src/main/java/com/hubspot/jinjava/el/ext/AstNamedParameter.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstNamedParameter.java
@@ -7,6 +7,7 @@ import de.odysseus.el.tree.impl.ast.AstNode;
 import javax.el.ELContext;
 
 public class AstNamedParameter extends AstLiteral {
+
   private final AstIdentifier name;
   private final AstNode value;
 

--- a/src/main/java/com/hubspot/jinjava/el/ext/AstRangeBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstRangeBracket.java
@@ -17,6 +17,7 @@ import javax.el.ELException;
 import javax.el.PropertyNotFoundException;
 
 public class AstRangeBracket extends AstBracket {
+
   protected final AstNode rangeMax;
 
   public AstRangeBracket(

--- a/src/main/java/com/hubspot/jinjava/el/ext/BeanELResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/BeanELResolver.java
@@ -55,11 +55,12 @@ import javax.el.PropertyNotWritableException;
  * @see ELResolver
  */
 public class BeanELResolver extends ELResolver {
-  private static PropertyNotFoundException propertyNotFoundException = new PropertyNotFoundException(
-    "Could not find property"
-  );
+
+  private static PropertyNotFoundException propertyNotFoundException =
+    new PropertyNotFoundException("Could not find property");
 
   protected static final class BeanProperties {
+
     private final Map<String, BeanProperty> map = new HashMap<String, BeanProperty>();
 
     public BeanProperties(Class<?> baseClass) {
@@ -80,6 +81,7 @@ public class BeanELResolver extends ELResolver {
   }
 
   protected static final class BeanProperty {
+
     private final PropertyDescriptor descriptor;
 
     private Method readMethod;

--- a/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
@@ -81,7 +81,8 @@ public class CollectionMembershipOperator extends SimpleOperator {
     return TOKEN.getImage();
   }
 
-  public static final CollectionMembershipOperator OP = new CollectionMembershipOperator();
+  public static final CollectionMembershipOperator OP =
+    new CollectionMembershipOperator();
   public static final Scanner.ExtensionToken TOKEN = new Scanner.ExtensionToken("in");
 
   public static final ExtensionHandler HANDLER = getHandler(false);
@@ -89,7 +90,6 @@ public class CollectionMembershipOperator extends SimpleOperator {
 
   private static ExtensionHandler getHandler(boolean eager) {
     return new ExtensionHandler(ExtensionPoint.CMP) {
-
       @Override
       public AstNode createAstNode(AstNode... children) {
         return eager

--- a/src/main/java/com/hubspot/jinjava/el/ext/CollectionNonMembershipOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/CollectionNonMembershipOperator.java
@@ -21,8 +21,10 @@ public class CollectionNonMembershipOperator extends SimpleOperator {
     return TOKEN.getImage();
   }
 
-  public static final CollectionNonMembershipOperator NOT_IN_OP = new CollectionNonMembershipOperator();
-  public static final CollectionMembershipOperator IN_OP = new CollectionMembershipOperator();
+  public static final CollectionNonMembershipOperator NOT_IN_OP =
+    new CollectionNonMembershipOperator();
+  public static final CollectionMembershipOperator IN_OP =
+    new CollectionMembershipOperator();
   public static final Scanner.ExtensionToken TOKEN = new Scanner.ExtensionToken("not in");
 
   public static final ExtensionHandler HANDLER = getHandler(false);
@@ -30,7 +32,6 @@ public class CollectionNonMembershipOperator extends SimpleOperator {
 
   private static ExtensionHandler getHandler(boolean eager) {
     return new ExtensionHandler(ExtensionPoint.CMP) {
-
       @Override
       public AstNode createAstNode(AstNode... children) {
         return eager

--- a/src/main/java/com/hubspot/jinjava/el/ext/DeferredParsingException.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/DeferredParsingException.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.el.ext;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 
 public class DeferredParsingException extends DeferredValueException {
+
   private final String deferredEvalResult;
   private final Object sourceNode;
   private final IdentifierPreservationStrategy identifierPreservationStrategy;

--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -51,6 +51,7 @@ import java.util.Set;
 import javax.el.ELException;
 
 public class ExtendedParser extends Parser {
+
   public static final String INTERPRETER = "____int3rpr3t3r____";
   public static final String FILTER_PREFIX = "filter:";
   public static final String EXPTEST_PREFIX = "exptest:";
@@ -116,7 +117,6 @@ public class ExtendedParser extends Parser {
     putExtensionHandler(
       PIPE,
       new ExtensionHandler(ExtensionPoint.AND) {
-
         @Override
         public AstNode createAstNode(AstNode... children) {
           throw new ELException("Illegal use of '|' operator");
@@ -626,7 +626,6 @@ public class ExtendedParser extends Parser {
   }
 
   private static final ExtensionHandler NULL_EXT_HANDLER = new ExtensionHandler(null) {
-
     @Override
     public AstNode createAstNode(AstNode... children) {
       return null;

--- a/src/main/java/com/hubspot/jinjava/el/ext/JinjavaBeanELResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/JinjavaBeanELResolver.java
@@ -19,6 +19,7 @@ import javax.el.MethodNotFoundException;
  * {@link BeanELResolver} supporting snake case property names.
  */
 public class JinjavaBeanELResolver extends BeanELResolver {
+
   private static final Set<String> DEFAULT_RESTRICTED_PROPERTIES = ImmutableSet
     .<String>builder()
     .add("class")
@@ -176,17 +177,13 @@ public class JinjavaBeanELResolver extends BeanELResolver {
       .stream()
       .filter(method -> checkAssignableParameterTypes(params, method))
       .min(JinjavaBeanELResolver::pickMoreSpecificMethod)
-      .orElseGet(
-        () ->
-          potentialMethods
-            .stream()
-            .findAny()
-            .orElseGet(
-              () ->
-                finalVarArgsMethod == null
-                  ? null
-                  : findAccessibleMethod(finalVarArgsMethod)
-            )
+      .orElseGet(() ->
+        potentialMethods
+          .stream()
+          .findAny()
+          .orElseGet(() ->
+            finalVarArgsMethod == null ? null : findAccessibleMethod(finalVarArgsMethod)
+          )
       );
   }
 

--- a/src/main/java/com/hubspot/jinjava/el/ext/NamedParameter.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/NamedParameter.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 public class NamedParameter implements PyishSerializable {
+
   private final String name;
   private final Object value;
 

--- a/src/main/java/com/hubspot/jinjava/el/ext/NamedParameterOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/NamedParameterOperator.java
@@ -9,13 +9,13 @@ import de.odysseus.el.tree.impl.ast.AstNode;
 import javax.el.ELException;
 
 public class NamedParameterOperator {
+
   public static final Scanner.ExtensionToken TOKEN = new Scanner.ExtensionToken("=");
 
   public static final ExtensionHandler HANDLER = getHandler(false);
 
   public static ExtensionHandler getHandler(boolean eager) {
     return new ExtensionHandler(ExtensionPoint.ADD) {
-
       @Override
       public AstNode createAstNode(AstNode... children) {
         if (!(children[0] instanceof AstIdentifier)) {

--- a/src/main/java/com/hubspot/jinjava/el/ext/PowerOfOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/PowerOfOperator.java
@@ -10,6 +10,7 @@ import de.odysseus.el.tree.impl.ast.AstBinary.SimpleOperator;
 import de.odysseus.el.tree.impl.ast.AstNode;
 
 public class PowerOfOperator extends SimpleOperator {
+
   public static final Scanner.ExtensionToken TOKEN = new Scanner.ExtensionToken("**");
   public static final PowerOfOperator OP = new PowerOfOperator();
 
@@ -50,7 +51,6 @@ public class PowerOfOperator extends SimpleOperator {
 
   public static ExtensionHandler getHandler(boolean eager) {
     return new ExtensionHandler(ExtensionPoint.MUL) {
-
       @Override
       public AstNode createAstNode(AstNode... children) {
         return eager

--- a/src/main/java/com/hubspot/jinjava/el/ext/StringConcatOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/StringConcatOperator.java
@@ -31,7 +31,6 @@ public class StringConcatOperator extends SimpleOperator {
 
   public static ExtensionHandler getHandler(boolean eager) {
     return new ExtensionHandler(ExtensionPoint.ADD) {
-
       @Override
       public AstNode createAstNode(AstNode... children) {
         return eager

--- a/src/main/java/com/hubspot/jinjava/el/ext/TruncDivOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/TruncDivOperator.java
@@ -10,6 +10,7 @@ import de.odysseus.el.tree.impl.ast.AstBinary.SimpleOperator;
 import de.odysseus.el.tree.impl.ast.AstNode;
 
 public class TruncDivOperator extends SimpleOperator {
+
   public static final Scanner.ExtensionToken TOKEN = new Scanner.ExtensionToken("//");
   public static final TruncDivOperator OP = new TruncDivOperator();
 
@@ -50,7 +51,6 @@ public class TruncDivOperator extends SimpleOperator {
 
   public static ExtensionHandler getHandler(boolean eager) {
     return new ExtensionHandler(ExtensionPoint.MUL) {
-
       @Override
       public AstNode createAstNode(AstNode... children) {
         return eager

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBinary.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBinary.java
@@ -10,6 +10,7 @@ import de.odysseus.el.tree.impl.ast.AstNode;
 import javax.el.ELContext;
 
 public class EagerAstBinary extends AstBinary implements EvalResultHolder {
+
   protected Object evalResult;
   protected boolean hasEvalResult;
   protected final EvalResultHolder left;

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstBracket.java
@@ -8,6 +8,7 @@ import de.odysseus.el.tree.impl.ast.AstNode;
 import javax.el.ELContext;
 
 public class EagerAstBracket extends AstBracket implements EvalResultHolder {
+
   protected Object evalResult;
   protected boolean hasEvalResult;
 

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoice.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstChoice.java
@@ -10,6 +10,7 @@ import javax.el.ELContext;
 import javax.el.ELException;
 
 public class EagerAstChoice extends AstChoice implements EvalResultHolder {
+
   protected Object evalResult;
   protected boolean hasEvalResult;
   protected final EvalResultHolder question;

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDot.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstDot.java
@@ -9,6 +9,7 @@ import javax.el.ELContext;
 import javax.el.ELException;
 
 public class EagerAstDot extends AstDot implements EvalResultHolder {
+
   protected Object evalResult;
   protected boolean hasEvalResult;
   protected final EvalResultHolder base;

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifier.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifier.java
@@ -7,6 +7,7 @@ import de.odysseus.el.tree.impl.ast.AstIdentifier;
 import javax.el.ELContext;
 
 public class EagerAstIdentifier extends AstIdentifier implements EvalResultHolder {
+
   protected Object evalResult;
   protected boolean hasEvalResult;
 

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstList.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstList.java
@@ -9,6 +9,7 @@ import java.util.StringJoiner;
 import javax.el.ELContext;
 
 public class EagerAstList extends AstList implements EvalResultHolder {
+
   protected Object evalResult;
   protected boolean hasEvalResult;
 

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMacroFunction.java
@@ -17,6 +17,7 @@ import javax.el.ELContext;
 import javax.el.ELException;
 
 public class EagerAstMacroFunction extends AstMacroFunction implements EvalResultHolder {
+
   protected Object evalResult;
   protected boolean hasEvalResult;
   // instanceof AstParameters
@@ -71,8 +72,7 @@ public class EagerAstMacroFunction extends AstMacroFunction implements EvalResul
     ELContext context,
     Object base,
     Method method
-  )
-    throws InvocationTargetException, IllegalAccessException {
+  ) throws InvocationTargetException, IllegalAccessException {
     Class<?>[] types = method.getParameterTypes();
     Object[] params = null;
     if (types.length > 0) {

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethod.java
@@ -12,6 +12,7 @@ import javax.el.ELContext;
 import javax.el.ELException;
 
 public class EagerAstMethod extends AstMethod implements EvalResultHolder {
+
   protected Object evalResult;
   protected boolean hasEvalResult;
   // instanceof AstProperty

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNamedParameter.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNamedParameter.java
@@ -11,6 +11,7 @@ import javax.el.ELContext;
 public class EagerAstNamedParameter
   extends AstNamedParameter
   implements EvalResultHolder {
+
   protected boolean hasEvalResult;
   protected Object evalResult;
   protected final AstIdentifier name;

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNested.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNested.java
@@ -12,6 +12,7 @@ import javax.el.ELContext;
  * AstNested is final so this decorates AstRightValue.
  */
 public class EagerAstNested extends AstRightValue implements EvalResultHolder {
+
   protected Object evalResult;
   protected boolean hasEvalResult;
   protected final AstNode child;

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNodeDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstNodeDecorator.java
@@ -15,6 +15,7 @@ import javax.el.ValueReference;
  * be an EvalResultHolder or wrapped with this decorator.
  */
 public class EagerAstNodeDecorator extends AstNode implements EvalResultHolder {
+
   private final AstNode astNode;
   protected Object evalResult;
   protected boolean hasEvalResult;

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstParameters.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstParameters.java
@@ -16,6 +16,7 @@ import javax.el.ELContext;
 import javax.el.ELException;
 
 public class EagerAstParameters extends AstParameters implements EvalResultHolder {
+
   protected Object evalResult;
   protected boolean hasEvalResult;
   protected final List<AstNode> nodes;
@@ -78,17 +79,16 @@ public class EagerAstParameters extends AstParameters implements EvalResultHolde
     nodes
       .stream()
       .map(node -> (EvalResultHolder) node)
-      .forEach(
-        node ->
-          joiner.add(
-            EvalResultHolder.reconstructNode(
-              bindings,
-              context,
-              node,
-              deferredParsingException,
-              identifierPreservationStrategy
-            )
+      .forEach(node ->
+        joiner.add(
+          EvalResultHolder.reconstructNode(
+            bindings,
+            context,
+            node,
+            deferredParsingException,
+            identifierPreservationStrategy
           )
+        )
       );
     return joiner.toString();
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstRangeBracket.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstRangeBracket.java
@@ -8,6 +8,7 @@ import de.odysseus.el.tree.impl.ast.AstNode;
 import javax.el.ELContext;
 
 public class EagerAstRangeBracket extends AstRangeBracket implements EvalResultHolder {
+
   protected Object evalResult;
   protected boolean hasEvalResult;
 

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstRoot.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstRoot.java
@@ -8,6 +8,7 @@ import javax.el.MethodInfo;
 import javax.el.ValueReference;
 
 public class EagerAstRoot extends AstNode {
+
   private AstNode rootNode;
 
   public EagerAstRoot(AstNode rootNode) {

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstTuple.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstTuple.java
@@ -9,6 +9,7 @@ import java.util.StringJoiner;
 import javax.el.ELContext;
 
 public class EagerAstTuple extends AstTuple implements EvalResultHolder {
+
   protected Object evalResult;
   protected boolean hasEvalResult;
 

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstUnary.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EagerAstUnary.java
@@ -8,6 +8,7 @@ import de.odysseus.el.tree.impl.ast.AstUnary;
 import javax.el.ELContext;
 
 public class EagerAstUnary extends AstUnary implements EvalResultHolder {
+
   protected Object evalResult;
   protected boolean hasEvalResult;
   protected final EvalResultHolder child;

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/MacroFunctionTempVariable.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/MacroFunctionTempVariable.java
@@ -4,6 +4,7 @@ import com.hubspot.jinjava.objects.serialization.PyishBlockSetSerializable;
 import java.util.Objects;
 
 public class MacroFunctionTempVariable implements PyishBlockSetSerializable {
+
   private static final String CONTEXT_KEY_PREFIX = "__macro_%s_%d_temp_variable_%d__";
   private final String deferredResult;
 

--- a/src/main/java/com/hubspot/jinjava/features/DateTimeFeatureActivationStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/features/DateTimeFeatureActivationStrategy.java
@@ -4,6 +4,7 @@ import com.hubspot.jinjava.interpret.Context;
 import java.time.ZonedDateTime;
 
 public class DateTimeFeatureActivationStrategy implements FeatureActivationStrategy {
+
   private final ZonedDateTime activateAt;
 
   public static DateTimeFeatureActivationStrategy of(ZonedDateTime activateAt) {

--- a/src/main/java/com/hubspot/jinjava/features/FeatureConfig.java
+++ b/src/main/java/com/hubspot/jinjava/features/FeatureConfig.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class FeatureConfig {
+
   Map<String, FeatureActivationStrategy> features;
 
   private FeatureConfig(Map<String, FeatureActivationStrategy> features) {
@@ -20,6 +21,7 @@ public class FeatureConfig {
   }
 
   public static class Builder {
+
     private final Map<String, FeatureActivationStrategy> features = new HashMap<>();
 
     public Builder add(String name, FeatureActivationStrategy strategy) {

--- a/src/main/java/com/hubspot/jinjava/features/FeatureStrategies.java
+++ b/src/main/java/com/hubspot/jinjava/features/FeatureStrategies.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.features;
 
 public class FeatureStrategies {
+
   public static final FeatureActivationStrategy INACTIVE = c -> false;
   public static final FeatureActivationStrategy ACTIVE = c -> true;
 }

--- a/src/main/java/com/hubspot/jinjava/features/Features.java
+++ b/src/main/java/com/hubspot/jinjava/features/Features.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.features;
 import com.hubspot.jinjava.interpret.Context;
 
 public class Features {
+
   private final FeatureConfig featureConfig;
 
   public Features(FeatureConfig featureConfig) {

--- a/src/main/java/com/hubspot/jinjava/interpret/CallStack.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/CallStack.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import java.util.Stack;
 
 public class CallStack {
+
   private final CallStack parent;
   private final Class<? extends TagCycleException> exceptionClass;
   private final Stack<String> stack = new Stack<>();

--- a/src/main/java/com/hubspot/jinjava/interpret/CannotReconstructValueException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/CannotReconstructValueException.java
@@ -4,6 +4,7 @@ import com.google.common.annotations.Beta;
 
 @Beta
 public class CannotReconstructValueException extends DeferredValueException {
+
   public static final String CANNOT_RECONSTRUCT_MESSAGE = "Cannot reconstruct value";
 
   public CannotReconstructValueException(String key) {

--- a/src/main/java/com/hubspot/jinjava/interpret/CollectionTooBigException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/CollectionTooBigException.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.interpret;
 
 public class CollectionTooBigException extends RuntimeException {
+
   private final int maxSize;
   private final int size;
 

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -51,6 +51,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class Context extends ScopeMap<String, Object> {
+
   public static final String GLOBAL_MACROS_SCOPE_KEY = "__macros__";
   public static final String IMPORT_RESOURCE_PATH_KEY = "import_resource_path";
   public static final String DEFERRED_IMPORT_RESOURCE_PATH_KEY =
@@ -74,7 +75,7 @@ public class Context extends ScopeMap<String, Object> {
     EXP_TEST,
     FILTER,
     FUNCTION,
-    TAG
+    TAG,
   }
 
   private final CallStack extendPathStack;
@@ -412,13 +413,11 @@ public class Context extends ScopeMap<String, Object> {
       .getCurrentMaybe()
       .map(i -> i.getConfig().getMaxNumDeferredTokens())
       .filter(maxNumDeferredTokens -> currentNumDeferredTokens >= maxNumDeferredTokens)
-      .ifPresent(
-        maxNumDeferredTokens -> {
-          throw new DeferredValueException(
-            "Too many Deferred Tokens, max is " + maxNumDeferredTokens
-          );
-        }
-      );
+      .ifPresent(maxNumDeferredTokens -> {
+        throw new DeferredValueException(
+          "Too many Deferred Tokens, max is " + maxNumDeferredTokens
+        );
+      });
   }
 
   @Beta
@@ -800,6 +799,7 @@ public class Context extends ScopeMap<String, Object> {
   }
 
   public static class TemporaryValueClosable<T> implements AutoCloseable {
+
     private final T previousValue;
     private final Consumer<T> resetValueConsumer;
 

--- a/src/main/java/com/hubspot/jinjava/interpret/DeferredLazyReference.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/DeferredLazyReference.java
@@ -5,6 +5,7 @@ import com.google.common.annotations.Beta;
 @Beta
 public class DeferredLazyReference
   implements DeferredValue, Cloneable, OneTimeReconstructible {
+
   private final LazyReference lazyReference;
   private boolean reconstructed;
 

--- a/src/main/java/com/hubspot/jinjava/interpret/DeferredLazyReferenceSource.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/DeferredLazyReferenceSource.java
@@ -6,7 +6,9 @@ import com.google.common.annotations.Beta;
 public class DeferredLazyReferenceSource
   extends DeferredValueImpl
   implements OneTimeReconstructible {
-  private static final DeferredLazyReferenceSource INSTANCE = new DeferredLazyReferenceSource();
+
+  private static final DeferredLazyReferenceSource INSTANCE =
+    new DeferredLazyReferenceSource();
 
   private boolean reconstructed;
 

--- a/src/main/java/com/hubspot/jinjava/interpret/DeferredMacroValueImpl.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/DeferredMacroValueImpl.java
@@ -4,6 +4,7 @@ import com.google.common.annotations.Beta;
 
 @Beta
 public class DeferredMacroValueImpl implements DeferredValue {
+
   private static final DeferredValue INSTANCE = new DeferredMacroValueImpl();
 
   private DeferredMacroValueImpl() {}

--- a/src/main/java/com/hubspot/jinjava/interpret/DeferredValueException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/DeferredValueException.java
@@ -6,6 +6,7 @@ package com.hubspot.jinjava.interpret;
  * and instead echo its contents to the output.
  */
 public class DeferredValueException extends InterpretException {
+
   public static final String MESSAGE_PREFIX = "Encountered a deferred value: ";
 
   public DeferredValueException(String message) {

--- a/src/main/java/com/hubspot/jinjava/interpret/DeferredValueImpl.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/DeferredValueImpl.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.interpret;
 import java.util.Objects;
 
 public class DeferredValueImpl implements DeferredValue {
+
   private static final DeferredValue INSTANCE = new DeferredValueImpl();
 
   private Object originalValue;

--- a/src/main/java/com/hubspot/jinjava/interpret/DisabledException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/DisabledException.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.interpret;
 
 public class DisabledException extends InterpretException {
+
   private final String token;
 
   public DisabledException(String token) {

--- a/src/main/java/com/hubspot/jinjava/interpret/ExtendsTagCycleException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/ExtendsTagCycleException.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.interpret;
 
 public class ExtendsTagCycleException extends TagCycleException {
+
   private static final long serialVersionUID = 3183769038400532542L;
 
   public ExtendsTagCycleException(String path, int lineNumber, int startPosition) {

--- a/src/main/java/com/hubspot/jinjava/interpret/FatalTemplateErrorsException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/FatalTemplateErrorsException.java
@@ -8,6 +8,7 @@ import java.util.Collection;
  * @author jstehler
  */
 public class FatalTemplateErrorsException extends InterpretException {
+
   private static final long serialVersionUID = 1L;
 
   private final String template;

--- a/src/main/java/com/hubspot/jinjava/interpret/FromTagCycleException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/FromTagCycleException.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.interpret;
 
 public class FromTagCycleException extends TagCycleException {
+
   private static final long serialVersionUID = -5487642459443650227L;
 
   public FromTagCycleException(String path, int lineNumber, int startPosition) {

--- a/src/main/java/com/hubspot/jinjava/interpret/ImportTagCycleException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/ImportTagCycleException.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.interpret;
 
 public class ImportTagCycleException extends TagCycleException {
+
   private static final long serialVersionUID = 1092085697026161185L;
 
   public ImportTagCycleException(String path, int lineNumber, int startPosition) {

--- a/src/main/java/com/hubspot/jinjava/interpret/IncludeTagCycleException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/IncludeTagCycleException.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.interpret;
 
 public class IncludeTagCycleException extends TagCycleException {
+
   private static final long serialVersionUID = -5487642459443650227L;
 
   public IncludeTagCycleException(String path, int lineNumber, int startPosition) {

--- a/src/main/java/com/hubspot/jinjava/interpret/InterpretException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/InterpretException.java
@@ -16,6 +16,7 @@ limitations under the License.
 package com.hubspot.jinjava.interpret;
 
 public class InterpretException extends RuntimeException {
+
   private static final long serialVersionUID = -3471306977643126138L;
 
   private int lineNumber = -1;

--- a/src/main/java/com/hubspot/jinjava/interpret/InvalidArgumentException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/InvalidArgumentException.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.interpret;
 import com.hubspot.jinjava.lib.Importable;
 
 public class InvalidArgumentException extends RuntimeException {
+
   private final int lineNumber;
   private final int startPosition;
   private final String message;

--- a/src/main/java/com/hubspot/jinjava/interpret/InvalidInputException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/InvalidInputException.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.interpret;
 import com.hubspot.jinjava.lib.Importable;
 
 public class InvalidInputException extends RuntimeException {
+
   private final int lineNumber;
   private final int startPosition;
   private final String message;

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -74,6 +74,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 public class JinjavaInterpreter implements PyishSerializable {
+
   public static final String IGNORED_OUTPUT_FROM_EXTENDS_NOTE =
     "ignored_output_from_extends";
   private final Multimap<String, BlockInfo> blocks = ArrayListMultimap.create();
@@ -828,17 +829,15 @@ public class JinjavaInterpreter implements PyishSerializable {
     childErrors
       .stream()
       .limit(MAX_ERROR_SIZE - errors.size())
-      .forEach(
-        error -> {
-          if (!error.getSourceTemplate().isPresent()) {
-            error.setMessage(getWrappedErrorMessage(childTemplateName, error));
-            error.setSourceTemplate(childTemplateName);
-          }
-          error.setStartPosition(this.getPosition());
-          error.setLineno(this.getLineNumber());
-          this.addError(error);
+      .forEach(error -> {
+        if (!error.getSourceTemplate().isPresent()) {
+          error.setMessage(getWrappedErrorMessage(childTemplateName, error));
+          error.setSourceTemplate(childTemplateName);
         }
-      );
+        error.setStartPosition(this.getPosition());
+        error.setLineno(this.getLineNumber());
+        this.addError(error);
+      });
   }
 
   // We cannot just remove this, other projects may depend on it.
@@ -851,9 +850,8 @@ public class JinjavaInterpreter implements PyishSerializable {
     return Lists.newArrayList(errors);
   }
 
-  private static final ThreadLocal<Stack<JinjavaInterpreter>> CURRENT_INTERPRETER = ThreadLocal.withInitial(
-    Stack::new
-  );
+  private static final ThreadLocal<Stack<JinjavaInterpreter>> CURRENT_INTERPRETER =
+    ThreadLocal.withInitial(Stack::new);
 
   public static JinjavaInterpreter getCurrent() {
     if (CURRENT_INTERPRETER.get().isEmpty()) {

--- a/src/main/java/com/hubspot/jinjava/interpret/LazyExpression.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/LazyExpression.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.function.Supplier;
 
 public class LazyExpression implements Supplier {
+
   private final Supplier supplier;
   private final String image;
   private final Memoization memoization;
@@ -11,7 +12,7 @@ public class LazyExpression implements Supplier {
 
   public enum Memoization {
     ON,
-    OFF
+    OFF,
   }
 
   protected LazyExpression(Supplier supplier, String image, Memoization memoization) {

--- a/src/main/java/com/hubspot/jinjava/interpret/LazyReference.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/LazyReference.java
@@ -4,6 +4,7 @@ import com.hubspot.jinjava.objects.serialization.PyishSerializable;
 import java.io.IOException;
 
 public class LazyReference extends LazyExpression implements PyishSerializable {
+
   private String referenceKey;
 
   protected LazyReference(Context referenceContext, String referenceKey) {

--- a/src/main/java/com/hubspot/jinjava/interpret/MacroTagCycleException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/MacroTagCycleException.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.interpret;
 
 public class MacroTagCycleException extends TagCycleException {
+
   private static final long serialVersionUID = -7552850581260771832L;
 
   public MacroTagCycleException(String path, int lineNumber, int startPosition) {

--- a/src/main/java/com/hubspot/jinjava/interpret/MissingEndTagException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/MissingEndTagException.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.interpret;
 import org.apache.commons.lang3.StringUtils;
 
 public class MissingEndTagException extends TemplateSyntaxException {
+
   private static final long serialVersionUID = 1L;
 
   private final String endTag;

--- a/src/main/java/com/hubspot/jinjava/interpret/NullValue.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/NullValue.java
@@ -6,6 +6,7 @@ package com.hubspot.jinjava.interpret;
  * we treat it as the there is not key "a" in the map.
  */
 public final class NullValue {
+
   public static final NullValue INSTANCE = new NullValue();
 
   private NullValue() {}

--- a/src/main/java/com/hubspot/jinjava/interpret/OutputTooBigException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/OutputTooBigException.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.interpret;
 
 public class OutputTooBigException extends RuntimeException {
+
   private long maxSize;
   private final long size;
 

--- a/src/main/java/com/hubspot/jinjava/interpret/RenderResult.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/RenderResult.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class RenderResult {
+
   private final String output;
   private final Context context;
   private final List<TemplateError> errors;

--- a/src/main/java/com/hubspot/jinjava/interpret/RevertibleObject.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/RevertibleObject.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 @Beta
 public class RevertibleObject {
+
   private final Object hashCode;
   private final Optional<String> pyishString;
 

--- a/src/main/java/com/hubspot/jinjava/interpret/TagCycleException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TagCycleException.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.interpret;
 import java.util.Optional;
 
 public class TagCycleException extends TemplateStateException {
+
   private static final long serialVersionUID = -3058494056577268723L;
 
   private final String path;

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateError.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 public class TemplateError {
+
   private static final Pattern GENERIC_TOSTRING_PATTERN = Pattern.compile(
     "@[0-9a-z]{4,}$"
   );
@@ -17,7 +18,7 @@ public class TemplateError {
 
   public enum ErrorType {
     FATAL,
-    WARNING
+    WARNING,
   }
 
   public enum ErrorReason {
@@ -32,7 +33,7 @@ public class TemplateError {
     OUTPUT_TOO_BIG,
     OVER_LIMIT,
     COLLECTION_TOO_BIG,
-    OTHER
+    OTHER,
   }
 
   public enum ErrorItem {
@@ -43,7 +44,7 @@ public class TemplateError {
     PROPERTY,
     FILTER,
     EXPRESSION_TEST,
-    OTHER
+    OTHER,
   }
 
   private final ErrorType severity;

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateStateException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateStateException.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.interpret;
 
 public class TemplateStateException extends InterpretException {
+
   private static final long serialVersionUID = 426925445445430522L;
 
   public TemplateStateException(String msg) {

--- a/src/main/java/com/hubspot/jinjava/interpret/TemplateSyntaxException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/TemplateSyntaxException.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.interpret;
 
 public class TemplateSyntaxException extends InterpretException {
+
   private static final long serialVersionUID = 1L;
 
   private final String code;

--- a/src/main/java/com/hubspot/jinjava/interpret/UnexpectedTokenException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/UnexpectedTokenException.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.interpret;
 
 public class UnexpectedTokenException extends TemplateSyntaxException {
+
   private static final long serialVersionUID = 1L;
 
   private final String token;

--- a/src/main/java/com/hubspot/jinjava/interpret/UnknownTagException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/UnknownTagException.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.interpret;
 import com.hubspot.jinjava.tree.parse.TagToken;
 
 public class UnknownTagException extends TemplateSyntaxException {
+
   private static final long serialVersionUID = 1L;
 
   private final String tag;

--- a/src/main/java/com/hubspot/jinjava/interpret/UnknownTokenException.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/UnknownTokenException.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.interpret;
 
 public class UnknownTokenException extends InterpretException {
+
   private static final long serialVersionUID = -388757722051666198L;
   private final String token;
 

--- a/src/main/java/com/hubspot/jinjava/interpret/errorcategory/BasicTemplateErrorCategory.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/errorcategory/BasicTemplateErrorCategory.java
@@ -8,5 +8,5 @@ public enum BasicTemplateErrorCategory implements TemplateErrorCategory {
   UNKNOWN,
   UNKNOWN_DATE,
   UNKNOWN_LOCALE,
-  UNKNOWN_PROPERTY
+  UNKNOWN_PROPERTY,
 }

--- a/src/main/java/com/hubspot/jinjava/lib/SimpleLibrary.java
+++ b/src/main/java/com/hubspot/jinjava/lib/SimpleLibrary.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public abstract class SimpleLibrary<T extends Importable> {
+
   private Map<String, T> lib = new HashMap<>();
   private Set<String> disabled = new HashSet<>();
 

--- a/src/main/java/com/hubspot/jinjava/lib/expression/DefaultExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/DefaultExpressionStrategy.java
@@ -9,6 +9,7 @@ import com.hubspot.jinjava.util.Logging;
 import org.apache.commons.lang3.StringUtils;
 
 public class DefaultExpressionStrategy implements ExpressionStrategy {
+
   private static final long serialVersionUID = 436239440273704843L;
 
   public RenderedOutputNode interpretOutput(

--- a/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/EagerExpressionStrategy.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 
 @Beta
 public class EagerExpressionStrategy implements ExpressionStrategy {
+
   private static final long serialVersionUID = -6792345439237764193L;
 
   @Override
@@ -38,8 +39,8 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
       eagerInterpreter ->
         EagerExpressionResolver.resolveExpression(master.getExpr(), interpreter),
       interpreter,
-      EagerContextWatcher
-        .EagerChildContextConfig.newBuilder()
+      EagerContextWatcher.EagerChildContextConfig
+        .newBuilder()
         .withTakeNewValue(true)
         .withPartialMacroEvaluation(
           interpreter.getConfig().isNestedInterpretationEnabled()
@@ -131,10 +132,9 @@ public class EagerExpressionStrategy implements ExpressionStrategy {
       .getErrors()
       .stream()
       .filter(Objects::nonNull)
-      .filter(
-        error ->
-          "Unclosed comment".equals(error.getMessage()) ||
-          error.getReason() == ErrorReason.DISABLED
+      .filter(error ->
+        "Unclosed comment".equals(error.getMessage()) ||
+        error.getReason() == ErrorReason.DISABLED
       )
       .count();
   }

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/CollectionExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/CollectionExpTest.java
@@ -4,6 +4,8 @@ import com.hubspot.jinjava.el.TruthyTypeConverter;
 import com.hubspot.jinjava.el.ext.CollectionMembershipOperator;
 
 public abstract class CollectionExpTest implements ExpTest {
+
   protected static final TruthyTypeConverter TYPE_CONVERTER = new TruthyTypeConverter();
-  protected static final CollectionMembershipOperator COLLECTION_MEMBERSHIP_OPERATOR = new CollectionMembershipOperator();
+  protected static final CollectionMembershipOperator COLLECTION_MEMBERSHIP_OPERATOR =
+    new CollectionMembershipOperator();
 }

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsBooleanExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsBooleanExpTest.java
@@ -13,7 +13,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
       code = "{% if true is boolean %}\n" +
       "      <!--this code will always render-->\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class IsBooleanExpTest implements ExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsDefinedExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsDefinedExpTest.java
@@ -13,7 +13,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
       code = "{% if variable is defined %}\n" +
       "<!--code to render if variable is defined-->\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class IsDefinedExpTest implements ExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsDivisibleByExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsDivisibleByExpTest.java
@@ -24,7 +24,7 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
       "{% else %}\n" +
       "   <!--code to render if variable cannot be divided by 5-->\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class IsDivisibleByExpTest implements ExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTest.java
@@ -18,7 +18,7 @@ import de.odysseus.el.misc.TypeConverter;
       type = "object",
       desc = "Another object to check equality against",
       required = true
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -29,10 +29,11 @@ import de.odysseus.el.misc.TypeConverter;
     @JinjavaSnippet(
       desc = "Usage with the selectattr filter",
       code = "{{ users|selectattr(\"email\", \"equalto\", \"foo@bar.invalid\") }}"
-    )
+    ),
   }
 )
 public class IsEqualToExpTest implements ExpTest {
+
   private static final TypeConverter TYPE_CONVERTER = new TruthyTypeConverter();
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsEvenExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsEvenExpTest.java
@@ -15,7 +15,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
       "{% else %}\n" +
       "   <!--code to render if variable is an odd number-->\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class IsEvenExpTest implements ExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsFalseExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsFalseExpTest.java
@@ -13,7 +13,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
       code = "{% if false is false %}\n" +
       "      <!--this code will always render-->\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class IsFalseExpTest implements ExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsFloatExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsFloatExpTest.java
@@ -14,7 +14,7 @@ import java.math.BigDecimal;
       code = "{% if num is float %}\n" +
       "      <!--code to render if num contains an floating point value-->\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class IsFloatExpTest implements ExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsGeTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsGeTest.java
@@ -18,7 +18,7 @@ import de.odysseus.el.misc.TypeConverter;
       type = "object",
       desc = "Another object to compare against",
       required = true
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -29,10 +29,11 @@ import de.odysseus.el.misc.TypeConverter;
     @JinjavaSnippet(
       desc = "Usage with the selectattr filter",
       code = "{{ users|selectattr(\"num\", \"ge\", \"2\") }}"
-    )
+    ),
   }
 )
 public class IsGeTest implements ExpTest {
+
   private static final TypeConverter TYPE_CONVERTER = new TruthyTypeConverter();
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsGtTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsGtTest.java
@@ -18,7 +18,7 @@ import de.odysseus.el.misc.TypeConverter;
       type = "object",
       desc = "Another object to compare against",
       required = true
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -29,10 +29,11 @@ import de.odysseus.el.misc.TypeConverter;
     @JinjavaSnippet(
       desc = "Usage with the selectattr filter",
       code = "{{ users|selectattr(\"num\", \"gt\", \"2\") }}"
-    )
+    ),
   }
 )
 public class IsGtTest implements ExpTest {
+
   private static final TypeConverter TYPE_CONVERTER = new TruthyTypeConverter();
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsInExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsInExpTest.java
@@ -21,7 +21,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
   snippets = {
     @JinjavaSnippet(code = "{{ 2 is in [1, 2, 3] }}"),
     @JinjavaSnippet(code = "{{ 'b' is in 'abc' }}"),
-    @JinjavaSnippet(code = "{{ 'k2' is in {'k1':'v1', 'k2':'v2'} }}")
+    @JinjavaSnippet(code = "{{ 'k2' is in {'k1':'v1', 'k2':'v2'} }}"),
   }
 )
 public class IsInExpTest extends CollectionExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsIntegerExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsIntegerExpTest.java
@@ -15,7 +15,7 @@ import java.math.BigInteger;
       code = "{% if num is integer %}\n" +
       "      <!--code to render if num contains an integral value-->\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class IsIntegerExpTest implements ExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsIterableExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsIterableExpTest.java
@@ -13,7 +13,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
       code = "{% if variable is iterable %}\n" +
       "       <!--code to render if items in a variable can be iterated through-->\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class IsIterableExpTest implements ExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsLeTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsLeTest.java
@@ -18,7 +18,7 @@ import de.odysseus.el.misc.TypeConverter;
       type = "object",
       desc = "Another object to compare against",
       required = true
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -29,10 +29,11 @@ import de.odysseus.el.misc.TypeConverter;
     @JinjavaSnippet(
       desc = "Usage with the selectattr filter",
       code = "{{ users|selectattr(\"num\", \"le\", \"2\") }}"
-    )
+    ),
   }
 )
 public class IsLeTest implements ExpTest {
+
   private static final TypeConverter TYPE_CONVERTER = new TruthyTypeConverter();
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsLowerExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsLowerExpTest.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.StringUtils;
       code = "{% if variable is lower %}\n" +
       "   <!--code to render if variable value is lowercased-->\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class IsLowerExpTest implements ExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsLtTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsLtTest.java
@@ -18,7 +18,7 @@ import de.odysseus.el.misc.TypeConverter;
       type = "object",
       desc = "Another object to compare against",
       required = true
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -29,10 +29,11 @@ import de.odysseus.el.misc.TypeConverter;
     @JinjavaSnippet(
       desc = "Usage with the selectattr filter",
       code = "{{ users|selectattr(\"num\", \"lt\", \"2\") }}"
-    )
+    ),
   }
 )
 public class IsLtTest implements ExpTest {
+
   private static final TypeConverter TYPE_CONVERTER = new TruthyTypeConverter();
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsMappingExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsMappingExpTest.java
@@ -14,7 +14,7 @@ import java.util.Map;
       code = "{% if variable is mapping %}\n" +
       "     <!--code to render when object is a dict-->\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class IsMappingExpTest implements ExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsNeExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsNeExpTest.java
@@ -18,7 +18,7 @@ import de.odysseus.el.misc.TypeConverter;
       type = "object",
       desc = "Another object to check inequality against",
       required = true
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -29,10 +29,11 @@ import de.odysseus.el.misc.TypeConverter;
     @JinjavaSnippet(
       desc = "Usage with the selectattr filter",
       code = "{{ users|selectattr(\"email\", \"ne\", \"foo@bar.invalid\") }}"
-    )
+    ),
   }
 )
 public class IsNeExpTest implements ExpTest {
+
   private static final TypeConverter TYPE_CONVERTER = new TruthyTypeConverter();
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsNoneExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsNoneExpTest.java
@@ -13,7 +13,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
       code = "{% unless variable is none %}\n" +
       "     <!--code to render unless the variable is null-->\n" +
       "{% endunless %}"
-    )
+    ),
   }
 )
 public class IsNoneExpTest implements ExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsNumberExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsNumberExpTest.java
@@ -15,7 +15,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
       "{% else %}\n" +
       "       The variable is not a number.\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class IsNumberExpTest implements ExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsOddExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsOddExpTest.java
@@ -15,7 +15,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
       "{% else %}\n" +
       "   <!--code to render if variable is an even number-->\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class IsOddExpTest implements ExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsSameAsExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsSameAsExpTest.java
@@ -20,7 +20,7 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
       code = "{% if var_one is sameas var_two %}\n" +
       "    <!--code to render if variables have the same value as one another-->\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class IsSameAsExpTest implements ExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsSequenceExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsSequenceExpTest.java
@@ -15,7 +15,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
       code = "{% if variable is sequence %}\n" +
       "      <!--code to render if items in a variable is a sequence-->\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class IsSequenceExpTest implements ExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringContainingExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringContainingExpTest.java
@@ -20,7 +20,7 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
       code = "{% if variable is string_containing 'foo' %}\n" +
       "      <!--code to render if variable contains 'foo' -->\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class IsStringContainingExpTest extends IsStringExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringExpTest.java
@@ -14,7 +14,7 @@ import com.hubspot.jinjava.objects.SafeString;
       code = "{% if variable is string %}\n" +
       "      <!--code to render if a variable contains a string value-->\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class IsStringExpTest implements ExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringStartingWithExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsStringStartingWithExpTest.java
@@ -20,7 +20,7 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
       code = "{% if variable is string_startingwith 'foo' %}\n" +
       "      <!--code to render if variable starts with 'foo'-->\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class IsStringStartingWithExpTest extends IsStringExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsTrueExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsTrueExpTest.java
@@ -13,7 +13,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
       code = "{% if false is true %}\n" +
       "      <!--this code will never render-->\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class IsTrueExpTest implements ExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsTruthyExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsTruthyExpTest.java
@@ -14,7 +14,7 @@ import com.hubspot.jinjava.util.ObjectTruthValue;
       code = "{% if variable is truthy %}\n" +
       "      <!--code to render a boolean variable is True-->\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class IsTruthyExpTest implements ExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsUndefinedExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsUndefinedExpTest.java
@@ -13,7 +13,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
       code = "{% if variable is undefined %}\n" +
       "      <!--code to render if variable is undefined-->\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class IsUndefinedExpTest implements ExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/exptest/IsUpperExpTest.java
+++ b/src/main/java/com/hubspot/jinjava/lib/exptest/IsUpperExpTest.java
@@ -15,7 +15,7 @@ import org.apache.commons.lang3.StringUtils;
       code = "{% if variable is upper %}\n" +
       "    <!-- code to render if variable value is uppercased -->\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class IsUpperExpTest implements ExpTest {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/AbsFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AbsFilter.java
@@ -33,7 +33,7 @@ import java.math.BigInteger;
     required = true
   ),
   snippets = {
-    @JinjavaSnippet(code = "{% set my_number = -53 %}\n" + "{{ my_number|abs }}")
+    @JinjavaSnippet(code = "{% set my_number = -53 %}\n" + "{{ my_number|abs }}"),
   }
 )
 public class AbsFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/AbstractFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AbstractFilter.java
@@ -43,8 +43,11 @@ import org.apache.commons.lang3.math.NumberUtils;
  * @see JinjavaParam
  */
 public abstract class AbstractFilter implements Filter {
-  private static final Map<Class, Map<String, JinjavaParam>> NAMED_ARGUMENTS_CACHE = new ConcurrentHashMap<>();
-  private static final Map<Class, Map<String, Object>> DEFAULT_VALUES_CACHE = new ConcurrentHashMap<>();
+
+  private static final Map<Class, Map<String, JinjavaParam>> NAMED_ARGUMENTS_CACHE =
+    new ConcurrentHashMap<>();
+  private static final Map<Class, Map<String, Object>> DEFAULT_VALUES_CACHE =
+    new ConcurrentHashMap<>();
 
   private final Map<String, JinjavaParam> namedArguments;
   private final Map<String, Object> defaultValues;
@@ -114,8 +117,8 @@ public abstract class AbstractFilter implements Filter {
 
     //Parse args based on their declared types
     Map<String, Object> parsedArgs = new HashMap<>();
-    namedArgs.forEach(
-      (k, v) -> parsedArgs.put(k, parseArg(interpreter, namedArguments.get(k), v))
+    namedArgs.forEach((k, v) ->
+      parsedArgs.put(k, parseArg(interpreter, namedArguments.get(k), v))
     );
 
     validateArgs(interpreter, parsedArgs);
@@ -204,9 +207,8 @@ public abstract class AbstractFilter implements Filter {
       .ofNullable(namedArguments)
       .map(Map::keySet)
       .map(ArrayList::new)
-      .flatMap(
-        argNames ->
-          Optional.ofNullable(argNames.size() > position ? argNames.get(position) : null)
+      .flatMap(argNames ->
+        Optional.ofNullable(argNames.size() > position ? argNames.get(position) : null)
       )
       .orElse(null);
   }
@@ -220,12 +222,13 @@ public abstract class AbstractFilter implements Filter {
     }
 
     if (jinjavaDoc != null) {
-      ImmutableMap.Builder<String, JinjavaParam> namedArgsBuilder = ImmutableMap.builder();
+      ImmutableMap.Builder<String, JinjavaParam> namedArgsBuilder =
+        ImmutableMap.builder();
 
       Arrays
         .stream(jinjavaDoc.params())
-        .forEachOrdered(
-          jinjavaParam -> namedArgsBuilder.put(jinjavaParam.value(), jinjavaParam)
+        .forEachOrdered(jinjavaParam ->
+          namedArgsBuilder.put(jinjavaParam.value(), jinjavaParam)
         );
 
       return namedArgsBuilder.build();

--- a/src/main/java/com/hubspot/jinjava/lib/filter/AddFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AddFilter.java
@@ -39,10 +39,10 @@ import java.math.BigDecimal;
       type = "number",
       desc = "The number added to the base number",
       required = true
-    )
+    ),
   },
   snippets = {
-    @JinjavaSnippet(code = "{% set my_num = 40 %} \n" + "{{ my_num|add(13) }}")
+    @JinjavaSnippet(code = "{% set my_num = 40 %} \n" + "{{ my_num|add(13) }}"),
   }
 )
 public class AddFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/AllowSnakeCaseFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AllowSnakeCaseFilter.java
@@ -20,6 +20,7 @@ import java.util.Map;
   snippets = { @JinjavaSnippet(code = "{{ {'fooBar': 'baz'}|allow_snake_case }}") }
 )
 public class AllowSnakeCaseFilter implements Filter {
+
   public static final String NAME = "allow_snake_case";
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/AttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AttrFilter.java
@@ -20,13 +20,13 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
       value = "name",
       desc = "The dictionary attribute name to access",
       required = true
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
       desc = "The filter example below is equivalent to rendering a variable that exists within a dictionary, such as content.absolute_url.",
       code = "{{ content|attr('absolute_url') }}"
-    )
+    ),
   }
 )
 public class AttrFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/Base64DecodeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/Base64DecodeFilter.java
@@ -24,7 +24,7 @@ import java.util.Base64;
       type = "string",
       desc = "The string encoding charset to use.",
       defaultValue = "UTF-8"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -34,10 +34,11 @@ import java.util.Base64;
     @JinjavaSnippet(
       desc = "Decode a Base 64-encoded ASCII string into a UTF-16 Little Endian string",
       code = "{{ 'Adg33A=='|b64decode(encoding='utf-16le') }}"
-    )
+    ),
   }
 )
 public class Base64DecodeFilter implements Filter {
+
   public static final String NAME = "b64decode";
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/Base64EncodeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/Base64EncodeFilter.java
@@ -30,7 +30,7 @@ import org.apache.commons.net.util.Charsets;
       type = "string",
       desc = "The string encoding charset to use.",
       defaultValue = "UTF-8"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -40,10 +40,11 @@ import org.apache.commons.net.util.Charsets;
     @JinjavaSnippet(
       desc = "Encode a value with UTF-16 Little Endian encoding into a Base 64 ASCII string",
       code = "{{ '\uD801\uDC37'|b64encode(encoding='utf-16le') }}"
-    )
+    ),
   }
 )
 public class Base64EncodeFilter implements Filter {
+
   public static final String NAME = "b64encode";
   public static final String AVAILABLE_CHARSETS = Joiner
     .on(", ")

--- a/src/main/java/com/hubspot/jinjava/lib/filter/BaseDateFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/BaseDateFilter.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public abstract class BaseDateFilter implements AdvancedFilter {
+
   private static final Map<String, ChronoUnit> unitMap = Arrays
     .stream(ChronoUnit.values())
     .collect(Collectors.toMap(u -> u.toString().toLowerCase(), u -> u));

--- a/src/main/java/com/hubspot/jinjava/lib/filter/BatchFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/BatchFilter.java
@@ -25,7 +25,7 @@ import org.apache.commons.lang3.math.NumberUtils;
       desc = "Number of items to include in the batch",
       defaultValue = "0"
     ),
-    @JinjavaParam(value = "fill_with", desc = "Value used to fill up missing items")
+    @JinjavaParam(value = "fill_with", desc = "Value used to fill up missing items"),
   },
   snippets = {
     @JinjavaSnippet(
@@ -51,7 +51,7 @@ import org.apache.commons.lang3.math.NumberUtils;
       "    <td>&nbsp;</td>\n" +
       "  </tr>\n" +
       "</table>"
-    )
+    ),
   }
 )
 public class BatchFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/BetweenTimesFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/BetweenTimesFilter.java
@@ -36,7 +36,7 @@ import java.util.Map;
       desc = "Datetime object or timestamp at the end of the period",
       required = true
     ),
-    @JinjavaParam(value = "unit", desc = "Which temporal unit to use", required = true)
+    @JinjavaParam(value = "unit", desc = "Which temporal unit to use", required = true),
   },
   snippets = { @JinjavaSnippet(code = "{{ begin|between_times(end, 'hours') }}") }
 )

--- a/src/main/java/com/hubspot/jinjava/lib/filter/BoolFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/BoolFilter.java
@@ -33,7 +33,7 @@ import org.apache.commons.lang3.BooleanUtils;
     @JinjavaSnippet(
       desc = "This example converts a text string value to a boolean",
       code = "{% if \"true\"|bool == true %}hello world{% endif %}"
-    )
+    ),
   }
 )
 public class BoolFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/CapitalizeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/CapitalizeFilter.java
@@ -17,7 +17,7 @@ import org.apache.commons.lang3.StringUtils;
     @JinjavaSnippet(
       code = "{% set sentence = \"the first letter of a sentence should always be capitalized.\" %}\n" +
       "{{ sentence|capitalize }}"
-    )
+    ),
   }
 )
 public class CapitalizeFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/CenterFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/CenterFilter.java
@@ -16,7 +16,7 @@ import org.apache.commons.lang3.math.NumberUtils;
       type = "number",
       defaultValue = "80",
       desc = "Width of field to center value in"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -25,7 +25,7 @@ import org.apache.commons.lang3.math.NumberUtils;
       "    {% set var = \"string to center\" %}\n" +
       "    {{ var|center(80) }}\n" +
       "</pre>"
-    )
+    ),
   }
 )
 public class CenterFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/CutFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/CutFilter.java
@@ -31,12 +31,12 @@ import org.apache.commons.lang3.StringUtils;
       value = "to_remove",
       desc = "String to remove from the original string",
       required = true
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
       code = "{% set my_string = \"Hello world.\" %}\n" + "{{ my_string|cut(' world') }}"
-    )
+    ),
   }
 )
 public class CutFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilter.java
@@ -35,13 +35,13 @@ import com.hubspot.jinjava.objects.date.StrftimeFormatter;
       type = "string",
       defaultValue = "us",
       desc = "The language code to use when formatting the datetime"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(code = "{% content.updated|datetimeformat('%B %e, %Y') %}"),
     @JinjavaSnippet(
       code = "{% content.updated|datetimeformat('%a %A %w %d %e %b %B %m %y %Y %H %I %k %l %p %M %S %f %z %Z %j %U %W %c %x %X %%') %}"
-    )
+    ),
   },
   deprecated = true
 )

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DefaultFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DefaultFilter.java
@@ -44,7 +44,7 @@ import java.util.Objects;
       type = "boolean",
       defaultValue = "False",
       desc = "Set to True to use with variables which evaluate to false"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -54,10 +54,11 @@ import java.util.Objects;
     @JinjavaSnippet(
       desc = "If you want to use default with variables that evaluate to false you have to set the second parameter to true",
       code = "{{ ''|default('the string was empty', true) }}"
-    )
+    ),
   }
 )
 public class DefaultFilter extends AbstractFilter implements AdvancedFilter {
+
   public static final String DEFAULT_VALUE_PARAM = "default_value";
   public static final String TRUTHY_PARAM = "truthy";
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DictSortFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DictSortFilter.java
@@ -27,7 +27,7 @@ import org.apache.commons.lang3.BooleanUtils;
       type = "enum key|value",
       defaultValue = "key",
       desc = "Sort by dict key or value"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -35,7 +35,7 @@ import org.apache.commons.lang3.BooleanUtils;
       code = "{% for item in contact|dictsort(false, 'value') %}\n" +
       "    {{item}}\n" +
       "{% endfor %}"
-    )
+    ),
   }
 )
 public class DictSortFilter implements Filter {
@@ -72,6 +72,7 @@ public class DictSortFilter implements Filter {
 
   private static class MapEntryComparator
     implements Comparator<Map.Entry<String, Object>>, Serializable {
+
     private static final long serialVersionUID = 1L;
 
     private final boolean caseSensitive;

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DifferenceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DifferenceFilter.java
@@ -21,7 +21,7 @@ import java.util.Set;
       type = "sequence",
       desc = "The second list",
       required = true
-    )
+    ),
   },
   snippets = { @JinjavaSnippet(code = "{{ [1, 2, 3]|difference([2, 3, 4]) }}") }
 )

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DivideFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DivideFilter.java
@@ -41,13 +41,14 @@ import java.util.Map;
       type = "number",
       desc = "The divisor to divide the value",
       required = true
-    )
+    ),
   },
   snippets = {
-    @JinjavaSnippet(code = "{% set numerator = 106 %}\n" + "{% numerator|divide(2) %}")
+    @JinjavaSnippet(code = "{% set numerator = 106 %}\n" + "{% numerator|divide(2) %}"),
   }
 )
 public class DivideFilter implements AdvancedFilter {
+
   private static final TruthyTypeConverter TYPE_CONVERTER = new TruthyTypeConverter();
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/DivisibleFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DivisibleFilter.java
@@ -35,7 +35,7 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
       type = "number",
       desc = "The divisor to check if the value is divisible by",
       required = true
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -44,7 +44,7 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
       "{% if num|divisible(2) %}\n" +
       "    The number is divisble by 2\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 public class DivisibleFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/EscapeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/EscapeFilter.java
@@ -31,10 +31,11 @@ import org.apache.commons.lang3.StringUtils;
     @JinjavaSnippet(
       code = "{% set escape_string = \"<div>This markup is printed as text</div>\" %}\n" +
       "{{ escape_string|escape }}"
-    )
+    ),
   }
 )
 public class EscapeFilter implements Filter {
+
   private static final String SAMP = "&";
   private static final String BAMP = "&amp;";
   private static final String SGT = ">";

--- a/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilter.java
@@ -33,16 +33,17 @@ import org.apache.commons.lang3.StringUtils;
       type = "boolean",
       desc = "Whether to only escape all curly braces or just when there are default expression, tag, or comment marks",
       defaultValue = "true"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
       code = "{% set escape_string = \"{{This markup is printed as text}}\" %}\n" +
       "{{ escape_string|escape_jinjava }}"
-    )
+    ),
   }
 )
 public class EscapeJinjavaFilter implements Filter {
+
   private static final String SLBRACE = "{";
   private static final String BLBRACE = "&lbrace;";
   private static final String SRBRACE = "}";

--- a/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJsFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/EscapeJsFilter.java
@@ -30,7 +30,7 @@ import java.util.Objects;
     @JinjavaSnippet(
       code = "{% set escape_string = \"This string can safely be inserted into JavaScript\" %}\n" +
       "{{ escape_string|escapejs }}"
-    )
+    ),
   }
 )
 public class EscapeJsFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FileSizeFormatFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FileSizeFormatFilter.java
@@ -21,10 +21,10 @@ import org.apache.commons.lang3.math.NumberUtils;
       type = "boolean",
       defaultValue = "False",
       desc = "Use binary prefixes (Mebi, Gibi)"
-    )
+    ),
   },
   snippets = {
-    @JinjavaSnippet(code = "{% set bytes = 100000 %}\n" + "{{ bytes|filesizeformat }}")
+    @JinjavaSnippet(code = "{% set bytes = 100000 %}\n" + "{{ bytes|filesizeformat }}"),
   }
 )
 public class FileSizeFormatFilter implements Filter {
@@ -76,7 +76,7 @@ public class FileSizeFormatFilter implements Filter {
     "PiB",
     "EiB",
     "ZiB",
-    "YiB"
+    "YiB",
   };
   private static final String[] DECIMAL_SIZES = {
     "KB",
@@ -86,6 +86,6 @@ public class FileSizeFormatFilter implements Filter {
     "PB",
     "EB",
     "ZB",
-    "YB"
+    "YB",
   };
 }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FirstFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FirstFilter.java
@@ -19,7 +19,7 @@ import com.hubspot.jinjava.util.ObjectIterator;
     @JinjavaSnippet(
       code = "{% set my_sequence = ['Item 1', 'Item 2', 'Item 3'] %}\n" +
       "{{ my_sequence|first }}"
-    )
+    ),
   }
 )
 public class FirstFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FloatFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FloatFilter.java
@@ -22,14 +22,14 @@ import org.apache.commons.lang3.math.NumberUtils;
       type = "float",
       defaultValue = "0.0",
       desc = "Value to return if conversion fails"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
       desc = "This example converts a text field string value to a float",
       code = "{% text \"my_text\" value='25', export_to_template_context=True %}\n" +
       "{% widget_data.my_text.value|float + 28 %}"
-    )
+    ),
   }
 )
 public class FloatFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ForceEscapeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ForceEscapeFilter.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.StringEscapeUtils;
     @JinjavaSnippet(
       code = "{% set escape_string = \"<div>This markup is printed as text</div>\" %}\n" +
       "{{ escape_string|forceescape }}\n"
-    )
+    ),
   }
 )
 public class ForceEscapeFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FormatFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FormatFilter.java
@@ -24,16 +24,17 @@ import java.util.Objects;
       value = "args",
       type = "String...",
       desc = "Values to insert into string"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
       desc = "%s can be replaced with other variables or values",
       code = "{{ \"Hi %s %s\"|format(contact.firstname, contact.lastname) }} "
-    )
+    ),
   }
 )
 public class FormatFilter implements AdvancedFilter {
+
   public static final String NAME = "format";
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FormatNumberFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FormatNumberFilter.java
@@ -33,15 +33,16 @@ import java.util.Optional;
       value = "max decimal precision",
       type = "number",
       desc = "A number input that determines the decimal precision of the formatted value. If the number of decimal digits from the input value is less than the decimal precision number, use the number of decimal digits from the input value. Otherwise, use the decimal precision number. The default is the number of decimal digits from the input value."
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(code = "{{ number|format_number }}"),
     @JinjavaSnippet(code = "{{ number|format_number(\"en-US\") }}"),
-    @JinjavaSnippet(code = "{{ number|format_number(\"en-US\", 3) }}")
+    @JinjavaSnippet(code = "{{ number|format_number(\"en-US\", 3) }}"),
   }
 )
 public class FormatNumberFilter implements Filter {
+
   private static final String FORMAT_NUMBER_FILTER_NAME = "format_number";
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/FromYamlFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/FromYamlFilter.java
@@ -19,6 +19,7 @@ import java.io.IOException;
   snippets = { @JinjavaSnippet(code = "{{object|fromYaml}}") }
 )
 public class FromYamlFilter implements Filter {
+
   private static final YAMLMapper OBJECT_MAPPER = new YAMLMapper();
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/GroupByFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/GroupByFilter.java
@@ -28,7 +28,7 @@ import java.util.Objects;
       value = "attribute",
       desc = "The common attribute to group by",
       required = true
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -41,7 +41,7 @@ import java.util.Objects;
       "            {% endfor %}</ul></li>\n" +
       "     {% endfor %}\n" +
       "</ul>"
-    )
+    ),
   }
 )
 public class GroupByFilter implements Filter {
@@ -89,6 +89,7 @@ public class GroupByFilter implements Filter {
   }
 
   public static class Group {
+
     private final String grouper;
     private final Object grouperObject;
     private final List<Object> list;

--- a/src/main/java/com/hubspot/jinjava/lib/filter/IndentFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IndentFilter.java
@@ -27,7 +27,7 @@ import org.apache.commons.lang3.StringUtils;
       type = "boolean",
       defaultValue = "False",
       desc = "If True, first line will be indented"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -36,10 +36,11 @@ import org.apache.commons.lang3.StringUtils;
       "    {% set var = \"string to indent\" %}\n" +
       "    {{ var|indent(2, true) }}\n" +
       "</pre>"
-    )
+    ),
   }
 )
 public class IndentFilter extends AbstractFilter {
+
   public static final String INDENT_FIRST_PARAM = "indentfirst";
   public static final String WIDTH_PARAM = "width";
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/IntFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IntFilter.java
@@ -25,14 +25,14 @@ import org.apache.commons.lang3.math.NumberUtils;
       type = "number",
       defaultValue = "0",
       desc = "Value to return if the conversion fails"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
       desc = "This example converts a text field string value to a integer",
       code = "{% text \"my_text\" value='25', export_to_template_context=True %}\n" +
       "{% widget_data.my_text.value|int + 28 %}"
-    )
+    ),
   }
 )
 public class IntFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/IntersectFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IntersectFilter.java
@@ -21,7 +21,7 @@ import java.util.Set;
       type = "sequence",
       desc = "The second list",
       required = true
-    )
+    ),
   },
   snippets = { @JinjavaSnippet(code = "{{ [1, 2, 3]|intersect([2, 3, 4]) }}") }
 )

--- a/src/main/java/com/hubspot/jinjava/lib/filter/IpAddrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/IpAddrFilter.java
@@ -35,7 +35,7 @@ import org.apache.commons.net.util.SubnetUtils;
       type = "string",
       defaultValue = "prefix",
       desc = "Name of function. Supported functions: 'prefix', 'netmask', 'network', 'address', 'broadcast'"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -49,10 +49,11 @@ import org.apache.commons.net.util.SubnetUtils;
       desc = "This example shows how to filter list of ip addresses",
       code = "{{ ['192.108.0.1', null, True, 13, '2000::'] | ipaddr }}",
       output = "['192.108.0.1', '2000::']"
-    )
+    ),
   }
 )
 public class IpAddrFilter implements Filter {
+
   private static final Pattern IP4_PATTERN = Pattern.compile(
     "(([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.){3}([01]?\\d\\d?|2[0-4]\\d|25[0-5])"
   );

--- a/src/main/java/com/hubspot/jinjava/lib/filter/Ipv4Filter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/Ipv4Filter.java
@@ -19,7 +19,7 @@ import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
       defaultValue = "prefix",
       desc = "Name of function. " +
       "Supported functions: 'prefix', 'netmask', 'network', 'address', 'broadcast'"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -33,7 +33,7 @@ import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
       desc = "This example shows how to filter list of ipv4 addresses",
       code = "{{ ['192.108.0.1', null, True, 13, '2000::'] | ipv4 }}",
       output = "['192.108.0.']"
-    )
+    ),
   }
 )
 public class Ipv4Filter extends IpAddrFilter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/Ipv6Filter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/Ipv6Filter.java
@@ -19,7 +19,7 @@ import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
       defaultValue = "prefix",
       desc = "Name of function. " +
       "Supported functions: 'prefix', 'netmask', 'network', 'address', 'broadcast'"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -33,7 +33,7 @@ import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
       desc = "This example shows how to filter list of ipv6 addresses",
       code = "{{ ['192.108.0.1', null, True, 13, '2000::'] | ipv6 }}",
       output = "['2000::']"
-    )
+    ),
   }
 )
 public class Ipv6Filter extends IpAddrFilter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/JoinFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/JoinFilter.java
@@ -26,7 +26,7 @@ import java.util.Objects;
     @JinjavaParam(
       value = "attr",
       desc = "Optional dict object attribute to use in joining"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(code = "{{ [1, 2, 3]|join('|') }}", output = "1|2|3"),
@@ -34,7 +34,7 @@ import java.util.Objects;
     @JinjavaSnippet(
       desc = "It is also possible to join certain attributes of an object",
       code = "{{ users|join(', ', attribute='username') }}"
-    )
+    ),
   }
 )
 public class JoinFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/LastFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/LastFilter.java
@@ -19,7 +19,7 @@ import com.hubspot.jinjava.util.ObjectIterator;
     @JinjavaSnippet(
       code = "{% set my_sequence = ['Item 1', 'Item 2', 'Item 3'] %}\n" +
       "{{ my_sequence|last }}"
-    )
+    ),
   }
 )
 public class LastFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/LengthFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/LengthFilter.java
@@ -35,7 +35,7 @@ import java.util.Map;
     @JinjavaSnippet(
       code = "{% set services = ['Web design', 'SEO', 'Inbound Marketing', 'PPC'] %}\n" +
       "{{ services|length }}"
-    )
+    ),
   }
 )
 public class LengthFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ListFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ListFilter.java
@@ -25,7 +25,7 @@ import org.apache.commons.lang3.ArrayUtils;
       "{% set three = 3 %}\n" +
       "{% set list_num = one|list + two|list + three|list %}\n" +
       "{{ list_num|list }}"
-    )
+    ),
   }
 )
 public class ListFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/LogFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/LogFilter.java
@@ -31,6 +31,7 @@ import java.math.RoundingMode;
   snippets = { @JinjavaSnippet(code = "{{ 25|log(5) }}") }
 )
 public class LogFilter implements Filter {
+
   private static final MathContext PRECISION = new MathContext(50);
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/MapFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/MapFilter.java
@@ -28,7 +28,7 @@ import java.util.Map;
       value = "attribute",
       desc = "Filter to apply to an object or dict attribute to lookup",
       required = true
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -38,10 +38,11 @@ import java.util.Map;
     @JinjavaSnippet(
       desc = "Alternatively you can let it invoke a filter by passing the name of the filter and the arguments afterwards. A good example would be applying a text conversion filter on a sequence",
       code = "{% set seq = ['item1', 'item2', 'item3'] %}\n" + "{{ seq|map('upper') }}"
-    )
+    ),
   }
 )
 public class MapFilter implements AdvancedFilter {
+
   private static final String ATTRIBUTE_ARGUMENT = "attribute";
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/Md5Filter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/Md5Filter.java
@@ -35,6 +35,7 @@ import java.security.NoSuchAlgorithmException;
   snippets = { @JinjavaSnippet(code = "{{ content.absolute_url|md5 }}") }
 )
 public class Md5Filter implements Filter {
+
   private static final String[] NOSTR = {
     "0",
     "1",
@@ -51,7 +52,7 @@ public class Md5Filter implements Filter {
     "c",
     "d",
     "e",
-    "f"
+    "f",
   };
   private static final String MD5 = "MD5";
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/MinusTimeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/MinusTimeFilter.java
@@ -32,7 +32,7 @@ import java.util.Map;
       desc = "The amount to subtract from the datetime",
       required = true
     ),
-    @JinjavaParam(value = "unit", desc = "Which temporal unit to use", required = true)
+    @JinjavaParam(value = "unit", desc = "Which temporal unit to use", required = true),
   },
   snippets = { @JinjavaSnippet(code = "{% mydatetime|minus_time(3, 'days') %}") }
 )

--- a/src/main/java/com/hubspot/jinjava/lib/filter/MultiplyFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/MultiplyFilter.java
@@ -41,11 +41,12 @@ import java.util.Map;
       type = "number",
       desc = "The multiplier",
       required = true
-    )
+    ),
   },
   snippets = { @JinjavaSnippet(code = "{% set n = 20 %}\n" + "{{ n|multiply(3) }}") }
 )
 public class MultiplyFilter implements AdvancedFilter {
+
   private static final TruthyTypeConverter TYPE_CONVERTER = new TruthyTypeConverter();
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/PlusTimeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/PlusTimeFilter.java
@@ -32,7 +32,7 @@ import java.util.Map;
       desc = "The amount to add to the datetime",
       required = true
     ),
-    @JinjavaParam(value = "unit", desc = "Which temporal unit to use", required = true)
+    @JinjavaParam(value = "unit", desc = "Which temporal unit to use", required = true),
   },
   snippets = { @JinjavaSnippet(code = "{% mydatetime|plus_time(3, 'days') %}") }
 )

--- a/src/main/java/com/hubspot/jinjava/lib/filter/PrettyPrintFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/PrettyPrintFilter.java
@@ -23,7 +23,7 @@ import java.util.Objects;
     @JinjavaSnippet(
       code = "{% set this_var =\"Variable that I want to debug\" %}\n" +
       "{{ this_var|pprint }}"
-    )
+    ),
   }
 )
 public class PrettyPrintFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RandomFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RandomFilter.java
@@ -39,7 +39,7 @@ import java.util.Map;
       code = "{% for content in contents|random %}\n" +
       "    <div class=\"post-item\">Post item markup</div>" +
       "{% endfor %}"
-    )
+    ),
   }
 )
 public class RandomFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilter.java
@@ -33,13 +33,13 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
       value = "new",
       desc = "The new string that you replace the matched substring",
       required = true
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
       code = "{{ \"It costs $300\"|regex_replace(\"[^a-zA-Z]\", \"\") }}",
       output = "Itcosts"
-    )
+    ),
   }
 )
 public class RegexReplaceFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RejectAttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RejectAttrFilter.java
@@ -26,7 +26,7 @@ import java.util.Map;
       type = "name of expression test",
       defaultValue = "truthy",
       desc = "Specify which expression test to run for making the rejection"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -34,7 +34,7 @@ import java.util.Map;
       code = "{% for content in contents|rejectattr('post_list_summary_featured_image') %}\n" +
       "    <div class=\"post-item\">Post in listing markup</div>\n" +
       "{% endfor %}"
-    )
+    ),
   }
 )
 public class RejectAttrFilter extends SelectAttrFilter implements AdvancedFilter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RejectFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RejectFilter.java
@@ -15,13 +15,13 @@ import com.hubspot.jinjava.lib.exptest.ExpTest;
       type = "name of expression test",
       desc = "Specify which expression test to run for making the selection",
       required = true
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
       code = "{% set some_numbers = [10, 12, 13, 3, 5, 17, 22] %}\n" +
       "{% some_numbers|reject('even') %}"
-    )
+    ),
   }
 )
 public class RejectFilter extends SelectFilter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RenderFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RenderFilter.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.math.NumberUtils;
   snippets = {
     @JinjavaSnippet(
       code = "{{ \"{% if my_val %} Hello {% else %} world {% endif %}\"|render }}"
-    )
+    ),
   }
 )
 public class RenderFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ReplaceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ReplaceFilter.java
@@ -35,7 +35,7 @@ import org.apache.commons.lang3.math.NumberUtils;
       value = "count",
       type = "number",
       desc = "Replace only the first N occurrences"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -45,7 +45,7 @@ import org.apache.commons.lang3.math.NumberUtils;
     @JinjavaSnippet(
       code = "{{ \"aaaaargh\"|replace(\"a\", \"d'oh, \", 2) }}",
       output = "d'oh, d'oh, aaargh"
-    )
+    ),
   }
 )
 public class ReplaceFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ReverseFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ReverseFilter.java
@@ -36,7 +36,7 @@ import java.util.Collection;
       "{% for num in nums|reverse %}\n" +
       "    {{ num }}\n" +
       "{% endfor %}"
-    )
+    ),
   }
 )
 public class ReverseFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RootFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RootFilter.java
@@ -30,6 +30,7 @@ import java.math.MathContext;
   snippets = { @JinjavaSnippet(code = "{{ 125|root(3) }}") }
 )
 public class RootFilter implements Filter {
+
   private static final MathContext PRECISION = new MathContext(50);
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RoundFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RoundFilter.java
@@ -30,7 +30,7 @@ import org.apache.commons.lang3.math.NumberUtils;
       type = "enum common|ceil|floor",
       defaultValue = "common",
       desc = "Method of rounding: 'common' rounds either up or down, 'ceil' always rounds up, and 'floor' always rounds down."
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -43,7 +43,7 @@ import org.apache.commons.lang3.math.NumberUtils;
       code = "{{ 42.55|round|int }}",
       output = "43",
       desc = "If you need a real integer, pipe it through int"
-    )
+    ),
   }
 )
 public class RoundFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SelectAttrFilter.java
@@ -35,7 +35,7 @@ import java.util.Map;
       type = "name of expression test",
       defaultValue = "truthy",
       desc = "Specify which expression test to run for making the selection"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -43,7 +43,7 @@ import java.util.Map;
       code = "{% for content in contents|selectattr('post_list_summary_featured_image') %}\n" +
       "    <div class=\"post-item\">Post in listing markup</div>\n" +
       "{% endfor %}"
-    )
+    ),
   }
 )
 public class SelectAttrFilter implements AdvancedFilter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SelectFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SelectFilter.java
@@ -29,13 +29,13 @@ import java.util.Map;
       type = "name of expression test",
       defaultValue = "truthy",
       desc = "Specify which expression test to run for making the selection"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
       code = "{% set some_numbers = [10, 12, 13, 3, 5, 17, 22] %}\n" +
       "{% some_numbers|select('even') %}"
-    )
+    ),
   }
 )
 public class SelectFilter implements AdvancedFilter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ShuffleFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ShuffleFilter.java
@@ -24,7 +24,7 @@ import java.util.List;
       code = "{% for content in contents|shuffle %}\n" +
       "    <div class=\"post-item\">Markup of each post</div>\n" +
       "{% endfor %}"
-    )
+    ),
   }
 )
 public class ShuffleFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
@@ -33,7 +33,7 @@ import org.apache.commons.lang3.math.NumberUtils;
       type = "object",
       desc = "Specifies which object to use to fill missing values on final iteration",
       required = false
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -48,7 +48,7 @@ import org.apache.commons.lang3.math.NumberUtils;
       "    </ul>\n" +
       "  {% endfor %}\n" +
       "</div>\n"
-    )
+    ),
   }
 )
 public class SliceFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SortFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SortFilter.java
@@ -39,7 +39,7 @@ import org.apache.commons.lang3.BooleanUtils;
       defaultValue = "False",
       desc = "Determines whether or not the sorting is case sensitive"
     ),
-    @JinjavaParam(value = "attribute", desc = "Specifies an attribute to sort by")
+    @JinjavaParam(value = "attribute", desc = "Specifies an attribute to sort by"),
   },
   snippets = {
     @JinjavaSnippet(
@@ -51,10 +51,11 @@ import org.apache.commons.lang3.BooleanUtils;
       "{% for item in my_posts|sort(False, False,'name') %}\n" +
       "    {{ item.name }}<br>\n" +
       "{% endfor %}"
-    )
+    ),
   }
 )
 public class SortFilter implements Filter {
+
   private static final Splitter DOT_SPLITTER = Splitter.on('.').omitEmptyStrings();
   private static final Joiner DOT_JOINER = Joiner.on('.');
 
@@ -118,6 +119,7 @@ public class SortFilter implements Filter {
   }
 
   private static class ObjectComparator implements Comparator<Object>, Serializable {
+
     private final boolean reverse;
     private final boolean caseSensitive;
 

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SplitFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SplitFilter.java
@@ -33,7 +33,7 @@ import org.apache.commons.lang3.math.NumberUtils;
       type = "number",
       defaultValue = "0",
       desc = "Limits resulting list by putting remainder of string into last list item"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -44,7 +44,7 @@ import org.apache.commons.lang3.math.NumberUtils;
       "       <li>{{ name }}</li>\n" +
       "   {% endfor %}\n" +
       "</ul>"
-    )
+    ),
   }
 )
 public class SplitFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/StringFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/StringFilter.java
@@ -16,7 +16,7 @@ import java.util.Objects;
   snippets = {
     @JinjavaSnippet(
       code = "{% set number_to_string = 45 %}\n" + "{{ number_to_string|string }}"
-    )
+    ),
   }
 )
 public class StringFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/StringToDateFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/StringToDateFilter.java
@@ -15,7 +15,7 @@ import com.hubspot.jinjava.lib.fn.Functions;
       value = "dateFormat",
       desc = "Format of the date string",
       required = true
-    )
+    ),
   },
   snippets = { @JinjavaSnippet(code = "{{ '3/3/21'|strtodate('M/d/yy') }}") }
 )

--- a/src/main/java/com/hubspot/jinjava/lib/filter/StringToTimeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/StringToTimeFilter.java
@@ -21,7 +21,7 @@ import com.hubspot.jinjava.lib.fn.Functions;
       value = "datetimeFormat",
       desc = "Format of the datetime string",
       required = true
-    )
+    ),
   },
   snippets = { @JinjavaSnippet(code = "{% mydatetime|unixtimestamp %}") }
 )

--- a/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/StripTagsFilter.java
@@ -23,10 +23,11 @@ import org.jsoup.safety.Safelist;
     @JinjavaSnippet(
       code = "{% set some_html = \"<div><strong>Some text</strong></div>\" %}\n" +
       "{{ some_html|striptags }}"
-    )
+    ),
   }
 )
 public class StripTagsFilter implements Filter {
+
   private static final Pattern WHITESPACE = Pattern.compile("\\s{2,}");
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SumFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SumFilter.java
@@ -28,7 +28,7 @@ import java.util.Objects;
     @JinjavaParam(
       value = "attribute",
       desc = "Specify an optional attribute of dict to sum"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -37,7 +37,7 @@ import java.util.Objects;
     @JinjavaSnippet(
       desc = "Sum up only certain attributes",
       code = "Total: {{ items|sum(attribute='price') }}"
-    )
+    ),
   }
 )
 public class SumFilter implements AdvancedFilter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SymmetricDifferenceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SymmetricDifferenceFilter.java
@@ -21,7 +21,7 @@ import java.util.Set;
       type = "sequence",
       desc = "The second list",
       required = true
-    )
+    ),
   },
   snippets = { @JinjavaSnippet(code = "{{ [1, 2, 3]|symmetric_difference([2, 3, 4]) }}") }
 )

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ToYamlFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ToYamlFilter.java
@@ -20,8 +20,9 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
   snippets = { @JinjavaSnippet(code = "{{object|toyaml}}") }
 )
 public class ToYamlFilter implements Filter {
+
   private static final YAMLMapper OBJECT_MAPPER = new YAMLMapper()
-  .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
+    .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TruncateFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TruncateFilter.java
@@ -48,7 +48,7 @@ import com.hubspot.jinjava.lib.fn.Functions;
       value = "end",
       defaultValue = "...",
       desc = "The characters that will be added to indicate where the text was truncated"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -58,7 +58,7 @@ import com.hubspot.jinjava.lib.fn.Functions;
     @JinjavaSnippet(
       code = "{{ \"I only want to show the first sentence. Not the second.\"|truncate(35, True, '..') }}",
       output = "I only want to show the first sente.."
-    )
+    ),
   }
 )
 public class TruncateFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilter.java
@@ -39,16 +39,17 @@ import org.jsoup.select.NodeVisitor;
       type = "boolean",
       defaultValue = "false",
       desc = "If set to true, text will be truncated in the middle of words"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
       code = "{{ \"<p>I want to truncate this text without breaking my HTML<p>\"|truncatehtml(28, '..', false) }}",
       output = "<p>I want to truncate this text without breaking my HTML</p>"
-    )
+    ),
   }
 )
 public class TruncateHtmlFilter implements AdvancedFilter {
+
   private static final int DEFAULT_TRUNCATE_LENGTH = 255;
   private static final String DEFAULT_END = "...";
   private static final String LENGTH_KEY = "length";
@@ -156,6 +157,7 @@ public class TruncateHtmlFilter implements AdvancedFilter {
   }
 
   private static class ContentTruncatingNodeVisitor implements NodeVisitor {
+
     private final int maxTextLen;
     private int textLen;
     private final String ending;

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UnescapeHtmlFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UnescapeHtmlFilter.java
@@ -29,7 +29,7 @@ import org.apache.commons.lang3.StringEscapeUtils;
     @JinjavaSnippet(
       code = "{% set escaped_string = \"<div>This &amp; that</div>\" %}\n" +
       "{{ escaped_string|unescape_html }}"
-    )
+    ),
   }
 )
 public class UnescapeHtmlFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UnionFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UnionFilter.java
@@ -21,7 +21,7 @@ import java.util.Set;
       type = "sequence",
       desc = "The second list",
       required = true
-    )
+    ),
   },
   snippets = { @JinjavaSnippet(code = "{{ [1, 2, 3]|union([2, 3, 4]) }}") }
 )

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UniqueFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UniqueFilter.java
@@ -21,7 +21,7 @@ import java.util.Map;
     @JinjavaParam(
       value = "attr",
       type = "Optional attribute on object to use as unique identifier"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -32,7 +32,7 @@ import java.util.Map;
     @JinjavaSnippet(
       desc = "Filter out duplicate blog posts",
       code = "{% for content in contents|unique(attr='slug') %}\n" + "\n{% endfor %}"
-    )
+    ),
   }
 )
 public class UniqueFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UrlDecodeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UrlDecodeFilter.java
@@ -24,7 +24,7 @@ import org.apache.commons.lang3.StringUtils;
     @JinjavaSnippet(
       code = "{{ \"http%3A%2F%2Ffoo.com%3Fbar%26food\"|urldecode }}",
       output = "http://foo.com?bar&food"
-    )
+    ),
   }
 )
 public class UrlDecodeFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UrlEncodeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UrlEncodeFilter.java
@@ -21,7 +21,7 @@ import org.apache.commons.lang3.StringUtils;
     required = true
   ),
   snippets = {
-    @JinjavaSnippet(code = "{{ \"Escape & URL encode this string\"|urlencode }}")
+    @JinjavaSnippet(code = "{{ \"Escape & URL encode this string\"|urlencode }}"),
   }
 )
 public class UrlEncodeFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UrlizeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UrlizeFilter.java
@@ -31,7 +31,7 @@ import org.apache.commons.lang3.math.NumberUtils;
       defaultValue = "False",
       desc = "Adds nofollow to generated link tag"
     ),
-    @JinjavaParam(value = "target", desc = "Adds target attr to generated link tag")
+    @JinjavaParam(value = "target", desc = "Adds target attr to generated link tag"),
   },
   snippets = {
     @JinjavaSnippet(
@@ -41,7 +41,7 @@ import org.apache.commons.lang3.math.NumberUtils;
     @JinjavaSnippet(
       desc = "If target is specified, the target attribute will be added to the <a> tag",
       code = "{{ \"http://www.hubspot.com\"|urlize(10, true, target='_blank') }}"
-    )
+    ),
   }
 )
 public class UrlizeFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/WordCountFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/WordCountFilter.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
     @JinjavaSnippet(
       code = "{%  set count_words = \"Count the number of words in this variable\" %}\n" +
       "{{ count_words|wordcount }}"
-    )
+    ),
   }
 )
 public class WordCountFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/WordWrapFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/WordWrapFilter.java
@@ -29,7 +29,7 @@ import org.apache.commons.lang3.text.WordUtils;
       type = "boolean",
       defaultValue = "True",
       desc = "If true, long words will be broken when wrapped"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -37,7 +37,7 @@ import org.apache.commons.lang3.text.WordUtils;
       code = "<pre>\n" +
       "    {{ \"Lorem ipsum dolor sit amet, consectetur adipiscing elit\"|wordwrap(10) }}\n" +
       "</pre>"
-    )
+    ),
   }
 )
 public class WordWrapFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/XmlAttrFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/XmlAttrFilter.java
@@ -26,13 +26,13 @@ import org.apache.commons.lang3.StringUtils;
       type = "boolean",
       defaultValue = "True",
       desc = "Automatically prepend a space in front of the item"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
       code = "{% set html_attributes = {'class': 'bold', 'id': 'sidebar'} %}\n" +
       "<div {{ html_attributes|xmlattr }}></div>"
-    )
+    ),
   }
 )
 public class XmlAttrFilter implements Filter {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/time/DateTimeFormatHelper.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/time/DateTimeFormatHelper.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 public final class DateTimeFormatHelper {
+
   public static final String FIXED_DATE_TIME_FILTER_NULL_ARG =
     "FIXED_DATE_TIME_FILTER_NULL_ARG";
   private final String name;
@@ -37,13 +38,12 @@ public final class DateTimeFormatHelper {
     ZoneId zoneId = arg(args, 1).map(this::parseZone).orElse(ZoneOffset.UTC);
     Locale locale = arg(args, 2)
       .map(this::parseLocale)
-      .orElseGet(
-        () ->
-          JinjavaInterpreter
-            .getCurrentMaybe()
-            .map(JinjavaInterpreter::getConfig)
-            .map(JinjavaConfig::getLocale)
-            .orElse(Locale.ENGLISH)
+      .orElseGet(() ->
+        JinjavaInterpreter
+          .getCurrentMaybe()
+          .map(JinjavaInterpreter::getConfig)
+          .map(JinjavaConfig::getLocale)
+          .orElse(Locale.ENGLISH)
       );
 
     return buildFormatter(format)

--- a/src/main/java/com/hubspot/jinjava/lib/filter/time/FormatDateFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/time/FormatDateFilter.java
@@ -29,17 +29,18 @@ import java.time.format.DateTimeFormatter;
       value = "locale",
       defaultValue = "Locale specified on JinjavaConfig",
       desc = "The locale to use for locale-aware formats"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(code = "{{ content.updated | format_date('long') }}"),
     @JinjavaSnippet(code = "{{ content.updated | format_date('yyyyy.MMMM.dd') }}"),
     @JinjavaSnippet(
       code = "{{ content.updated | format_date('medium', 'America/New_York', 'de-DE') }}"
-    )
+    ),
   }
 )
 public class FormatDateFilter implements Filter {
+
   private static final String NAME = "format_date";
   private static final DateTimeFormatHelper HELPER = new DateTimeFormatHelper(
     NAME,

--- a/src/main/java/com/hubspot/jinjava/lib/filter/time/FormatDatetimeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/time/FormatDatetimeFilter.java
@@ -29,7 +29,7 @@ import java.time.format.DateTimeFormatter;
       value = "locale",
       defaultValue = "Locale specified on JinjavaConfig",
       desc = "The locale to use for locale-aware formats"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(code = "{{ content.updated | format_datetime('long') }}"),
@@ -38,10 +38,11 @@ import java.time.format.DateTimeFormatter;
     ),
     @JinjavaSnippet(
       code = "{{ content.updated | format_datetime('medium', 'America/New_York', 'de-DE') }}"
-    )
+    ),
   }
 )
 public class FormatDatetimeFilter implements Filter {
+
   private static final String NAME = "format_datetime";
   private static final DateTimeFormatHelper HELPER = new DateTimeFormatHelper(
     NAME,

--- a/src/main/java/com/hubspot/jinjava/lib/filter/time/FormatTimeFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/time/FormatTimeFilter.java
@@ -29,17 +29,18 @@ import java.time.format.DateTimeFormatter;
       value = "locale",
       defaultValue = "Locale specified on JinjavaConfig",
       desc = "The locale to use for locale-aware formats"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(code = "{{ content.updated | format_time('long') }}"),
     @JinjavaSnippet(code = "{{ content.updated | format_time('hh:mm a') }}"),
     @JinjavaSnippet(
       code = "{{ content.updated | format_time('medium', 'America/New_York', 'de-DE') }}"
-    )
+    ),
   }
 )
 public class FormatTimeFilter implements Filter {
+
   private static final String NAME = "format_time";
   private static final DateTimeFormatHelper HELPER = new DateTimeFormatHelper(
     NAME,

--- a/src/main/java/com/hubspot/jinjava/lib/fn/ELFunctionDefinition.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/ELFunctionDefinition.java
@@ -5,6 +5,7 @@ import com.hubspot.jinjava.lib.Importable;
 import java.lang.reflect.Method;
 
 public class ELFunctionDefinition implements Importable {
+
   private String namespace;
   private String localName;
   private Method method;

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -43,6 +43,7 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 
 public class Functions {
+
   public static final String STRING_TO_TIME_FUNCTION = "stringToTime";
   public static final String STRING_TO_DATE_FUNCTION = "stringToDate";
 
@@ -58,7 +59,7 @@ public class Functions {
         "    ...\n" +
         "    {{ super() }}\n" +
         "{% endblock %}"
-      )
+      ),
     }
   )
   public static String renderSuperBlock() {
@@ -91,12 +92,12 @@ public class Functions {
         value = "kwargs",
         type = "NamedParameter...",
         desc = "Keyword arguments to put into the namespace dictionary"
-      )
+      ),
     },
     snippets = {
       @JinjavaSnippet(code = "{% set ns = namespace() %}"),
       @JinjavaSnippet(code = "{% set ns = namespace(b=false) %}"),
-      @JinjavaSnippet(code = "{% set ns = namespace(my_map, b=false) %}")
+      @JinjavaSnippet(code = "{% set ns = namespace(my_map, b=false) %}"),
     }
   )
   public static Namespace createNamespace(Object... parameters) {
@@ -118,8 +119,8 @@ public class Functions {
     namespace.putAll(
       Arrays
         .stream(parameters)
-        .filter(
-          p -> p instanceof NamedParameter && ((NamedParameter) p).getValue() != null
+        .filter(p ->
+          p instanceof NamedParameter && ((NamedParameter) p).getValue() != null
         )
         .map(p -> (NamedParameter) p)
         .collect(Collectors.toMap(NamedParameter::getName, NamedParameter::getValue))
@@ -135,7 +136,7 @@ public class Functions {
     value = "converts a key-value pair into a Map.Entry",
     params = {
       @JinjavaParam(value = "key", type = "object"),
-      @JinjavaParam(value = "value", type = "object")
+      @JinjavaParam(value = "value", type = "object"),
     },
     hidden = true
   )
@@ -151,7 +152,7 @@ public class Functions {
         type = "string",
         defaultValue = "utc",
         desc = "timezone"
-      )
+      ),
     }
   )
   public static ZonedDateTime today(String... var) {
@@ -185,7 +186,7 @@ public class Functions {
         value = "timezone",
         defaultValue = "utc",
         desc = "Time zone of output date"
-      )
+      ),
     }
   )
   public static String dateTimeFormat(Object var, String... format) {
@@ -305,7 +306,7 @@ public class Functions {
   @JinjavaDoc(
     value = "gets the unix timestamp milliseconds value of a datetime",
     params = {
-      @JinjavaParam(value = "var", type = "date", defaultValue = "current time")
+      @JinjavaParam(value = "var", type = "date", defaultValue = "current time"),
     }
   )
   public static long unixtimestamp(Object... var) {
@@ -351,7 +352,7 @@ public class Functions {
         value = "var",
         type = "datetimeFormat",
         desc = "format of the datetime string"
-      )
+      ),
     }
   )
   public static PyishDate stringToTime(String datetimeString, String datetimeFormat) {
@@ -400,7 +401,7 @@ public class Functions {
         value = "dateFormat",
         type = "string",
         desc = "format of the date string"
-      )
+      ),
     }
   )
   public static PyishDate stringToDate(String dateString, String dateFormat) {
@@ -469,7 +470,7 @@ public class Functions {
         value = "end",
         defaultValue = "...",
         desc = "The characters that will be added to indicate where the text was truncated"
-      )
+      ),
     }
   )
   public static Object truncate(Object var, Object... arg) {
@@ -558,7 +559,7 @@ public class Functions {
     params = {
       @JinjavaParam(value = "start", type = "number", defaultValue = "0"),
       @JinjavaParam(value = "end", type = "number"),
-      @JinjavaParam(value = "step", type = "number", defaultValue = "1")
+      @JinjavaParam(value = "step", type = "number", defaultValue = "1"),
     }
   )
   public static List<Integer> range(Object arg1, Object... args) {

--- a/src/main/java/com/hubspot/jinjava/lib/fn/InjectedContextFunctionProxy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/InjectedContextFunctionProxy.java
@@ -13,6 +13,7 @@ import javassist.CtNewMethod;
 import javassist.bytecode.AccessFlag;
 
 public class InjectedContextFunctionProxy {
+
   private static final String GUICE_CLASS_INDICATOR = "$$EnhancerByGuice$$";
 
   public static ELFunctionDefinition defineProxy(

--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -22,6 +22,7 @@ import java.util.Optional;
  *
  */
 public class MacroFunction extends AbstractCallableMethod {
+
   public static final String KWARGS_KEY = "kwargs";
   public static final String VARARGS_KEY = "varargs";
   protected final List<Node> content;
@@ -85,16 +86,15 @@ public class MacroFunction extends AbstractCallableMethod {
     );
 
     // pushWithoutCycleCheck() is used to here so that macros calling macros from the same file will not throw a TagCycleException
-    importFile.ifPresent(
-      path ->
-        interpreter
-          .getContext()
-          .getCurrentPathStack()
-          .pushWithoutCycleCheck(
-            path,
-            interpreter.getLineNumber(),
-            interpreter.getPosition()
-          )
+    importFile.ifPresent(path ->
+      interpreter
+        .getContext()
+        .getCurrentPathStack()
+        .pushWithoutCycleCheck(
+          path,
+          interpreter.getLineNumber(),
+          interpreter.getPosition()
+        )
     );
     return importFile;
   }
@@ -214,17 +214,15 @@ public class MacroFunction extends AbstractCallableMethod {
       return penultimateParent
         .getDeferredTokens()
         .stream()
-        .filter(
-          deferredToken ->
-            Objects.equals(importResourcePath, deferredToken.getImportResourcePath())
+        .filter(deferredToken ->
+          Objects.equals(importResourcePath, deferredToken.getImportResourcePath())
         )
-        .anyMatch(
-          deferredToken ->
-            deferredToken.getSetDeferredWords().contains(key) ||
-            deferredToken
-              .getUsedDeferredWords()
-              .stream()
-              .anyMatch(used -> key.equals(used.split("\\.", 2)[0]))
+        .anyMatch(deferredToken ->
+          deferredToken.getSetDeferredWords().contains(key) ||
+          deferredToken
+            .getUsedDeferredWords()
+            .stream()
+            .anyMatch(used -> key.equals(used.split("\\.", 2)[0]))
         );
     }
     return false;

--- a/src/main/java/com/hubspot/jinjava/lib/fn/TypeFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/TypeFunction.java
@@ -16,6 +16,7 @@ import java.util.Map.Entry;
   value = "Get a string that describes the type of the object, similar to Python's type()"
 )
 public class TypeFunction {
+
   private static Map<Class<?>, String> CLASS_TYPE_TO_NAME = ImmutableMap
     .<Class<?>, String>builder()
     .put(AstDict.class, "dict")

--- a/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
@@ -34,6 +34,7 @@ import org.apache.commons.lang3.StringUtils;
 
 @Beta
 public class EagerMacroFunction extends MacroFunction {
+
   private AtomicInteger callCount = new AtomicInteger();
   private boolean reconstructing = false;
 
@@ -79,8 +80,7 @@ public class EagerMacroFunction extends MacroFunction {
         }
         return result.asTemplateString();
       } finally {
-        importFile.ifPresent(
-          path -> interpreter.getContext().getCurrentPathStack().pop()
+        importFile.ifPresent(path -> interpreter.getContext().getCurrentPathStack().pop()
         );
       }
     }
@@ -103,10 +103,11 @@ public class EagerMacroFunction extends MacroFunction {
         interpreter.getContext().isDeferredExecutionMode()
       )
     ) {
-      PrefixToPreserveState prefixToPreserveState = EagerReconstructionUtils.resetAndDeferSpeculativeBindings(
-        interpreter,
-        eagerExecutionResult
-      );
+      PrefixToPreserveState prefixToPreserveState =
+        EagerReconstructionUtils.resetAndDeferSpeculativeBindings(
+          interpreter,
+          eagerExecutionResult
+        );
 
       String tempVarName = MacroFunctionTempVariable.getVarName(
         getName(),

--- a/src/main/java/com/hubspot/jinjava/lib/tag/AutoEscapeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/AutoEscapeTag.java
@@ -16,10 +16,11 @@ import org.apache.commons.lang3.StringUtils;
   snippets = {
     @JinjavaSnippet(
       code = "{% autoescape %}\n" + "<div>Code to escape</div>\n" + "{% endautoescape %}"
-    )
+    ),
   }
 )
 public class AutoEscapeTag implements Tag {
+
   public static final String TAG_NAME = "autoescape";
 
   private static final long serialVersionUID = 786006577642541285L;

--- a/src/main/java/com/hubspot/jinjava/lib/tag/BlockTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/BlockTag.java
@@ -39,7 +39,7 @@ import com.hubspot.jinjava.util.WhitespaceUtils;
     @JinjavaParam(
       value = "block_name",
       desc = "A unique name for the block that should be used in both the parent and child template"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -47,12 +47,13 @@ import com.hubspot.jinjava.util.WhitespaceUtils;
       "{% block my_sidebar %}\n" +
       "   <!--Content that will render within a block of the same name in the parent template-->\n" +
       "{% endblock %}"
-    )
+    ),
   }
 )
 @JinjavaHasCodeBody
 @JinjavaTextMateSnippet(code = "{% block ${1:name} %}\n$0\n{% endblock $1 %}")
 public class BlockTag implements Tag {
+
   public static final String TAG_NAME = "block";
 
   private static final long serialVersionUID = -2362317415797088108L;

--- a/src/main/java/com/hubspot/jinjava/lib/tag/CallTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/CallTag.java
@@ -46,13 +46,14 @@ import java.util.LinkedHashMap;
       "       <dd>{{ user.description }}</dd>\n" +
       "  </dl>\n" +
       " {% endcall %}"
-    )
+    ),
   }
 )
 @JinjavaTextMateSnippet(
   code = "{% call ${1:macro_name}(${2:argument_names}) %}\n" + "$0\n" + "{% endcall %}"
 )
 public class CallTag implements Tag {
+
   public static final String TAG_NAME = "call";
 
   private static final long serialVersionUID = 7231253469979314727L;

--- a/src/main/java/com/hubspot/jinjava/lib/tag/CycleTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/CycleTag.java
@@ -38,7 +38,7 @@ import java.util.List;
     @JinjavaParam(
       value = "string_to_print",
       desc = "A comma separated list of strings to print with each interation. The list will repeat if there are more iterations than string parameter values."
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -46,11 +46,12 @@ import java.util.List;
       code = "{% for content in contents %}\n" +
       "    <div class=\"post-item {% cycle \'odd\',\'even\' %}\">Blog post content</div>\n" +
       "{% endfor %}"
-    )
+    ),
   }
 )
 @JinjavaTextMateSnippet(code = "{% cycle '${1:string_to_print}' %}")
 public class CycleTag implements Tag {
+
   public static final String TAG_NAME = "cycle";
   public static final String LOOP_INDEX = "loop.index0";
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/DoTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/DoTag.java
@@ -18,11 +18,12 @@ import org.apache.commons.lang3.StringUtils;
       "{% set foo = [] %}\n" +
       "{{ foo.append('a') }}\n" +
       "{% enddo %}"
-    )
+    ),
   }
 )
 @JinjavaTextMateSnippet(code = "{% do ${1:expr} %}")
 public class DoTag implements Tag, FlexibleTag {
+
   public static final String TAG_NAME = "do";
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ElseIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ElseIfTag.java
@@ -13,12 +13,13 @@ import com.hubspot.jinjava.tree.TagNode;
       value = "condition",
       type = "conditional expression",
       desc = "An expression that evaluates to either true or false"
-    )
+    ),
   },
   hidden = true
 )
 @JinjavaHasCodeBody
 public class ElseIfTag implements Tag {
+
   public static final String TAG_NAME = "elif";
 
   private static final long serialVersionUID = -7988057025956316803L;

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ElseTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ElseTag.java
@@ -23,6 +23,7 @@ import com.hubspot.jinjava.tree.TagNode;
 @JinjavaDoc(value = "", hidden = true)
 @JinjavaHasCodeBody
 public class ElseTag implements Tag {
+
   public static final String TAG_NAME = "else";
 
   private static final long serialVersionUID = 1082768429113702148L;

--- a/src/main/java/com/hubspot/jinjava/lib/tag/EndTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/EndTag.java
@@ -6,6 +6,7 @@ import com.hubspot.jinjava.tree.TagNode;
 
 @JinjavaDoc(value = "", hidden = true)
 public final class EndTag implements Tag {
+
   private static final long serialVersionUID = -3309842733119867221L;
   private final String endTagName;
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ExtendsTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ExtendsTag.java
@@ -32,7 +32,7 @@ import java.io.IOException;
   value = "Template inheritance allows you to build a base “skeleton” template that contains all the " +
   "common elements of your site and defines blocks that child templates can override.",
   params = {
-    @JinjavaParam(value = "path", desc = "Design Manager file path to parent template")
+    @JinjavaParam(value = "path", desc = "Design Manager file path to parent template"),
   },
   snippets = {
     @JinjavaSnippet(
@@ -76,11 +76,12 @@ import java.io.IOException;
       "      Welcome to my awesome homepage.\n" +
       "    </p>\n" +
       "{% endblock %}"
-    )
+    ),
   }
 )
 @JinjavaTextMateSnippet(code = "{% extends '${1:path}' %}")
 public class ExtendsTag implements Tag {
+
   public static final String TAG_NAME = "extends";
 
   private static final long serialVersionUID = 4692863362280761393L;

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -66,7 +66,7 @@ import org.apache.commons.lang3.tuple.Pair;
     @JinjavaParam(
       value = "items_to_iterate",
       desc = "Specifies the name of a single item in the sequence or dict."
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -87,7 +87,7 @@ import org.apache.commons.lang3.tuple.Pair;
       code = "{% for content in contents %}\n" +
       "    Post content variables\n" +
       "{% endfor %}"
-    )
+    ),
   }
 )
 @JinjavaHasCodeBody
@@ -95,6 +95,7 @@ import org.apache.commons.lang3.tuple.Pair;
   code = "{% for ${1:items} in ${2:list} %}\n" + "$0\n" + "{% endfor %}"
 )
 public class ForTag implements Tag {
+
   public static final String TAG_NAME = "for";
 
   public static final String LOOP = "loop";
@@ -164,10 +165,11 @@ public class ForTag implements Tag {
   ) {
     ForLoop loop = ObjectIterator.getLoop(collection);
 
-    Set<String> removedMetaContextVariables = EagerReconstructionUtils.removeMetaContextVariables(
-      loopVars.stream(),
-      interpreter.getContext()
-    );
+    Set<String> removedMetaContextVariables =
+      EagerReconstructionUtils.removeMetaContextVariables(
+        loopVars.stream(),
+        interpreter.getContext()
+      );
     try (InterpreterScopeClosable c = interpreter.enterScope()) {
       if (interpreter.isValidationMode() && !loop.hasNext()) {
         loop = ObjectIterator.getLoop(new DummyObject());

--- a/src/main/java/com/hubspot/jinjava/lib/tag/FromTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/FromTag.java
@@ -37,7 +37,7 @@ import java.util.Optional;
     @JinjavaParam(
       value = "macro_name",
       desc = "Name of macro or comma separated macros to import (import macro_name)"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -53,11 +53,12 @@ import java.util.Optional;
       desc = "The macro html file is accessed from a different template, but only the footer macro is imported and executed",
       code = "{% from 'custom/page/web_page_basic/my_macros.html' import footer %}\n" +
       "{{ footer('h2', 'My footer info') }}"
-    )
+    ),
   }
 )
 @JinjavaTextMateSnippet(code = "{% from '${1:path}' import ${2:macro_name} %}")
 public class FromTag implements Tag {
+
   public static final String TAG_NAME = "from";
 
   private static final long serialVersionUID = 6152691434172265022L;

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IfTag.java
@@ -38,7 +38,7 @@ import org.apache.commons.lang3.StringUtils;
       value = "condition",
       type = "conditional expression",
       desc = "An expression that evaluates to either true or false"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -56,12 +56,13 @@ import org.apache.commons.lang3.StringUtils;
       "{% else %}\n" +
       "Variable named number is greater than 6.\n" +
       "{% endif %}"
-    )
+    ),
   }
 )
 @JinjavaTextMateSnippet(code = "{% if '${1:condition}' %}\n\n{% endif %}")
 @JinjavaHasCodeBody
 public class IfTag implements Tag {
+
   public static final String TAG_NAME = "if";
 
   private static final long serialVersionUID = -3784039314941268904L;

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IfchangedTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IfchangedTag.java
@@ -32,11 +32,12 @@ import org.apache.commons.lang3.StringUtils;
       code = "{% ifchanged var %}\n" +
       "Variable to test if changed\n" +
       "{% endifchanged %}"
-    )
+    ),
   }
 )
 @JinjavaHasCodeBody
 public class IfchangedTag implements Tag {
+
   public static final String TAG_NAME = "ifchanged";
 
   private static final long serialVersionUID = 3567908136629704724L;

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -43,7 +43,7 @@ import org.apache.commons.lang3.StringUtils;
     @JinjavaParam(
       value = "import_name",
       desc = "Give a name to the imported file to access macros from"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -60,11 +60,12 @@ import org.apache.commons.lang3.StringUtils;
       code = "{% import 'custom/page/web_page_basic/my_macros.html' as header_footer %}\n" +
       "{{ header_footer.header('h1', 'My page title') }}\n" +
       "{{ header_footer.footer('h3', 'Company footer info') }}"
-    )
+    ),
   }
 )
 @JinjavaTextMateSnippet(code = "{% import '${1:path}' ${2: as ${3:import_name}} %}")
 public class ImportTag implements Tag {
+
   public static final String TAG_NAME = "import";
 
   private static final long serialVersionUID = 8433638845398005260L;
@@ -184,8 +185,7 @@ public class ImportTag implements Tag {
   ) {
     node
       .getChildren()
-      .forEach(
-        deferredChild -> interpreter.getContext().handleDeferredNode(deferredChild)
+      .forEach(deferredChild -> interpreter.getContext().handleDeferredNode(deferredChild)
       );
     if (StringUtils.isBlank(contextVar)) {
       for (MacroFunction macro : child.getContext().getGlobalMacros().values()) {
@@ -213,8 +213,7 @@ public class ImportTag implements Tag {
   public static Node parseTemplateAsNode(
     JinjavaInterpreter interpreter,
     String templateFile
-  )
-    throws IOException {
+  ) throws IOException {
     interpreter
       .getContext()
       .getCurrentPathStack()

--- a/src/main/java/com/hubspot/jinjava/lib/tag/IncludeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/IncludeTag.java
@@ -41,16 +41,17 @@ import org.apache.commons.lang3.StringUtils;
     @JinjavaParam(
       value = "path",
       desc = "Design Manager path to the file that you would like to include"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(code = "{% include \"custom/page/web_page_basic/my_footer.html\" %}"),
     @JinjavaSnippet(code = "{% include \"generated_global_groups/2781996615.html\" %}"),
-    @JinjavaSnippet(code = "{% include \"hubspot/styles/patches/recommended.css\" %}")
+    @JinjavaSnippet(code = "{% include \"hubspot/styles/patches/recommended.css\" %}"),
   }
 )
 @JinjavaTextMateSnippet(code = "{% include '${1:path}' %}")
 public class IncludeTag implements Tag {
+
   public static final String TAG_NAME = "include";
 
   private static final long serialVersionUID = -8391753639874726854L;

--- a/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/MacroTag.java
@@ -30,7 +30,7 @@ import org.apache.commons.lang3.StringUtils;
     @JinjavaParam(
       value = "argument_names",
       desc = "Named arguments that are dynamically, when the macro is run"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -54,12 +54,13 @@ import org.apache.commons.lang3.StringUtils;
     @JinjavaSnippet(
       desc = "The macro can then be called like a function. The macro is printed for anchor tags in CSS.",
       code = "a { {{ trans(\"all .2s ease-in-out\") }} }"
-    )
+    ),
   }
 )
 @JinjavaHasCodeBody
 @JinjavaTextMateSnippet(code = "{% macro ${1:name}(${2:values) %}\n\t$0\n{% endmacro %}")
 public class MacroTag implements Tag {
+
   public static final String TAG_NAME = "macro";
 
   private static final long serialVersionUID = 8397609322126956077L;

--- a/src/main/java/com/hubspot/jinjava/lib/tag/PrintTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/PrintTag.java
@@ -17,10 +17,11 @@ import java.util.Objects;
   snippets = {
     @JinjavaSnippet(
       code = "{% set string_to_echo = \"Print me\" %}\n" + "{% print string_to_echo %}"
-    )
+    ),
   }
 )
 public class PrintTag implements Tag {
+
   public static final String TAG_NAME = "print";
 
   private static final long serialVersionUID = -8613906103187594569L;

--- a/src/main/java/com/hubspot/jinjava/lib/tag/RawTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/RawTag.java
@@ -15,10 +15,11 @@ import org.apache.commons.lang3.StringUtils;
       code = "{% raw %}\n" +
       "    The personalization token for a contact's first name is {{ contact.firstname }}\n" +
       "{% endraw %}"
-    )
+    ),
   }
 )
 public class RawTag implements Tag {
+
   public static final String TAG_NAME = "raw";
 
   private static final long serialVersionUID = -6963360187396753883L;

--- a/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
@@ -54,7 +54,7 @@ import org.apache.commons.lang3.StringUtils;
       value = "expr",
       type = "expression",
       desc = "The value stored in the variable (string, number, boolean, or sequence"
-    )
+    ),
   },
   snippets = {
     @JinjavaSnippet(
@@ -73,11 +73,12 @@ import org.apache.commons.lang3.StringUtils;
       "{% set message %}\n" +
       "My name is {{ name }}\n" +
       "{% endset %}"
-    )
+    ),
   }
 )
 @JinjavaTextMateSnippet(code = "{% set ${1:var} = ${2:expr} %}")
 public class SetTag implements Tag, FlexibleTag {
+
   public static final String TAG_NAME = "set";
   public static final String IGNORED_VARIABLE_NAME = "__ignored__";
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/UnlessTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/UnlessTag.java
@@ -32,6 +32,7 @@ import com.hubspot.jinjava.util.ObjectTruthValue;
 @JinjavaHasCodeBody
 @JinjavaTextMateSnippet(code = "{% unless ${1:condition} %}\n\t$0\n{% endunless %}")
 public class UnlessTag extends IfTag {
+
   public static final String TAG_NAME = "unless";
 
   private static final long serialVersionUID = 1562284758153763419L;

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/DeferredToken.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/DeferredToken.java
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 public class DeferredToken {
 
   public static class DeferredTokenBuilder {
+
     private final Token token;
     private Stream<String> usedDeferredWords;
     private Stream<String> setDeferredWords;
@@ -41,10 +42,9 @@ public class DeferredToken {
           ? usedDeferredWords
             .map(prop -> prop.split("\\.", 2)[0])
             .distinct()
-            .filter(
-              word ->
-                interpreter == null ||
-                !(interpreter.getContext().get(word) instanceof DeferredMacroValueImpl)
+            .filter(word ->
+              interpreter == null ||
+              !(interpreter.getContext().get(word) instanceof DeferredMacroValueImpl)
             )
             .collect(Collectors.toSet())
           : Collections.emptySet(),
@@ -251,12 +251,10 @@ public class DeferredToken {
       context,
       usedDeferredWords
         .stream()
-        .filter(
-          word -> {
-            Object value = context.get(word);
-            return value != null && !(value instanceof DeferredValue);
-          }
-        )
+        .filter(word -> {
+          Object value = context.get(word);
+          return value != null && !(value instanceof DeferredValue);
+        })
         .collect(Collectors.toCollection(HashSet::new))
     );
   }
@@ -312,37 +310,32 @@ public class DeferredToken {
           .getScope()
           .entrySet()
           .stream()
-          .filter(
-            entry ->
-              entry.getValue() == wordValue ||
-              (
-                entry.getValue() instanceof DeferredValue &&
-                ((DeferredValue) entry.getValue()).getOriginalValue() == wordValue
-              )
+          .filter(entry ->
+            entry.getValue() == wordValue ||
+            (
+              entry.getValue() instanceof DeferredValue &&
+              ((DeferredValue) entry.getValue()).getOriginalValue() == wordValue
+            )
           )
-          .forEach(
-            entry -> {
-              matchingEntries.add(entry);
-              deferredLazyReference.getOriginalValue().setReferenceKey(entry.getKey());
-            }
-          );
+          .forEach(entry -> {
+            matchingEntries.add(entry);
+            deferredLazyReference.getOriginalValue().setReferenceKey(entry.getKey());
+          });
         temp = temp.getParent();
       }
       if (matchingEntries.size() > 1) { // at least one duplicate
-        matchingEntries.forEach(
-          entry -> {
-            if (
-              deferredLazyReference
-                .getOriginalValue()
-                .getReferenceKey()
-                .equals(entry.getKey())
-            ) {
-              convertToDeferredLazyReferenceSource(context, entry);
-            } else {
-              entry.setValue(deferredLazyReference.clone());
-            }
+        matchingEntries.forEach(entry -> {
+          if (
+            deferredLazyReference
+              .getOriginalValue()
+              .getReferenceKey()
+              .equals(entry.getKey())
+          ) {
+            convertToDeferredLazyReferenceSource(context, entry);
+          } else {
+            entry.setValue(deferredLazyReference.clone());
           }
-        );
+        });
       }
     }
   }
@@ -355,9 +348,10 @@ public class DeferredToken {
     if (val instanceof DeferredLazyReferenceSource) {
       return;
     }
-    DeferredLazyReferenceSource deferredLazyReferenceSource = DeferredLazyReferenceSource.instance(
-      val instanceof DeferredValue ? ((DeferredValue) val).getOriginalValue() : val
-    );
+    DeferredLazyReferenceSource deferredLazyReferenceSource =
+      DeferredLazyReferenceSource.instance(
+        val instanceof DeferredValue ? ((DeferredValue) val).getOriginalValue() : val
+      );
 
     context.replace(entry.getKey(), deferredLazyReferenceSource);
     entry.setValue(deferredLazyReferenceSource);
@@ -370,25 +364,21 @@ public class DeferredToken {
   ) {
     return wordsToDefer
       .stream()
-      .filter(
-        prop -> {
-          Object val = context.get(prop);
-          if (replacing) {
-            return (
-              !(val instanceof DeferredValue) || context.getScope().containsKey(prop)
-            );
-          }
-          return !(val instanceof DeferredValue);
+      .filter(prop -> {
+        Object val = context.get(prop);
+        if (replacing) {
+          return (
+            !(val instanceof DeferredValue) || context.getScope().containsKey(prop)
+          );
         }
-      )
+        return !(val instanceof DeferredValue);
+      })
       .filter(prop -> !context.getMetaContextVariables().contains(prop))
-      .filter(
-        prop -> {
-          DeferredValue deferredValue = convertToDeferredValue(context, prop);
-          context.put(prop, deferredValue);
-          return !(deferredValue instanceof DeferredValueShadow);
-        }
-      )
+      .filter(prop -> {
+        DeferredValue deferredValue = convertToDeferredValue(context, prop);
+        context.put(prop, deferredValue);
+        return !(deferredValue instanceof DeferredValueShadow);
+      })
       .collect(Collectors.toList());
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.tuple.Triple;
 
 @Beta
 public class EagerBlockSetTagStrategy extends EagerSetTagStrategy {
+
   public static final EagerBlockSetTagStrategy INSTANCE = new EagerBlockSetTagStrategy(
     new SetTag()
   );
@@ -39,8 +40,8 @@ public class EagerBlockSetTagStrategy extends EagerSetTagStrategy {
           eagerInterpreter
         ),
       interpreter,
-      EagerContextWatcher
-        .EagerChildContextConfig.newBuilder()
+      EagerContextWatcher.EagerChildContextConfig
+        .newBuilder()
         .withTakeNewValue(true)
         .build()
     );
@@ -74,12 +75,13 @@ public class EagerBlockSetTagStrategy extends EagerSetTagStrategy {
         true
       );
       if (filterPos >= 0) {
-        EagerExecutionResult filterResult = EagerInlineSetTagStrategy.INSTANCE.getEagerExecutionResult(
-          tagNode,
-          variables,
-          tagNode.getHelpers().trim(),
-          interpreter
-        );
+        EagerExecutionResult filterResult =
+          EagerInlineSetTagStrategy.INSTANCE.getEagerExecutionResult(
+            tagNode,
+            variables,
+            tagNode.getHelpers().trim(),
+            interpreter
+          );
         if (filterResult.getResult().isFullyResolved()) {
           setTag.executeSet(
             (TagToken) tagNode.getMaster(),
@@ -117,10 +119,10 @@ public class EagerBlockSetTagStrategy extends EagerSetTagStrategy {
       .add(tagNode.getSymbols().getExpressionEndWithTag());
 
     PrefixToPreserveState prefixToPreserveState = getPrefixToPreserveState(
-        eagerExecutionResult,
-        variables,
-        interpreter
-      )
+      eagerExecutionResult,
+      variables,
+      interpreter
+    )
       .withAllInFront(
         EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
           interpreter,
@@ -168,12 +170,13 @@ public class EagerBlockSetTagStrategy extends EagerSetTagStrategy {
     int filterPos = tagNode.getHelpers().indexOf('|');
     String filterSetPostfix = "";
     if (filterPos >= 0) {
-      EagerExecutionResult filterResult = EagerInlineSetTagStrategy.INSTANCE.getEagerExecutionResult(
-        tagNode,
-        variables,
-        tagNode.getHelpers().trim(),
-        interpreter
-      );
+      EagerExecutionResult filterResult =
+        EagerInlineSetTagStrategy.INSTANCE.getEagerExecutionResult(
+          tagNode,
+          variables,
+          tagNode.getHelpers().trim(),
+          interpreter
+        );
       if (filterResult.getResult().isFullyResolved()) {
         setTag.executeSet(
           (TagToken) tagNode.getMaster(),
@@ -203,12 +206,13 @@ public class EagerBlockSetTagStrategy extends EagerSetTagStrategy {
     EagerExecutionResult eagerExecutionResult,
     JinjavaInterpreter interpreter
   ) {
-    Triple<String, String, String> triple = EagerInlineSetTagStrategy.INSTANCE.getPrefixTokenAndSuffix(
-      tagNode,
-      variables,
-      eagerExecutionResult,
-      interpreter
-    );
+    Triple<String, String, String> triple =
+      EagerInlineSetTagStrategy.INSTANCE.getPrefixTokenAndSuffix(
+        tagNode,
+        variables,
+        eagerExecutionResult,
+        interpreter
+      );
     if (
       eagerExecutionResult.getResult().isFullyResolved() &&
       interpreter.getContext().isDeferredExecutionMode()

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCallTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCallTag.java
@@ -63,8 +63,8 @@ public class EagerCallTag extends EagerStateChangingTag<CallTag> {
               interpreter
             ),
           interpreter,
-          EagerContextWatcher
-            .EagerChildContextConfig.newBuilder()
+          EagerContextWatcher.EagerChildContextConfig
+            .newBuilder()
             .withTakeNewValue(true)
             .withPartialMacroEvaluation(
               interpreter.getConfig().isNestedInterpretationEnabled()
@@ -115,7 +115,7 @@ public class EagerCallTag extends EagerStateChangingTag<CallTag> {
         eagerExecutionResult.getResult(),
         eagerExecutionResult.getSpeculativeBindings()
       )
-      .getPrefixToPreserveState()
+        .getPrefixToPreserveState()
     );
     joiner =
       new LengthLimitingStringJoiner(interpreter.getConfig().getMaxOutputSize(), " ");
@@ -143,8 +143,8 @@ public class EagerCallTag extends EagerStateChangingTag<CallTag> {
             eagerInterpreter ->
               EagerExpressionResult.fromString(renderChildren(tagNode, eagerInterpreter)),
             interpreter,
-            EagerContextWatcher
-              .EagerChildContextConfig.newBuilder()
+            EagerContextWatcher.EagerChildContextConfig
+              .newBuilder()
               .withForceDeferredExecutionMode(true)
               .build()
           )

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
@@ -51,8 +51,8 @@ public class EagerCycleTag extends EagerStateChangingTag<CycleTag> {
       eagerInterpreter ->
         EagerExpressionResolver.resolveExpression(expression, interpreter),
       interpreter,
-      EagerContextWatcher
-        .EagerChildContextConfig.newBuilder()
+      EagerContextWatcher.EagerChildContextConfig
+        .newBuilder()
         .withTakeNewValue(true)
         .build()
     );

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerDoTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerDoTag.java
@@ -30,18 +30,19 @@ public class EagerDoTag extends EagerStateChangingTag<DoTag> implements Flexible
     InterpretException e
   ) {
     if (hasEndTag((TagToken) tagNode.getMaster())) {
-      EagerExecutionResult eagerExecutionResult = EagerContextWatcher.executeInChildContext(
-        eagerInterpreter ->
-          EagerExpressionResult.fromSupplier(
-            () -> renderChildren(tagNode, interpreter),
-            eagerInterpreter
-          ),
-        interpreter,
-        EagerContextWatcher
-          .EagerChildContextConfig.newBuilder()
-          .withTakeNewValue(true)
-          .build()
-      );
+      EagerExecutionResult eagerExecutionResult =
+        EagerContextWatcher.executeInChildContext(
+          eagerInterpreter ->
+            EagerExpressionResult.fromSupplier(
+              () -> renderChildren(tagNode, interpreter),
+              eagerInterpreter
+            ),
+          interpreter,
+          EagerContextWatcher.EagerChildContextConfig
+            .newBuilder()
+            .withTakeNewValue(true)
+            .build()
+        );
       PrefixToPreserveState prefixToPreserveState = new PrefixToPreserveState();
       if (interpreter.getContext().isDeferredExecutionMode()) {
         prefixToPreserveState.withAll(eagerExecutionResult.getPrefixToPreserveState());

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -46,8 +46,8 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
           interpreter
         ),
       interpreter,
-      EagerContextWatcher
-        .EagerChildContextConfig.newBuilder()
+      EagerContextWatcher.EagerChildContextConfig
+        .newBuilder()
         .withCheckForContextChanges(!interpreter.getContext().isDeferredExecutionMode())
         .build()
     );
@@ -184,12 +184,13 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
         List<String> loopVars = getTag()
           .getLoopVarsAndExpression((TagToken) tagNode.getMaster())
           .getLeft();
-        Set<String> removedMetaContextVariables = EagerReconstructionUtils.removeMetaContextVariables(
-          loopVars.stream(),
-          interpreter.getContext()
-        );
-        loopVars.forEach(
-          var -> interpreter.getContext().put(var, DeferredValue.instance())
+        Set<String> removedMetaContextVariables =
+          EagerReconstructionUtils.removeMetaContextVariables(
+            loopVars.stream(),
+            interpreter.getContext()
+          );
+        loopVars.forEach(var ->
+          interpreter.getContext().put(var, DeferredValue.instance())
         );
         try {
           return EagerExpressionResult.fromString(
@@ -203,8 +204,8 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
         }
       },
       interpreter,
-      EagerContextWatcher
-        .EagerChildContextConfig.newBuilder()
+      EagerContextWatcher.EagerChildContextConfig
+        .newBuilder()
         .withForceDeferredExecutionMode(true)
         .build()
     );
@@ -217,10 +218,8 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
     List<String> loopVars = loopVarsAndExpression.getLeft();
     String loopExpression = loopVarsAndExpression.getRight();
 
-    EagerExpressionResult eagerExpressionResult = EagerExpressionResolver.resolveExpression(
-      loopExpression,
-      interpreter
-    );
+    EagerExpressionResult eagerExpressionResult =
+      EagerExpressionResolver.resolveExpression(loopExpression, interpreter);
 
     LengthLimitingStringJoiner joiner = new LengthLimitingStringJoiner(
       interpreter.getConfig().getMaxOutputSize(),
@@ -234,11 +233,12 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
       .add("in")
       .add(eagerExpressionResult.toString())
       .add(tagToken.getSymbols().getExpressionEndWithTag());
-    PrefixToPreserveState prefixToPreserveState = EagerReconstructionUtils.hydrateReconstructionFromContextBeforeDeferring(
-      new PrefixToPreserveState(),
-      eagerExpressionResult.getDeferredWords(),
-      interpreter
-    );
+    PrefixToPreserveState prefixToPreserveState =
+      EagerReconstructionUtils.hydrateReconstructionFromContextBeforeDeferring(
+        new PrefixToPreserveState(),
+        eagerExpressionResult.getDeferredWords(),
+        interpreter
+      );
     prefixToPreserveState.withAllInFront(
       EagerReconstructionUtils.handleDeferredTokenAndReconstructReferences(
         interpreter,

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTag.java
@@ -40,21 +40,19 @@ public class EagerFromTag extends EagerStateChangingTag<FromTag> {
     } catch (DeferredValueException e) {
       imports
         .values()
-        .forEach(
-          value -> {
-            MacroFunction deferredMacro = new MacroFunction(
-              null,
-              value,
-              null,
-              false,
-              null,
-              tagToken.getLineNumber(),
-              tagToken.getStartPosition()
-            );
-            deferredMacro.setDeferred(true);
-            interpreter.getContext().addGlobalMacro(deferredMacro);
-          }
-        );
+        .forEach(value -> {
+          MacroFunction deferredMacro = new MacroFunction(
+            null,
+            value,
+            null,
+            false,
+            null,
+            tagToken.getLineNumber(),
+            tagToken.getStartPosition()
+          );
+          deferredMacro.setDeferred(true);
+          interpreter.getContext().addGlobalMacro(deferredMacro);
+        });
       return (
         EagerReconstructionUtils.buildBlockOrInlineSetTag(
           RelativePathResolver.CURRENT_PATH_CONTEXT_KEY,
@@ -138,10 +136,9 @@ public class EagerFromTag extends EagerStateChangingTag<FromTag> {
       .entrySet()
       .stream()
       .filter(e -> !e.getKey().equals(e.getValue()))
-      .filter(
-        e ->
-          interpreter.getContext().containsKey(e.getValue()) ||
-          !interpreter.getContext().isGlobalMacro(e.getValue())
+      .filter(e ->
+        interpreter.getContext().containsKey(e.getValue()) ||
+        !interpreter.getContext().isGlobalMacro(e.getValue())
       )
       .collect(Collectors.toMap(Entry::getValue, Entry::getKey)); // flip order
   }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTag.java
@@ -61,8 +61,8 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
               eagerRenderBranches(tagNode, eagerInterpreter, e)
             ),
           interpreter,
-          EagerContextWatcher
-            .EagerChildContextConfig.newBuilder()
+          EagerContextWatcher.EagerChildContextConfig
+            .newBuilder()
             .withForceDeferredExecutionMode(true)
             .build()
         )
@@ -114,8 +114,8 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
               evaluateBranch(tagNode, finalBranchStart, branchEnd, interpreter)
             ),
           interpreter,
-          EagerContextWatcher
-            .EagerChildContextConfig.newBuilder()
+          EagerContextWatcher.EagerChildContextConfig
+            .newBuilder()
             .withForceDeferredExecutionMode(true)
             .build()
         );
@@ -154,10 +154,11 @@ public class EagerIfTag extends EagerTagDecorator<IfTag> {
       }
       branchStart = branchEnd + 1;
     }
-    PrefixToPreserveState prefixToPreserveState = EagerReconstructionUtils.deferWordsAndReconstructReferences(
-      interpreter,
-      bindingsToDefer
-    );
+    PrefixToPreserveState prefixToPreserveState =
+      EagerReconstructionUtils.deferWordsAndReconstructReferences(
+        interpreter,
+        bindingsToDefer
+      );
     return prefixToPreserveState + sb.toString();
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
@@ -30,9 +30,8 @@ public class EagerIncludeTag extends EagerTagDecorator<IncludeTag> {
         tagNode.getStartPosition()
       );
       templateFile = interpreter.resolveResourceLocation(templateFile);
-      final String initialPathSetter = EagerImportingStrategyFactory.getSetTagForCurrentPath(
-        interpreter
-      );
+      final String initialPathSetter =
+        EagerImportingStrategyFactory.getSetTagForCurrentPath(interpreter);
       final String newPathSetter = EagerReconstructionUtils.buildBlockOrInlineSetTag(
         RelativePathResolver.CURRENT_PATH_CONTEXT_KEY,
         templateFile,

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang3.tuple.Triple;
 
 @Beta
 public class EagerInlineSetTagStrategy extends EagerSetTagStrategy {
+
   public static final EagerInlineSetTagStrategy INSTANCE = new EagerInlineSetTagStrategy(
     new SetTag()
   );
@@ -37,8 +38,8 @@ public class EagerInlineSetTagStrategy extends EagerSetTagStrategy {
       eagerInterpreter ->
         EagerExpressionResolver.resolveExpression('[' + expression + ']', interpreter),
       interpreter,
-      EagerContextWatcher
-        .EagerChildContextConfig.newBuilder()
+      EagerContextWatcher.EagerChildContextConfig
+        .newBuilder()
         .withTakeNewValue(true)
         .build()
     );

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerPrintTag.java
@@ -57,8 +57,8 @@ public class EagerPrintTag extends EagerStateChangingTag<PrintTag> {
     EagerExecutionResult eagerExecutionResult = EagerContextWatcher.executeInChildContext(
       eagerInterpreter -> EagerExpressionResolver.resolveExpression(expr, interpreter),
       interpreter,
-      EagerContextWatcher
-        .EagerChildContextConfig.newBuilder()
+      EagerContextWatcher.EagerChildContextConfig
+        .newBuilder()
         .withTakeNewValue(true)
         .build()
     );

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang3.tuple.Triple;
 
 @Beta
 public abstract class EagerSetTagStrategy {
+
   protected final SetTag setTag;
 
   protected EagerSetTagStrategy(SetTag setTag) {
@@ -159,9 +160,8 @@ public abstract class EagerSetTagStrategy {
       return "";
     }
     StringBuilder suffixToPreserveState = new StringBuilder();
-    Optional<String> maybeTemporaryImportAlias = AliasedEagerImportingStrategy.getTemporaryImportAlias(
-      interpreter.getContext()
-    );
+    Optional<String> maybeTemporaryImportAlias =
+      AliasedEagerImportingStrategy.getTemporaryImportAlias(interpreter.getContext());
     if (
       maybeTemporaryImportAlias.isPresent() &&
       !AliasedEagerImportingStrategy.isTemporaryImportAlias(variables) &&

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecorator.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 
 @Beta
 public abstract class EagerTagDecorator<T extends Tag> implements Tag {
+
   private final T tag;
 
   public EagerTagDecorator(T tag) {
@@ -123,8 +124,8 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
               renderChildren(tagNode, eagerInterpreter)
             ),
           interpreter,
-          EagerContextWatcher
-            .EagerChildContextConfig.newBuilder()
+          EagerContextWatcher.EagerChildContextConfig
+            .newBuilder()
             .withForceDeferredExecutionMode(true)
             .build()
         )
@@ -216,10 +217,11 @@ public abstract class EagerTagDecorator<T extends Tag> implements Tag {
       .add(tagToken.getSymbols().getExpressionStartWithTag())
       .add(tagToken.getTagName());
 
-    EagerExpressionResult eagerExpressionResult = EagerExpressionResolver.resolveExpression(
-      tagToken.getHelpers().trim(),
-      interpreter
-    );
+    EagerExpressionResult eagerExpressionResult =
+      EagerExpressionResolver.resolveExpression(
+        tagToken.getHelpers().trim(),
+        interpreter
+      );
     String resolvedString = eagerExpressionResult.toString();
     if (StringUtils.isNotBlank(resolvedString)) {
       joiner.add(resolvedString);

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactory.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactory.java
@@ -29,20 +29,22 @@ import java.util.Set;
 
 @Beta
 public class EagerTagFactory {
-  public static final Map<Class<? extends Tag>, Class<? extends EagerTagDecorator<? extends Tag>>> EAGER_TAG_OVERRIDES = ImmutableMap
-    .<Class<? extends Tag>, Class<? extends EagerTagDecorator<?>>>builder()
-    .put(SetTag.class, EagerSetTag.class)
-    .put(DoTag.class, EagerDoTag.class)
-    .put(PrintTag.class, EagerPrintTag.class)
-    .put(FromTag.class, EagerFromTag.class)
-    .put(ImportTag.class, EagerImportTag.class)
-    .put(IncludeTag.class, EagerIncludeTag.class)
-    .put(ForTag.class, EagerForTag.class)
-    .put(CycleTag.class, EagerCycleTag.class)
-    .put(IfTag.class, EagerIfTag.class)
-    .put(UnlessTag.class, EagerUnlessTag.class)
-    .put(CallTag.class, EagerCallTag.class)
-    .build();
+
+  public static final Map<Class<? extends Tag>, Class<? extends EagerTagDecorator<? extends Tag>>> EAGER_TAG_OVERRIDES =
+    ImmutableMap
+      .<Class<? extends Tag>, Class<? extends EagerTagDecorator<?>>>builder()
+      .put(SetTag.class, EagerSetTag.class)
+      .put(DoTag.class, EagerDoTag.class)
+      .put(PrintTag.class, EagerPrintTag.class)
+      .put(FromTag.class, EagerFromTag.class)
+      .put(ImportTag.class, EagerImportTag.class)
+      .put(IncludeTag.class, EagerIncludeTag.class)
+      .put(ForTag.class, EagerForTag.class)
+      .put(CycleTag.class, EagerCycleTag.class)
+      .put(IfTag.class, EagerIfTag.class)
+      .put(UnlessTag.class, EagerUnlessTag.class)
+      .put(CallTag.class, EagerCallTag.class)
+      .build();
   // These classes don't need an eager decorator.
   public static final Set<Class<? extends Tag>> TAG_CLASSES_TO_SKIP = ImmutableSet
     .<Class<? extends Tag>>builder()
@@ -63,9 +65,8 @@ public class EagerTagFactory {
       if (TAG_CLASSES_TO_SKIP.contains(clazz)) {
         return Optional.empty();
       }
-      Class<? extends EagerTagDecorator<? extends Tag>> eagerOverrideClass = EAGER_TAG_OVERRIDES.get(
-        clazz
-      );
+      Class<? extends EagerTagDecorator<? extends Tag>> eagerOverrideClass =
+        EAGER_TAG_OVERRIDES.get(clazz);
       if (eagerOverrideClass != null) {
         EagerTagDecorator<?> decorator = eagerOverrideClass
           .getDeclaredConstructor(clazz)

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/AliasedEagerImportingStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/AliasedEagerImportingStrategy.java
@@ -22,6 +22,7 @@ import java.util.StringJoiner;
 import java.util.stream.Stream;
 
 public class AliasedEagerImportingStrategy implements EagerImportingStrategy {
+
   private static final String TEMPORARY_IMPORT_ALIAS_PREFIX = "__temp_import_alias_";
   private static final String TEMPORARY_IMPORT_ALIAS_FORMAT =
     TEMPORARY_IMPORT_ALIAS_PREFIX + "%d__";
@@ -118,12 +119,11 @@ public class AliasedEagerImportingStrategy implements EagerImportingStrategy {
     childBindings
       .entrySet()
       .stream()
-      .filter(
-        entry ->
-          !(
-            entry.getKey().equals(Context.GLOBAL_MACROS_SCOPE_KEY) ||
-            entry.getKey().equals(Context.IMPORT_RESOURCE_ALIAS_KEY)
-          )
+      .filter(entry ->
+        !(
+          entry.getKey().equals(Context.GLOBAL_MACROS_SCOPE_KEY) ||
+          entry.getKey().equals(Context.IMPORT_RESOURCE_ALIAS_KEY)
+        )
       )
       .forEach(entry -> mapForCurrentContextAlias.put(entry.getKey(), entry.getValue()));
   }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/EagerImportingStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/EagerImportingStrategy.java
@@ -22,20 +22,18 @@ public interface EagerImportingStrategy {
     return childBindings
       .entrySet()
       .stream()
-      .filter(
-        entry ->
-          entry.getValue() instanceof DeferredValue &&
-          ((DeferredValue) entry.getValue()).getOriginalValue() != null
+      .filter(entry ->
+        entry.getValue() instanceof DeferredValue &&
+        ((DeferredValue) entry.getValue()).getOriginalValue() != null
       )
       .filter(entry -> !interpreter.getContext().containsKey(entry.getKey()))
       .filter(entry -> !entry.getKey().equals(currentImportAlias))
-      .map(
-        entry ->
-          EagerReconstructionUtils.buildBlockOrInlineSetTag( // don't register deferred token so that we don't defer them on higher context scopes; they only exist in the child scope
-            entry.getKey(),
-            ((DeferredValue) entry.getValue()).getOriginalValue(),
-            interpreter
-          )
+      .map(entry ->
+        EagerReconstructionUtils.buildBlockOrInlineSetTag( // don't register deferred token so that we don't defer them on higher context scopes; they only exist in the child scope
+          entry.getKey(),
+          ((DeferredValue) entry.getValue()).getOriginalValue(),
+          interpreter
+        )
       )
       .collect(Collectors.joining());
   }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/EagerImportingStrategyFactory.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/EagerImportingStrategyFactory.java
@@ -34,11 +34,10 @@ public class EagerImportingStrategyFactory {
         .getContext()
         .getCurrentPathStack()
         .peek()
-        .orElseGet(
-          () ->
-            (String) interpreter
-              .getContext()
-              .getOrDefault(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY, "")
+        .orElseGet(() ->
+          (String) interpreter
+            .getContext()
+            .getOrDefault(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY, "")
         ),
       interpreter
     );

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/FlatEagerImportingStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/FlatEagerImportingStrategy.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class FlatEagerImportingStrategy implements EagerImportingStrategy {
+
   private final ImportingData importingData;
 
   @VisibleForTesting
@@ -46,17 +47,15 @@ public class FlatEagerImportingStrategy implements EagerImportingStrategy {
 
     childBindings.remove(Context.GLOBAL_MACROS_SCOPE_KEY);
     childBindings.remove(Context.IMPORT_RESOURCE_ALIAS_KEY);
-    Map<String, Object> childBindingsWithoutImportResourcePath = ImportTag.getChildBindingsWithoutImportResourcePath(
-      childBindings
-    );
+    Map<String, Object> childBindingsWithoutImportResourcePath =
+      ImportTag.getChildBindingsWithoutImportResourcePath(childBindings);
     if (parent.getContext().isDeferredExecutionMode()) {
       childBindingsWithoutImportResourcePath
         .keySet()
-        .forEach(
-          key ->
-            parent
-              .getContext()
-              .put(key, DeferredValue.instance(parent.getContext().get(key)))
+        .forEach(key ->
+          parent
+            .getContext()
+            .put(key, DeferredValue.instance(parent.getContext().get(key)))
         );
     } else {
       parent.getContext().putAll(childBindingsWithoutImportResourcePath);
@@ -81,9 +80,8 @@ public class FlatEagerImportingStrategy implements EagerImportingStrategy {
           .getSessionBindings()
           .entrySet()
           .stream()
-          .filter(
-            entry ->
-              !(entry.getValue() instanceof DeferredValue) && entry.getValue() != null
+          .filter(entry ->
+            !(entry.getValue() instanceof DeferredValue) && entry.getValue() != null
           )
           .filter(entry -> !metaContextVariables.contains(entry.getKey()))
           .collect(Collectors.toMap(Entry::getKey, entry -> "")),

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/ImportingData.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/ImportingData.java
@@ -5,6 +5,7 @@ import com.hubspot.jinjava.tree.parse.TagToken;
 import java.util.List;
 
 public class ImportingData {
+
   private final JinjavaInterpreter originalInterpreter;
   private final TagToken tagToken;
   private final List<String> helpers;

--- a/src/main/java/com/hubspot/jinjava/loader/CascadingResourceLocator.java
+++ b/src/main/java/com/hubspot/jinjava/loader/CascadingResourceLocator.java
@@ -6,6 +6,7 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 
 public class CascadingResourceLocator implements ResourceLocator {
+
   private Iterable<ResourceLocator> locators;
 
   public CascadingResourceLocator(ResourceLocator... locators) {
@@ -17,8 +18,7 @@ public class CascadingResourceLocator implements ResourceLocator {
     String fullName,
     Charset encoding,
     JinjavaInterpreter interpreter
-  )
-    throws IOException {
+  ) throws IOException {
     for (ResourceLocator locator : locators) {
       try {
         return locator.getString(fullName, encoding, interpreter);

--- a/src/main/java/com/hubspot/jinjava/loader/ClasspathResourceLocator.java
+++ b/src/main/java/com/hubspot/jinjava/loader/ClasspathResourceLocator.java
@@ -12,8 +12,7 @@ public class ClasspathResourceLocator implements ResourceLocator {
     String fullName,
     Charset encoding,
     JinjavaInterpreter interpreter
-  )
-    throws IOException {
+  ) throws IOException {
     try {
       return Resources.toString(Resources.getResource(fullName), encoding);
     } catch (IllegalArgumentException e) {

--- a/src/main/java/com/hubspot/jinjava/loader/FileLocator.java
+++ b/src/main/java/com/hubspot/jinjava/loader/FileLocator.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 
 public class FileLocator implements ResourceLocator {
+
   private File baseDir;
 
   /**

--- a/src/main/java/com/hubspot/jinjava/loader/RelativePathResolver.java
+++ b/src/main/java/com/hubspot/jinjava/loader/RelativePathResolver.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class RelativePathResolver implements LocationResolver {
+
   public static final String CURRENT_PATH_CONTEXT_KEY = "current_path";
 
   @Override
@@ -14,9 +15,8 @@ public class RelativePathResolver implements LocationResolver {
         .getContext()
         .getCurrentPathStack()
         .peek()
-        .orElseGet(
-          () ->
-            (String) interpreter.getContext().getOrDefault(CURRENT_PATH_CONTEXT_KEY, "")
+        .orElseGet(() ->
+          (String) interpreter.getContext().getOrDefault(CURRENT_PATH_CONTEXT_KEY, "")
         );
 
       Path templatePath = Paths.get(parentPath);

--- a/src/main/java/com/hubspot/jinjava/loader/ResourceNotFoundException.java
+++ b/src/main/java/com/hubspot/jinjava/loader/ResourceNotFoundException.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.loader;
 import java.io.IOException;
 
 public class ResourceNotFoundException extends IOException {
+
   private static final long serialVersionUID = 1L;
 
   public ResourceNotFoundException(String message) {

--- a/src/main/java/com/hubspot/jinjava/mode/DefaultExecutionMode.java
+++ b/src/main/java/com/hubspot/jinjava/mode/DefaultExecutionMode.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.mode;
 
 public class DefaultExecutionMode implements ExecutionMode {
+
   private static final ExecutionMode INSTANCE = new DefaultExecutionMode();
 
   private DefaultExecutionMode() {}

--- a/src/main/java/com/hubspot/jinjava/mode/EagerExecutionMode.java
+++ b/src/main/java/com/hubspot/jinjava/mode/EagerExecutionMode.java
@@ -9,16 +9,18 @@ import com.hubspot.jinjava.loader.RelativePathResolver;
 import java.util.Optional;
 
 public class EagerExecutionMode implements ExecutionMode {
+
   private static final ExecutionMode INSTANCE = new EagerExecutionMode();
 
   // These meta context variables should never be removed from the set of meta context variables
-  public static final ImmutableSet<String> STATIC_META_CONTEXT_VARIABLES = ImmutableSet.of(
-    Context.GLOBAL_MACROS_SCOPE_KEY,
-    Context.IMPORT_RESOURCE_PATH_KEY,
-    Context.DEFERRED_IMPORT_RESOURCE_PATH_KEY,
-    Context.IMPORT_RESOURCE_ALIAS_KEY,
-    RelativePathResolver.CURRENT_PATH_CONTEXT_KEY
-  );
+  public static final ImmutableSet<String> STATIC_META_CONTEXT_VARIABLES =
+    ImmutableSet.of(
+      Context.GLOBAL_MACROS_SCOPE_KEY,
+      Context.IMPORT_RESOURCE_PATH_KEY,
+      Context.DEFERRED_IMPORT_RESOURCE_PATH_KEY,
+      Context.IMPORT_RESOURCE_ALIAS_KEY,
+      RelativePathResolver.CURRENT_PATH_CONTEXT_KEY
+    );
 
   protected EagerExecutionMode() {}
 

--- a/src/main/java/com/hubspot/jinjava/mode/NonRevertingEagerExecutionMode.java
+++ b/src/main/java/com/hubspot/jinjava/mode/NonRevertingEagerExecutionMode.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.mode;
 
 public class NonRevertingEagerExecutionMode extends EagerExecutionMode {
+
   private static final ExecutionMode INSTANCE = new NonRevertingEagerExecutionMode();
 
   protected NonRevertingEagerExecutionMode() {}

--- a/src/main/java/com/hubspot/jinjava/mode/PreserveRawExecutionMode.java
+++ b/src/main/java/com/hubspot/jinjava/mode/PreserveRawExecutionMode.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.mode;
 
 public class PreserveRawExecutionMode implements ExecutionMode {
+
   private static final ExecutionMode INSTANCE = new PreserveRawExecutionMode();
 
   private PreserveRawExecutionMode() {}

--- a/src/main/java/com/hubspot/jinjava/objects/Namespace.java
+++ b/src/main/java/com/hubspot/jinjava/objects/Namespace.java
@@ -24,8 +24,8 @@ public class Namespace extends SizeLimitingPyMap implements PyishSerializable {
   @SuppressWarnings("unchecked")
   public <T extends Appendable & CharSequence> T appendPyishString(T appendable)
     throws IOException {
-    return (T) PyishSerializable
-      .super.appendPyishString((T) appendable.append("namespace("))
+    return (T) PyishSerializable.super
+      .appendPyishString((T) appendable.append("namespace("))
       .append(')');
   }
 }

--- a/src/main/java/com/hubspot/jinjava/objects/SafeString.java
+++ b/src/main/java/com/hubspot/jinjava/objects/SafeString.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.objects;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public class SafeString {
+
   private final String value;
 
   public SafeString(String value) {

--- a/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Objects;
 
 public class PyList extends ForwardingList<Object> implements PyWrapper {
+
   private boolean computingHashCode = false;
   private final List<Object> list;
 

--- a/src/main/java/com/hubspot/jinjava/objects/collections/PyMap.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/PyMap.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 import java.util.Set;
 
 public class PyMap extends ForwardingMap<String, Object> implements PyWrapper {
+
   private boolean computingHashCode = false;
 
   private final Map<String, Object> map;

--- a/src/main/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyList.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyList.java
@@ -12,6 +12,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 public class SizeLimitingPyList extends PyList implements PyWrapper {
+
   private int maxSize;
   private boolean hasWarned;
 

--- a/src/main/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyMap.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/SizeLimitingPyMap.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.Map;
 
 public class SizeLimitingPyMap extends PyMap implements PyWrapper {
+
   private int maxSize;
   private boolean hasWarned;
 

--- a/src/main/java/com/hubspot/jinjava/objects/date/FixedDateTimeProvider.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/FixedDateTimeProvider.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.objects.date;
 
 public class FixedDateTimeProvider implements DateTimeProvider {
+
   private long currentTimeMillis;
 
   public FixedDateTimeProvider(long currentTimeMillis) {

--- a/src/main/java/com/hubspot/jinjava/objects/date/FormattedDate.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/FormattedDate.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava.objects.date;
 import java.time.ZonedDateTime;
 
 public class FormattedDate {
+
   private final String format;
   private final String language;
   private final ZonedDateTime date;

--- a/src/main/java/com/hubspot/jinjava/objects/date/InvalidDateFormatException.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/InvalidDateFormatException.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.objects.date;
 
 public class InvalidDateFormatException extends IllegalArgumentException {
+
   private static final long serialVersionUID = -1577669116818659228L;
 
   private final String format;

--- a/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.math.NumberUtils;
 public final class PyishDate
   extends Date
   implements Serializable, PyWrapper, PyishSerializable {
+
   private static final long serialVersionUID = 1L;
   public static final String PYISH_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
   public static final String FULL_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
@@ -54,14 +55,13 @@ public final class PyishDate
         Instant.ofEpochMilli(
           Optional
             .ofNullable(epochMillis)
-            .orElseGet(
-              () ->
-                JinjavaInterpreter
-                  .getCurrentMaybe()
-                  .map(JinjavaInterpreter::getConfig)
-                  .map(JinjavaConfig::getDateTimeProvider)
-                  .map(DateTimeProvider::getCurrentTimeMillis)
-                  .orElseGet(System::currentTimeMillis)
+            .orElseGet(() ->
+              JinjavaInterpreter
+                .getCurrentMaybe()
+                .map(JinjavaInterpreter::getConfig)
+                .map(JinjavaConfig::getDateTimeProvider)
+                .map(DateTimeProvider::getCurrentTimeMillis)
+                .orElseGet(System::currentTimeMillis)
             )
         ),
         ZoneOffset.UTC

--- a/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/StrftimeFormatter.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.StringUtils;
  * @author jstehler
  */
 public class StrftimeFormatter {
+
   public static final String DEFAULT_DATE_FORMAT = "%H:%M / %d-%m-%Y";
   /*
    * Mapped from http://strftime.org/, http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html
@@ -106,12 +107,11 @@ public class StrftimeFormatter {
 
       Optional
         .ofNullable(components.get(finalChar))
-        .orElseThrow(
-          () ->
-            new InvalidDateFormatException(
-              strftime,
-              String.format("unknown format code '%s'", finalChar)
-            )
+        .orElseThrow(() ->
+          new InvalidDateFormatException(
+            strftime,
+            String.format("unknown format code '%s'", finalChar)
+          )
         )
         .append(builder, stripLeadingZero);
     }

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/BothCasingBeanSerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/BothCasingBeanSerializer.java
@@ -7,6 +7,7 @@ import com.hubspot.jinjava.lib.filter.AllowSnakeCaseFilter;
 import java.io.IOException;
 
 public class BothCasingBeanSerializer<T> extends JsonSerializer<T> {
+
   private final JsonSerializer<T> orignalSerializer;
 
   private BothCasingBeanSerializer(JsonSerializer<T> jsonSerializer) {
@@ -24,8 +25,7 @@ public class BothCasingBeanSerializer<T> extends JsonSerializer<T> {
     T value,
     JsonGenerator gen,
     SerializerProvider serializerProvider
-  )
-    throws IOException {
+  ) throws IOException {
     if (
       Boolean.TRUE.equals(
         serializerProvider.getAttribute(PyishObjectMapper.ALLOW_SNAKE_CASE_ATTRIBUTE)

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/LengthLimitingJsonProcessingException.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/LengthLimitingJsonProcessingException.java
@@ -5,6 +5,7 @@ import com.google.common.annotations.Beta;
 
 @Beta
 public class LengthLimitingJsonProcessingException extends JsonProcessingException {
+
   private final int maxSize;
   private final int attemptedSize;
 

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/LengthLimitingWriter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/LengthLimitingWriter.java
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 @Beta
 public class LengthLimitingWriter extends Writer {
+
   public static final String REMAINING_LENGTH_ATTRIBUTE = "remainingLength";
   private final CharArrayWriter charArrayWriter;
   private final AtomicInteger remainingLength;

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/MapEntrySerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/MapEntrySerializer.java
@@ -12,6 +12,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 @Beta
 public class MapEntrySerializer extends JsonSerializer<Entry<?, ?>> {
+
   public static final MapEntrySerializer INSTANCE = new MapEntrySerializer();
 
   private MapEntrySerializer() {}
@@ -21,8 +22,7 @@ public class MapEntrySerializer extends JsonSerializer<Entry<?, ?>> {
     Entry<?, ?> entry,
     JsonGenerator jsonGenerator,
     SerializerProvider serializerProvider
-  )
-    throws IOException {
+  ) throws IOException {
     AtomicInteger remainingLength = (AtomicInteger) serializerProvider.getAttribute(
       LengthLimitingWriter.REMAINING_LENGTH_ATTRIBUTE
     );

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishBeanSerializerModifier.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishBeanSerializerModifier.java
@@ -10,7 +10,9 @@ import java.util.Map;
 
 @Beta
 public class PyishBeanSerializerModifier extends BeanSerializerModifier {
-  public static final PyishBeanSerializerModifier INSTANCE = new PyishBeanSerializerModifier();
+
+  public static final PyishBeanSerializerModifier INSTANCE =
+    new PyishBeanSerializerModifier();
 
   private PyishBeanSerializerModifier() {}
 

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishCharacterEscapes.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishCharacterEscapes.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 
 @Beta
 public class PyishCharacterEscapes extends CharacterEscapes {
+
   public static final PyishCharacterEscapes INSTANCE = new PyishCharacterEscapes();
   private final int[] asciiEscapes;
 

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapper.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 @Beta
 public class PyishObjectMapper {
+
   public static final ObjectWriter PYISH_OBJECT_WRITER;
   public static final ObjectWriter SNAKE_CASE_PYISH_OBJECT_WRITER;
   public static final String ALLOW_SNAKE_CASE_ATTRIBUTE = "allowSnakeCase";
@@ -43,7 +44,7 @@ public class PyishObjectMapper {
     ObjectMapper mapper = new ObjectMapper(
       new JsonFactoryBuilder().quoteChar('\'').build()
     )
-    .registerModule(
+      .registerModule(
         new SimpleModule()
           .setSerializerModifier(PyishBeanSerializerModifier.INSTANCE)
           .addSerializer(PyishSerializable.class, PyishSerializer.INSTANCE)
@@ -95,9 +96,8 @@ public class PyishObjectMapper {
     throws IOException {
     boolean useSnakeCaseMappingOverride = JinjavaInterpreter
       .getCurrentMaybe()
-      .map(
-        interpreter ->
-          interpreter.getConfig().getLegacyOverrides().isUseSnakeCasePropertyNaming()
+      .map(interpreter ->
+        interpreter.getConfig().getLegacyOverrides().isUseSnakeCasePropertyNaming()
       )
       .orElse(false);
     ObjectWriter objectWriter = useSnakeCaseMappingOverride
@@ -136,8 +136,7 @@ public class PyishObjectMapper {
       Object o,
       JsonGenerator jsonGenerator,
       SerializerProvider serializerProvider
-    )
-      throws IOException {
+    ) throws IOException {
       jsonGenerator.writeFieldName("");
     }
   }

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishPrettyPrinter.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishPrettyPrinter.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 
 @Beta
 public class PyishPrettyPrinter extends DefaultPrettyPrinter {
+
   public static final PyishPrettyPrinter INSTANCE = new PyishPrettyPrinter();
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializable.java
@@ -48,17 +48,16 @@ public interface PyishSerializable extends PyWrapper {
   default void writePyishSelf(
     JsonGenerator jsonGenerator,
     SerializerProvider serializerProvider
-  )
-    throws IOException {
+  ) throws IOException {
     AtomicInteger remainingLength = (AtomicInteger) serializerProvider.getAttribute(
       LengthLimitingWriter.REMAINING_LENGTH_ATTRIBUTE
     );
     jsonGenerator.writeRawValue(
       appendPyishString(
-          remainingLength == null
-            ? new StringBuilder()
-            : new LengthLimitingStringBuilder(remainingLength.get())
-        )
+        remainingLength == null
+          ? new StringBuilder()
+          : new LengthLimitingStringBuilder(remainingLength.get())
+      )
         .toString()
     );
   }

--- a/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
+++ b/src/main/java/com/hubspot/jinjava/objects/serialization/PyishSerializer.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 
 @Beta
 public class PyishSerializer extends JsonSerializer<Object> {
+
   public static final PyishSerializer INSTANCE = new PyishSerializer();
 
   private PyishSerializer() {}
@@ -18,8 +19,7 @@ public class PyishSerializer extends JsonSerializer<Object> {
     Object object,
     JsonGenerator jsonGenerator,
     SerializerProvider serializerProvider
-  )
-    throws IOException {
+  ) throws IOException {
     jsonGenerator.setPrettyPrinter(PyishPrettyPrinter.INSTANCE);
     jsonGenerator.setCharacterEscapes(PyishCharacterEscapes.INSTANCE);
     String string;

--- a/src/main/java/com/hubspot/jinjava/random/DeferredRandomNumberGenerator.java
+++ b/src/main/java/com/hubspot/jinjava/random/DeferredRandomNumberGenerator.java
@@ -10,6 +10,7 @@ import java.util.stream.LongStream;
  * A random number generator that throws {@link com.hubspot.jinjava.interpret.DeferredValueException} for all supported methods.
  */
 public class DeferredRandomNumberGenerator extends Random {
+
   private static final String EXCEPTION_MESSAGE = "Generating random number";
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/random/RandomNumberGeneratorStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/random/RandomNumberGeneratorStrategy.java
@@ -3,5 +3,5 @@ package com.hubspot.jinjava.random;
 public enum RandomNumberGeneratorStrategy {
   THREAD_LOCAL,
   CONSTANT_ZERO,
-  DEFERRED
+  DEFERRED,
 }

--- a/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/ExpressionNode.java
@@ -24,6 +24,7 @@ import com.hubspot.jinjava.tree.output.RenderedOutputNode;
 import com.hubspot.jinjava.tree.parse.ExpressionToken;
 
 public class ExpressionNode extends Node {
+
   private static final long serialVersionUID = -6063173739682221042L;
 
   private final ExpressionStrategy expressionStrategy;

--- a/src/main/java/com/hubspot/jinjava/tree/Node.java
+++ b/src/main/java/com/hubspot/jinjava/tree/Node.java
@@ -25,6 +25,7 @@ import java.util.LinkedList;
 import org.apache.commons.lang3.StringUtils;
 
 public abstract class Node implements Serializable {
+
   private static final long serialVersionUID = -6194634312533310816L;
 
   private final Token master;

--- a/src/main/java/com/hubspot/jinjava/tree/RootNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/RootNode.java
@@ -20,6 +20,7 @@ import com.hubspot.jinjava.tree.output.OutputNode;
 import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
 
 public class RootNode extends Node {
+
   private static final long serialVersionUID = 5904181260202954424L;
   private final TokenScannerSymbols symbols;
 

--- a/src/main/java/com/hubspot/jinjava/tree/TagNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TagNode.java
@@ -29,6 +29,7 @@ import com.hubspot.jinjava.tree.parse.TagToken;
 import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
 
 public class TagNode extends Node {
+
   private static final long serialVersionUID = -6971280448795354252L;
 
   private final Tag tag;

--- a/src/main/java/com/hubspot/jinjava/tree/TextNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TextNode.java
@@ -21,6 +21,7 @@ import com.hubspot.jinjava.tree.output.RenderedOutputNode;
 import com.hubspot.jinjava.tree.parse.TextToken;
 
 public class TextNode extends Node {
+
   private static final long serialVersionUID = 127827773323298439L;
 
   private final TextToken master;

--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -41,6 +41,7 @@ import com.hubspot.jinjava.tree.parse.UnclosedToken;
 import org.apache.commons.lang3.StringUtils;
 
 public class TreeParser {
+
   private final PeekingIterator<Token> scanner;
   private final JinjavaInterpreter interpreter;
   private final TokenScannerSymbols symbols;

--- a/src/main/java/com/hubspot/jinjava/tree/output/BlockInfo.java
+++ b/src/main/java/com/hubspot/jinjava/tree/output/BlockInfo.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class BlockInfo {
+
   private final List<? extends Node> nodes;
 
   private final Optional<String> parentPath;

--- a/src/main/java/com/hubspot/jinjava/tree/output/BlockPlaceholderOutputNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/output/BlockPlaceholderOutputNode.java
@@ -4,6 +4,7 @@ import com.google.common.base.Charsets;
 import java.nio.charset.Charset;
 
 public class BlockPlaceholderOutputNode implements OutputNode {
+
   private final String blockName;
   private String output;
 

--- a/src/main/java/com/hubspot/jinjava/tree/output/OutputList.java
+++ b/src/main/java/com/hubspot/jinjava/tree/output/OutputList.java
@@ -9,6 +9,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class OutputList {
+
   public static final String PREVENT_ACCIDENTAL_EXPRESSIONS =
     "PREVENT_ACCIDENTAL_EXPRESSIONS";
   private final List<OutputNode> nodes = new LinkedList<>();
@@ -54,15 +55,14 @@ public class OutputList {
     return JinjavaInterpreter
       .getCurrentMaybe()
       .map(JinjavaInterpreter::getConfig)
-      .filter(
-        config ->
-          config
-            .getFeatures()
-            .getActivationStrategy(PREVENT_ACCIDENTAL_EXPRESSIONS)
-            .isActive(null)
+      .filter(config ->
+        config
+          .getFeatures()
+          .getActivationStrategy(PREVENT_ACCIDENTAL_EXPRESSIONS)
+          .isActive(null)
       )
-      .map(
-        config -> joinNodesWithoutAddingExpressions(val, config.getTokenScannerSymbols())
+      .map(config ->
+        joinNodesWithoutAddingExpressions(val, config.getTokenScannerSymbols())
       )
       .orElseGet(() -> joinNodes(val));
   }

--- a/src/main/java/com/hubspot/jinjava/tree/output/RenderedOutputNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/output/RenderedOutputNode.java
@@ -4,6 +4,7 @@ import com.google.common.base.Charsets;
 import java.nio.charset.Charset;
 
 public class RenderedOutputNode implements OutputNode {
+
   private final String output;
 
   public RenderedOutputNode(String output) {

--- a/src/main/java/com/hubspot/jinjava/tree/parse/DefaultTokenScannerSymbols.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/DefaultTokenScannerSymbols.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.tree.parse;
 
 public class DefaultTokenScannerSymbols extends TokenScannerSymbols {
+
   private static final long serialVersionUID = 3825893609777542598L;
 
   char TOKEN_PREFIX_CHAR = '{';

--- a/src/main/java/com/hubspot/jinjava/tree/parse/ExpressionToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/ExpressionToken.java
@@ -19,6 +19,7 @@ import com.hubspot.jinjava.util.WhitespaceUtils;
 import org.apache.commons.lang3.StringUtils;
 
 public class ExpressionToken extends Token {
+
   private static final long serialVersionUID = 6336768632140743908L;
   private String expr;
 

--- a/src/main/java/com/hubspot/jinjava/tree/parse/NoteToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/NoteToken.java
@@ -16,6 +16,7 @@ limitations under the License.
 package com.hubspot.jinjava.tree.parse;
 
 public class NoteToken extends Token {
+
   private static final long serialVersionUID = -3859011447900311329L;
 
   public NoteToken(

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TagToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TagToken.java
@@ -18,6 +18,7 @@ package com.hubspot.jinjava.tree.parse;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 
 public class TagToken extends Token {
+
   private static final long serialVersionUID = -4927751270481832992L;
 
   private String tagName;

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TextToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TextToken.java
@@ -18,6 +18,7 @@ package com.hubspot.jinjava.tree.parse;
 import org.apache.commons.lang3.StringUtils;
 
 public class TextToken extends Token {
+
   private static final long serialVersionUID = -6168990984496468543L;
 
   public TextToken(

--- a/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
@@ -22,6 +22,7 @@ import com.hubspot.jinjava.interpret.UnexpectedTokenException;
 import java.io.Serializable;
 
 public abstract class Token implements Serializable {
+
   private static final long serialVersionUID = 3359084948763661809L;
 
   protected String image;

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TokenScanner.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TokenScanner.java
@@ -21,6 +21,7 @@ import com.google.common.collect.AbstractIterator;
 import com.hubspot.jinjava.JinjavaConfig;
 
 public class TokenScanner extends AbstractIterator<Token> {
+
   private final JinjavaConfig config;
 
   private final char[] is;

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TokenScannerSymbols.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TokenScannerSymbols.java
@@ -18,6 +18,7 @@ package com.hubspot.jinjava.tree.parse;
 import java.io.Serializable;
 
 public abstract class TokenScannerSymbols implements Serializable {
+
   private static final long serialVersionUID = -4810220023023256534L;
 
   private String expressionStart = null;

--- a/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class DeferredValueUtils {
+
   private static final String TEMPLATE_TAG_REGEX = "(\\w+(?:\\.\\w+)*)";
   private static final Pattern TEMPLATE_TAG_PATTERN = Pattern.compile(TEMPLATE_TAG_REGEX);
 
@@ -40,21 +41,19 @@ public class DeferredValueUtils {
     Set<String> keysToKeep
   ) {
     HashMap<String, Object> deferredContext = new HashMap<>(context.size());
-    context.forEach(
-      (contextKey, contextItem) -> {
-        if (keysToKeep.size() > 0 && !keysToKeep.contains(contextKey)) {
-          return;
-        }
-        if (contextItem instanceof DeferredValue) {
-          if (((DeferredValue) contextItem).getOriginalValue() != null) {
-            deferredContext.put(
-              contextKey,
-              ((DeferredValue) contextItem).getOriginalValue()
-            );
-          }
+    context.forEach((contextKey, contextItem) -> {
+      if (keysToKeep.size() > 0 && !keysToKeep.contains(contextKey)) {
+        return;
+      }
+      if (contextItem instanceof DeferredValue) {
+        if (((DeferredValue) contextItem).getOriginalValue() != null) {
+          deferredContext.put(
+            contextKey,
+            ((DeferredValue) contextItem).getOriginalValue()
+          );
         }
       }
-    );
+    });
     return deferredContext;
   }
 
@@ -116,17 +115,15 @@ public class DeferredValueUtils {
       .stream()
       .filter(prop -> !(context.get(prop) instanceof DeferredValue))
       .filter(prop -> !context.getMetaContextVariables().contains(prop))
-      .forEach(
-        prop -> {
-          Object value = context.get(prop);
-          if (value != null) {
-            context.put(prop, DeferredValue.instance(value));
-          } else {
-            //Handle set props
-            context.put(prop, DeferredValue.instance());
-          }
+      .forEach(prop -> {
+        Object value = context.get(prop);
+        if (value != null) {
+          context.put(prop, DeferredValue.instance(value));
+        } else {
+          //Handle set props
+          context.put(prop, DeferredValue.instance());
         }
-      );
+      });
   }
 
   private static Set<DeferredTag> getDeferredTags(Node node, int depth) {
@@ -210,6 +207,7 @@ public class DeferredValueUtils {
   }
 
   private static class DeferredTag {
+
     String tag;
     String normalizedTag;
 

--- a/src/main/java/com/hubspot/jinjava/util/EagerContextWatcher.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerContextWatcher.java
@@ -59,11 +59,8 @@ public class EagerContextWatcher {
         entrySet,
         metaContextVariables
       );
-      final Map<String, String> initiallyResolvedAsStrings = getInitiallyResolvedAsStrings(
-        interpreter,
-        entrySet,
-        initiallyResolvedHashes
-      );
+      final Map<String, String> initiallyResolvedAsStrings =
+        getInitiallyResolvedAsStrings(interpreter, entrySet, initiallyResolvedHashes);
       initialResult = applyFunction(function, interpreter, eagerChildContextConfig);
       speculativeBindings =
         getAllSpeculativeBindings(
@@ -129,17 +126,16 @@ public class EagerContextWatcher {
           : interpreter.getContext().getCombinedScope().entrySet()
       ).stream()
         .filter(entry -> initiallyResolvedHashes.containsKey(entry.getKey()))
-        .filter(
-          entry -> EagerExpressionResolver.isResolvableObject(entry.getValue(), 4, 400) // TODO make this configurable
+        .filter(entry ->
+          EagerExpressionResolver.isResolvableObject(entry.getValue(), 4, 400) // TODO make this configurable
         );
-    entryStream.forEach(
-      entry ->
-        cacheRevertibleObject(
-          interpreter,
-          initiallyResolvedHashes,
-          initiallyResolvedAsStrings,
-          entry
-        )
+    entryStream.forEach(entry ->
+      cacheRevertibleObject(
+        interpreter,
+        initiallyResolvedHashes,
+        initiallyResolvedAsStrings,
+        entry
+      )
     );
     return initiallyResolvedAsStrings;
   }
@@ -152,11 +148,11 @@ public class EagerContextWatcher {
     entrySet
       .stream()
       .filter(entry -> !metaContextVariables.contains(entry.getKey()))
-      .filter(
-        entry -> !(entry.getValue() instanceof DeferredValue) && entry.getValue() != null
+      .filter(entry ->
+        !(entry.getValue() instanceof DeferredValue) && entry.getValue() != null
       )
-      .forEach(
-        entry -> mapOfHashes.put(entry.getKey(), getObjectOrHashCode(entry.getValue()))
+      .forEach(entry ->
+        mapOfHashes.put(entry.getKey(), getObjectOrHashCode(entry.getValue()))
       ); // Avoid NPE when getObjectOrHashCode(entry.getValue()) is null)
     return mapOfHashes;
   }
@@ -201,13 +197,12 @@ public class EagerContextWatcher {
             .getScope()
             .entrySet()
             .stream()
-            .filter(
-              entry ->
-                entry.getValue() instanceof OneTimeReconstructible &&
-                !(((OneTimeReconstructible) entry.getValue()).isReconstructed())
+            .filter(entry ->
+              entry.getValue() instanceof OneTimeReconstructible &&
+              !(((OneTimeReconstructible) entry.getValue()).isReconstructed())
             )
-            .peek(
-              entry -> ((OneTimeReconstructible) entry.getValue()).setReconstructed(true)
+            .peek(entry ->
+              ((OneTimeReconstructible) entry.getValue()).setReconstructed(true)
             )
             .collect(Collectors.toMap(Entry::getKey, Entry::getValue))
         );
@@ -218,33 +213,31 @@ public class EagerContextWatcher {
       .stream()
       .filter(entry -> !ignoredKeys.contains(entry.getKey()))
       .filter(entry -> !"loop".equals(entry.getKey()))
-      .map(
-        entry -> {
-          if (
-            eagerExecutionResult.getResult().isFullyResolved() ||
-            eagerChildContextConfig.takeNewValue
-          ) {
-            return entry;
-          }
-
-          Object contextValue = interpreter.getContext().get(entry.getKey());
-          if (
-            contextValue instanceof DeferredValue &&
-            ((DeferredValue) contextValue).getOriginalValue() != null
-          ) {
-            if (
-              !eagerChildContextConfig.takeNewValue &&
-              !EagerExpressionResolver.isResolvableObject(
-                ((DeferredValue) contextValue).getOriginalValue()
-              )
-            ) {
-              throw new CannotReconstructValueException(entry.getKey());
-            }
-            return new AbstractMap.SimpleImmutableEntry<>(entry.getKey(), contextValue);
-          }
-          return null;
+      .map(entry -> {
+        if (
+          eagerExecutionResult.getResult().isFullyResolved() ||
+          eagerChildContextConfig.takeNewValue
+        ) {
+          return entry;
         }
-      )
+
+        Object contextValue = interpreter.getContext().get(entry.getKey());
+        if (
+          contextValue instanceof DeferredValue &&
+          ((DeferredValue) contextValue).getOriginalValue() != null
+        ) {
+          if (
+            !eagerChildContextConfig.takeNewValue &&
+            !EagerExpressionResolver.isResolvableObject(
+              ((DeferredValue) contextValue).getOriginalValue()
+            )
+          ) {
+            throw new CannotReconstructValueException(entry.getKey());
+          }
+          return new AbstractMap.SimpleImmutableEntry<>(entry.getKey(), contextValue);
+        }
+        return null;
+      })
       .filter(Objects::nonNull)
       .filter(entry -> entry.getValue() != null)
       .filter(entry -> !isDeferredWithOriginalValueNull(entry.getValue()))
@@ -263,29 +256,26 @@ public class EagerContextWatcher {
       .getSpeculativeBindings()
       .entrySet()
       .stream()
-      .filter(
-        entry ->
-          entry.getValue() != null &&
-          !entry.getValue().equals(interpreter.getContext().get(entry.getKey()))
+      .filter(entry ->
+        entry.getValue() != null &&
+        !entry.getValue().equals(interpreter.getContext().get(entry.getKey()))
       )
-      .filter(
-        entry -> !(interpreter.getContext().get(entry.getKey()) instanceof DeferredValue)
+      .filter(entry ->
+        !(interpreter.getContext().get(entry.getKey()) instanceof DeferredValue)
       )
       .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
     speculativeBindings.putAll(
       initiallyResolvedHashes
         .keySet()
         .stream()
-        .map(
-          key ->
-            new AbstractMap.SimpleImmutableEntry<>(key, interpreter.getContext().get(key))
+        .map(key ->
+          new AbstractMap.SimpleImmutableEntry<>(key, interpreter.getContext().get(key))
         )
-        .filter(
-          entry ->
-            !Objects.equals(
-              initiallyResolvedHashes.get(entry.getKey()),
-              getObjectOrHashCode(entry.getValue())
-            )
+        .filter(entry ->
+          !Objects.equals(
+            initiallyResolvedHashes.get(entry.getKey()),
+            getObjectOrHashCode(entry.getValue())
+          )
         )
         .collect(
           Collectors.toMap(
@@ -345,8 +335,8 @@ public class EagerContextWatcher {
       }
       revertibleObject
         .getPyishString()
-        .ifPresent(
-          pyishString -> initiallyResolvedAsStrings.put(entry.getKey(), pyishString)
+        .ifPresent(pyishString ->
+          initiallyResolvedAsStrings.put(entry.getKey(), pyishString)
         );
     } catch (Exception e) {
       interpreter
@@ -408,6 +398,7 @@ public class EagerContextWatcher {
   }
 
   public static class EagerChildContextConfig {
+
     private final boolean takeNewValue;
 
     private final boolean discardSessionBindings;
@@ -435,6 +426,7 @@ public class EagerContextWatcher {
     }
 
     public static class Builder {
+
       private boolean takeNewValue;
 
       private boolean discardSessionBindings;

--- a/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang3.StringUtils;
 
 @Beta
 public class EagerExpressionResolver {
+
   public static final String JINJAVA_NULL = "null";
   public static final String JINJAVA_EMPTY_STRING = "''";
 
@@ -348,6 +349,7 @@ public class EagerExpressionResolver {
   }
 
   public static class EagerExpressionResult {
+
     private final Object resolvedObject;
     private final Set<String> deferredWords;
     private final ResolutionState resolutionState;
@@ -509,6 +511,7 @@ public class EagerExpressionResolver {
   }
 
   private static class FoundQuotedExpressionTags {
+
     Integer firstStartTagFoundLocation;
     Integer lastEndTagFoundLocation;
 

--- a/src/main/java/com/hubspot/jinjava/util/ForLoop.java
+++ b/src/main/java/com/hubspot/jinjava/util/ForLoop.java
@@ -18,6 +18,7 @@ package com.hubspot.jinjava.util;
 import java.util.Iterator;
 
 public class ForLoop implements Iterator<Object> {
+
   private static final int NULL_VALUE = Integer.MIN_VALUE;
 
   private int index = -1;

--- a/src/main/java/com/hubspot/jinjava/util/HelperStringTokenizer.java
+++ b/src/main/java/com/hubspot/jinjava/util/HelperStringTokenizer.java
@@ -26,6 +26,7 @@ import java.util.List;
  *
  */
 public class HelperStringTokenizer extends AbstractIterator<String> {
+
   private final char[] value;
   private final int length;
 

--- a/src/main/java/com/hubspot/jinjava/util/LengthLimitingStringBuilder.java
+++ b/src/main/java/com/hubspot/jinjava/util/LengthLimitingStringBuilder.java
@@ -6,6 +6,7 @@ import java.util.stream.IntStream;
 
 public class LengthLimitingStringBuilder
   implements Serializable, CharSequence, Appendable {
+
   private static final long serialVersionUID = -1891922886257965755L;
 
   private final StringBuilder builder;

--- a/src/main/java/com/hubspot/jinjava/util/LengthLimitingStringJoiner.java
+++ b/src/main/java/com/hubspot/jinjava/util/LengthLimitingStringJoiner.java
@@ -4,6 +4,7 @@ import com.hubspot.jinjava.interpret.OutputTooBigException;
 import java.util.StringJoiner;
 
 public class LengthLimitingStringJoiner {
+
   private final StringJoiner joiner;
   private final int delimiterLength;
   private final long maxLength;

--- a/src/main/java/com/hubspot/jinjava/util/PrefixToPreserveState.java
+++ b/src/main/java/com/hubspot/jinjava/util/PrefixToPreserveState.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 @Beta
 public class PrefixToPreserveState extends ForwardingMap<String, String> {
+
   private Map<String, String> reconstructedValues;
 
   public PrefixToPreserveState() {

--- a/src/main/java/com/hubspot/jinjava/util/ScopeMap.java
+++ b/src/main/java/com/hubspot/jinjava/util/ScopeMap.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 public class ScopeMap<K, V> implements Map<K, V> {
+
   private final Map<K, V> scope;
   private final ScopeMap<K, V> parent;
 
@@ -214,6 +215,7 @@ public class ScopeMap<K, V> implements Map<K, V> {
   }
 
   public static class ScopeMapEntry<K, V> implements Map.Entry<K, V> {
+
     private final Map<K, V> map;
     private final K key;
     private V value;

--- a/src/main/java/com/hubspot/jinjava/util/Variable.java
+++ b/src/main/java/com/hubspot/jinjava/util/Variable.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 
 public class Variable {
+
   private static final Splitter DOT_SPLITTER = Splitter.on('.');
 
   private final JinjavaInterpreter interpreter;

--- a/src/main/java/com/hubspot/jinjava/util/WhitespaceUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/WhitespaceUtils.java
@@ -5,6 +5,7 @@ import com.hubspot.jinjava.interpret.InterpretException;
 import javax.annotation.Nullable;
 
 public final class WhitespaceUtils {
+
   private static final char[] QUOTE_CHARS = new char[] { '\'', '"' };
 
   public static boolean startsWith(String s, String prefix) {

--- a/src/test/java/com/hubspot/jinjava/BaseInterpretingTest.java
+++ b/src/test/java/com/hubspot/jinjava/BaseInterpretingTest.java
@@ -6,6 +6,7 @@ import org.junit.After;
 import org.junit.Before;
 
 public abstract class BaseInterpretingTest extends BaseJinjavaTest {
+
   public JinjavaInterpreter interpreter;
   public Context context;
 

--- a/src/test/java/com/hubspot/jinjava/BaseJinjavaTest.java
+++ b/src/test/java/com/hubspot/jinjava/BaseJinjavaTest.java
@@ -3,6 +3,7 @@ package com.hubspot.jinjava;
 import org.junit.Before;
 
 public abstract class BaseJinjavaTest {
+
   public Jinjava jinjava;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -33,6 +33,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 public class EagerTest {
+
   private JinjavaInterpreter interpreter;
   private Jinjava jinjava;
   private ExpectedTemplateInterpreter expectedTemplateInterpreter;
@@ -56,8 +57,7 @@ public class EagerTest {
           String fullName,
           Charset encoding,
           JinjavaInterpreter interpreter
-        )
-          throws IOException {
+        ) throws IOException {
           return Resources.toString(
             Resources.getResource(String.format("tags/macrotag/%s", fullName)),
             StandardCharsets.UTF_8
@@ -117,10 +117,10 @@ public class EagerTest {
   @Test
   public void itDefersNodeWhenModifiedInForLoop() {
     assertThat(
-        interpreter.render(
-          "{% set bar = 'bar' %}{% set foo = 0 %}{% for i in deferred %}{{ bar ~ foo ~ bar }} {% set foo = foo + 1 %}{% endfor %}"
-        )
+      interpreter.render(
+        "{% set bar = 'bar' %}{% set foo = 0 %}{% for i in deferred %}{{ bar ~ foo ~ bar }} {% set foo = foo + 1 %}{% endfor %}"
       )
+    )
       .isEqualTo(
         "{% set foo = 0 %}{% for i in deferred %}{{ 'bar' ~ foo ~ 'bar' }} {% set foo = foo + 1 %}{% endfor %}"
       );
@@ -364,9 +364,8 @@ public class EagerTest {
     DeferredValue varInScopeDeferred = (DeferredValue) varInScope;
     assertThat(varInScopeDeferred.getOriginalValue()).isEqualTo("outside if statement");
 
-    HashMap<String, Object> deferredContext = DeferredValueUtils.getDeferredContextWithOriginalValues(
-      localContext
-    );
+    HashMap<String, Object> deferredContext =
+      DeferredValueUtils.getDeferredContextWithOriginalValues(localContext);
     deferredContext.forEach(localContext::put);
     String secondRender = interpreter.render(output);
     assertThat(secondRender).isEqualTo("outside if statement entered if statement");
@@ -396,9 +395,8 @@ public class EagerTest {
     assertThat(output.trim())
       .isEqualTo("{% if deferred == 'testvalue' %} true {% else %} false {% endif %}");
 
-    HashMap<String, Object> deferredContext = DeferredValueUtils.getDeferredContextWithOriginalValues(
-      localContext
-    );
+    HashMap<String, Object> deferredContext =
+      DeferredValueUtils.getDeferredContextWithOriginalValues(localContext);
     deferredContext.forEach(localContext::put);
     String secondRender = interpreter.render(output);
     assertThat(secondRender.trim()).isEqualTo("true");
@@ -421,9 +419,8 @@ public class EagerTest {
     );
     localContext.put("deferredValue", DeferredValue.instance("resolved"));
     String output = interpreter.render(template);
-    HashMap<String, Object> deferredContext = DeferredValueUtils.getDeferredContextWithOriginalValues(
-      localContext
-    );
+    HashMap<String, Object> deferredContext =
+      DeferredValueUtils.getDeferredContextWithOriginalValues(localContext);
     deferredContext.forEach(localContext::put);
     String secondRender = interpreter.render(output);
     assertThat(secondRender.trim()).isEqualTo("inside first scope".trim());
@@ -438,9 +435,8 @@ public class EagerTest {
     localContext.put("deferredValue", DeferredValue.instance("resolved"));
     String output = interpreter.render(template);
 
-    HashMap<String, Object> deferredContext = DeferredValueUtils.getDeferredContextWithOriginalValues(
-      localContext
-    );
+    HashMap<String, Object> deferredContext =
+      DeferredValueUtils.getDeferredContextWithOriginalValues(localContext);
     deferredContext.forEach(localContext::put);
     String secondRender = interpreter.render(output);
     assertThat(secondRender.trim())
@@ -484,8 +480,8 @@ public class EagerTest {
     Object deferredValue2 = localContext.get("deferredValue2");
     localContext
       .getDeferredNodes()
-      .forEach(
-        node -> DeferredValueUtils.findAndMarkDeferredProperties(localContext, node)
+      .forEach(node ->
+        DeferredValueUtils.findAndMarkDeferredProperties(localContext, node)
       );
     assertThat(deferredValue2).isInstanceOf(DeferredValue.class);
     assertThat(output)
@@ -504,20 +500,20 @@ public class EagerTest {
   public void itEvaluatesNonEagerSet() {
     expectedTemplateInterpreter.assertExpectedOutput("evaluates-non-eager-set");
     assertThat(
-        localContext
-          .getDeferredTokens()
-          .stream()
-          .flatMap(deferredToken -> deferredToken.getSetDeferredWords().stream())
-          .collect(Collectors.toSet())
-      )
+      localContext
+        .getDeferredTokens()
+        .stream()
+        .flatMap(deferredToken -> deferredToken.getSetDeferredWords().stream())
+        .collect(Collectors.toSet())
+    )
       .isEmpty();
     assertThat(
-        localContext
-          .getDeferredTokens()
-          .stream()
-          .flatMap(deferredToken -> deferredToken.getUsedDeferredWords().stream())
-          .collect(Collectors.toSet())
-      )
+      localContext
+        .getDeferredTokens()
+        .stream()
+        .flatMap(deferredToken -> deferredToken.getUsedDeferredWords().stream())
+        .collect(Collectors.toSet())
+    )
       .contains("deferred");
   }
 
@@ -786,7 +782,7 @@ public class EagerTest {
     JinjavaInterpreter.pushCurrent(noNestedInterpreter);
     try {
       new ExpectedTemplateInterpreter(jinjava, noNestedInterpreter, "eager")
-      .assertExpectedOutput("wraps-certain-output-in-raw");
+        .assertExpectedOutput("wraps-certain-output-in-raw");
       assertThat(noNestedInterpreter.getErrors()).isEmpty();
     } finally {
       JinjavaInterpreter.popCurrent();
@@ -863,7 +859,7 @@ public class EagerTest {
     try {
       JinjavaInterpreter.pushCurrent(eagerInterpreter);
       new ExpectedTemplateInterpreter(jinjava, eagerInterpreter, "eager")
-      .assertExpectedOutput("handles-unknown-function-errors");
+        .assertExpectedOutput("handles-unknown-function-errors");
     } finally {
       JinjavaInterpreter.popCurrent();
     }
@@ -871,7 +867,7 @@ public class EagerTest {
       JinjavaInterpreter.pushCurrent(defaultInterpreter);
 
       new ExpectedTemplateInterpreter(jinjava, defaultInterpreter, "eager")
-      .assertExpectedOutput("handles-unknown-function-errors");
+        .assertExpectedOutput("handles-unknown-function-errors");
     } finally {
       JinjavaInterpreter.popCurrent();
     }

--- a/src/test/java/com/hubspot/jinjava/ExpectedNodeInterpreter.java
+++ b/src/test/java/com/hubspot/jinjava/ExpectedNodeInterpreter.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 public class ExpectedNodeInterpreter {
+
   private JinjavaInterpreter interpreter;
   private Tag tag;
   private String path;

--- a/src/test/java/com/hubspot/jinjava/ExpectedTemplateInterpreter.java
+++ b/src/test/java/com/hubspot/jinjava/ExpectedTemplateInterpreter.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 public class ExpectedTemplateInterpreter {
+
   private Jinjava jinjava;
   private JinjavaInterpreter interpreter;
   private String path;

--- a/src/test/java/com/hubspot/jinjava/FeaturesTest.java
+++ b/src/test/java/com/hubspot/jinjava/FeaturesTest.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class FeaturesTest {
+
   private static final String ALWAYS_OFF = "alwaysOff";
   private static final String ALWAYS_ON = "alwaysOn";
   private static final String DATE_PAST = "datePast";

--- a/src/test/java/com/hubspot/jinjava/FullSnippetsTest.java
+++ b/src/test/java/com/hubspot/jinjava/FullSnippetsTest.java
@@ -17,6 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class FullSnippetsTest {
+
   private JinjavaInterpreter interpreter;
   private Jinjava jinjava;
   private ExpectedTemplateInterpreter expectedTemplateInterpreter;
@@ -36,8 +37,7 @@ public class FullSnippetsTest {
           String fullName,
           Charset encoding,
           JinjavaInterpreter interpreter
-        )
-          throws IOException {
+        ) throws IOException {
           return Resources.toString(
             Resources.getResource(String.format("tags/macrotag/%s", fullName)),
             StandardCharsets.UTF_8

--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverPerformanceTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverPerformanceTest.java
@@ -17,6 +17,7 @@ public class ExpressionResolverPerformanceTest {
   }
 
   public static class PerformanceTester {
+
     private JinjavaInterpreter interpreter;
     private Context context;
     private long startTime;

--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 
 @SuppressWarnings("unchecked")
 public class ExpressionResolverTest {
+
   private JinjavaInterpreter interpreter;
   private Context context;
   private Jinjava jinjava;
@@ -70,11 +71,11 @@ public class ExpressionResolverTest {
   public void itCanCompareStrings() {
     context.put("foo", "white");
     assertThat(
-        interpreter.resolveELExpression(
-          "'2013-12-08 16:00:00+00:00' > '2013-12-08 13:00:00+00:00'",
-          -1
-        )
+      interpreter.resolveELExpression(
+        "'2013-12-08 16:00:00+00:00' > '2013-12-08 13:00:00+00:00'",
+        -1
       )
+    )
       .isEqualTo(Boolean.TRUE);
     assertThat(interpreter.resolveELExpression("foo == \"white\"", -1))
       .isEqualTo(Boolean.TRUE);
@@ -190,6 +191,7 @@ public class ExpressionResolverTest {
   }
 
   public static final class MyCustomMap implements Map<String, String> {
+
     Map<String, String> data = ImmutableMap.of("foo", "bar", "two", "2", "size", "777");
 
     @Override
@@ -273,6 +275,7 @@ public class ExpressionResolverTest {
   }
 
   public static class MyCustomList<T> extends ForwardingList<T> implements PyWrapper {
+
     private final List<T> list;
 
     public MyCustomList(List<T> list) {
@@ -315,8 +318,8 @@ public class ExpressionResolverTest {
     assertThat(interpreter.resolveELExpression("\"<hr>\" in bar or \"<hr/>\" in bar", -1))
       .isEqualTo(true);
     assertThat(
-        interpreter.resolveELExpression("\"<har>\" in foo or \"<har/>\" in foo", -1)
-      )
+      interpreter.resolveELExpression("\"<har>\" in foo or \"<har/>\" in foo", -1)
+    )
       .isEqualTo(false);
   }
 
@@ -548,8 +551,8 @@ public class ExpressionResolverTest {
       new NestedOptionalProperty(new OptionalProperty(new MyClass(new Date(0)), "foo"))
     );
     assertThat(
-        Objects.toString(interpreter.resolveELExpression("myobj.nested.nested.date", -1))
-      )
+      Objects.toString(interpreter.resolveELExpression("myobj.nested.nested.date", -1))
+    )
       .isEqualTo("1970-01-01 00:00:00");
     assertThat(interpreter.getErrorsCopy()).isEmpty();
   }
@@ -607,48 +610,48 @@ public class ExpressionResolverTest {
     assertThat(interpreter.render("{% if 2 is even %}yes{% endif %}")).isEqualTo("yes");
 
     assertThat(
-        interpreter.render(
-          "{% if exptest:even.evaluate(2, ____int3rpr3t3r____) %}yes{% endif %}"
-        )
+      interpreter.render(
+        "{% if exptest:even.evaluate(2, ____int3rpr3t3r____) %}yes{% endif %}"
       )
+    )
       .isEqualTo("yes");
     assertThat(
-        interpreter.render(
-          "{% if exptest:false.evaluate(false, ____int3rpr3t3r____) %}yes{% endif %}"
-        )
+      interpreter.render(
+        "{% if exptest:false.evaluate(false, ____int3rpr3t3r____) %}yes{% endif %}"
       )
+    )
       .isEqualTo("yes");
   }
 
   @Test
   public void itResolvesAlternateExpTestSyntaxForTrueAndFalseExpTests() {
     assertThat(
-        interpreter.render(
-          "{% if exptest:false.evaluate(false, ____int3rpr3t3r____) %}yes{% endif %}"
-        )
+      interpreter.render(
+        "{% if exptest:false.evaluate(false, ____int3rpr3t3r____) %}yes{% endif %}"
       )
+    )
       .isEqualTo("yes");
     assertThat(
-        interpreter.render(
-          "{% if exptest:true.evaluate(true, ____int3rpr3t3r____) %}yes{% endif %}"
-        )
+      interpreter.render(
+        "{% if exptest:true.evaluate(true, ____int3rpr3t3r____) %}yes{% endif %}"
       )
+    )
       .isEqualTo("yes");
   }
 
   @Test
   public void itResolvesAlternateExpTestSyntaxForInExpTests() {
     assertThat(
-        interpreter.render(
-          "{% if exptest:in.evaluate(1, ____int3rpr3t3r____, [1]) %}yes{% endif %}"
-        )
+      interpreter.render(
+        "{% if exptest:in.evaluate(1, ____int3rpr3t3r____, [1]) %}yes{% endif %}"
       )
+    )
       .isEqualTo("yes");
     assertThat(
-        interpreter.render(
-          "{% if exptest:in.evaluate(2, ____int3rpr3t3r____, [1]) %}yes{% else %}no{% endif %}"
-        )
+      interpreter.render(
+        "{% if exptest:in.evaluate(2, ____int3rpr3t3r____, [1]) %}yes{% else %}no{% endif %}"
       )
+    )
       .isEqualTo("no");
   }
 
@@ -667,6 +670,7 @@ public class ExpressionResolverTest {
   }
 
   public static class TestClass {
+
     private boolean touched = false;
     private String name = "Amazing test class";
 
@@ -684,6 +688,7 @@ public class ExpressionResolverTest {
   }
 
   public static final class MyClass {
+
     private Date date;
 
     MyClass(Date date) {
@@ -700,6 +705,7 @@ public class ExpressionResolverTest {
   }
 
   public static final class OptionalProperty {
+
     private MyClass nested;
     private String val;
 
@@ -718,6 +724,7 @@ public class ExpressionResolverTest {
   }
 
   public static final class NestedOptionalProperty {
+
     private OptionalProperty nested;
 
     public NestedOptionalProperty(OptionalProperty nested) {

--- a/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 @SuppressWarnings("unchecked")
 public class ExtendedSyntaxBuilderTest {
+
   private Context context;
   private JinjavaInterpreter interpreter;
 
@@ -339,10 +340,10 @@ public class ExtendedSyntaxBuilderTest {
   @Test
   public void itReturnsCorrectSyntaxErrorPositions() {
     assertThat(
-        interpreter.render(
-          "hi {{ missing thing }}{{ missing thing }}\nI am {{ blah blabbity }} too"
-        )
+      interpreter.render(
+        "hi {{ missing thing }}{{ missing thing }}\nI am {{ blah blabbity }} too"
       )
+    )
       .isEqualTo("hi \nI am  too");
     assertThat(interpreter.getErrorsCopy().size()).isEqualTo(3);
     assertThat(interpreter.getErrorsCopy().get(0).getLineno()).isEqualTo(1);

--- a/src/test/java/com/hubspot/jinjava/el/TypeConvertingMapELResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/TypeConvertingMapELResolverTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TypeConvertingMapELResolverTest {
+
   private TypeConvertingMapELResolver typeConvertingMapELResolver;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/el/ext/AdditionOperatorTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/AdditionOperatorTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 
 @SuppressWarnings("unchecked")
 public class AdditionOperatorTest {
+
   private JinjavaInterpreter interpreter;
 
   @Before
@@ -38,30 +39,30 @@ public class AdditionOperatorTest {
   @Test
   public void itCombinesTwoLists() {
     assertThat(
-        (Collection<Object>) interpreter.resolveELExpression(
-          "['foo', 'bar'] + ['other', 'one']",
-          -1
-        )
+      (Collection<Object>) interpreter.resolveELExpression(
+        "['foo', 'bar'] + ['other', 'one']",
+        -1
       )
+    )
       .containsExactly("foo", "bar", "other", "one");
   }
 
   @Test
   public void itAddsToList() {
     assertThat(
-        (Collection<Object>) interpreter.resolveELExpression("['foo'] + 'bar'", -1)
-      )
+      (Collection<Object>) interpreter.resolveELExpression("['foo'] + 'bar'", -1)
+    )
       .containsExactly("foo", "bar");
   }
 
   @Test
   public void itCombinesTwoDicts() {
     assertThat(
-        (Map<Object, Object>) interpreter.resolveELExpression(
-          "{'k1':'v1'} + {'k2':'v2'}",
-          -1
-        )
+      (Map<Object, Object>) interpreter.resolveELExpression(
+        "{'k1':'v1'} + {'k2':'v2'}",
+        -1
       )
+    )
       .containsOnly(entry("k1", "v1"), entry("k2", "v2"));
   }
 }

--- a/src/test/java/com/hubspot/jinjava/el/ext/AstDictTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/AstDictTest.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class AstDictTest {
+
   private JinjavaInterpreter interpreter;
 
   @Before
@@ -67,6 +68,7 @@ public class AstDictTest {
   }
 
   public class TestClass {
+
     private Map<ErrorType, String> myMap;
 
     public TestClass(Map<ErrorType, String> myMap) {

--- a/src/test/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperatorTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperatorTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class CollectionMembershipOperatorTest {
+
   private JinjavaInterpreter interpreter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/el/ext/CollectionNonMembershipOperatorTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/CollectionNonMembershipOperatorTest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class CollectionNonMembershipOperatorTest {
+
   private JinjavaInterpreter interpreter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/el/ext/JinjavaBeanELResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/JinjavaBeanELResolverTest.java
@@ -16,6 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class JinjavaBeanELResolverTest {
+
   private JinjavaBeanELResolver jinjavaBeanELResolver;
   private ELContext elContext;
 
@@ -32,24 +33,24 @@ public class JinjavaBeanELResolverTest {
   @Test
   public void itInvokesProperStringReplace() {
     assertThat(
-        jinjavaBeanELResolver.invoke(
-          elContext,
-          "abcd",
-          "replace",
-          null,
-          new Object[] { "abcd", "efgh" }
-        )
+      jinjavaBeanELResolver.invoke(
+        elContext,
+        "abcd",
+        "replace",
+        null,
+        new Object[] { "abcd", "efgh" }
       )
+    )
       .isEqualTo("efgh");
     assertThat(
-        jinjavaBeanELResolver.invoke(
-          elContext,
-          "abcd",
-          "replace",
-          null,
-          new Object[] { 'a', 'e' }
-        )
+      jinjavaBeanELResolver.invoke(
+        elContext,
+        "abcd",
+        "replace",
+        null,
+        new Object[] { 'a', 'e' }
       )
+    )
       .isEqualTo("ebcd");
   }
 
@@ -75,34 +76,28 @@ public class JinjavaBeanELResolverTest {
     }
     Temp var = new Temp();
     assertThat(
-        jinjavaBeanELResolver.invoke(
-          elContext,
-          var,
-          "getResult",
-          null,
-          new Object[] { 1 }
-        )
-      )
+      jinjavaBeanELResolver.invoke(elContext, var, "getResult", null, new Object[] { 1 })
+    )
       .isEqualTo("int");
     assertThat(
-        jinjavaBeanELResolver.invoke(
-          elContext,
-          var,
-          "getResult",
-          null,
-          new Object[] { "1" }
-        )
+      jinjavaBeanELResolver.invoke(
+        elContext,
+        var,
+        "getResult",
+        null,
+        new Object[] { "1" }
       )
+    )
       .isEqualTo("String");
     assertThat(
-        jinjavaBeanELResolver.invoke(
-          elContext,
-          var,
-          "getResult",
-          null,
-          new Object[] { new Object() }
-        )
+      jinjavaBeanELResolver.invoke(
+        elContext,
+        var,
+        "getResult",
+        null,
+        new Object[] { new Object() }
       )
+    )
       .isEqualTo("Object");
   }
 
@@ -124,34 +119,34 @@ public class JinjavaBeanELResolverTest {
     }
     Temp var = new Temp();
     assertThat(
-        jinjavaBeanELResolver.invoke(
-          elContext,
-          var,
-          "getResult",
-          null,
-          new Object[] { 1, 2 }
-        )
+      jinjavaBeanELResolver.invoke(
+        elContext,
+        var,
+        "getResult",
+        null,
+        new Object[] { 1, 2 }
       )
+    )
       .isEqualTo("int Integer");
     assertThat(
-        jinjavaBeanELResolver.invoke(
-          elContext,
-          var,
-          "getResult",
-          null,
-          new Object[] { 1, Integer.valueOf(2) }
-        )
+      jinjavaBeanELResolver.invoke(
+        elContext,
+        var,
+        "getResult",
+        null,
+        new Object[] { 1, Integer.valueOf(2) }
       )
+    )
       .isEqualTo("int Integer"); // should be "int object", but we can't figure that out
     assertThat(
-        jinjavaBeanELResolver.invoke(
-          elContext,
-          var,
-          "getResult",
-          null,
-          new Object[] { Integer.valueOf(1), 2 }
-        )
+      jinjavaBeanELResolver.invoke(
+        elContext,
+        var,
+        "getResult",
+        null,
+        new Object[] { Integer.valueOf(1), 2 }
       )
+    )
       .isEqualTo("int Integer"); // should be "Number int", but we can't figure that out
   }
 
@@ -159,9 +154,8 @@ public class JinjavaBeanELResolverTest {
   public void itThrowsExceptionWhenMethodIsRestrictedFromConfig() {
     JinjavaInterpreter.pushCurrent(interpreter);
     when(config.getRestrictedMethods()).thenReturn(ImmutableSet.of("foo"));
-    assertThatThrownBy(
-        () ->
-          jinjavaBeanELResolver.invoke(elContext, "abcd", "foo", null, new Object[] { 1 })
+    assertThatThrownBy(() ->
+        jinjavaBeanELResolver.invoke(elContext, "abcd", "foo", null, new Object[] { 1 })
       )
       .isInstanceOf(MethodNotFoundException.class)
       .hasMessageStartingWith("Cannot find method 'foo'");
@@ -172,8 +166,8 @@ public class JinjavaBeanELResolverTest {
   public void itThrowsExceptionWhenPropertyIsRestrictedFromConfig() {
     JinjavaInterpreter.pushCurrent(interpreter);
     when(config.getRestrictedProperties()).thenReturn(ImmutableSet.of("property1"));
-    assertThatThrownBy(
-        () -> jinjavaBeanELResolver.getValue(elContext, "abcd", "property1")
+    assertThatThrownBy(() ->
+        jinjavaBeanELResolver.getValue(elContext, "abcd", "property1")
       )
       .isInstanceOf(PropertyNotFoundException.class)
       .hasMessageStartingWith("Could not find property");

--- a/src/test/java/com/hubspot/jinjava/el/ext/PowerOfTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/PowerOfTest.java
@@ -36,7 +36,7 @@ public class PowerOfTest {
       { "{% set x = base ** negativeExponent %}{{x}}", "0" },
       { "{% set x = 2 ** -8 %}{{x}}", "0" },
       { "{% set x = negativeBase ** oddExponent %}{{x}}", "-128" },
-      { "{% set x = -2 ** 7 %}{{x}}", "-128" }
+      { "{% set x = -2 ** 7 %}{{x}}", "-128" },
     };
 
     for (String[] testCase : testCases) {
@@ -66,7 +66,7 @@ public class PowerOfTest {
       { "{% set x = base ** negativeExponent %}{{x}}", "0.00390625" },
       { "{% set x = 2 ** -8.0 %}{{x}}", "0.00390625" },
       { "{% set x = negativeBase ** oddExponent %}{{x}}", "-128.0" },
-      { "{% set x = -2 ** 7.0 %}{{x}}", "-128.0" }
+      { "{% set x = -2 ** 7.0 %}{{x}}", "-128.0" },
     };
 
     for (String[] testCase : testCases) {

--- a/src/test/java/com/hubspot/jinjava/el/ext/RangeStringTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/RangeStringTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
  * Created by anev on 11/05/16.
  */
 public class RangeStringTest {
+
   private Jinjava jinjava;
   private Map<String, Object> context;
 

--- a/src/test/java/com/hubspot/jinjava/el/ext/TruncDivTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/TruncDivTest.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TruncDivTest {
+
   private Jinjava jinja;
 
   @Before
@@ -39,7 +40,7 @@ public class TruncDivTest {
       { "{% set x = dividend // negativeDivisor %}{{x}}", "-3" },
       { "{% set x = 5 // -2 %}{{x}}", "-3" },
       { "{% set x = negativeDividend // negativeDivisor %}{{x}}", "2" },
-      { "{% set x = -5 // -2 %}{{x}}", "2" }
+      { "{% set x = -5 // -2 %}{{x}}", "2" },
     };
 
     for (String[] testCase : testCases) {
@@ -71,7 +72,7 @@ public class TruncDivTest {
       { "{% set x = dividend // negativeDivisor %}{{x}}", "-3.0" },
       { "{% set x = 5.0 // -2 %}{{x}}", "-3.0" },
       { "{% set x = negativeDividend // negativeDivisor %}{{x}}", "2.0" },
-      { "{% set x = -5.0 // -2 %}{{x}}", "2.0" }
+      { "{% set x = -5.0 // -2 %}{{x}}", "2.0" },
     };
 
     for (String[] testCase : testCases) {

--- a/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifierTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstIdentifierTest.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class EagerAstIdentifierTest extends BaseInterpretingTest {
+
   private JinjavaELContext elContext;
 
   @Before
@@ -29,7 +30,7 @@ public class EagerAstIdentifierTest extends BaseInterpretingTest {
         new ValueExpression[] {
           jinjava
             .getEagerExpressionFactory()
-            .createValueExpression(elContext, "#{foo}", Object.class)
+            .createValueExpression(elContext, "#{foo}", Object.class),
         }
       ),
       elContext

--- a/src/test/java/com/hubspot/jinjava/interpret/ContextTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/ContextTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class ContextTest {
+
   private static final String RESOLVED_EXPRESSION = "exp";
   private static final String RESOLVED_FUNCTION = "func";
   private static final String RESOLVED_VALUE = "val";

--- a/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/DeferredTest.java
@@ -17,6 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class DeferredTest {
+
   private JinjavaInterpreter interpreter;
   private Jinjava jinjava = new Jinjava();
   Context globalContext = new Context();
@@ -251,9 +252,8 @@ public class DeferredTest {
     DeferredValue varInScopeDeferred = (DeferredValue) varInScope;
     assertThat(varInScopeDeferred.getOriginalValue()).isEqualTo("outside if statement");
 
-    HashMap<String, Object> deferredContext = DeferredValueUtils.getDeferredContextWithOriginalValues(
-      localContext
-    );
+    HashMap<String, Object> deferredContext =
+      DeferredValueUtils.getDeferredContextWithOriginalValues(localContext);
     deferredContext.forEach(localContext::put);
     String secondRender = interpreter.render(output);
     assertThat(secondRender).isEqualTo("outside if statement entered if statement");
@@ -317,9 +317,8 @@ public class DeferredTest {
     DeferredValue varSetInsideDeferred = (DeferredValue) varSetInside;
     assertThat(varSetInsideDeferred.getOriginalValue()).isEqualTo("inside first scope");
 
-    HashMap<String, Object> deferredContext = DeferredValueUtils.getDeferredContextWithOriginalValues(
-      localContext
-    );
+    HashMap<String, Object> deferredContext =
+      DeferredValueUtils.getDeferredContextWithOriginalValues(localContext);
     deferredContext.forEach(localContext::put);
     String secondRender = interpreter.render(output);
     assertThat(secondRender.trim())
@@ -359,8 +358,8 @@ public class DeferredTest {
     Object deferredValue2 = localContext.get("deferredValue2");
     localContext
       .getDeferredNodes()
-      .forEach(
-        node -> DeferredValueUtils.findAndMarkDeferredProperties(localContext, node)
+      .forEach(node ->
+        DeferredValueUtils.findAndMarkDeferredProperties(localContext, node)
       );
     assertThat(deferredValue2).isInstanceOf(DeferredValue.class);
     assertThat(output)

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -32,6 +32,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class JinjavaInterpreterTest {
+
   private Jinjava jinjava;
   private JinjavaInterpreter interpreter;
   private TokenScannerSymbols symbols;
@@ -102,6 +103,7 @@ public class JinjavaInterpreterTest {
   // Ex VariableChain stuff
 
   static class Foo {
+
     private String bar;
 
     public Foo(String bar) {
@@ -154,10 +156,10 @@ public class JinjavaInterpreterTest {
   @Test
   public void triesBeanMethodFirst() {
     assertThat(
-        interpreter
-          .resolveProperty(ZonedDateTime.parse("2013-09-19T12:12:12+00:00"), "year")
-          .toString()
-      )
+      interpreter
+        .resolveProperty(ZonedDateTime.parse("2013-09-19T12:12:12+00:00"), "year")
+        .toString()
+    )
       .isEqualTo("2013");
   }
 
@@ -298,7 +300,7 @@ public class JinjavaInterpreterTest {
       "{% set a, b = {}, [] %}{% macro a.foo()%} 1-{{ b.bar() }}. {% endmacro %} {{ a.foo() }}";
 
     RenderResult renderResult = new Jinjava()
-    .renderForResult(input, ImmutableMap.of("deferred", DeferredValue.instance()));
+      .renderForResult(input, ImmutableMap.of("deferred", DeferredValue.instance()));
     assertThat(renderResult.getOutput().trim()).isEqualTo("1-.");
     // Does not contain an error about 'a.foo()' being unknown.
     assertThat(renderResult.getErrors()).hasSize(1);
@@ -307,20 +309,19 @@ public class JinjavaInterpreterTest {
   @Test
   public void itThrowsFatalErrors() {
     interpreter.getContext().setThrowInterpreterErrors(true);
-    assertThatThrownBy(
-        () ->
-          interpreter.addError(
-            new TemplateError(
-              ErrorType.FATAL,
-              ErrorReason.UNKNOWN,
-              ErrorItem.PROPERTY,
-              "",
-              "",
-              interpreter.getLineNumber(),
-              interpreter.getPosition(),
-              new RuntimeException()
-            )
+    assertThatThrownBy(() ->
+        interpreter.addError(
+          new TemplateError(
+            ErrorType.FATAL,
+            ErrorReason.UNKNOWN,
+            ErrorItem.PROPERTY,
+            "",
+            "",
+            interpreter.getLineNumber(),
+            interpreter.getPosition(),
+            new RuntimeException()
           )
+        )
       )
       .isInstanceOf(TemplateSyntaxException.class);
     assertThat(interpreter.getErrors()).isEmpty();

--- a/src/test/java/com/hubspot/jinjava/interpret/LegacyOperatorPrecedenceTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/LegacyOperatorPrecedenceTest.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class LegacyOperatorPrecedenceTest {
+
   Jinjava legacy;
   Jinjava modern;
 

--- a/src/test/java/com/hubspot/jinjava/interpret/LegacyWhitespaceControlParsingTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/LegacyWhitespaceControlParsingTest.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class LegacyWhitespaceControlParsingTest {
+
   Jinjava legacy;
   Jinjava modern;
 

--- a/src/test/java/com/hubspot/jinjava/interpret/TemplateErrorTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/TemplateErrorTest.java
@@ -56,7 +56,7 @@ public class TemplateErrorTest {
   @Test
   public void itSetsFieldNameCaseForSyntaxErrorInFor() {
     RenderResult renderResult = new Jinjava()
-    .renderForResult("{% for item inna navigation %}{% endfor %}", ImmutableMap.of());
+      .renderForResult("{% for item inna navigation %}{% endfor %}", ImmutableMap.of());
     assertThat(renderResult.getErrors().get(0).getFieldName())
       .isEqualTo("item inna navigation");
   }

--- a/src/test/java/com/hubspot/jinjava/interpret/VariableFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/VariableFunctionTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.junit.Test;
 
 public class VariableFunctionTest {
+
   private static final DynamicVariableResolver VARIABLE_FUNCTION = s -> {
     switch (s) {
       case "name":

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsContainingAllExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsContainingAllExpTestTest.java
@@ -7,72 +7,73 @@ import java.util.HashMap;
 import org.junit.Test;
 
 public class IsContainingAllExpTestTest extends BaseJinjavaTest {
+
   private static final String CONTAINING_TEMPLATE =
     "{%% if %s is containingall %s %%}pass{%% else %%}fail{%% endif %%}";
 
   @Test
   public void itPassesOnContainedValues() {
     assertThat(
-        jinjava.render(
-          String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "[1, 2]"),
-          new HashMap<>()
-        )
+      jinjava.render(
+        String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "[1, 2]"),
+        new HashMap<>()
       )
+    )
       .isEqualTo("pass");
   }
 
   @Test
   public void itPassesOnContainedDuplicatedValues() {
     assertThat(
-        jinjava.render(
-          String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "[1, 2, 2]"),
-          new HashMap<>()
-        )
+      jinjava.render(
+        String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "[1, 2, 2]"),
+        new HashMap<>()
       )
+    )
       .isEqualTo("pass");
   }
 
   @Test
   public void itFailsOnOnlySomeContainedValues() {
     assertThat(
-        jinjava.render(
-          String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "[1, 2, 4]"),
-          new HashMap<>()
-        )
+      jinjava.render(
+        String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "[1, 2, 4]"),
+        new HashMap<>()
       )
+    )
       .isEqualTo("fail");
   }
 
   @Test
   public void itFailsOnNullSequence() {
     assertThat(
-        jinjava.render(
-          String.format(CONTAINING_TEMPLATE, "null", "[1, 2, 4]"),
-          new HashMap<>()
-        )
+      jinjava.render(
+        String.format(CONTAINING_TEMPLATE, "null", "[1, 2, 4]"),
+        new HashMap<>()
       )
+    )
       .isEqualTo("fail");
   }
 
   @Test
   public void itFailsOnNullValues() {
     assertThat(
-        jinjava.render(
-          String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "null"),
-          new HashMap<>()
-        )
+      jinjava.render(
+        String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "null"),
+        new HashMap<>()
       )
+    )
       .isEqualTo("fail");
   }
 
   @Test
   public void itPerformsTypeConversion() {
     assertThat(
-        jinjava.render(
-          String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "['2', '3']"),
-          new HashMap<>()
-        )
+      jinjava.render(
+        String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "['2', '3']"),
+        new HashMap<>()
       )
+    )
       .isEqualTo("pass");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsContainingExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsContainingExpTestTest.java
@@ -7,80 +7,78 @@ import java.util.HashMap;
 import org.junit.Test;
 
 public class IsContainingExpTestTest extends BaseJinjavaTest {
+
   private static final String CONTAINING_TEMPLATE =
     "{%% if %s is containing %s %%}pass{%% else %%}fail{%% endif %%}";
 
   @Test
   public void itPassesOnContainedValue() {
     assertThat(
-        jinjava.render(
-          String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "2"),
-          new HashMap<>()
-        )
+      jinjava.render(
+        String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "2"),
+        new HashMap<>()
       )
+    )
       .isEqualTo("pass");
   }
 
   @Test
   public void itFailsOnNullContainedValue() {
     assertThat(
-        jinjava.render(
-          String.format(CONTAINING_TEMPLATE, "[1, 2, null]", "null"),
-          new HashMap<>()
-        )
+      jinjava.render(
+        String.format(CONTAINING_TEMPLATE, "[1, 2, null]", "null"),
+        new HashMap<>()
       )
+    )
       .isEqualTo("fail");
   }
 
   @Test
   public void itFailsOnMissingValue() {
     assertThat(
-        jinjava.render(
-          String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "4"),
-          new HashMap<>()
-        )
+      jinjava.render(
+        String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "4"),
+        new HashMap<>()
       )
+    )
       .isEqualTo("fail");
   }
 
   @Test
   public void itFailsOnEmptyValue() {
     assertThat(
-        jinjava.render(
-          String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", ""),
-          new HashMap<>()
-        )
-      )
+      jinjava.render(String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", ""), new HashMap<>())
+    )
       .isEqualTo("fail");
   }
 
   @Test
   public void itFailsOnNullValue() {
     assertThat(
-        jinjava.render(
-          String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "null"),
-          new HashMap<>()
-        )
+      jinjava.render(
+        String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "null"),
+        new HashMap<>()
       )
+    )
       .isEqualTo("fail");
   }
 
   @Test
   public void itFailsOnNullSequence() {
     assertThat(
-        jinjava.render(String.format(CONTAINING_TEMPLATE, "null", "2"), new HashMap<>())
-      )
+      jinjava.render(String.format(CONTAINING_TEMPLATE, "null", "2"), new HashMap<>())
+    )
       .isEqualTo("fail");
   }
 
   @Test
   public void itPerformsTypeConversion() {
     assertThat(
-        jinjava.render(
-          String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "'2'"),
-          new HashMap<>()
-        )
+      jinjava.render(
+        String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "'2'"),
+        new HashMap<>()
       )
+    )
       .isEqualTo("pass");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsEqualToExpTestTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.junit.Test;
 
 public class IsEqualToExpTestTest extends BaseJinjavaTest {
+
   private static final String EQUAL_TEMPLATE = "{{ %s is equalto %s }}";
 
   @Test
@@ -22,37 +23,37 @@ public class IsEqualToExpTestTest extends BaseJinjavaTest {
   @Test
   public void itEquatesStrings() {
     assertThat(
-        jinjava.render(
-          String.format(EQUAL_TEMPLATE, "\"jinjava\"", "\"jinjava\""),
-          new HashMap<>()
-        )
+      jinjava.render(
+        String.format(EQUAL_TEMPLATE, "\"jinjava\"", "\"jinjava\""),
+        new HashMap<>()
       )
+    )
       .isEqualTo("true");
     assertThat(
-        jinjava.render(
-          String.format(EQUAL_TEMPLATE, "\"jinjava\"", "\"not jinjava\""),
-          new HashMap<>()
-        )
+      jinjava.render(
+        String.format(EQUAL_TEMPLATE, "\"jinjava\"", "\"not jinjava\""),
+        new HashMap<>()
       )
+    )
       .isEqualTo("false");
   }
 
   @Test
   public void itEquatesCollectionsToStrings() {
     assertThat(
-        jinjava.render(
-          String.format(EQUAL_TEMPLATE, "\"[1, 2, 3]\"", "[1, 2, 3]"),
-          new HashMap<>()
-        )
+      jinjava.render(
+        String.format(EQUAL_TEMPLATE, "\"[1, 2, 3]\"", "[1, 2, 3]"),
+        new HashMap<>()
       )
+    )
       .isEqualTo("true");
 
     assertThat(
-        jinjava.render(
-          String.format(EQUAL_TEMPLATE, "\"[1, 2, 3]\"", "[1, 2, 4]"),
-          new HashMap<>()
-        )
+      jinjava.render(
+        String.format(EQUAL_TEMPLATE, "\"[1, 2, 3]\"", "[1, 2, 4]"),
+        new HashMap<>()
       )
+    )
       .isEqualTo("false");
   }
 
@@ -84,32 +85,32 @@ public class IsEqualToExpTestTest extends BaseJinjavaTest {
   @Test
   public void itEquatesBooleans() {
     assertThat(
-        jinjava.render(String.format(EQUAL_TEMPLATE, "true", "true"), new HashMap<>())
-      )
+      jinjava.render(String.format(EQUAL_TEMPLATE, "true", "true"), new HashMap<>())
+    )
       .isEqualTo("true");
     assertThat(
-        jinjava.render(String.format(EQUAL_TEMPLATE, "true", "false"), new HashMap<>())
-      )
+      jinjava.render(String.format(EQUAL_TEMPLATE, "true", "false"), new HashMap<>())
+    )
       .isEqualTo("false");
   }
 
   @Test
   public void itEquatesDifferentTypes() {
     assertThat(
-        jinjava.render(String.format(EQUAL_TEMPLATE, "4", "\"4\""), new HashMap<>())
-      )
+      jinjava.render(String.format(EQUAL_TEMPLATE, "4", "\"4\""), new HashMap<>())
+    )
       .isEqualTo("true");
     assertThat(
-        jinjava.render(String.format(EQUAL_TEMPLATE, "4", "\"5\""), new HashMap<>())
-      )
+      jinjava.render(String.format(EQUAL_TEMPLATE, "4", "\"5\""), new HashMap<>())
+    )
       .isEqualTo("false");
     assertThat(
-        jinjava.render(String.format(EQUAL_TEMPLATE, "'c'", "\"c\""), new HashMap<>())
-      )
+      jinjava.render(String.format(EQUAL_TEMPLATE, "'c'", "\"c\""), new HashMap<>())
+    )
       .isEqualTo("true");
     assertThat(
-        jinjava.render(String.format(EQUAL_TEMPLATE, "'c'", "\"b\""), new HashMap<>())
-      )
+      jinjava.render(String.format(EQUAL_TEMPLATE, "'c'", "\"b\""), new HashMap<>())
+    )
       .isEqualTo("false");
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsFloatExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsFloatExpTestTest.java
@@ -34,17 +34,14 @@ public class IsFloatExpTestTest extends BaseJinjavaTest {
     assertThat(jinjava.render("{{ (4|add(-4.5)) is float }}", new HashMap<>()))
       .isEqualTo("true");
     assertThat(
-        jinjava.render(
-          "{{ (4|add(4.0000000000000000000001)) is float }}",
-          new HashMap<>()
-        )
-      )
+      jinjava.render("{{ (4|add(4.0000000000000000000001)) is float }}", new HashMap<>())
+    )
       .isEqualTo("true");
     assertThat(jinjava.render("{{ (4|add(40.0)) is float }}", new HashMap<>()))
       .isEqualTo("true");
     assertThat(
-        jinjava.render("{{ (4|add(1000000000000000000)) is float }}", new HashMap<>())
-      )
+      jinjava.render("{{ (4|add(1000000000000000000)) is float }}", new HashMap<>())
+    )
       .isEqualTo("false");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsIntegerExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsIntegerExpTestTest.java
@@ -14,8 +14,8 @@ public class IsIntegerExpTestTest extends BaseJinjavaTest {
     assertThat(jinjava.render("{{ -1 is integer }}", new HashMap<>())).isEqualTo("true");
     long number = Integer.MAX_VALUE;
     assertThat(
-        jinjava.render(String.format("{{ %d is integer }}", number + 1), new HashMap<>())
-      )
+      jinjava.render(String.format("{{ %d is integer }}", number + 1), new HashMap<>())
+    )
       .isEqualTo("true");
     assertThat(jinjava.render("{{ 1000000000000000000 is integer }}", new HashMap<>()))
       .isEqualTo("true");
@@ -40,17 +40,17 @@ public class IsIntegerExpTestTest extends BaseJinjavaTest {
     assertThat(jinjava.render("{{ (4|add(-4.5)) is integer }}", new HashMap<>()))
       .isEqualTo("false");
     assertThat(
-        jinjava.render(
-          "{{ (4|add(4.0000000000000000000001)) is integer }}",
-          new HashMap<>()
-        )
+      jinjava.render(
+        "{{ (4|add(4.0000000000000000000001)) is integer }}",
+        new HashMap<>()
       )
+    )
       .isEqualTo("false");
     assertThat(jinjava.render("{{ (4|add(40.0)) is integer }}", new HashMap<>()))
       .isEqualTo("false");
     assertThat(
-        jinjava.render("{{ (4|add(1000000000000000000)) is integer }}", new HashMap<>())
-      )
+      jinjava.render("{{ (4|add(1000000000000000000)) is integer }}", new HashMap<>())
+    )
       .isEqualTo("true");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsStringContainingExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsStringContainingExpTestTest.java
@@ -8,38 +8,39 @@ import com.hubspot.jinjava.objects.SafeString;
 import org.junit.Test;
 
 public class IsStringContainingExpTestTest extends BaseJinjavaTest {
+
   private static final String CONTAINING_TEMPLATE = "{{ var is string_containing arg }}";
 
   @Test
   public void itReturnsTrueForContainedString() {
     assertThat(
-        jinjava.render(
-          CONTAINING_TEMPLATE,
-          ImmutableMap.of("var", "testing", "arg", "esti")
-        )
+      jinjava.render(
+        CONTAINING_TEMPLATE,
+        ImmutableMap.of("var", "testing", "arg", "esti")
       )
+    )
       .isEqualTo("true");
     assertThat(
-        jinjava.render(CONTAINING_TEMPLATE, ImmutableMap.of("var", "testing", "arg", ""))
-      )
+      jinjava.render(CONTAINING_TEMPLATE, ImmutableMap.of("var", "testing", "arg", ""))
+    )
       .isEqualTo("true");
     assertThat(
-        jinjava.render(
-          CONTAINING_TEMPLATE,
-          ImmutableMap.of("var", "testing", "arg", "testing")
-        )
+      jinjava.render(
+        CONTAINING_TEMPLATE,
+        ImmutableMap.of("var", "testing", "arg", "testing")
       )
+    )
       .isEqualTo("true");
   }
 
   @Test
   public void itReturnsFalseForExcludedString() {
     assertThat(
-        jinjava.render(
-          CONTAINING_TEMPLATE,
-          ImmutableMap.of("var", "testing", "arg", "blah")
-        )
+      jinjava.render(
+        CONTAINING_TEMPLATE,
+        ImmutableMap.of("var", "testing", "arg", "blah")
       )
+    )
       .isEqualTo("false");
   }
 
@@ -52,11 +53,11 @@ public class IsStringContainingExpTestTest extends BaseJinjavaTest {
   @Test
   public void itWorksForSafeString() {
     assertThat(
-        jinjava.render(
-          CONTAINING_TEMPLATE,
-          ImmutableMap.of("var", "testing", "arg", new SafeString("testing"))
-        )
+      jinjava.render(
+        CONTAINING_TEMPLATE,
+        ImmutableMap.of("var", "testing", "arg", new SafeString("testing"))
       )
+    )
       .isEqualTo("true");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsStringStartingWithExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsStringStartingWithExpTestTest.java
@@ -8,35 +8,36 @@ import com.hubspot.jinjava.objects.SafeString;
 import org.junit.Test;
 
 public class IsStringStartingWithExpTestTest extends BaseJinjavaTest {
+
   private static final String STARTING_TEMPLATE = "{{ var is string_startingwith arg }}";
 
   @Test
   public void itReturnsTrueForContainedString() {
     assertThat(
-        jinjava.render(STARTING_TEMPLATE, ImmutableMap.of("var", "testing", "arg", "tes"))
-      )
+      jinjava.render(STARTING_TEMPLATE, ImmutableMap.of("var", "testing", "arg", "tes"))
+    )
       .isEqualTo("true");
     assertThat(
-        jinjava.render(STARTING_TEMPLATE, ImmutableMap.of("var", "testing", "arg", ""))
-      )
+      jinjava.render(STARTING_TEMPLATE, ImmutableMap.of("var", "testing", "arg", ""))
+    )
       .isEqualTo("true");
     assertThat(
-        jinjava.render(
-          STARTING_TEMPLATE,
-          ImmutableMap.of("var", "testing", "arg", "testing")
-        )
+      jinjava.render(
+        STARTING_TEMPLATE,
+        ImmutableMap.of("var", "testing", "arg", "testing")
       )
+    )
       .isEqualTo("true");
   }
 
   @Test
   public void itReturnsFalseForExcludedString() {
     assertThat(
-        jinjava.render(
-          STARTING_TEMPLATE,
-          ImmutableMap.of("var", "testing", "arg", "esting")
-        )
+      jinjava.render(
+        STARTING_TEMPLATE,
+        ImmutableMap.of("var", "testing", "arg", "esting")
       )
+    )
       .isEqualTo("false");
   }
 
@@ -49,11 +50,11 @@ public class IsStringStartingWithExpTestTest extends BaseJinjavaTest {
   @Test
   public void itWorksForSafeString() {
     assertThat(
-        jinjava.render(
-          STARTING_TEMPLATE,
-          ImmutableMap.of("var", "testing", "arg", new SafeString("tes"))
-        )
+      jinjava.render(
+        STARTING_TEMPLATE,
+        ImmutableMap.of("var", "testing", "arg", new SafeString("tes"))
       )
+    )
       .isEqualTo("true");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsUpperExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsUpperExpTestTest.java
@@ -8,6 +8,7 @@ import com.hubspot.jinjava.objects.SafeString;
 import org.junit.Test;
 
 public class IsUpperExpTestTest extends BaseJinjavaTest {
+
   private static final String STARTING_TEMPLATE = "{{ var is upper }}";
   private static final String SAFE_TEMPLATE = "{{ (var|safe) is upper }}";
 
@@ -26,8 +27,8 @@ public class IsUpperExpTestTest extends BaseJinjavaTest {
   @Test
   public void itWorksForSafeStrings() {
     assertThat(
-        jinjava.render(STARTING_TEMPLATE, ImmutableMap.of("var", new SafeString("UPPER")))
-      )
+      jinjava.render(STARTING_TEMPLATE, ImmutableMap.of("var", new SafeString("UPPER")))
+    )
       .isEqualTo("true");
     assertThat(jinjava.render(SAFE_TEMPLATE, ImmutableMap.of("var", "UPPER")))
       .isEqualTo("true");

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/IsWithinExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/IsWithinExpTestTest.java
@@ -7,14 +7,15 @@ import java.util.HashMap;
 import org.junit.Test;
 
 public class IsWithinExpTestTest extends BaseJinjavaTest {
+
   private static final String IN_TEMPLATE =
     "{%% if %s is within %s %%}pass{%% else %%}fail{%% endif %%}";
 
   @Test
   public void itPassesOnValueInSequence() {
     assertThat(
-        jinjava.render(String.format(IN_TEMPLATE, "2", "[1, 2, 3]"), new HashMap<>())
-      )
+      jinjava.render(String.format(IN_TEMPLATE, "2", "[1, 2, 3]"), new HashMap<>())
+    )
       .isEqualTo("pass");
   }
 
@@ -33,27 +34,27 @@ public class IsWithinExpTestTest extends BaseJinjavaTest {
   @Test
   public void itFailsOnValueNotInSequence() {
     assertThat(
-        jinjava.render(String.format(IN_TEMPLATE, "4", "[1, 2, 3]"), new HashMap<>())
-      )
+      jinjava.render(String.format(IN_TEMPLATE, "4", "[1, 2, 3]"), new HashMap<>())
+    )
       .isEqualTo("fail");
   }
 
   @Test
   public void itFailsOnNullValueNotInSequence() {
     assertThat(
-        jinjava.render(String.format(IN_TEMPLATE, "null", "[1, 2, 3]"), new HashMap<>())
-      )
+      jinjava.render(String.format(IN_TEMPLATE, "null", "[1, 2, 3]"), new HashMap<>())
+    )
       .isEqualTo("fail");
   }
 
   @Test
   public void itPerformsTypeConversion() {
     assertThat(
-        jinjava.render(
-          String.format(IN_TEMPLATE, "'1'", "[100000000000, 1]"),
-          new HashMap<>()
-        )
+      jinjava.render(
+        String.format(IN_TEMPLATE, "'1'", "[100000000000, 1]"),
+        new HashMap<>()
       )
+    )
       .isEqualTo("pass");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/NegatedExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/NegatedExpTestTest.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import org.junit.Test;
 
 public class NegatedExpTestTest extends BaseJinjavaTest {
+
   private static final String TEMPLATE =
     "{%% if %s is %s %s %%}pass{%% else %%}fail{%% endif %%}";
   private static final String CONTAINING_TEMPLATE =
@@ -15,23 +16,23 @@ public class NegatedExpTestTest extends BaseJinjavaTest {
   @Test
   public void itNegatesDefined() {
     assertThat(
-        jinjava.render(String.format(TEMPLATE, "blah", "", "defined"), new HashMap<>())
-      )
+      jinjava.render(String.format(TEMPLATE, "blah", "", "defined"), new HashMap<>())
+    )
       .isEqualTo("fail");
     assertThat(
-        jinjava.render(String.format(TEMPLATE, "blah", "not", "defined"), new HashMap<>())
-      )
+      jinjava.render(String.format(TEMPLATE, "blah", "not", "defined"), new HashMap<>())
+    )
       .isEqualTo("pass");
   }
 
   @Test
   public void itNegatesContaining() {
     assertThat(
-        jinjava.render(
-          String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "4"),
-          new HashMap<>()
-        )
+      jinjava.render(
+        String.format(CONTAINING_TEMPLATE, "[1, 2, 3]", "4"),
+        new HashMap<>()
       )
+    )
       .isEqualTo("pass");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/isDivisibleByExpTestTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/isDivisibleByExpTestTest.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import org.junit.Test;
 
 public class isDivisibleByExpTestTest extends BaseJinjavaTest {
+
   private static final String DIVISIBLE_BY_TEMPLATE = "{{ %s is divisibleby %s }}";
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/filter/AbstractFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/AbstractFilterTest.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import org.junit.Test;
 
 public class AbstractFilterTest extends BaseInterpretingTest {
+
   private ArgCapturingFilter filter;
 
   public static class NoJinjavaDocFilter extends ArgCapturingFilter {}
@@ -37,7 +38,7 @@ public class AbstractFilterTest extends BaseInterpretingTest {
     params = {
       @JinjavaParam(value = "1st", desc = "1st"),
       @JinjavaParam(value = "2nd", desc = "2nd"),
-      @JinjavaParam(value = "3rd", desc = "3rd")
+      @JinjavaParam(value = "3rd", desc = "3rd"),
     }
   )
   public static class TwoParamTypesFilter extends ArgCapturingFilter {}
@@ -65,7 +66,7 @@ public class AbstractFilterTest extends BaseInterpretingTest {
       @JinjavaParam(value = "double", type = "double", desc = "double"),
       @JinjavaParam(value = "number", type = "number", desc = "number"),
       @JinjavaParam(value = "object", type = "object", desc = "object"),
-      @JinjavaParam(value = "dict", type = "dict", desc = "dict")
+      @JinjavaParam(value = "dict", type = "dict", desc = "dict"),
     }
   )
   public static class AllParamTypesFilter extends ArgCapturingFilter {}
@@ -107,8 +108,8 @@ public class AbstractFilterTest extends BaseInterpretingTest {
   public void itValidatesRequiredArgs() {
     filter = new AllParamTypesFilter();
 
-    assertThatThrownBy(
-        () -> filter.filter(null, interpreter, new Object[] {}, Collections.emptyMap())
+    assertThatThrownBy(() ->
+        filter.filter(null, interpreter, new Object[] {}, Collections.emptyMap())
       )
       .hasMessageContaining("Argument named 'boolean' is required");
   }
@@ -117,14 +118,13 @@ public class AbstractFilterTest extends BaseInterpretingTest {
   public void itErrorsOnTooManyArgs() {
     filter = new AllParamTypesFilter();
 
-    assertThatThrownBy(
-        () ->
-          filter.filter(
-            null,
-            interpreter,
-            new Object[] { true, null, null, null, null, null, null, null, null },
-            Collections.emptyMap()
-          )
+    assertThatThrownBy(() ->
+        filter.filter(
+          null,
+          interpreter,
+          new Object[] { true, null, null, null, null, null, null, null, null },
+          Collections.emptyMap()
+        )
       )
       .hasMessageContaining("Argument at index")
       .hasMessageContaining("is invalid");
@@ -134,19 +134,19 @@ public class AbstractFilterTest extends BaseInterpretingTest {
   public void itErrorsUnknownNamedArg() {
     filter = new AllParamTypesFilter();
 
-    assertThatThrownBy(
-        () ->
-          filter.filter(
-            null,
-            interpreter,
-            new Object[] { true },
-            ImmutableMap.of("unknown", "unknown")
-          )
+    assertThatThrownBy(() ->
+        filter.filter(
+          null,
+          interpreter,
+          new Object[] { true },
+          ImmutableMap.of("unknown", "unknown")
+        )
       )
       .hasMessageContaining("Argument named 'unknown' is invalid");
   }
 
   public static class ArgCapturingFilter extends AbstractFilter {
+
     public Map<String, Object> parsedArgs;
 
     @Override

--- a/src/test/java/com/hubspot/jinjava/lib/filter/AbstractSetFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/AbstractSetFilterTest.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class AbstractSetFilterTest extends BaseJinjavaTest {
+
   private static final IntersectFilter concreteSetFilter = new IntersectFilter();
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/filter/AdvancedFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/AdvancedFilterTest.java
@@ -28,7 +28,6 @@ public class AdvancedFilterTest extends BaseJinjavaTest {
   public void testOnlyKwargs() {
     Object[] expectedArgs = new Object[] {};
     Map<String, Object> expectedKwargs = new HashMap<String, Object>() {
-
       {
         put("named10", "str");
         put("named2", 3L);
@@ -41,11 +40,11 @@ public class AdvancedFilterTest extends BaseJinjavaTest {
       .registerFilter(new MyMirrorFilter(expectedArgs, expectedKwargs));
 
     assertThat(
-        jinjava.render(
-          "{{ 'test'|mirror(named2=3, named10='str', namedB=true) }}",
-          new HashMap<>()
-        )
+      jinjava.render(
+        "{{ 'test'|mirror(named2=3, named10='str', namedB=true) }}",
+        new HashMap<>()
       )
+    )
       .isEqualTo("test");
   }
 
@@ -53,7 +52,6 @@ public class AdvancedFilterTest extends BaseJinjavaTest {
   public void itTestsNullKwargs() {
     Object[] expectedArgs = new Object[] {};
     Map<String, Object> expectedKwargs = new HashMap<String, Object>() {
-
       {
         put("named1", null);
       }
@@ -71,7 +69,6 @@ public class AdvancedFilterTest extends BaseJinjavaTest {
   public void testMixedArgsAndKwargs() {
     Object[] expectedArgs = new Object[] { 1L, 2L };
     Map<String, Object> expectedKwargs = new HashMap<String, Object>() {
-
       {
         put("named", "test");
       }
@@ -89,7 +86,6 @@ public class AdvancedFilterTest extends BaseJinjavaTest {
   public void testUnorderedArgsAndKwargs() {
     Object[] expectedArgs = new Object[] { "1", 2L };
     Map<String, Object> expectedKwargs = new HashMap<String, Object>() {
-
       {
         put("named", "test");
       }
@@ -100,8 +96,8 @@ public class AdvancedFilterTest extends BaseJinjavaTest {
       .registerFilter(new MyMirrorFilter(expectedArgs, expectedKwargs));
 
     assertThat(
-        jinjava.render("{{ 'test'|mirror('1', named='test', 2) }}", new HashMap<>())
-      )
+      jinjava.render("{{ 'test'|mirror('1', named='test', 2) }}", new HashMap<>())
+    )
       .isEqualTo("test");
   }
 
@@ -109,7 +105,6 @@ public class AdvancedFilterTest extends BaseJinjavaTest {
   public void testRepeatedKwargs() {
     Object[] expectedArgs = new Object[] { true };
     Map<String, Object> expectedKwargs = new HashMap<String, Object>() {
-
       {
         put("named", "overwrite");
       }
@@ -120,15 +115,16 @@ public class AdvancedFilterTest extends BaseJinjavaTest {
       .registerFilter(new MyMirrorFilter(expectedArgs, expectedKwargs));
 
     assertThat(
-        jinjava.render(
-          "{{ 'test'|mirror(true, named='test', named='overwrite') }}",
-          new HashMap<>()
-        )
+      jinjava.render(
+        "{{ 'test'|mirror(true, named='test', named='overwrite') }}",
+        new HashMap<>()
       )
+    )
       .isEqualTo("test");
   }
 
   private static class MyMirrorFilter implements AdvancedFilter {
+
     private Object[] expectedArgs;
     private Map<String, Object> expectedKwargs;
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/Base64FilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/Base64FilterTest.java
@@ -20,41 +20,41 @@ public class Base64FilterTest extends BaseJinjavaTest {
   @Test
   public void itEncodesWithUtf16Le() {
     assertThat(
-        jinjava.render(
-          "{{ '\uD801\uDC37'|b64encode(encoding='utf-16le') }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{{ '\uD801\uDC37'|b64encode(encoding='utf-16le') }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("Adg33A==");
   }
 
   @Test
   public void itDecodesWithUtf16Le() {
     assertThat(
-        jinjava.render(
-          "{{ 'Adg33A=='|b64decode(encoding='utf-16le') }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{{ 'Adg33A=='|b64decode(encoding='utf-16le') }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("\uD801\uDC37");
   }
 
   @Test
   public void itEncodesAndDecodesDefaultCharset() {
     assertThat(
-        jinjava.render("{{ 123456789|b64encode|b64decode }}", Collections.emptyMap())
-      )
+      jinjava.render("{{ 123456789|b64encode|b64decode }}", Collections.emptyMap())
+    )
       .isEqualTo("123456789");
   }
 
   @Test
   public void itEncodesAndDecodesUtf16Le() {
     assertThat(
-        jinjava.render(
-          "{{ 123456789|b64encode(encoding='utf-16le')|b64decode(encoding='utf-16le') }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{{ 123456789|b64encode(encoding='utf-16le')|b64decode(encoding='utf-16le') }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("123456789");
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/BoolFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/BoolFilterTest.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class BoolFilterTest extends BaseInterpretingTest {
+
   BoolFilter filter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/filter/CloseHtmlFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/CloseHtmlFilterTest.java
@@ -7,6 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class CloseHtmlFilterTest extends BaseInterpretingTest {
+
   CloseHtmlFilter f;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DAliasedDefaultFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DAliasedDefaultFilterTest.java
@@ -11,8 +11,8 @@ public class DAliasedDefaultFilterTest extends BaseJinjavaTest {
   @Test
   public void itSetsDefaultStringValues() {
     assertThat(
-        jinjava.render("{% set d=d |d(\"some random value\") %}{{ d }}", new HashMap<>())
-      )
+      jinjava.render("{% set d=d |d(\"some random value\") %}{{ d }}", new HashMap<>())
+    )
       .isEqualTo("some random value");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class DateTimeFormatFilterTest extends BaseInterpretingTest {
+
   DateTimeFormatFilter filter;
 
   ZonedDateTime d;
@@ -76,17 +77,17 @@ public class DateTimeFormatFilterTest extends BaseInterpretingTest {
     assertThat(filter.filter(1539277785000L, interpreter, "%B %d, %Y, at %I:%M %p"))
       .isEqualTo("October 11, 2018, at 05:09 PM");
     assertThat(
-        filter.filter(
-          1539277785000L,
-          interpreter,
-          "%B %d, %Y, at %I:%M %p",
-          "America/New_York"
-        )
+      filter.filter(
+        1539277785000L,
+        interpreter,
+        "%B %d, %Y, at %I:%M %p",
+        "America/New_York"
       )
+    )
       .isEqualTo("October 11, 2018, at 01:09 PM");
     assertThat(
-        filter.filter(1539277785000L, interpreter, "%B %d, %Y, at %I:%M %p", "UTC+8")
-      )
+      filter.filter(1539277785000L, interpreter, "%B %d, %Y, at %I:%M %p", "UTC+8")
+    )
       .isEqualTo("October 12, 2018, at 01:09 AM");
   }
 
@@ -116,24 +117,24 @@ public class DateTimeFormatFilterTest extends BaseInterpretingTest {
   @Test
   public void itConvertsToLocaleSpecificDateTimeFormat() {
     assertThat(
-        filter.filter(
-          1539277785000L,
-          interpreter,
-          "%x %X - %c",
-          "America/New_York",
-          "en-US"
-        )
+      filter.filter(
+        1539277785000L,
+        interpreter,
+        "%x %X - %c",
+        "America/New_York",
+        "en-US"
       )
+    )
       .isEqualTo("10/11/18 1:09:45 PM - Oct 11, 2018, 1:09:45 PM");
     assertThat(
-        filter.filter(
-          1539277785000L,
-          interpreter,
-          "%x %X - %c",
-          "America/New_York",
-          "de-DE"
-        )
+      filter.filter(
+        1539277785000L,
+        interpreter,
+        "%x %X - %c",
+        "America/New_York",
+        "de-DE"
       )
+    )
       .isEqualTo("11.10.18 13:09:45 - 11.10.2018, 13:09:45");
   }
 
@@ -142,10 +143,8 @@ public class DateTimeFormatFilterTest extends BaseInterpretingTest {
     interpreter.getContext().put("d", d);
 
     assertThat(
-        interpreter.renderFlat(
-          "{{ d|datetimeformat('%A, %e %B', 'UTC', 'not_a_locale') }}"
-        )
-      )
+      interpreter.renderFlat("{{ d|datetimeformat('%A, %e %B', 'UTC', 'not_a_locale') }}")
+    )
       .isEqualTo(Functions.dateTimeFormat(d, "%A, %e %B", "UTC", "America/Los_Angeles"));
   }
 
@@ -154,10 +153,8 @@ public class DateTimeFormatFilterTest extends BaseInterpretingTest {
     interpreter.getContext().put("d", d);
 
     assertThat(
-        interpreter.renderFlat(
-          "{{ d|datetimeformat('%A, %e %B, %I:%M %p', null, 'sv') }}"
-        )
-      )
+      interpreter.renderFlat("{{ d|datetimeformat('%A, %e %B, %I:%M %p', null, 'sv') }}")
+    )
       .isEqualTo("onsdag, 6 november, 02:22 em");
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DefaultFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DefaultFilterTest.java
@@ -21,84 +21,84 @@ public class DefaultFilterTest extends BaseJinjavaTest {
   @Test
   public void itSetsDefaultStringValues() {
     assertThat(
-        jinjava.render(
-          "{% set d=d | default(\"some random value\") %}{{ d }}",
-          new HashMap<>()
-        )
+      jinjava.render(
+        "{% set d=d | default(\"some random value\") %}{{ d }}",
+        new HashMap<>()
       )
+    )
       .isEqualTo("some random value");
   }
 
   @Test
   public void itSetsDefaultObjectValue() {
     assertThat(
-        jinjava.render(
-          "{% set d=d | default({\"key\": \"value\"}) %}Value = {{ d.key }}",
-          new HashMap<>()
-        )
+      jinjava.render(
+        "{% set d=d | default({\"key\": \"value\"}) %}Value = {{ d.key }}",
+        new HashMap<>()
       )
+    )
       .isEqualTo("Value = value");
   }
 
   @Test
   public void itChecksForType() {
     assertThat(
-        jinjava.render(
-          "{% set d=d | default({\"key\": \"value\"}) %}Type = {{ type(d.key) }}",
-          new HashMap<>()
-        )
+      jinjava.render(
+        "{% set d=d | default({\"key\": \"value\"}) %}Type = {{ type(d.key) }}",
+        new HashMap<>()
       )
+    )
       .isEqualTo("Type = str");
     assertThat(
-        jinjava.render(
-          "{% set d=d | default(\"some random value\") %}{{ type(d) }}",
-          new HashMap<>()
-        )
+      jinjava.render(
+        "{% set d=d | default(\"some random value\") %}{{ type(d) }}",
+        new HashMap<>()
       )
+    )
       .isEqualTo("str");
   }
 
   @Test
   public void itCorrectlyProcessesNamedParameters() {
     assertThat(
-        jinjava.render(
-          "{% set d=d | default(truthy=False, default_value={\"key\": \"value\"}) %}Type = {{ type(d.key) }}",
-          new HashMap<>()
-        )
+      jinjava.render(
+        "{% set d=d | default(truthy=False, default_value={\"key\": \"value\"}) %}Type = {{ type(d.key) }}",
+        new HashMap<>()
       )
+    )
       .isEqualTo("Type = str");
   }
 
   @Test
   public void itIgnoresBadTruthyValue() {
     assertThat(
-        jinjava.render(
-          "{% set d=d | default({\"key\": \"value\"}, \"Blah\") %}Type = {{ type(d.key) }}",
-          new HashMap<>()
-        )
+      jinjava.render(
+        "{% set d=d | default({\"key\": \"value\"}, \"Blah\") %}Type = {{ type(d.key) }}",
+        new HashMap<>()
       )
+    )
       .isEqualTo("Type = str");
   }
 
   @Test
   public void itDefaultsNullToNull() {
     assertThat(
-        jinjava.render(
-          "{% set d=d | default(null) %}{% if (d == null) %}default yields real null{% else %}default yields something other than null{% endif %}",
-          new HashMap<>()
-        )
+      jinjava.render(
+        "{% set d=d | default(null) %}{% if (d == null) %}default yields real null{% else %}default yields something other than null{% endif %}",
+        new HashMap<>()
       )
+    )
       .isEqualTo("default yields real null");
   }
 
   @Test
   public void itDefaultsNullToNullWithTruthyParam() {
     assertThat(
-        jinjava.render(
-          "{% set d=d | default(null, true) %}{% if (d == null) %}default with truthy yields real null{% else %}default with truthy yields something other than null{% endif %}",
-          new HashMap<>()
-        )
+      jinjava.render(
+        "{% set d=d | default(null, true) %}{% if (d == null) %}default with truthy yields real null{% else %}default with truthy yields something other than null{% endif %}",
+        new HashMap<>()
       )
+    )
       .isEqualTo("default with truthy yields real null");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DictSortFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DictSortFilterTest.java
@@ -9,6 +9,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class DictSortFilterTest extends BaseJinjavaTest {
+
   private static Map<String, Object> context;
 
   @BeforeClass

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DifferenceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DifferenceFilterTest.java
@@ -17,12 +17,12 @@ public class DifferenceFilterTest extends BaseJinjavaTest {
   @Test
   public void itComputesSetDifferences() {
     assertThat(
-        jinjava.render("{{ [1, 2, 3, 3, 4]|difference([1, 2, 5, 6]) }}", new HashMap<>())
-      )
+      jinjava.render("{{ [1, 2, 3, 3, 4]|difference([1, 2, 5, 6]) }}", new HashMap<>())
+    )
       .isEqualTo("[3, 4]");
     assertThat(
-        jinjava.render("{{ ['do', 'ray']|difference(['ray', 'me']) }}", new HashMap<>())
-      )
+      jinjava.render("{{ ['do', 'ray']|difference(['ray', 'me']) }}", new HashMap<>())
+    )
       .isEqualTo("['do']");
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DivideFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DivideFilterTest.java
@@ -14,36 +14,36 @@ public class DivideFilterTest extends BaseJinjavaTest {
   @Test
   public void itDivides() {
     assertThat(
-        jinjava.render(
-          "{{ numerator|divide(denominator) }}",
-          ImmutableMap.of("numerator", 10, "denominator", 2)
-        )
+      jinjava.render(
+        "{{ numerator|divide(denominator) }}",
+        ImmutableMap.of("numerator", 10, "denominator", 2)
       )
+    )
       .isEqualTo("5");
     assertThat(
-        jinjava.render(
-          "{{ numerator // denominator }}",
-          ImmutableMap.of("numerator", 10, "denominator", 2)
-        )
+      jinjava.render(
+        "{{ numerator // denominator }}",
+        ImmutableMap.of("numerator", 10, "denominator", 2)
       )
+    )
       .isEqualTo("5");
     assertThat(
-        jinjava.render(
-          "{{ numerator / denominator }}",
-          ImmutableMap.of("numerator", 10, "denominator", 2)
-        )
+      jinjava.render(
+        "{{ numerator / denominator }}",
+        ImmutableMap.of("numerator", 10, "denominator", 2)
       )
+    )
       .isEqualTo("5.0");
   }
 
   @Test
   public void itDividesIntegersWithNonIntegerResult() {
     assertThat(
-        jinjava.render(
-          "{{ numerator|divide(denominator) }} {{ numerator / denominator }}",
-          ImmutableMap.of("numerator", 9, "denominator", 10)
-        )
+      jinjava.render(
+        "{{ numerator|divide(denominator) }} {{ numerator / denominator }}",
+        ImmutableMap.of("numerator", 9, "denominator", 10)
       )
+    )
       .isEqualTo("1 0.9");
   }
 
@@ -60,19 +60,19 @@ public class DivideFilterTest extends BaseJinjavaTest {
     );
 
     assertThat(
-        jinjava.render(
-          "{{ numerator|divide(denominator) }}",
-          ImmutableMap.of("numerator", 2, "denominator", 100)
-        )
+      jinjava.render(
+        "{{ numerator|divide(denominator) }}",
+        ImmutableMap.of("numerator", 2, "denominator", 100)
       )
+    )
       .isEqualTo("0");
 
     assertThat(
-        customJinjava.render(
-          "{{ numerator|divide(denominator) }}",
-          ImmutableMap.of("numerator", 2, "denominator", 100)
-        )
+      customJinjava.render(
+        "{{ numerator|divide(denominator) }}",
+        ImmutableMap.of("numerator", 2, "denominator", 100)
       )
+    )
       .isEqualTo("0.02");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/EscapeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/EscapeFilterTest.java
@@ -14,6 +14,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 public class EscapeFilterTest extends BaseInterpretingTest {
+
   EscapeFilter f;
 
   @Before
@@ -33,10 +34,8 @@ public class EscapeFilterTest extends BaseInterpretingTest {
   @Test
   public void testSafeStringCanBeEscaped() {
     assertThat(
-        f
-          .filter(new SafeString("<a>Previously marked as safe<a/>"), interpreter)
-          .toString()
-      )
+      f.filter(new SafeString("<a>Previously marked as safe<a/>"), interpreter).toString()
+    )
       .isEqualTo("&lt;a&gt;Previously marked as safe&lt;a/&gt;");
     assertThat(f.filter(new SafeString("<a>Previously marked as safe<a/>"), interpreter))
       .isInstanceOf(SafeString.class);

--- a/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJinjavaFilterTest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class EscapeJinjavaFilterTest extends BaseInterpretingTest {
+
   EscapeJinjavaFilter f;
 
   @Before
@@ -34,8 +35,8 @@ public class EscapeJinjavaFilterTest extends BaseInterpretingTest {
   @Test
   public void testDoesNotEscapeJson() {
     assertThat(
-        f.filter("{'foo': 'bar', '{{{ foo }}}': '{% bar %}'}", interpreter, "false")
-      )
+      f.filter("{'foo': 'bar', '{{{ foo }}}': '{% bar %}'}", interpreter, "false")
+    )
       .isEqualTo(
         "{'foo': 'bar', '&lbrace;&lbrace;{ foo &rbrace;&rbrace;}': '&lbrace;% bar %&rbrace;'}"
       );

--- a/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJsFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJsFilterTest.java
@@ -44,19 +44,16 @@ public class EscapeJsFilterTest extends BaseJinjavaTest {
   @Test
   public void testHandlesDoubleQuotes() {
     assertThat(
-        jinjava.render(
-          "{{ 'Testing a \"quote for the week\"'|escapejs }}",
-          new HashMap<>()
-        )
-      )
+      jinjava.render("{{ 'Testing a \"quote for the week\"'|escapejs }}", new HashMap<>())
+    )
       .isEqualTo("Testing a \\\"quote for the week\\\"");
   }
 
   @Test
   public void testSafeStringCanBeEscaped() {
     assertThat(
-        jinjava.render("{{ 'Testing\nlineb\"reak\n'|safe|escapejs }}", new HashMap<>())
-      )
+      jinjava.render("{{ 'Testing\nlineb\"reak\n'|safe|escapejs }}", new HashMap<>())
+    )
       .isEqualTo("Testing\\nlineb\\\"reak\\n");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJsonFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/EscapeJsonFilterTest.java
@@ -41,11 +41,11 @@ public class EscapeJsonFilterTest extends BaseJinjavaTest {
   @Test
   public void testHandlesDoubleQuotes() {
     assertThat(
-        jinjava.render(
-          "{{ 'Testing a \"quote for the week\"'|escapejson }}",
-          new HashMap<>()
-        )
+      jinjava.render(
+        "{{ 'Testing a \"quote for the week\"'|escapejson }}",
+        new HashMap<>()
       )
+    )
       .isEqualTo("Testing a \\\"quote for the week\\\"");
   }
 
@@ -62,8 +62,8 @@ public class EscapeJsonFilterTest extends BaseJinjavaTest {
   @Test
   public void testSafeStringCanBeEscaped() {
     assertThat(
-        jinjava.render("{{ 'Testing\nlineb\"reak\n'|safe|escapejs }}", new HashMap<>())
-      )
+      jinjava.render("{{ 'Testing\nlineb\"reak\n'|safe|escapejs }}", new HashMap<>())
+    )
       .isEqualTo("Testing\\nlineb\\\"reak\\n");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/FileSizeFormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FileSizeFormatFilterTest.java
@@ -22,16 +22,16 @@ public class FileSizeFormatFilterTest extends BaseJinjavaTest {
     assertThat(jinjava.render("{{1000|filesizeformat}}", new HashMap<String, Object>()))
       .isEqualTo("1.0 KB");
     assertThat(
-        jinjava.render("{{1024|filesizeformat(true)}}", new HashMap<String, Object>())
-      )
+      jinjava.render("{{1024|filesizeformat(true)}}", new HashMap<String, Object>())
+    )
       .isEqualTo("1.0 KiB");
     assertThat(
-        jinjava.render("{{3531836|filesizeformat(true)}}", new HashMap<String, Object>())
-      )
+      jinjava.render("{{3531836|filesizeformat(true)}}", new HashMap<String, Object>())
+    )
       .isEqualTo("3.4 MiB");
     assertThat(
-        jinjava.render("{{1000000000|filesizeformat}}", new HashMap<String, Object>())
-      )
+      jinjava.render("{{1000000000|filesizeformat}}", new HashMap<String, Object>())
+    )
       .isEqualTo("1.0 GB");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/FirstFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FirstFilterTest.java
@@ -7,6 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class FirstFilterTest {
+
   FirstFilter filter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/filter/FloatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FloatFilterTest.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class FloatFilterTest extends BaseInterpretingTest {
+
   private static final Locale FRENCH_LOCALE = new Locale("fr", "FR");
   private static final JinjavaConfig FRENCH_LOCALE_CONFIG = new JinjavaConfig(
     StandardCharsets.UTF_8,
@@ -116,14 +117,14 @@ public class FloatFilterTest extends BaseInterpretingTest {
   public void itInterpretsFrenchCommasAndPeriodsWithFrenchLocale() {
     interpreter = new Jinjava(FRENCH_LOCALE_CONFIG).newInterpreter();
     assertThat(
-        filter.filter(
-          String.format(
-            "123%c123,45",
-            DecimalFormatSymbols.getInstance(Locale.FRENCH).getGroupingSeparator()
-          ),
-          interpreter
-        )
+      filter.filter(
+        String.format(
+          "123%c123,45",
+          DecimalFormatSymbols.getInstance(Locale.FRENCH).getGroupingSeparator()
+        ),
+        interpreter
       )
+    )
       .isEqualTo(123123.45f);
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/FormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FormatFilterTest.java
@@ -20,8 +20,8 @@ public class FormatFilterTest extends BaseJinjavaTest {
   @Test
   public void testFormatFilter() {
     assertThat(
-        jinjava.render("{{ '%s - %s'|format(\"Hello?\", \"Foo!\") }}", new HashMap<>())
-      )
+      jinjava.render("{{ '%s - %s'|format(\"Hello?\", \"Foo!\") }}", new HashMap<>())
+    )
       .isEqualTo("Hello? - Foo!");
   }
 
@@ -33,8 +33,8 @@ public class FormatFilterTest extends BaseJinjavaTest {
 
   @Test
   public void itThrowsExceptionOnMissingFormatArgument() {
-    assertThatThrownBy(
-        () -> jinjava.render("{{ '%s %s'|format(10000) }}", new HashMap<>())
+    assertThatThrownBy(() ->
+        jinjava.render("{{ '%s %s'|format(10000) }}", new HashMap<>())
       )
       .isInstanceOf(FatalTemplateErrorsException.class)
       .hasMessageContaining("Missing format argument");
@@ -49,8 +49,7 @@ public class FormatFilterTest extends BaseJinjavaTest {
 
   @Test
   public void itThrowsExceptionOnFormat() {
-    assertThatThrownBy(
-        () -> jinjava.render("{{ '%0.0f'|format(1000) }}", new HashMap<>())
+    assertThatThrownBy(() -> jinjava.render("{{ '%0.0f'|format(1000) }}", new HashMap<>())
       )
       .isInstanceOf(FatalTemplateErrorsException.class)
       .hasMessageContaining("'%0.0f' is missing a width");

--- a/src/test/java/com/hubspot/jinjava/lib/filter/FormatNumberFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FormatNumberFilterTest.java
@@ -17,27 +17,27 @@ public class FormatNumberFilterTest extends BaseJinjavaTest {
   @Test
   public void testFormatNumberFilter() {
     assertThat(
-        jinjava.render("{{1000|format_number('en-US')}}", new HashMap<String, Object>())
-      )
+      jinjava.render("{{1000|format_number('en-US')}}", new HashMap<String, Object>())
+    )
       .isEqualTo("1,000");
     assertThat(
-        jinjava.render(
-          "{{ 1000.333|format_number('en-US') }}",
-          new HashMap<String, Object>()
-        )
+      jinjava.render(
+        "{{ 1000.333|format_number('en-US') }}",
+        new HashMap<String, Object>()
       )
+    )
       .isEqualTo("1,000.333");
     assertThat(
-        jinjava.render(
-          "{{ 1000.333|format_number('en-US', 2) }}",
-          new HashMap<String, Object>()
-        )
+      jinjava.render(
+        "{{ 1000.333|format_number('en-US', 2) }}",
+        new HashMap<String, Object>()
       )
+    )
       .isEqualTo("1,000.33");
 
     assertThat(
-        jinjava.render("{{ 1000|format_number('fr') }}", new HashMap<String, Object>())
-      )
+      jinjava.render("{{ 1000|format_number('fr') }}", new HashMap<String, Object>())
+    )
       .isEqualTo(
         String.format(
           "1%s000",
@@ -45,11 +45,8 @@ public class FormatNumberFilterTest extends BaseJinjavaTest {
         )
       );
     assertThat(
-        jinjava.render(
-          "{{ 1000.333|format_number('fr') }}",
-          new HashMap<String, Object>()
-        )
-      )
+      jinjava.render("{{ 1000.333|format_number('fr') }}", new HashMap<String, Object>())
+    )
       .isEqualTo(
         String.format(
           "1%s000,333",
@@ -57,11 +54,11 @@ public class FormatNumberFilterTest extends BaseJinjavaTest {
         )
       );
     assertThat(
-        jinjava.render(
-          "{{ 1000.333|format_number('fr', 2) }}",
-          new HashMap<String, Object>()
-        )
+      jinjava.render(
+        "{{ 1000.333|format_number('fr', 2) }}",
+        new HashMap<String, Object>()
       )
+    )
       .isEqualTo(
         String.format(
           "1%s000,33",
@@ -70,22 +67,19 @@ public class FormatNumberFilterTest extends BaseJinjavaTest {
       );
 
     assertThat(
-        jinjava.render("{{ 1000|format_number('es') }}", new HashMap<String, Object>())
-      )
+      jinjava.render("{{ 1000|format_number('es') }}", new HashMap<String, Object>())
+    )
       .isEqualTo("1.000");
     assertThat(
-        jinjava.render(
-          "{{ 1000.333|format_number('es') }}",
-          new HashMap<String, Object>()
-        )
-      )
+      jinjava.render("{{ 1000.333|format_number('es') }}", new HashMap<String, Object>())
+    )
       .isEqualTo("1.000,333");
     assertThat(
-        jinjava.render(
-          "{{ 1000.333|format_number('es', 2) }}",
-          new HashMap<String, Object>()
-        )
+      jinjava.render(
+        "{{ 1000.333|format_number('es', 2) }}",
+        new HashMap<String, Object>()
       )
+    )
       .isEqualTo("1.000,33");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/FromJsonFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FromJsonFilterTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class FromJsonFilterTest extends BaseInterpretingTest {
+
   private FromJsonFilter filter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/filter/FromYamlFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/FromYamlFilterTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class FromYamlFilterTest extends BaseInterpretingTest {
+
   private FromYamlFilter filter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/filter/GroupByFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/GroupByFilterTest.java
@@ -41,6 +41,7 @@ public class GroupByFilterTest extends BaseJinjavaTest {
   }
 
   public static class Person {
+
     private String gender;
     private String firstName;
     private String lastName;

--- a/src/test/java/com/hubspot/jinjava/lib/filter/IndentFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/IndentFilterTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class IndentFilterTest extends BaseJinjavaTest {
+
   private final Map<String, Object> VARS = new HashMap<>();
 
   @Before
@@ -27,11 +28,11 @@ public class IndentFilterTest extends BaseJinjavaTest {
   @Test
   public void itIndentsFirstline() {
     assertThat(
-        jinjava.render(
-          "{% set d=multiLine | indent(indentfirst= True, width=1) %}{{ d }}",
-          VARS
-        )
+      jinjava.render(
+        "{% set d=multiLine | indent(indentfirst= True, width=1) %}{{ d }}",
+        VARS
       )
+    )
       .isEqualTo(" 1\n" + " 2\n" + " 3");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/IntFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/IntFilterTest.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class IntFilterTest extends BaseInterpretingTest {
+
   private static final Locale FRENCH_LOCALE = new Locale("fr", "FR");
   private static final JinjavaConfig FRENCH_LOCALE_CONFIG = new JinjavaConfig(
     StandardCharsets.UTF_8,
@@ -112,14 +113,14 @@ public class IntFilterTest extends BaseInterpretingTest {
   public void itInterpretsFrenchCommasAndPeriodsWithFrenchLocale() {
     interpreter = new Jinjava(FRENCH_LOCALE_CONFIG).newInterpreter();
     assertThat(
-        filter.filter(
-          String.format(
-            "123%c123,12",
-            DecimalFormatSymbols.getInstance(Locale.FRENCH).getGroupingSeparator()
-          ),
-          interpreter
-        )
+      filter.filter(
+        String.format(
+          "123%c123,12",
+          DecimalFormatSymbols.getInstance(Locale.FRENCH).getGroupingSeparator()
+        ),
+        interpreter
       )
+    )
       .isEqualTo(123123);
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/IntersectFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/IntersectFilterTest.java
@@ -17,12 +17,12 @@ public class IntersectFilterTest extends BaseJinjavaTest {
   @Test
   public void itComputesSetIntersections() {
     assertThat(
-        jinjava.render("{{ [1, 1, 2, 3]|intersect([1, 2, 5, 6]) }}", new HashMap<>())
-      )
+      jinjava.render("{{ [1, 1, 2, 3]|intersect([1, 2, 5, 6]) }}", new HashMap<>())
+    )
       .isEqualTo("[1, 2]");
     assertThat(
-        jinjava.render("{{ ['do', 'ray']|intersect(['ray', 'me']) }}", new HashMap<>())
-      )
+      jinjava.render("{{ ['do', 'ray']|intersect(['ray', 'me']) }}", new HashMap<>())
+    )
       .isEqualTo("['ray']");
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/IpAddrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/IpAddrFilterTest.java
@@ -15,6 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class IpAddrFilterTest extends BaseInterpretingTest {
+
   private IpAddrFilter ipAddrFilter;
   private Ipv4Filter ipv4Filter;
   private Ipv6Filter ipv6Filter;
@@ -46,8 +47,8 @@ public class IpAddrFilterTest extends BaseInterpretingTest {
   @Test
   public void itAcceptsValidIpV6Address() {
     assertThat(
-        ipAddrFilter.filter("1200:0000:AB00:1234:0000:2552:7777:1313", interpreter)
-      )
+      ipAddrFilter.filter("1200:0000:AB00:1234:0000:2552:7777:1313", interpreter)
+    )
       .isEqualTo(true);
     assertThat(ipAddrFilter.filter("21DA:D3:0:2F3B:2AA:FF:FE28:9C5A", interpreter))
       .isEqualTo(true);
@@ -59,8 +60,8 @@ public class IpAddrFilterTest extends BaseInterpretingTest {
     assertThat(ipAddrFilter.filter("1200::AB00:1234::2552:7777:1313", interpreter))
       .isEqualTo(false);
     assertThat(
-        ipAddrFilter.filter("1200:0000:AB00:1234:O000:2552:7777:1313", interpreter)
-      )
+      ipAddrFilter.filter("1200:0000:AB00:1234:O000:2552:7777:1313", interpreter)
+    )
       .isEqualTo(false);
     assertThat(ipAddrFilter.filter("1200::AB00:1234::2552:7777:1313:1232", interpreter))
       .isEqualTo(false);
@@ -76,12 +77,12 @@ public class IpAddrFilterTest extends BaseInterpretingTest {
   @Test
   public void itReturnsIpv6AddressPrefix() {
     assertThat(
-        ipAddrFilter.filter(
-          "1200:0000:AB00:1234:0000:2552:7777:1313/43",
-          interpreter,
-          "prefix"
-        )
+      ipAddrFilter.filter(
+        "1200:0000:AB00:1234:0000:2552:7777:1313/43",
+        interpreter,
+        "prefix"
       )
+    )
       .isEqualTo(43);
   }
 
@@ -100,12 +101,12 @@ public class IpAddrFilterTest extends BaseInterpretingTest {
   @Test
   public void itReturnsIpv6AddressNetMask() {
     assertThat(
-        ipAddrFilter.filter(
-          "1200:0000:AB00:1234:0000:2552:7777:1313/43",
-          interpreter,
-          "netmask"
-        )
+      ipAddrFilter.filter(
+        "1200:0000:AB00:1234:0000:2552:7777:1313/43",
+        interpreter,
+        "netmask"
       )
+    )
       .isEqualTo("ffff:ffff:ffe0::");
   }
 
@@ -118,12 +119,12 @@ public class IpAddrFilterTest extends BaseInterpretingTest {
   @Test
   public void itReturnsIpv6AddressBroadcast() {
     assertThat(
-        ipAddrFilter.filter(
-          "1200:0000:AB00:1234:0000:2552:7777:1313/43",
-          interpreter,
-          "broadcast"
-        )
+      ipAddrFilter.filter(
+        "1200:0000:AB00:1234:0000:2552:7777:1313/43",
+        interpreter,
+        "broadcast"
       )
+    )
       .isEqualTo("1200:0:ab1f:ffff:ffff:ffff:ffff:ffff");
   }
 
@@ -138,20 +139,20 @@ public class IpAddrFilterTest extends BaseInterpretingTest {
   @Test
   public void itReturnsIpv6AddressAddress() {
     assertThat(
-        ipAddrFilter.filter(
-          "1200:0000:AB00:1234:0000:2552:7777:1313/43",
-          interpreter,
-          "address"
-        )
+      ipAddrFilter.filter(
+        "1200:0000:AB00:1234:0000:2552:7777:1313/43",
+        interpreter,
+        "address"
       )
+    )
       .isEqualTo("1200:0000:AB00:1234:0000:2552:7777:1313");
     assertThat(
-        ipAddrFilter.filter(
-          "1200:0000:AB00:1234:0000:2552:7777:1314",
-          interpreter,
-          "address"
-        )
+      ipAddrFilter.filter(
+        "1200:0000:AB00:1234:0000:2552:7777:1314",
+        interpreter,
+        "address"
       )
+    )
       .isEqualTo("1200:0000:AB00:1234:0000:2552:7777:1314");
   }
 
@@ -164,12 +165,12 @@ public class IpAddrFilterTest extends BaseInterpretingTest {
   @Test
   public void itReturnsIpv6AddressNetwork() {
     assertThat(
-        ipAddrFilter.filter(
-          "1200:0000:AB00:1234:0000:2552:7777:1313/43",
-          interpreter,
-          "network"
-        )
+      ipAddrFilter.filter(
+        "1200:0000:AB00:1234:0000:2552:7777:1313/43",
+        interpreter,
+        "network"
       )
+    )
       .isEqualTo("1200:0:ab00::");
   }
 
@@ -182,27 +183,27 @@ public class IpAddrFilterTest extends BaseInterpretingTest {
   @Test
   public void itReturnsIpv6AddressGateway() {
     assertThat(
-        ipAddrFilter.filter(
-          "1200:0000:AB00:1234:0000:2552:7777:1313/43",
-          interpreter,
-          "gateway"
-        )
+      ipAddrFilter.filter(
+        "1200:0000:AB00:1234:0000:2552:7777:1313/43",
+        interpreter,
+        "gateway"
       )
+    )
       .isEqualTo("1200:0:ab00::1");
   }
 
   @Test
   public void itAddsErrorOnInvalidCidrAddress() {
-    assertThatThrownBy(
-        () -> ipAddrFilter.filter("192.168.0.1/200", interpreter, "broadcast")
+    assertThatThrownBy(() ->
+        ipAddrFilter.filter("192.168.0.1/200", interpreter, "broadcast")
       )
       .hasMessageContaining("must be a valid CIDR address");
   }
 
   @Test
   public void itAddsErrorOnInvalidFunctionName() {
-    assertThatThrownBy(
-        () -> ipAddrFilter.filter("192.168.0.1/20", interpreter, "notAFunction")
+    assertThatThrownBy(() ->
+        ipAddrFilter.filter("192.168.0.1/20", interpreter, "notAFunction")
       )
       .hasMessageContaining("must be one of");
   }
@@ -402,19 +403,19 @@ public class IpAddrFilterTest extends BaseInterpretingTest {
   @Test
   public void itWorksWithSafeString() throws Exception {
     assertThat(
-        ipAddrFilter.filter(
-          new SafeString("1200:0000:AB00:1234:0000:2552:7777:1313"),
-          interpreter
-        )
+      ipAddrFilter.filter(
+        new SafeString("1200:0000:AB00:1234:0000:2552:7777:1313"),
+        interpreter
       )
+    )
       .isEqualTo(true);
     assertThat(ipAddrFilter.filter(new SafeString("255.182.100.abc"), interpreter))
       .isEqualTo(false);
     assertThat(ipAddrFilter.filter(new SafeString("   128.0.0.1   "), interpreter))
       .isEqualTo(true);
     assertThat(
-        ipAddrFilter.filter(new SafeString("255.182.100.1/10"), interpreter, "netmask")
-      )
+      ipAddrFilter.filter(new SafeString("255.182.100.1/10"), interpreter, "netmask")
+    )
       .isEqualTo("255.192.0.0");
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/JoinFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/JoinFilterTest.java
@@ -29,8 +29,8 @@ public class JoinFilterTest extends BaseJinjavaTest {
   @Test
   public void testJoinAttrs() {
     assertThat(
-        jinjava.render("{{ users|join(', ', attribute='username') }}", new HashMap<>())
-      )
+      jinjava.render("{{ users|join(', ', attribute='username') }}", new HashMap<>())
+    )
       .isEqualTo("foo, bar");
   }
 
@@ -49,6 +49,7 @@ public class JoinFilterTest extends BaseJinjavaTest {
   }
 
   public static class User {
+
     private String username;
 
     public User(String username) {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/LastFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/LastFilterTest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class LastFilterTest {
+
   LastFilter filter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/filter/ListFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/ListFilterTest.java
@@ -31,6 +31,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class ListFilterTest {
+
   ListFilter filter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/filter/LogFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/LogFilterTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class LogFilterTest extends BaseInterpretingTest {
+
   LogFilter filter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/filter/MapFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/MapFilterTest.java
@@ -14,105 +14,99 @@ public class MapFilterTest extends BaseJinjavaTest {
   @Test
   public void mapAttr() {
     assertThat(
-        jinjava.render(
-          "{{ users|map(attribute='username')|join(', ') }}",
-          ImmutableMap.of(
-            "users",
-            (Object) Lists.newArrayList(new User("foo"), new User("bar"))
-          )
+      jinjava.render(
+        "{{ users|map(attribute='username')|join(', ') }}",
+        ImmutableMap.of(
+          "users",
+          (Object) Lists.newArrayList(new User("foo"), new User("bar"))
         )
       )
+    )
       .isEqualTo("foo, bar");
   }
 
   @Test
   public void mapFilter() {
     assertThat(
-        jinjava.render(
-          "{{ titles|map('lower')|join(', ') }}",
-          ImmutableMap.of(
-            "titles",
-            (Object) Lists.newArrayList("Happy Day", "FOO", "bar")
-          )
-        )
+      jinjava.render(
+        "{{ titles|map('lower')|join(', ') }}",
+        ImmutableMap.of("titles", (Object) Lists.newArrayList("Happy Day", "FOO", "bar"))
       )
+    )
       .isEqualTo("happy day, foo, bar");
   }
 
   @Test
   public void itPassesAdditionalArgumentsIntoFilter() {
     assertThat(
-        jinjava.render(
-          "{{ titles|map('truncate', 5, true, '')|join(', ') }}",
-          ImmutableMap.of(
-            "titles",
-            (Object) Lists.newArrayList("Happy Day", "FOOBAR", "barfoo")
-          )
+      jinjava.render(
+        "{{ titles|map('truncate', 5, true, '')|join(', ') }}",
+        ImmutableMap.of(
+          "titles",
+          (Object) Lists.newArrayList("Happy Day", "FOOBAR", "barfoo")
         )
       )
+    )
       .isEqualTo("Happy, FOOBA, barfo");
   }
 
   @Test
   public void itUsesAttributeIfAttributeNameClashesWithFilter() {
     assertThat(
-        jinjava.render(
-          "{{ titles|map(attribute='date')|join(' ') }}",
-          ImmutableMap.of("titles", (Object) Lists.newArrayList(new TestClass(12345)))
-        )
+      jinjava.render(
+        "{{ titles|map(attribute='date')|join(' ') }}",
+        ImmutableMap.of("titles", (Object) Lists.newArrayList(new TestClass(12345)))
       )
+    )
       .isEqualTo("12345");
   }
 
   @Test
   public void itMapsFirstArgumentToFilterIfFilterExists() {
-    assertThatThrownBy(
-        () ->
-          jinjava.render(
-            "{{ titles|map('date')|join(' ') }}",
-            ImmutableMap.of("titles", (Object) Lists.newArrayList(new TestClass(12345)))
-          )
+    assertThatThrownBy(() ->
+        jinjava.render(
+          "{{ titles|map('date')|join(' ') }}",
+          ImmutableMap.of("titles", (Object) Lists.newArrayList(new TestClass(12345)))
+        )
       )
       .hasMessageContaining("Input to function must be a date object");
   }
 
   @Test
   public void itAddsErrorIfFirstArgumentIsNull() {
-    assertThatThrownBy(
-        () ->
-          jinjava.render(
-            "{{ titles|map(null)|join(' ') }}",
-            ImmutableMap.of("titles", (Object) Lists.newArrayList(new TestClass(12345)))
-          )
+    assertThatThrownBy(() ->
+        jinjava.render(
+          "{{ titles|map(null)|join(' ') }}",
+          ImmutableMap.of("titles", (Object) Lists.newArrayList(new TestClass(12345)))
+        )
       )
       .hasMessageContaining("1st argument cannot be null");
   }
 
   @Test
   public void itAddsErrorIfAttributeArgumentIsNull() {
-    assertThatThrownBy(
-        () ->
-          jinjava.render(
-            "{{ titles|map(attribute=null)|join(' ') }}",
-            ImmutableMap.of("titles", (Object) Lists.newArrayList(new TestClass(12345)))
-          )
+    assertThatThrownBy(() ->
+        jinjava.render(
+          "{{ titles|map(attribute=null)|join(' ') }}",
+          ImmutableMap.of("titles", (Object) Lists.newArrayList(new TestClass(12345)))
+        )
       )
       .hasMessageContaining("'attribute' argument cannot be null");
   }
 
   @Test
   public void itAddsErrorIfNoArgumentsAreProvided() {
-    assertThatThrownBy(
-        () ->
-          jinjava.render(
-            "{{ titles|map()|join(' ') }}",
-            ImmutableMap.of("titles", (Object) Lists.newArrayList(new TestClass(12345)))
-          )
+    assertThatThrownBy(() ->
+        jinjava.render(
+          "{{ titles|map()|join(' ') }}",
+          ImmutableMap.of("titles", (Object) Lists.newArrayList(new TestClass(12345)))
+        )
       )
       .hasMessageContaining("requires 1 argument");
   }
 
   public class TestClass {
+
     private final long date;
 
     public TestClass(long date) {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/PrettyPrintFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/PrettyPrintFilterTest.java
@@ -16,6 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class PrettyPrintFilterTest {
+
   JinjavaInterpreter i;
   PrettyPrintFilter f;
 
@@ -41,11 +42,11 @@ public class PrettyPrintFilterTest {
   @Test
   public void ppPyDate() {
     assertThat(
-        f.filter(
-          new PyishDate(ZonedDateTime.of(2014, 8, 4, 0, 0, 0, 0, ZoneOffset.UTC)),
-          null
-        )
+      f.filter(
+        new PyishDate(ZonedDateTime.of(2014, 8, 4, 0, 0, 0, 0, ZoneOffset.UTC)),
+        null
       )
+    )
       .isEqualTo("{% raw %}(PyishDate: 2014-08-04 00:00:00){% endraw %}");
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RandomFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RandomFilterTest.java
@@ -16,6 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class RandomFilterTest {
+
   RandomFilter filter = new RandomFilter();
 
   JinjavaInterpreter interpreter = mock(JinjavaInterpreter.class);

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RegexReplaceFilterTest.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class RegexReplaceFilterTest extends BaseInterpretingTest {
+
   RegexReplaceFilter filter;
 
   @Before
@@ -28,8 +29,8 @@ public class RegexReplaceFilterTest extends BaseInterpretingTest {
 
   @Test
   public void expectsNotNullArgs() {
-    assertThatThrownBy(
-        () -> filter.filter("foo", interpreter, new String[] { null, null })
+    assertThatThrownBy(() ->
+        filter.filter("foo", interpreter, new String[] { null, null })
       )
       .hasMessageContaining("both a valid regex");
   }
@@ -52,10 +53,10 @@ public class RegexReplaceFilterTest extends BaseInterpretingTest {
   @Test
   public void itMatchesRegexAndReplacesStringForSafeString() {
     assertThat(
-        filter
-          .filter(new SafeString("It costs $300"), interpreter, "[^a-zA-Z]", "")
-          .toString()
-      )
+      filter
+        .filter(new SafeString("It costs $300"), interpreter, "[^a-zA-Z]", "")
+        .toString()
+    )
       .isEqualTo("Itcosts");
   }
 
@@ -65,15 +66,14 @@ public class RegexReplaceFilterTest extends BaseInterpretingTest {
     for (int i = 0; i < 101; i++) {
       sb.append('a');
     }
-    assertThatThrownBy(
-        () ->
-          filter.filter(
-            sb.toString(),
-            new Jinjava(JinjavaConfig.newBuilder().withMaxStringLength(10).build())
+    assertThatThrownBy(() ->
+        filter.filter(
+          sb.toString(),
+          new Jinjava(JinjavaConfig.newBuilder().withMaxStringLength(10).build())
             .newInterpreter(),
-            "O",
-            "0"
-          )
+          "O",
+          "0"
+        )
       )
       .isInstanceOf(InvalidInputException.class)
       .hasMessageContaining(

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RejectAttrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RejectAttrFilterTest.java
@@ -29,56 +29,54 @@ public class RejectAttrFilterTest extends BaseJinjavaTest {
   @Test
   public void rejectAttrWithNoExp() {
     assertThat(
-        jinjava.render(
-          "{{ users|rejectattr('is_active') }}",
-          new HashMap<String, Object>()
-        )
-      )
+      jinjava.render("{{ users|rejectattr('is_active') }}", new HashMap<String, Object>())
+    )
       .isEqualTo("[0, 2]");
   }
 
   @Test
   public void rejectAttrWithExp() {
     assertThat(
-        jinjava.render(
-          "{{ users|rejectattr('email', 'none') }}",
-          new HashMap<String, Object>()
-        )
+      jinjava.render(
+        "{{ users|rejectattr('email', 'none') }}",
+        new HashMap<String, Object>()
       )
+    )
       .isEqualTo("[0, 1]");
   }
 
   @Test
   public void rejectAttrWithIsEqualToExp() {
     assertThat(
-        jinjava.render(
-          "{{ users|rejectattr('email', 'equalto', 'bar@bar.com') }}",
-          new HashMap<String, Object>()
-        )
+      jinjava.render(
+        "{{ users|rejectattr('email', 'equalto', 'bar@bar.com') }}",
+        new HashMap<String, Object>()
       )
+    )
       .isEqualTo("[0, 2]");
   }
 
   @Test
   public void rejectAttrWithNestedProperty() {
     assertThat(
-        jinjava.render(
-          "{{ users|rejectattr('option.id', 'equalto', 1) }}",
-          new HashMap<String, Object>()
-        )
+      jinjava.render(
+        "{{ users|rejectattr('option.id', 'equalto', 1) }}",
+        new HashMap<String, Object>()
       )
+    )
       .isEqualTo("[0, 2]");
 
     assertThat(
-        jinjava.render(
-          "{{ users|rejectattr('option.name', 'equalto', 'option0') }}",
-          new HashMap<String, Object>()
-        )
+      jinjava.render(
+        "{{ users|rejectattr('option.name', 'equalto', 'option0') }}",
+        new HashMap<String, Object>()
       )
+    )
       .isEqualTo("[1, 2]");
   }
 
   public static class User implements PyishSerializable {
+
     private int num;
     private boolean isActive;
     private String email;
@@ -121,6 +119,7 @@ public class RejectAttrFilterTest extends BaseJinjavaTest {
   }
 
   public static class Option {
+
     private long id;
     private String name;
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RenderFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RenderFilterTest.java
@@ -7,6 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class RenderFilterTest extends BaseInterpretingTest {
+
   private RenderFilter filter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/filter/ReplaceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/ReplaceFilterTest.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class ReplaceFilterTest extends BaseInterpretingTest {
+
   ReplaceFilter filter;
 
   @Before
@@ -44,10 +45,10 @@ public class ReplaceFilterTest extends BaseInterpretingTest {
   @Test
   public void replaceSafeStringWithCount() {
     assertThat(
-        filter
-          .filter(new SafeString("aaaaargh"), interpreter, "a", "d'oh, ", "2")
-          .toString()
-      )
+      filter
+        .filter(new SafeString("aaaaargh"), interpreter, "a", "d'oh, ", "2")
+        .toString()
+    )
       .isEqualTo("d'oh, d'oh, aaargh");
   }
 
@@ -63,15 +64,14 @@ public class ReplaceFilterTest extends BaseInterpretingTest {
     for (int i = 0; i < 101; i++) {
       sb.append('a');
     }
-    assertThatThrownBy(
-        () ->
-          filter.filter(
-            sb.toString(),
-            new Jinjava(JinjavaConfig.newBuilder().withMaxStringLength(10).build())
+    assertThatThrownBy(() ->
+        filter.filter(
+          sb.toString(),
+          new Jinjava(JinjavaConfig.newBuilder().withMaxStringLength(10).build())
             .newInterpreter(),
-            "O",
-            "0"
-          )
+          "O",
+          "0"
+        )
       )
       .isInstanceOf(InvalidInputException.class)
       .hasMessageContaining(

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RootFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RootFilterTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class RootFilterTest extends BaseInterpretingTest {
+
   RootFilter filter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SafeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SafeFilterTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class SafeFilterTest extends BaseInterpretingTest {
+
   private static final String HTML = "<a>Link</a>";
   private static final List<Integer> TEST_NUMBERS = ImmutableList.of(43, 1, 24);
   private static final List<String> TEST_STRINGS = ImmutableList.of(
@@ -88,8 +89,8 @@ public class SafeFilterTest extends BaseInterpretingTest {
       for (String testString : TEST_STRINGS) {
         interpreter.getContext().put("string_under_test", testString);
         assertThat(
-            interpreter.renderFlat("{{ string_under_test|safe|" + testFilter + "|safe }}")
-          )
+          interpreter.renderFlat("{{ string_under_test|safe|" + testFilter + "|safe }}")
+        )
           .as(
             "Testing behaviour of filter with and without safe filter: " +
             testFilter +
@@ -105,8 +106,8 @@ public class SafeFilterTest extends BaseInterpretingTest {
       for (Integer testInt : TEST_NUMBERS) {
         interpreter.getContext().put("string_under_test", testInt);
         assertThat(
-            interpreter.renderFlat("{{ string_under_test|safe|" + testFilter + " }}")
-          )
+          interpreter.renderFlat("{{ string_under_test|safe|" + testFilter + " }}")
+        )
           .as(
             "Testing behaviour of filter with and without safe filter: " +
             testFilter +

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SelectAttrFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SelectAttrFilterTest.java
@@ -42,122 +42,120 @@ public class SelectAttrFilterTest extends BaseJinjavaTest {
   @Test
   public void selectAttrWithNoExp() {
     assertThat(
-        jinjava.render(
-          "{{ users|selectattr('is_active') }}",
-          new HashMap<String, Object>()
-        )
-      )
+      jinjava.render("{{ users|selectattr('is_active') }}", new HashMap<String, Object>())
+    )
       .isEqualTo("[1]");
   }
 
   @Test
   public void selectAttrWithExp() {
     assertThat(
-        jinjava.render(
-          "{{ users|selectattr('email', 'none') }}",
-          new HashMap<String, Object>()
-        )
+      jinjava.render(
+        "{{ users|selectattr('email', 'none') }}",
+        new HashMap<String, Object>()
       )
+    )
       .isEqualTo("[2]");
   }
 
   @Test
   public void selectAttrWithSymbolicExp() {
     assertThat(
-        jinjava.render(
-          "{{ users|selectattr('isActive', '==', 'true') }}",
-          new HashMap<String, Object>()
-        )
+      jinjava.render(
+        "{{ users|selectattr('isActive', '==', 'true') }}",
+        new HashMap<String, Object>()
       )
+    )
       .isEqualTo("[1]");
   }
 
   @Test
   public void selectAttrWithIsEqualToExp() {
     assertThat(
-        jinjava.render(
-          "{{ users|selectattr('email', 'equalto', 'bar@bar.com') }}",
-          new HashMap<String, Object>()
-        )
+      jinjava.render(
+        "{{ users|selectattr('email', 'equalto', 'bar@bar.com') }}",
+        new HashMap<String, Object>()
       )
+    )
       .isEqualTo("[1]");
   }
 
   @Test
   public void selectAttrWithNumericIsEqualToExp() {
     assertThat(
-        jinjava.render(
-          "{{ users|selectattr('num', 'equalto', 1) }}",
-          new HashMap<String, Object>()
-        )
+      jinjava.render(
+        "{{ users|selectattr('num', 'equalto', 1) }}",
+        new HashMap<String, Object>()
       )
+    )
       .isEqualTo("[1]");
   }
 
   @Test
   public void selectAttrWithNestedProperty() {
     assertThat(
-        jinjava.render(
-          "{{ users|selectattr('option.id', 'equalto', 1) }}",
-          new HashMap<String, Object>()
-        )
+      jinjava.render(
+        "{{ users|selectattr('option.id', 'equalto', 1) }}",
+        new HashMap<String, Object>()
       )
+    )
       .isEqualTo("[1]");
 
     assertThat(
-        jinjava.render(
-          "{{ users|selectattr('option.name', 'equalto', 'option2') }}",
-          new HashMap<String, Object>()
-        )
+      jinjava.render(
+        "{{ users|selectattr('option.name', 'equalto', 'option2') }}",
+        new HashMap<String, Object>()
       )
+    )
       .isEqualTo("[2]");
   }
 
   @Test
   public void selectAttrWithSymbolicLtExp() {
     assertThat(
-        jinjava.render(
-          "{{ numbers|selectattr('number', '<', '3')|map('number') }}",
-          new HashMap<String, Object>()
-        )
+      jinjava.render(
+        "{{ numbers|selectattr('number', '<', '3')|map('number') }}",
+        new HashMap<String, Object>()
       )
+    )
       .isEqualTo("[1, 2]");
   }
 
   @Test
   public void selectAttrWithSymbolicLeExp() {
     assertThat(
-        jinjava.render(
-          "{{ numbers|selectattr('number', '<=', '3')|map('number') }}",
-          new HashMap<String, Object>()
-        )
+      jinjava.render(
+        "{{ numbers|selectattr('number', '<=', '3')|map('number') }}",
+        new HashMap<String, Object>()
       )
+    )
       .isEqualTo("[1, 2, 3]");
   }
 
   @Test
   public void selectAttrWithSymbolicGtExp() {
     assertThat(
-        jinjava.render(
-          "{{ numbers|selectattr('number', '>', '3')|map('number') }}",
-          new HashMap<String, Object>()
-        )
+      jinjava.render(
+        "{{ numbers|selectattr('number', '>', '3')|map('number') }}",
+        new HashMap<String, Object>()
       )
+    )
       .isEqualTo("[4]");
   }
 
   @Test
   public void selectAttrWithSymbolicGeExp() {
     assertThat(
-        jinjava.render(
-          "{{ numbers|selectattr('number', '>=', '3')|map('number') }}",
-          new HashMap<String, Object>()
-        )
+      jinjava.render(
+        "{{ numbers|selectattr('number', '>=', '3')|map('number') }}",
+        new HashMap<String, Object>()
       )
+    )
       .isEqualTo("[3, 4]");
   }
 
   public static class User implements PyishSerializable {
+
     private long num;
     private boolean isActive;
     private String email;
@@ -200,6 +198,7 @@ public class SelectAttrFilterTest extends BaseJinjavaTest {
   }
 
   public static class Option implements PyishSerializable {
+
     private long id;
     private String name;
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/ShuffleFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/ShuffleFilterTest.java
@@ -14,6 +14,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import org.junit.Test;
 
 public class ShuffleFilterTest {
+
   ShuffleFilter filter = new ShuffleFilter();
 
   JinjavaInterpreter interpreter = mock(JinjavaInterpreter.class);

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SortFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SortFilterTest.java
@@ -33,13 +33,13 @@ public class SortFilterTest extends BaseJinjavaTest {
   public void sortWithNamedAttributes() throws Exception {
     // even if named attributes were never supported for this filter, ensure parameters are passed in order and it works
     assertThat(
-        render(
-          "(reverse=false, case_sensitive=false, attribute='foo.date')",
-          new MyBar(new MyFoo(new Date(250L))),
-          new MyBar(new MyFoo(new Date(0L))),
-          new MyBar(new MyFoo(new Date(100000000L)))
-        )
+      render(
+        "(reverse=false, case_sensitive=false, attribute='foo.date')",
+        new MyBar(new MyFoo(new Date(250L))),
+        new MyBar(new MyFoo(new Date(0L))),
+        new MyBar(new MyFoo(new Date(100000000L)))
       )
+    )
       .isEqualTo("0250100000000");
   }
 
@@ -51,26 +51,26 @@ public class SortFilterTest extends BaseJinjavaTest {
   @Test
   public void sortWithAttr() {
     assertThat(
-        render(
-          "(false, false, 'date')",
-          new MyFoo(new Date(250L)),
-          new MyFoo(new Date(0L)),
-          new MyFoo(new Date(100000000L))
-        )
+      render(
+        "(false, false, 'date')",
+        new MyFoo(new Date(250L)),
+        new MyFoo(new Date(0L)),
+        new MyFoo(new Date(100000000L))
       )
+    )
       .isEqualTo("0250100000000");
   }
 
   @Test
   public void sortWithNestedAttr() {
     assertThat(
-        render(
-          "(false, false, 'foo.date')",
-          new MyBar(new MyFoo(new Date(250L))),
-          new MyBar(new MyFoo(new Date(0L))),
-          new MyBar(new MyFoo(new Date(100000000L)))
-        )
+      render(
+        "(false, false, 'foo.date')",
+        new MyBar(new MyFoo(new Date(250L))),
+        new MyBar(new MyFoo(new Date(0L))),
+        new MyBar(new MyFoo(new Date(100000000L)))
       )
+    )
       .isEqualTo("0250100000000");
   }
 
@@ -138,6 +138,7 @@ public class SortFilterTest extends BaseJinjavaTest {
   }
 
   public static class MyFoo implements PyishSerializable {
+
     private Date date;
 
     MyFoo(Date date) {
@@ -162,6 +163,7 @@ public class SortFilterTest extends BaseJinjavaTest {
   }
 
   public static class MyBar implements PyishSerializable {
+
     private MyFoo foo;
 
     MyBar(MyFoo foo) {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SplitFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SplitFilterTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 
 @SuppressWarnings("unchecked")
 public class SplitFilterTest extends BaseInterpretingTest {
+
   SplitFilter filter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/filter/StringToTimeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/StringToTimeFilterTest.java
@@ -34,8 +34,8 @@ public class StringToTimeFilterTest extends BaseJinjavaTest {
     Map<String, Object> vars = ImmutableMap.of("datetime", datetime, "format", format);
 
     assertThat(
-        jinjava.renderForResult("{{ datetime|strtotime(format) }}", vars).getErrors()
-      )
+      jinjava.renderForResult("{{ datetime|strtotime(format) }}", vars).getErrors()
+    )
       .hasSize(1);
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/StripTagsFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/StripTagsFilterTest.java
@@ -23,6 +23,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StripTagsFilterTest {
+
   private JinjavaInterpreter interpreter;
 
   @InjectMocks
@@ -105,8 +106,8 @@ public class StripTagsFilterTest {
   @Test
   public void itExecutesJinjavaInsideTag() {
     assertThat(
-        filter.filter("{% for i in [1, 2, 3] %}<div>{{i}}</div>{% endfor %}", interpreter)
-      )
+      filter.filter("{% for i in [1, 2, 3] %}<div>{{i}}</div>{% endfor %}", interpreter)
+    )
       .isEqualTo("1 2 3");
   }
 
@@ -123,19 +124,18 @@ public class StripTagsFilterTest {
     Context mockedContext = mock(Context.class);
     when(mockedInterpreter.getContext()).thenReturn(mockedContext);
     when(mockedContext.getDeferredTokens())
-      .thenAnswer(
-        i ->
-          counter.getAndIncrement() == 0
-            ? Collections.emptySet()
-            : Collections.singleton(
-              DeferredToken
-                .builderFromImage(
-                  "{{ deferred && other }}",
-                  ExpressionToken.class,
-                  interpreter
-                )
-                .build()
-            )
+      .thenAnswer(i ->
+        counter.getAndIncrement() == 0
+          ? Collections.emptySet()
+          : Collections.singleton(
+            DeferredToken
+              .builderFromImage(
+                "{{ deferred && other }}",
+                ExpressionToken.class,
+                interpreter
+              )
+              .build()
+          )
       );
     assertThatThrownBy(() -> filter.filter("{{ deferred && other }}", mockedInterpreter))
       .isInstanceOf(DeferredValueException.class);

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SumFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SumFilterTest.java
@@ -38,6 +38,7 @@ public class SumFilterTest extends BaseJinjavaTest {
   }
 
   public static class Item {
+
     private Number price;
 
     public Item(Number price) {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SymmetricDifferenceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SymmetricDifferenceFilterTest.java
@@ -17,26 +17,26 @@ public class SymmetricDifferenceFilterTest extends BaseJinjavaTest {
   @Test
   public void itComputesSetDifferences() {
     assertThat(
-        jinjava.render(
-          "{{ [1, 2, 3, 3, 4]|symmetric_difference([1, 2, 5, 6]) }}",
-          new HashMap<>()
-        )
+      jinjava.render(
+        "{{ [1, 2, 3, 3, 4]|symmetric_difference([1, 2, 5, 6]) }}",
+        new HashMap<>()
       )
+    )
       .isEqualTo("[3, 4, 5, 6]");
     assertThat(
-        jinjava.render(
-          "{{ ['do', 'ray']|symmetric_difference(['ray', 'me']) }}",
-          new HashMap<>()
-        )
+      jinjava.render(
+        "{{ ['do', 'ray']|symmetric_difference(['ray', 'me']) }}",
+        new HashMap<>()
       )
+    )
       .isEqualTo("['do', 'me']");
   }
 
   @Test
   public void itReturnsEmptyOnNullParameters() {
     assertThat(
-        jinjava.render("{{ [1, 2, 3]|symmetric_difference(null) }}", new HashMap<>())
-      )
+      jinjava.render("{{ [1, 2, 3]|symmetric_difference(null) }}", new HashMap<>())
+    )
       .isEqualTo("[1, 2, 3]");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/ToJsonFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/ToJsonFilterTest.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class ToJsonFilterTest extends BaseInterpretingTest {
+
   private ToJsonFilter filter;
 
   @Before
@@ -44,7 +45,7 @@ public class ToJsonFilterTest extends BaseInterpretingTest {
     }
     interpreter =
       new Jinjava(JinjavaConfig.newBuilder().withMaxOutputSize(500).build())
-      .newInterpreter();
+        .newInterpreter();
     assertThat(filter.filter(original, interpreter)).asString().contains("[[]]]]");
     for (int i = 0; i < 400; i++) {
       List<List<?>> nested = new ArrayList<>();

--- a/src/test/java/com/hubspot/jinjava/lib/filter/ToYamlFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/ToYamlFilterTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class ToYamlFilterTest extends BaseInterpretingTest {
+
   private ToYamlFilter filter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/filter/TrimFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/TrimFilterTest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TrimFilterTest extends BaseInterpretingTest {
+
   TrimFilter filter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/filter/TruncateFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/TruncateFilterTest.java
@@ -12,6 +12,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TruncateFilterTest {
+
   @Mock
   JinjavaInterpreter interpreter;
 
@@ -27,10 +28,10 @@ public class TruncateFilterTest {
   @Test
   public void itTruncatesText() throws Exception {
     assertThat(
-        filter
-          .filter(StringUtils.rightPad("", 256, 'x') + "y", interpreter, "255", "True")
-          .toString()
-      )
+      filter
+        .filter(StringUtils.rightPad("", 256, 'x') + "y", interpreter, "255", "True")
+        .toString()
+    )
       .hasSize(258)
       .endsWith("x...");
   }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/TruncateHtmlFilterTest.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TruncateHtmlFilterTest extends BaseInterpretingTest {
+
   TruncateHtmlFilter filter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/filter/UnescapeHtmlFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/UnescapeHtmlFilterTest.java
@@ -7,6 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class UnescapeHtmlFilterTest extends BaseInterpretingTest {
+
   UnescapeHtmlFilter f;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/filter/UnionFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/UnionFilterTest.java
@@ -19,8 +19,8 @@ public class UnionFilterTest extends BaseJinjavaTest {
     assertThat(jinjava.render("{{ [1, 2, 3, 3]|union([1, 2, 5, 6]) }}", new HashMap<>()))
       .isEqualTo("[1, 2, 3, 5, 6]");
     assertThat(
-        jinjava.render("{{ ['do', 'ray']|union(['ray', 'me']) }}", new HashMap<>())
-      )
+      jinjava.render("{{ ['do', 'ray']|union(['ray', 'me']) }}", new HashMap<>())
+    )
       .isEqualTo("['do', 'ray', 'me']");
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/filter/UniqueFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/UniqueFilterTest.java
@@ -25,14 +25,14 @@ public class UniqueFilterTest extends BaseJinjavaTest {
   @Test
   public void itFiltersDuplicatesFromSeqByAttr() {
     assertThat(
-        render(
-          "name",
-          new MyClass("a"),
-          new MyClass("b"),
-          new MyClass("a"),
-          new MyClass("c")
-        )
+      render(
+        "name",
+        new MyClass("a"),
+        new MyClass("b"),
+        new MyClass("a"),
+        new MyClass("c")
       )
+    )
       .isEqualTo("[Name:a][Name:b][Name:c]");
   }
 
@@ -56,6 +56,7 @@ public class UniqueFilterTest extends BaseJinjavaTest {
   }
 
   public static class MyClass implements PyishSerializable {
+
     private final String name;
 
     public MyClass(String name) {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilterTest.java
@@ -16,6 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class UnixTimestampFilterTest extends BaseInterpretingTest {
+
   private final ZonedDateTime d = ZonedDateTime.parse(
     "2013-11-06T14:22:00.000+00:00[UTC]"
   );

--- a/src/test/java/com/hubspot/jinjava/lib/filter/UpperFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/UpperFilterTest.java
@@ -7,6 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class UpperFilterTest extends BaseInterpretingTest {
+
   private UpperFilter filter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/filter/UrlDecodeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/UrlDecodeFilterTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class UrlDecodeFilterTest extends BaseInterpretingTest {
+
   private UrlDecodeFilter filter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/filter/UrlEncodeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/UrlEncodeFilterTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class UrlEncodeFilterTest extends BaseInterpretingTest {
+
   UrlEncodeFilter filter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/filter/WordCountFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/WordCountFilterTest.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class WordCountFilterTest {
+
   WordCountFilter filter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/filter/time/FormatDateFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/time/FormatDateFilterTest.java
@@ -17,6 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class FormatDateFilterTest {
+
   private static final ZonedDateTime DATE_TIME = ZonedDateTime.of(
     2022,
     11,
@@ -39,8 +40,8 @@ public class FormatDateFilterTest {
   @Test
   public void itFormatsNumbers() {
     assertThat(
-        jinjava.render("{{ d | format_date }}", ImmutableMap.of("d", 1668120547000L))
-      )
+      jinjava.render("{{ d | format_date }}", ImmutableMap.of("d", 1668120547000L))
+    )
       .isEqualTo("Nov 10, 2022");
   }
 
@@ -73,43 +74,43 @@ public class FormatDateFilterTest {
   @Test
   public void itUsesShortFormat() {
     assertThat(
-        jinjava.render("{{ d | format_date('short') }}", ImmutableMap.of("d", DATE_TIME))
-      )
+      jinjava.render("{{ d | format_date('short') }}", ImmutableMap.of("d", DATE_TIME))
+    )
       .isEqualTo("11/10/22");
   }
 
   @Test
   public void itUsesMediumFormat() {
     assertThat(
-        jinjava.render("{{ d | format_date('medium') }}", ImmutableMap.of("d", DATE_TIME))
-      )
+      jinjava.render("{{ d | format_date('medium') }}", ImmutableMap.of("d", DATE_TIME))
+    )
       .isEqualTo("Nov 10, 2022");
   }
 
   @Test
   public void itUsesLongFormat() {
     assertThat(
-        jinjava.render("{{ d | format_date('long') }}", ImmutableMap.of("d", DATE_TIME))
-      )
+      jinjava.render("{{ d | format_date('long') }}", ImmutableMap.of("d", DATE_TIME))
+    )
       .isEqualTo("November 10, 2022");
   }
 
   @Test
   public void itUsesFullFormat() {
     assertThat(
-        jinjava.render("{{ d | format_date('full') }}", ImmutableMap.of("d", DATE_TIME))
-      )
+      jinjava.render("{{ d | format_date('full') }}", ImmutableMap.of("d", DATE_TIME))
+    )
       .isEqualTo("Thursday, November 10, 2022");
   }
 
   @Test
   public void itUsesCustomFormats() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_date('yyyyy.MMMM.dd') }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
+      jinjava.render(
+        "{{ d | format_date('yyyyy.MMMM.dd') }}",
+        ImmutableMap.of("d", DATE_TIME)
       )
+    )
       .isEqualTo("02022.November.10");
   }
 
@@ -129,11 +130,11 @@ public class FormatDateFilterTest {
   @Test
   public void itUsesGivenTimeZone() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_date('long', 'Asia/Jakarta') }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
+      jinjava.render(
+        "{{ d | format_date('long', 'Asia/Jakarta') }}",
+        ImmutableMap.of("d", DATE_TIME)
       )
+    )
       .isEqualTo("November 11, 2022");
   }
 
@@ -163,11 +164,11 @@ public class FormatDateFilterTest {
   @Test
   public void itUsesGivenLocale() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_date('medium', 'America/New_York', 'de-DE') }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
+      jinjava.render(
+        "{{ d | format_date('medium', 'America/New_York', 'de-DE') }}",
+        ImmutableMap.of("d", DATE_TIME)
       )
+    )
       .isEqualTo("10.11.2022");
   }
 
@@ -197,33 +198,33 @@ public class FormatDateFilterTest {
   @Test
   public void itUsesMediumIfNullFormatPassed() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_date(null, 'America/New_York', 'de-DE') }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
+      jinjava.render(
+        "{{ d | format_date(null, 'America/New_York', 'de-DE') }}",
+        ImmutableMap.of("d", DATE_TIME)
       )
+    )
       .isEqualTo("10.11.2022");
   }
 
   @Test
   public void itUsesUtcIfNullZonePassed() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_date('short', null, 'de-DE') }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
+      jinjava.render(
+        "{{ d | format_date('short', null, 'de-DE') }}",
+        ImmutableMap.of("d", DATE_TIME)
       )
+    )
       .isEqualTo("10.11.22");
   }
 
   @Test
   public void itUsesJinjavaConfigIfNullLocalePassed() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_date('short', 'America/New_York', null) }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
+      jinjava.render(
+        "{{ d | format_date('short', 'America/New_York', null) }}",
+        ImmutableMap.of("d", DATE_TIME)
       )
+    )
       .isEqualTo("11/10/22");
   }
 
@@ -255,11 +256,11 @@ public class FormatDateFilterTest {
       );
 
     assertThat(
-        jinjava.render(
-          "{{ d | format_date('short', 'America/New_York', null) }}",
-          ImmutableMap.of()
-        )
+      jinjava.render(
+        "{{ d | format_date('short', 'America/New_York', null) }}",
+        ImmutableMap.of()
       )
+    )
       .isEqualTo("1/30/09");
   }
 
@@ -283,11 +284,11 @@ public class FormatDateFilterTest {
       );
 
     assertThat(
-        jinjava.render(
-          "{{ d | format_date('short', 'America/New_York', null) }}",
-          ImmutableMap.of()
-        )
+      jinjava.render(
+        "{{ d | format_date('short', 'America/New_York', null) }}",
+        ImmutableMap.of()
       )
+    )
       .isEqualTo("11/10/22");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/time/FormatDatetimeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/time/FormatDatetimeFilterTest.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class FormatDatetimeFilterTest {
+
   private static final ZonedDateTime DATE_TIME = ZonedDateTime.of(
     2022,
     11,
@@ -34,8 +35,8 @@ public class FormatDatetimeFilterTest {
   @Test
   public void itFormatsNumbers() {
     assertThat(
-        jinjava.render("{{ d | format_datetime }}", ImmutableMap.of("d", 1668120547000L))
-      )
+      jinjava.render("{{ d | format_datetime }}", ImmutableMap.of("d", 1668120547000L))
+    )
       .isEqualTo("Nov 10, 2022, 10:49:07 PM");
   }
 
@@ -44,16 +45,16 @@ public class FormatDatetimeFilterTest {
     PyishDate pyishDate = new PyishDate(1668120547000L);
 
     assertThat(
-        jinjava.render("{{ d | format_datetime }}", ImmutableMap.of("d", pyishDate))
-      )
+      jinjava.render("{{ d | format_datetime }}", ImmutableMap.of("d", pyishDate))
+    )
       .isEqualTo("Nov 10, 2022, 10:49:07 PM");
   }
 
   @Test
   public void itFormatsZonedDateTime() {
     assertThat(
-        jinjava.render("{{ d | format_datetime }}", ImmutableMap.of("d", DATE_TIME))
-      )
+      jinjava.render("{{ d | format_datetime }}", ImmutableMap.of("d", DATE_TIME))
+    )
       .isEqualTo("Nov 10, 2022, 10:49:07 PM");
   }
 
@@ -72,55 +73,49 @@ public class FormatDatetimeFilterTest {
   @Test
   public void itUsesShortFormat() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_datetime('short') }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
+      jinjava.render(
+        "{{ d | format_datetime('short') }}",
+        ImmutableMap.of("d", DATE_TIME)
       )
+    )
       .isEqualTo("11/10/22, 10:49 PM");
   }
 
   @Test
   public void itUsesMediumFormat() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_datetime('medium') }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
+      jinjava.render(
+        "{{ d | format_datetime('medium') }}",
+        ImmutableMap.of("d", DATE_TIME)
       )
+    )
       .isEqualTo("Nov 10, 2022, 10:49:07 PM");
   }
 
   @Test
   public void itUsesLongFormat() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_datetime('long') }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
-      )
+      jinjava.render("{{ d | format_datetime('long') }}", ImmutableMap.of("d", DATE_TIME))
+    )
       .isEqualTo("November 10, 2022 at 10:49:07 PM Z");
   }
 
   @Test
   public void itUsesFullFormat() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_datetime('full') }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
-      )
+      jinjava.render("{{ d | format_datetime('full') }}", ImmutableMap.of("d", DATE_TIME))
+    )
       .isEqualTo("Thursday, November 10, 2022 at 10:49:07 PM Z");
   }
 
   @Test
   public void itUsesCustomFormats() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_datetime('yyyyy.MMMM.dd GGG hh:mm a') }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
+      jinjava.render(
+        "{{ d | format_datetime('yyyyy.MMMM.dd GGG hh:mm a') }}",
+        ImmutableMap.of("d", DATE_TIME)
       )
+    )
       .isEqualTo("02022.November.10 AD 10:49 PM");
   }
 
@@ -140,11 +135,11 @@ public class FormatDatetimeFilterTest {
   @Test
   public void itUsesGivenTimeZone() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_datetime('long', 'America/New_York') }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
+      jinjava.render(
+        "{{ d | format_datetime('long', 'America/New_York') }}",
+        ImmutableMap.of("d", DATE_TIME)
       )
+    )
       .isEqualTo("November 10, 2022 at 5:49:07 PM EST");
   }
 
@@ -174,11 +169,11 @@ public class FormatDatetimeFilterTest {
   @Test
   public void itUsesGivenLocale() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_datetime('medium', 'America/New_York', 'de-DE') }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
+      jinjava.render(
+        "{{ d | format_datetime('medium', 'America/New_York', 'de-DE') }}",
+        ImmutableMap.of("d", DATE_TIME)
       )
+    )
       .isEqualTo("10.11.2022, 17:49:07");
   }
 
@@ -208,33 +203,33 @@ public class FormatDatetimeFilterTest {
   @Test
   public void itUsesMediumIfNullFormatPassed() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_datetime(null, 'America/New_York', 'de-DE') }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
+      jinjava.render(
+        "{{ d | format_datetime(null, 'America/New_York', 'de-DE') }}",
+        ImmutableMap.of("d", DATE_TIME)
       )
+    )
       .isEqualTo("10.11.2022, 17:49:07");
   }
 
   @Test
   public void itUsesUtcIfNullZonePassed() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_datetime('short', null, 'de-DE') }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
+      jinjava.render(
+        "{{ d | format_datetime('short', null, 'de-DE') }}",
+        ImmutableMap.of("d", DATE_TIME)
       )
+    )
       .isEqualTo("10.11.22, 22:49");
   }
 
   @Test
   public void itUsesJinjavaConfigIfNullLocalePassed() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_datetime('short', 'America/New_York', null) }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
+      jinjava.render(
+        "{{ d | format_datetime('short', 'America/New_York', null) }}",
+        ImmutableMap.of("d", DATE_TIME)
       )
+    )
       .isEqualTo("11/10/22, 5:49 PM");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/time/FormatTimeFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/time/FormatTimeFilterTest.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class FormatTimeFilterTest {
+
   private static final ZonedDateTime DATE_TIME = ZonedDateTime.of(
     2022,
     11,
@@ -34,8 +35,8 @@ public class FormatTimeFilterTest {
   @Test
   public void itFormatsNumbers() {
     assertThat(
-        jinjava.render("{{ d | format_time }}", ImmutableMap.of("d", 1668120547000L))
-      )
+      jinjava.render("{{ d | format_time }}", ImmutableMap.of("d", 1668120547000L))
+    )
       .isEqualTo("10:49:07 PM");
   }
 
@@ -68,43 +69,40 @@ public class FormatTimeFilterTest {
   @Test
   public void itUsesShortFormat() {
     assertThat(
-        jinjava.render("{{ d | format_time('short') }}", ImmutableMap.of("d", DATE_TIME))
-      )
+      jinjava.render("{{ d | format_time('short') }}", ImmutableMap.of("d", DATE_TIME))
+    )
       .isEqualTo("10:49 PM");
   }
 
   @Test
   public void itUsesMediumFormat() {
     assertThat(
-        jinjava.render("{{ d | format_time('medium') }}", ImmutableMap.of("d", DATE_TIME))
-      )
+      jinjava.render("{{ d | format_time('medium') }}", ImmutableMap.of("d", DATE_TIME))
+    )
       .isEqualTo("10:49:07 PM");
   }
 
   @Test
   public void itUsesLongFormat() {
     assertThat(
-        jinjava.render("{{ d | format_time('long') }}", ImmutableMap.of("d", DATE_TIME))
-      )
+      jinjava.render("{{ d | format_time('long') }}", ImmutableMap.of("d", DATE_TIME))
+    )
       .isEqualTo("10:49:07 PM Z");
   }
 
   @Test
   public void itUsesFullFormat() {
     assertThat(
-        jinjava.render("{{ d | format_time('full') }}", ImmutableMap.of("d", DATE_TIME))
-      )
+      jinjava.render("{{ d | format_time('full') }}", ImmutableMap.of("d", DATE_TIME))
+    )
       .isEqualTo("10:49:07 PM Z");
   }
 
   @Test
   public void itUsesCustomFormats() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_time('hh:mm a') }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
-      )
+      jinjava.render("{{ d | format_time('hh:mm a') }}", ImmutableMap.of("d", DATE_TIME))
+    )
       .isEqualTo("10:49 PM");
   }
 
@@ -124,11 +122,11 @@ public class FormatTimeFilterTest {
   @Test
   public void itUsesGivenTimeZone() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_time('long', 'America/New_York') }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
+      jinjava.render(
+        "{{ d | format_time('long', 'America/New_York') }}",
+        ImmutableMap.of("d", DATE_TIME)
       )
+    )
       .isEqualTo("5:49:07 PM EST");
   }
 
@@ -158,11 +156,11 @@ public class FormatTimeFilterTest {
   @Test
   public void itUsesGivenLocale() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_time('medium', 'America/New_York', 'de-DE') }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
+      jinjava.render(
+        "{{ d | format_time('medium', 'America/New_York', 'de-DE') }}",
+        ImmutableMap.of("d", DATE_TIME)
       )
+    )
       .isEqualTo("17:49:07");
   }
 
@@ -192,33 +190,33 @@ public class FormatTimeFilterTest {
   @Test
   public void itUsesMediumIfNullFormatPassed() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_time(null, 'America/New_York', 'de-DE') }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
+      jinjava.render(
+        "{{ d | format_time(null, 'America/New_York', 'de-DE') }}",
+        ImmutableMap.of("d", DATE_TIME)
       )
+    )
       .isEqualTo("17:49:07");
   }
 
   @Test
   public void itUsesUtcIfNullZonePassed() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_time('short', null, 'de-DE') }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
+      jinjava.render(
+        "{{ d | format_time('short', null, 'de-DE') }}",
+        ImmutableMap.of("d", DATE_TIME)
       )
+    )
       .isEqualTo("22:49");
   }
 
   @Test
   public void itUsesJinjavaConfigIfNullLocalePassed() {
     assertThat(
-        jinjava.render(
-          "{{ d | format_time('short', 'America/New_York', null) }}",
-          ImmutableMap.of("d", DATE_TIME)
-        )
+      jinjava.render(
+        "{{ d | format_time('short', 'America/New_York', null) }}",
+        ImmutableMap.of("d", DATE_TIME)
       )
+    )
       .isEqualTo("5:49 PM");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/fn/DateFormatFunctionsTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/DateFormatFunctionsTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class DateFormatFunctionsTest {
+
   Jinjava jinjava;
 
   @Before
@@ -20,42 +21,33 @@ public class DateFormatFunctionsTest {
   @Test
   public void itFormatsDates() {
     assertThat(
-        jinjava.render(
-          "{{ format_date(d, 'medium') }}",
-          ImmutableMap.of(
-            "d",
-            ZonedDateTime.of(2022, 11, 28, 16, 30, 4, 0, ZoneOffset.UTC)
-          )
-        )
+      jinjava.render(
+        "{{ format_date(d, 'medium') }}",
+        ImmutableMap.of("d", ZonedDateTime.of(2022, 11, 28, 16, 30, 4, 0, ZoneOffset.UTC))
       )
+    )
       .isEqualTo("Nov 28, 2022");
   }
 
   @Test
   public void itFormatsTimes() {
     assertThat(
-        jinjava.render(
-          "{{ format_time(d, 'medium') }}",
-          ImmutableMap.of(
-            "d",
-            ZonedDateTime.of(2022, 11, 28, 16, 30, 4, 0, ZoneOffset.UTC)
-          )
-        )
+      jinjava.render(
+        "{{ format_time(d, 'medium') }}",
+        ImmutableMap.of("d", ZonedDateTime.of(2022, 11, 28, 16, 30, 4, 0, ZoneOffset.UTC))
       )
+    )
       .isEqualTo("4:30:04 PM");
   }
 
   @Test
   public void itFormatsDateTimes() {
     assertThat(
-        jinjava.render(
-          "{{ format_datetime(d, 'medium') }}",
-          ImmutableMap.of(
-            "d",
-            ZonedDateTime.of(2022, 11, 28, 16, 30, 4, 0, ZoneOffset.UTC)
-          )
-        )
+      jinjava.render(
+        "{{ format_datetime(d, 'medium') }}",
+        ImmutableMap.of("d", ZonedDateTime.of(2022, 11, 28, 16, 30, 4, 0, ZoneOffset.UTC))
       )
+    )
       .isEqualTo("Nov 28, 2022, 4:30:04 PM");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/fn/InjectedContextFunctionProxyTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/InjectedContextFunctionProxyTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 public class InjectedContextFunctionProxyTest {
 
   public static class MyClass {
+
     private String state;
 
     public MyClass(String state) {
@@ -20,6 +21,7 @@ public class InjectedContextFunctionProxyTest {
   }
 
   public static class OtherClass {
+
     private String state;
 
     public OtherClass(String state) {

--- a/src/test/java/com/hubspot/jinjava/lib/fn/RangeFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/RangeFunctionTest.java
@@ -15,6 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class RangeFunctionTest {
+
   private JinjavaConfig config;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/fn/StringToTimeFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/StringToTimeFunctionTest.java
@@ -17,16 +17,16 @@ public class StringToTimeFunctionTest {
       ZonedDateTime.of(2018, 7, 14, 14, 31, 30, 0, ZoneOffset.ofHoursMinutes(5, 30))
     );
     assertThat(
-        Functions.stringToTime("2018-07-14T14:31:30+0530", "yyyy-MM-dd'T'HH:mm:ssZ")
-      )
+      Functions.stringToTime("2018-07-14T14:31:30+0530", "yyyy-MM-dd'T'HH:mm:ssZ")
+    )
       .isEqualTo(expected);
   }
 
   @Test
   public void itFailsOnInvalidFormat() {
     assertThatExceptionOfType(InterpretException.class)
-      .isThrownBy(
-        () -> Functions.stringToTime("2018-07-14T14:31:30+0530", "not a time format")
+      .isThrownBy(() ->
+        Functions.stringToTime("2018-07-14T14:31:30+0530", "not a time format")
       )
       .withMessageContaining("requires valid datetime format");
   }
@@ -34,12 +34,11 @@ public class StringToTimeFunctionTest {
   @Test
   public void itFailsOnTimeFormatMismatch() {
     assertThatExceptionOfType(InterpretException.class)
-      .isThrownBy(
-        () ->
-          Functions.stringToTime(
-            "Saturday, Jul 14, 2018 14:31:06 PM",
-            "yyyy-MM-dd'T'HH:mm:ssZ"
-          )
+      .isThrownBy(() ->
+        Functions.stringToTime(
+          "Saturday, Jul 14, 2018 14:31:06 PM",
+          "yyyy-MM-dd'T'HH:mm:ssZ"
+        )
       )
       .withMessageContaining("could not match datetime input");
   }

--- a/src/test/java/com/hubspot/jinjava/lib/fn/TodayFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/TodayFunctionTest.java
@@ -17,6 +17,7 @@ import java.time.ZonedDateTime;
 import org.junit.Test;
 
 public class TodayFunctionTest extends BaseInterpretingTest {
+
   private static final String ZONE_NAME = "America/New_York";
   private static final ZoneId ZONE_ID = ZoneId.of(ZONE_NAME);
 

--- a/src/test/java/com/hubspot/jinjava/lib/fn/TypeFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/TypeFunctionTest.java
@@ -33,8 +33,8 @@ public class TypeFunctionTest {
   @Test
   public void testDate() {
     assertThat(
-        TypeFunction.type(ZonedDateTime.parse("2013-11-06T14:22:00.000+00:00[UTC]"))
-      )
+      TypeFunction.type(ZonedDateTime.parse("2013-11-06T14:22:00.000+00:00[UTC]"))
+    )
       .isEqualTo("datetime");
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
@@ -15,6 +15,7 @@ import org.junit.After;
 import org.junit.Test;
 
 public class UnixTimestampFunctionTest {
+
   private final ZonedDateTime d = ZonedDateTime.parse(
     "2013-11-06T14:22:12.345+00:00[UTC]"
   );

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ExtendsTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ExtendsTagTest.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class ExtendsTagTest extends BaseInterpretingTest {
+
   private ExtendsTagTestResourceLocator locator;
 
   @Before
@@ -258,6 +259,7 @@ public class ExtendsTagTest extends BaseInterpretingTest {
   }
 
   private static class ExtendsTagTestResourceLocator implements ResourceLocator {
+
     private RelativePathResolver relativePathResolver = new RelativePathResolver();
 
     @Override
@@ -265,8 +267,7 @@ public class ExtendsTagTest extends BaseInterpretingTest {
       String fullName,
       Charset encoding,
       JinjavaInterpreter interpreter
-    )
-      throws IOException {
+    ) throws IOException {
       return fixture(fullName);
     }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
@@ -33,6 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class ForTagTest extends BaseInterpretingTest {
+
   public Tag tag;
 
   @Before
@@ -77,12 +78,12 @@ public class ForTagTest extends BaseInterpretingTest {
   public void forLoopNestedFor() {
     TagNode tagNode = (TagNode) fixture("nested-fors");
     assertThat(
-        Splitter
-          .on("\n")
-          .trimResults()
-          .omitEmptyStrings()
-          .split(tag.interpret(tagNode, interpreter))
-      )
+      Splitter
+        .on("\n")
+        .trimResults()
+        .omitEmptyStrings()
+        .split(tag.interpret(tagNode, interpreter))
+    )
       .contains("02", "03", "12", "13");
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/FromTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/FromTagTest.java
@@ -33,8 +33,7 @@ public class FromTagTest extends BaseInterpretingTest {
           String fullName,
           Charset encoding,
           JinjavaInterpreter interpreter
-        )
-          throws IOException {
+        ) throws IOException {
           return Resources.toString(
             Resources.getResource(String.format("tags/macrotag/%s", fullName)),
             StandardCharsets.UTF_8

--- a/src/test/java/com/hubspot/jinjava/lib/tag/IfTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/IfTagTest.java
@@ -15,6 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class IfTagTest extends BaseInterpretingTest {
+
   public Tag tag;
 
   @Before
@@ -132,6 +133,7 @@ public class IfTagTest extends BaseInterpretingTest {
   }
 
   private class TestObject implements HasObjectTruthValue {
+
     private boolean objectTruthValue = false;
 
     public TestObject setObjectTruthValue(boolean objectTruthValue) {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ImportTagTest.java
@@ -31,12 +31,11 @@ public class ImportTagTest extends BaseInterpretingTest {
 
   @Before
   public void setup() {
-    jinjava.setResourceLocator(
-      (fullName, encoding, interpreter) ->
-        Resources.toString(
-          Resources.getResource(String.format("tags/macrotag/%s", fullName)),
-          StandardCharsets.UTF_8
-        )
+    jinjava.setResourceLocator((fullName, encoding, interpreter) ->
+      Resources.toString(
+        Resources.getResource(String.format("tags/macrotag/%s", fullName)),
+        StandardCharsets.UTF_8
+      )
     );
 
     context.put("padding", 42);
@@ -189,11 +188,11 @@ public class ImportTagTest extends BaseInterpretingTest {
       .map(Node::reconstructImage)
       .collect(Collectors.toSet());
     assertThat(
-        deferredImages
-          .stream()
-          .filter(image -> image.contains("{% set primary_line_height"))
-          .collect(Collectors.toSet())
-      )
+      deferredImages
+        .stream()
+        .filter(image -> image.contains("{% set primary_line_height"))
+        .collect(Collectors.toSet())
+    )
       .isNotEmpty();
   }
 
@@ -210,11 +209,11 @@ public class ImportTagTest extends BaseInterpretingTest {
       .map(Node::reconstructImage)
       .collect(Collectors.toSet());
     assertThat(
-        deferredImages
-          .stream()
-          .filter(image -> image.contains("{% set primary_line_height"))
-          .collect(Collectors.toSet())
-      )
+      deferredImages
+        .stream()
+        .filter(image -> image.contains("{% set primary_line_height"))
+        .collect(Collectors.toSet())
+    )
       .isNotEmpty();
   }
 
@@ -275,8 +274,7 @@ public class ImportTagTest extends BaseInterpretingTest {
           String fullName,
           Charset encoding,
           JinjavaInterpreter interpreter
-        )
-          throws IOException {
+        ) throws IOException {
           return Resources.toString(
             Resources.getResource(String.format("%s", fullName)),
             StandardCharsets.UTF_8
@@ -373,10 +371,10 @@ public class ImportTagTest extends BaseInterpretingTest {
   public void itCorrectlySetsNestedPaths() {
     context.put("foo", "foo");
     assertThat(
-        interpreter.render(
-          "{% import 'double-import-macro.jinja' %}{{ print_path_macro2(foo) }}"
-        )
+      interpreter.render(
+        "{% import 'double-import-macro.jinja' %}{{ print_path_macro2(foo) }}"
       )
+    )
       .isEqualTo("double-import-macro.jinja\n\nimport-macro.jinja\nfoo\n");
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/IncludeTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/IncludeTagTest.java
@@ -126,8 +126,7 @@ public class IncludeTagTest extends BaseInterpretingTest {
           String fullName,
           Charset encoding,
           JinjavaInterpreter interpreter
-        )
-          throws IOException {
+        ) throws IOException {
           return Resources.toString(
             Resources.getResource(String.format("%s", fullName)),
             StandardCharsets.UTF_8

--- a/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
@@ -60,11 +60,11 @@ public class MacroTagTest extends BaseInterpretingTest {
     assertThat(fn.getArguments()).containsExactly("link", "text");
 
     assertThat(
-        snippet("{{section_link('mylink', 'mytext')}}")
-          .render(interpreter)
-          .getValue()
-          .trim()
-      )
+      snippet("{{section_link('mylink', 'mytext')}}")
+        .render(interpreter)
+        .getValue()
+        .trim()
+    )
       .isEqualTo("link: mylink, text: mytext");
   }
 
@@ -83,11 +83,8 @@ public class MacroTagTest extends BaseInterpretingTest {
 
     interpreter.getContext().put("mylink", DeferredValue.instance());
     assertThat(
-        snippet("{{section_link(mylink, 'mytext')}}")
-          .render(interpreter)
-          .getValue()
-          .trim()
-      )
+      snippet("{{section_link(mylink, 'mytext')}}").render(interpreter).getValue().trim()
+    )
       .isEqualTo("{{section_link(mylink, 'mytext')}}");
   }
 
@@ -120,20 +117,20 @@ public class MacroTagTest extends BaseInterpretingTest {
     assertThat(fn.getDefaults()).contains(entry("last", false));
 
     assertThat(
-        snippet("{{ article('mytitle','mythumb','mylink','mysummary') }}")
-          .render(interpreter)
-          .getValue()
-          .trim()
-      )
+      snippet("{{ article('mytitle','mythumb','mylink','mysummary') }}")
+        .render(interpreter)
+        .getValue()
+        .trim()
+    )
       .isEqualTo(
         "title: mytitle, thumb: mythumb, link: mylink, summary: mysummary, last: false"
       );
     assertThat(
-        snippet("{{ article('mytitle','mythumb','mylink','mysummary', last=true) }}")
-          .render(interpreter)
-          .getValue()
-          .trim()
-      )
+      snippet("{{ article('mytitle','mythumb','mylink','mysummary', last=true) }}")
+        .render(interpreter)
+        .getValue()
+        .trim()
+    )
       .isEqualTo(
         "title: mytitle, thumb: mythumb, link: mylink, summary: mysummary, last: true"
       );
@@ -213,7 +210,7 @@ public class MacroTagTest extends BaseInterpretingTest {
     // I need a different configuration here therefore
     interpreter =
       new Jinjava(JinjavaConfig.newBuilder().withEnableRecursiveMacroCalls(true).build())
-      .newInterpreter();
+        .newInterpreter();
     JinjavaInterpreter.pushCurrent(interpreter);
 
     try {
@@ -237,7 +234,7 @@ public class MacroTagTest extends BaseInterpretingTest {
           .withMaxMacroRecursionDepth(10)
           .build()
       )
-      .newInterpreter();
+        .newInterpreter();
     JinjavaInterpreter.pushCurrent(interpreter);
 
     try {
@@ -261,7 +258,7 @@ public class MacroTagTest extends BaseInterpretingTest {
           .withValidationMode(true)
           .build()
       )
-      .newInterpreter();
+        .newInterpreter();
     JinjavaInterpreter.pushCurrent(interpreter);
 
     try {
@@ -284,7 +281,7 @@ public class MacroTagTest extends BaseInterpretingTest {
           .withMaxMacroRecursionDepth(2)
           .build()
       )
-      .newInterpreter();
+        .newInterpreter();
     JinjavaInterpreter.pushCurrent(interpreter);
 
     try {
@@ -355,7 +352,7 @@ public class MacroTagTest extends BaseInterpretingTest {
           .withMaxMacroRecursionDepth(2)
           .build()
       )
-      .newInterpreter();
+        .newInterpreter();
     JinjavaInterpreter.pushCurrent(interpreter);
     try {
       String result = interpreter.render(fixtureText("scoping"));

--- a/src/test/java/com/hubspot/jinjava/lib/tag/RawTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/RawTagTest.java
@@ -21,6 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class RawTagTest extends BaseInterpretingTest {
+
   Tag tag;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/tag/SetTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/SetTagTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 @SuppressWarnings("unchecked")
 public class SetTagTest extends BaseInterpretingTest {
+
   public Tag tag;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/tag/TagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/TagTest.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TagTest {
+
   Jinjava jinjava;
 
   String script;

--- a/src/test/java/com/hubspot/jinjava/lib/tag/UnlessTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/UnlessTagTest.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class UnlessTagTest extends BaseInterpretingTest {
+
   public Tag tag;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ValidationModeTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ValidationModeTest.java
@@ -25,6 +25,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ValidationModeTest {
+
   JinjavaInterpreter interpreter;
   JinjavaInterpreter validatingInterpreter;
 
@@ -34,6 +35,7 @@ public class ValidationModeTest {
   ValidationFilter validationFilter;
 
   class ValidationFilter implements Filter {
+
     private int executionCount = 0;
 
     @Override
@@ -235,6 +237,7 @@ public class ValidationModeTest {
   }
 
   private class InstrumentedMacroFunction extends MacroFunction {
+
     private int invocationCount = 0;
 
     InstrumentedMacroFunction(

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTagTest.java
@@ -16,6 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class EagerCycleTagTest extends CycleTagTest {
+
   private static final long MAX_OUTPUT_SIZE = 500L;
   private Tag tag;
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerDoTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerDoTagTest.java
@@ -16,6 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class EagerDoTagTest extends DoTagTest {
+
   private static final long MAX_OUTPUT_SIZE = 500L;
   private Tag tag;
   private ExpectedNodeInterpreter expectedNodeInterpreter;

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerExtendsTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerExtendsTagTest.java
@@ -16,6 +16,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 public class EagerExtendsTagTest extends ExtendsTagTest {
+
   private ExpectedTemplateInterpreter expectedTemplateInterpreter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerForTagTest.java
@@ -18,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class EagerForTagTest extends ForTagTest {
+
   private static final long MAX_OUTPUT_SIZE = 5000L;
   private ExpectedNodeInterpreter expectedNodeInterpreter;
 
@@ -100,13 +101,13 @@ public class EagerForTagTest extends ForTagTest {
   @Test
   public void itUsesDeferredExecutionModeWhenChildrenAreLarge() {
     assertThat(
-        interpreter.render(
-          String.format(
-            "{%% for item in range(%d) %%}1234567890{%% endfor %%}",
-            MAX_OUTPUT_SIZE / 10 - 1
-          )
+      interpreter.render(
+        String.format(
+          "{%% for item in range(%d) %%}1234567890{%% endfor %%}",
+          MAX_OUTPUT_SIZE / 10 - 1
         )
       )
+    )
       .hasSize((int) MAX_OUTPUT_SIZE - 10);
     assertThat(interpreter.getContext().getDeferredTokens()).isEmpty();
     assertThat(interpreter.getContext().getDeferredNodes()).isEmpty();

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTagTest.java
@@ -35,8 +35,7 @@ public class EagerFromTagTest extends FromTagTest {
           String fullName,
           Charset encoding,
           JinjavaInterpreter interpreter
-        )
-          throws IOException {
+        ) throws IOException {
           return Resources.toString(
             Resources.getResource(String.format("tags/macrotag/%s", fullName)),
             StandardCharsets.UTF_8

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerIfTagTest.java
@@ -15,6 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class EagerIfTagTest extends IfTagTest {
+
   private ExpectedNodeInterpreter expectedNodeInterpreter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -39,6 +39,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 public class EagerImportTagTest extends ImportTagTest {
+
   private static final String CONTEXT_VAR = "context_var";
   private static final String TEMPLATE_FILE = "template.jinja";
 
@@ -145,21 +146,21 @@ public class EagerImportTagTest extends ImportTagTest {
 
     assertThat(interpreter.getContext().get(CONTEXT_VAR)).isInstanceOf(Map.class);
     assertThat(
-        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2Alias)
-      )
+      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2Alias)
+    )
       .isInstanceOf(Map.class);
     assertThat(
-        (
-          (Map<String, Object>) (
-            (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
-          ).get(child2Alias)
-        ).get("foo")
-      )
+      (
+        (Map<String, Object>) (
+          (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
+        ).get(child2Alias)
+      ).get("foo")
+    )
       .isEqualTo("foo val");
 
     assertThat(
-        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar")
-      )
+      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar")
+    )
       .isEqualTo("bar val");
   }
 
@@ -175,37 +176,37 @@ public class EagerImportTagTest extends ImportTagTest {
 
     assertThat(result.getContext().get(CONTEXT_VAR)).isInstanceOf(DeferredValue.class);
     assertThat(
-        (
-          (Map<String, Object>) (
-            (DeferredValue) result.getContext().get(CONTEXT_VAR)
-          ).getOriginalValue()
-        ).get(child2Alias)
-      )
+      (
+        (Map<String, Object>) (
+          (DeferredValue) result.getContext().get(CONTEXT_VAR)
+        ).getOriginalValue()
+      ).get(child2Alias)
+    )
       .isInstanceOf(DeferredValue.class);
     assertThat(
+      (
         (
-          (
-            (Map<String, Object>) (
-              (DeferredValue) (
-                (
-                  (Map<String, Object>) (
-                    (DeferredValue) result.getContext().get(CONTEXT_VAR)
-                  ).getOriginalValue()
-                )
-              ).get(child2Alias)
-            ).getOriginalValue()
-          ).get("foo")
-        )
+          (Map<String, Object>) (
+            (DeferredValue) (
+              (
+                (Map<String, Object>) (
+                  (DeferredValue) result.getContext().get(CONTEXT_VAR)
+                ).getOriginalValue()
+              )
+            ).get(child2Alias)
+          ).getOriginalValue()
+        ).get("foo")
       )
+    )
       .isEqualTo("foo val");
 
     assertThat(
-        (
-          (Map<String, Object>) (
-            (DeferredValue) result.getContext().get(CONTEXT_VAR)
-          ).getOriginalValue()
-        ).get("bar")
-      )
+      (
+        (Map<String, Object>) (
+          (DeferredValue) result.getContext().get(CONTEXT_VAR)
+        ).getOriginalValue()
+      ).get("bar")
+    )
       .isEqualTo("bar val");
   }
 
@@ -221,14 +222,14 @@ public class EagerImportTagTest extends ImportTagTest {
     getFlatStrategy(interpreter).integrateChild(child);
     assertThat(interpreter.getContext().get("foo")).isInstanceOf(DeferredValue.class);
     assertThat(
-        (((DeferredValue) (interpreter.getContext().get("foo"))).getOriginalValue())
-      )
+      (((DeferredValue) (interpreter.getContext().get("foo"))).getOriginalValue())
+    )
       .isEqualTo("foo val");
 
     assertThat(interpreter.getContext().get("bar")).isInstanceOf(DeferredValue.class);
     assertThat(
-        (((DeferredValue) (interpreter.getContext().get("bar"))).getOriginalValue())
-      )
+      (((DeferredValue) (interpreter.getContext().get("bar"))).getOriginalValue())
+    )
       .isEqualTo("bar val");
   }
 
@@ -250,25 +251,25 @@ public class EagerImportTagTest extends ImportTagTest {
 
     assertThat(interpreter.getContext().get(CONTEXT_VAR)).isInstanceOf(Map.class);
     assertThat(
-        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child3Alias)
-      )
+      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child3Alias)
+    )
       .isInstanceOf(Map.class);
     assertThat(
-        (
-          (Map<String, Object>) (
-            (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
-          ).get(child3Alias)
-        ).get("foobar")
-      )
+      (
+        (Map<String, Object>) (
+          (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
+        ).get(child3Alias)
+      ).get("foobar")
+    )
       .isEqualTo("foobar val");
 
     assertThat(
-        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar")
-      )
+      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar")
+    )
       .isEqualTo("bar val");
     assertThat(
-        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("foo")
-      )
+      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("foo")
+    )
       .isEqualTo("foo val");
   }
 
@@ -292,35 +293,33 @@ public class EagerImportTagTest extends ImportTagTest {
 
     assertThat(interpreter.getContext().get(CONTEXT_VAR)).isInstanceOf(Map.class);
     assertThat(
-        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2Alias)
-      )
+      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2Alias)
+    )
       .isInstanceOf(Map.class);
     assertThat(
-        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(
-            child2BAlias
-          )
-      )
+      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get(child2BAlias)
+    )
       .isInstanceOf(Map.class);
     assertThat(
-        (
-          (Map<String, Object>) (
-            (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
-          ).get(child2Alias)
-        ).get("foo")
-      )
+      (
+        (Map<String, Object>) (
+          (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
+        ).get(child2Alias)
+      ).get("foo")
+    )
       .isEqualTo("foo val");
     assertThat(
-        (
-          (Map<String, Object>) (
-            (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
-          ).get(child2BAlias)
-        ).get("foo_b")
-      )
+      (
+        (Map<String, Object>) (
+          (Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)
+        ).get(child2BAlias)
+      ).get("foo_b")
+    )
       .isEqualTo("foo_b val");
 
     assertThat(
-        ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar")
-      )
+      ((Map<String, Object>) interpreter.getContext().get(CONTEXT_VAR)).get("bar")
+    )
       .isEqualTo("bar val");
   }
 
@@ -732,8 +731,7 @@ public class EagerImportTagTest extends ImportTagTest {
           String fullName,
           Charset encoding,
           JinjavaInterpreter interpreter
-        )
-          throws IOException {
+        ) throws IOException {
           return Resources.toString(
             Resources.getResource(String.format("tags/eager/importtag/%s", fullName)),
             StandardCharsets.UTF_8

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTagTest.java
@@ -23,6 +23,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 public class EagerIncludeTagTest extends IncludeTagTest {
+
   private ExpectedTemplateInterpreter expectedTemplateInterpreter;
 
   @Before
@@ -52,8 +53,7 @@ public class EagerIncludeTagTest extends IncludeTagTest {
           String fullName,
           Charset encoding,
           JinjavaInterpreter interpreter
-        )
-          throws IOException {
+        ) throws IOException {
           return Resources.toString(
             Resources.getResource(String.format("tags/eager/includetag/%s", fullName)),
             StandardCharsets.UTF_8
@@ -78,20 +78,20 @@ public class EagerIncludeTagTest extends IncludeTagTest {
     setupResourceLocator();
     expectedTemplateInterpreter.assertExpectedOutputNonIdempotent("includes-deferred");
     assertThat(
-        context
-          .getDeferredTokens()
-          .stream()
-          .flatMap(deferredToken -> deferredToken.getUsedDeferredWords().stream())
-          .collect(Collectors.toSet())
-      )
+      context
+        .getDeferredTokens()
+        .stream()
+        .flatMap(deferredToken -> deferredToken.getUsedDeferredWords().stream())
+        .collect(Collectors.toSet())
+    )
       .containsExactlyInAnyOrder("foo", "deferred");
     assertThat(
-        context
-          .getDeferredTokens()
-          .stream()
-          .flatMap(deferredToken -> deferredToken.getSetDeferredWords().stream())
-          .collect(Collectors.toSet())
-      )
+      context
+        .getDeferredTokens()
+        .stream()
+        .flatMap(deferredToken -> deferredToken.getSetDeferredWords().stream())
+        .collect(Collectors.toSet())
+    )
       .containsExactlyInAnyOrder("foo");
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagTest.java
@@ -18,6 +18,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 public class EagerSetTagTest extends SetTagTest {
+
   private static final long MAX_OUTPUT_SIZE = 500L;
   private ExpectedNodeInterpreter expectedNodeInterpreter;
 
@@ -117,20 +118,20 @@ public class EagerSetTagTest extends SetTagTest {
 
     assertThat(result).isEqualTo("{% set foo %}i am{{ deferred }}{% endset %}{{ foo }}");
     assertThat(
-        context
-          .getDeferredTokens()
-          .stream()
-          .flatMap(deferredToken -> deferredToken.getSetDeferredWords().stream())
-          .collect(Collectors.toSet())
-      )
+      context
+        .getDeferredTokens()
+        .stream()
+        .flatMap(deferredToken -> deferredToken.getSetDeferredWords().stream())
+        .collect(Collectors.toSet())
+    )
       .containsExactly("foo");
     assertThat(
-        context
-          .getDeferredTokens()
-          .stream()
-          .flatMap(deferredToken -> deferredToken.getUsedDeferredWords().stream())
-          .collect(Collectors.toSet())
-      )
+      context
+        .getDeferredTokens()
+        .stream()
+        .flatMap(deferredToken -> deferredToken.getUsedDeferredWords().stream())
+        .collect(Collectors.toSet())
+    )
       .containsExactlyInAnyOrder("foo", "deferred");
   }
 
@@ -145,20 +146,20 @@ public class EagerSetTagTest extends SetTagTest {
         "{% set foo = filter:add.filter(2, ____int3rpr3t3r____, deferred) %}{{ foo }}"
       );
     assertThat(
-        context
-          .getDeferredTokens()
-          .stream()
-          .flatMap(deferredToken -> deferredToken.getSetDeferredWords().stream())
-          .collect(Collectors.toSet())
-      )
+      context
+        .getDeferredTokens()
+        .stream()
+        .flatMap(deferredToken -> deferredToken.getSetDeferredWords().stream())
+        .collect(Collectors.toSet())
+    )
       .containsExactly("foo");
     assertThat(
-        context
-          .getDeferredTokens()
-          .stream()
-          .flatMap(deferredToken -> deferredToken.getUsedDeferredWords().stream())
-          .collect(Collectors.toSet())
-      )
+      context
+        .getDeferredTokens()
+        .stream()
+        .flatMap(deferredToken -> deferredToken.getUsedDeferredWords().stream())
+        .collect(Collectors.toSet())
+    )
       .containsExactlyInAnyOrder("deferred", "foo", "add");
   }
 
@@ -197,20 +198,20 @@ public class EagerSetTagTest extends SetTagTest {
         "{% set foo %}1{% endset %}{% set foo = filter:add.filter(1, ____int3rpr3t3r____, deferred) %}{{ foo }}"
       );
     assertThat(
-        context
-          .getDeferredTokens()
-          .stream()
-          .flatMap(deferredToken -> deferredToken.getSetDeferredWords().stream())
-          .collect(Collectors.toSet())
-      )
+      context
+        .getDeferredTokens()
+        .stream()
+        .flatMap(deferredToken -> deferredToken.getSetDeferredWords().stream())
+        .collect(Collectors.toSet())
+    )
       .containsExactly("foo");
     assertThat(
-        context
-          .getDeferredTokens()
-          .stream()
-          .flatMap(deferredToken -> deferredToken.getUsedDeferredWords().stream())
-          .collect(Collectors.toSet())
-      )
+      context
+        .getDeferredTokens()
+        .stream()
+        .flatMap(deferredToken -> deferredToken.getUsedDeferredWords().stream())
+        .collect(Collectors.toSet())
+    )
       .containsExactlyInAnyOrder("deferred", "foo", "add");
     context.remove("foo");
     context.put("deferred", 2);

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagDecoratorTest.java
@@ -28,6 +28,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EagerTagDecoratorTest extends BaseInterpretingTest {
+
   private static final long MAX_OUTPUT_SIZE = 50L;
   private Tag mockTag;
   private EagerGenericTag<Tag> eagerTagDecorator;
@@ -122,9 +123,8 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
     TagNode tagNode = (TagNode) (
       interpreter.parse("{% print range(0, 50) %}").getChildren().get(0)
     );
-    assertThatThrownBy(
-        () ->
-          eagerTagDecorator.getEagerTagImage((TagToken) tagNode.getMaster(), interpreter)
+    assertThatThrownBy(() ->
+        eagerTagDecorator.getEagerTagImage((TagToken) tagNode.getMaster(), interpreter)
       )
       .isInstanceOf(OutputTooBigException.class);
   }
@@ -146,8 +146,8 @@ public class EagerTagDecoratorTest extends BaseInterpretingTest {
   public void itDoesntModifyContextWhenResultIsDeferred() {
     context.put("foo", new ArrayList<>());
     assertThat(
-        interpreter.render("{{ modify_context('foo', 'bar') ~ deferred }}{{ foo }}")
-      )
+      interpreter.render("{{ modify_context('foo', 'bar') ~ deferred }}{{ foo }}")
+    )
       .isEqualTo("{{ null ~ deferred }}[bar]");
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactoryTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactoryTest.java
@@ -14,18 +14,16 @@ public class EagerTagFactoryTest {
 
   @Test
   public void itGetsEagerTagDecoratorForOverrides() {
-    Set<EagerTagDecorator<?>> eagerTagDecoratorSet = EagerTagFactory
-      .EAGER_TAG_OVERRIDES.keySet()
+    Set<EagerTagDecorator<?>> eagerTagDecoratorSet = EagerTagFactory.EAGER_TAG_OVERRIDES
+      .keySet()
       .stream()
-      .map(
-        clazz -> {
-          try {
-            return clazz.getDeclaredConstructor().newInstance();
-          } catch (Exception ignored) {
-            return null;
-          }
+      .map(clazz -> {
+        try {
+          return clazz.getDeclaredConstructor().newInstance();
+        } catch (Exception ignored) {
+          return null;
         }
-      )
+      })
       .filter(Objects::nonNull)
       .map(EagerTagFactory::getEagerTagDecorator)
       .filter(Optional::isPresent)
@@ -34,19 +32,18 @@ public class EagerTagFactoryTest {
     assertThat(eagerTagDecoratorSet.size())
       .isEqualTo(EagerTagFactory.EAGER_TAG_OVERRIDES.keySet().size());
     assertThat(
-        eagerTagDecoratorSet
-          .stream()
-          .map(e -> e.getTag().getClass())
-          .collect(Collectors.toSet())
-      )
+      eagerTagDecoratorSet
+        .stream()
+        .map(e -> e.getTag().getClass())
+        .collect(Collectors.toSet())
+    )
       .isEqualTo(EagerTagFactory.EAGER_TAG_OVERRIDES.keySet());
   }
 
   @Test
   public void itGetsEagerTagDecoratorForNonOverride() {
-    Optional<? extends EagerTagDecorator<? extends Tag>> maybeEagerGenericTag = EagerTagFactory.getEagerTagDecorator(
-      new IfchangedTag()
-    );
+    Optional<? extends EagerTagDecorator<? extends Tag>> maybeEagerGenericTag =
+      EagerTagFactory.getEagerTagDecorator(new IfchangedTag());
     assertThat(maybeEagerGenericTag).isPresent();
     assertThat(maybeEagerGenericTag.get()).isInstanceOf(EagerGenericTag.class);
     assertThat(maybeEagerGenericTag.get().getTag()).isInstanceOf(IfchangedTag.class);

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerUnlessTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerUnlessTagTest.java
@@ -15,6 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class EagerUnlessTagTest extends UnlessTagTest {
+
   private ExpectedNodeInterpreter expectedNodeInterpreter;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/loader/CascadingResourceLocatorTest.java
+++ b/src/test/java/com/hubspot/jinjava/loader/CascadingResourceLocatorTest.java
@@ -14,6 +14,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("unchecked")
 public class CascadingResourceLocatorTest {
+
   @Mock
   ResourceLocator first;
 

--- a/src/test/java/com/hubspot/jinjava/loader/ClasspathResourceLocatorTest.java
+++ b/src/test/java/com/hubspot/jinjava/loader/ClasspathResourceLocatorTest.java
@@ -11,9 +11,9 @@ public class ClasspathResourceLocatorTest extends BaseInterpretingTest {
   @Test
   public void testLoadFromClasspath() throws Exception {
     assertThat(
-        new ClasspathResourceLocator()
+      new ClasspathResourceLocator()
         .getString("loader/cp/foo/bar.jinja", StandardCharsets.UTF_8, interpreter)
-      )
+    )
       .isEqualTo("hello world.");
   }
 

--- a/src/test/java/com/hubspot/jinjava/loader/FileLocatorTest.java
+++ b/src/test/java/com/hubspot/jinjava/loader/FileLocatorTest.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class FileLocatorTest extends BaseInterpretingTest {
+
   FileLocator locatorWorkingDir;
   FileLocator locatorTmpDir;
 
@@ -23,8 +24,8 @@ public class FileLocatorTest extends BaseInterpretingTest {
   public void setUp() throws Exception {
     locatorWorkingDir = new FileLocator();
 
-    File tmpDir = java
-      .nio.file.Files.createTempDirectory(getClass().getSimpleName())
+    File tmpDir = java.nio.file.Files
+      .createTempDirectory(getClass().getSimpleName())
       .toFile();
     locatorTmpDir = new FileLocator(tmpDir);
 
@@ -41,44 +42,44 @@ public class FileLocatorTest extends BaseInterpretingTest {
   @Test
   public void testWorkingDirRelative() throws Exception {
     assertThat(
-        locatorWorkingDir.getString(
-          "target/loader-test-data/second.jinja",
-          StandardCharsets.UTF_8,
-          interpreter
-        )
+      locatorWorkingDir.getString(
+        "target/loader-test-data/second.jinja",
+        StandardCharsets.UTF_8,
+        interpreter
       )
+    )
       .isEqualTo("second");
   }
 
   @Test
   public void testWorkingDirAbs() throws Exception {
     assertThat(
-        locatorWorkingDir.getString(
-          second.getAbsolutePath(),
-          StandardCharsets.UTF_8,
-          interpreter
-        )
+      locatorWorkingDir.getString(
+        second.getAbsolutePath(),
+        StandardCharsets.UTF_8,
+        interpreter
       )
+    )
       .isEqualTo("second");
   }
 
   @Test
   public void testTmpDirRel() throws Exception {
     assertThat(
-        locatorTmpDir.getString("foo/first.jinja", StandardCharsets.UTF_8, interpreter)
-      )
+      locatorTmpDir.getString("foo/first.jinja", StandardCharsets.UTF_8, interpreter)
+    )
       .isEqualTo("first");
   }
 
   @Test
   public void testTmpDirAbs() throws Exception {
     assertThat(
-        locatorTmpDir.getString(
-          first.getAbsolutePath(),
-          StandardCharsets.UTF_8,
-          interpreter
-        )
+      locatorTmpDir.getString(
+        first.getAbsolutePath(),
+        StandardCharsets.UTF_8,
+        interpreter
       )
+    )
       .isEqualTo("first");
   }
 

--- a/src/test/java/com/hubspot/jinjava/objects/NamespaceTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/NamespaceTest.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class NamespaceTest {
+
   private Namespace namespace;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyListTest.java
@@ -15,66 +15,66 @@ public class PyListTest extends BaseJinjavaTest {
   @Test
   public void itSupportsAppendOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{% do test.append(4) %}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" + "{% do test.append(4) %}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("[1, 2, 3, 4]");
   }
 
   @Test
   public void itSupportsExtendOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{% do test.extend([4, 5, 6]) %}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" + "{% do test.extend([4, 5, 6]) %}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("[1, 2, 3, 4, 5, 6]");
   }
 
   @Test
   public void itSupportsExtendOperationWithNullList() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{% do test.extend(null) %}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" + "{% do test.extend(null) %}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("[1, 2, 3]");
   }
 
   @Test
   public void itSupportsInsertOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{% do test.insert(1, 4) %}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" + "{% do test.insert(1, 4) %}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("[1, 4, 2, 3]");
   }
 
   @Test
   public void itSupportsInsertOperationWithNegativeIndex() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{% do test.insert(-1, 4) %}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" + "{% do test.insert(-1, 4) %}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("[1, 2, 4, 3]");
   }
 
   @Test
   public void itSupportsInsertOperationWithLargeNegativeIndex() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{% do test.insert(-99, 4) %}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" + "{% do test.insert(-99, 4) %}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("[4, 1, 2, 3]");
   }
 
@@ -94,33 +94,33 @@ public class PyListTest extends BaseJinjavaTest {
   @Test
   public void itSupportsPopOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{{ test.pop() }}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" + "{{ test.pop() }}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("3[1, 2]");
   }
 
   @Test
   public void itSupportsPopAtIndexOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{{ test.pop(1) }}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" + "{{ test.pop(1) }}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("2[1, 3]");
   }
 
   @Test
   public void itSupportsPopAtNegativeIndexOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{{ test.pop(-1) }}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" + "{{ test.pop(-1) }}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("3[1, 2]");
   }
 
@@ -153,113 +153,113 @@ public class PyListTest extends BaseJinjavaTest {
   @Test
   public void itSupportsClearOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{% do test.clear() %}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" + "{% do test.clear() %}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("[]");
   }
 
   @Test
   public void itSupportsCountOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 1, 2, 2, 2, 3] %}" + "{{ test.count(2) }}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 1, 2, 2, 2, 3] %}" + "{{ test.count(2) }}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("3[1, 1, 2, 2, 2, 3]");
   }
 
   @Test
   public void itSupportsReverseOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{% do test.reverse() %}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" + "{% do test.reverse() %}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("[3, 2, 1]");
   }
 
   @Test
   public void itSupportsCopyOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" +
-          "{% set test2 = test.copy() %}" +
-          "{% do test.append(4) %}" +
-          "{{ test }}{{test2}}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" +
+        "{% set test2 = test.copy() %}" +
+        "{% do test.append(4) %}" +
+        "{{ test }}{{test2}}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("[1, 2, 3, 4][1, 2, 3]");
   }
 
   @Test
   public void itSupportsIndexOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [10, 20, 30, 10, 20, 30] %}" + "{{ test.index(20) }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [10, 20, 30, 10, 20, 30] %}" + "{{ test.index(20) }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("1");
   }
 
   @Test
   public void itSupportsIndexWithinBoundsOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [10, 20, 30, 10, 20, 30] %}" + "{{ test.index(20, 2, 6) }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [10, 20, 30, 10, 20, 30] %}" + "{{ test.index(20, 2, 6) }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("4");
   }
 
   @Test
   public void itReturnsNegativeOneForMissingObjectForIndex() {
     assertThat(
-        jinjava.render(
-          "{% set test = [10, 20, 30, 10, 20, 30] %}" + "{{ test.index(999) }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [10, 20, 30, 10, 20, 30] %}" + "{{ test.index(999) }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("-1");
   }
 
   @Test
   public void itReturnsNegativeOneForMissingObjectForIndexWithinBounds() {
     assertThat(
-        jinjava.render(
-          "{% set test = [10, 20, 30, 10, 20, 30] %}" + "{{ test.index(999, 1, 5) }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [10, 20, 30, 10, 20, 30] %}" + "{{ test.index(999, 1, 5) }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("-1");
   }
 
   @Test
   public void itDisallowsInsertingSelf() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1,2] %}" + "{% do test.insert(0, test) %}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1,2] %}" + "{% do test.insert(0, test) %}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("[1, 2]");
   }
 
   @Test
   public void itDisallowsAppendingSelf() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2] %}" + "{% do test.append(test) %}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2] %}" + "{% do test.append(test) %}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("[1, 2]");
   }
 

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
@@ -21,55 +21,55 @@ public class PyMapTest extends BaseJinjavaTest {
   @Test
   public void itSupportsAppendOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{% do test.append(4) %}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" + "{% do test.append(4) %}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("[1, 2, 3, 4]");
   }
 
   @Test
   public void itSupportsExtendOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{% do test.extend([4, 5, 6]) %}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" + "{% do test.extend([4, 5, 6]) %}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("[1, 2, 3, 4, 5, 6]");
   }
 
   @Test
   public void itSupportsInsertOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{% do test.insert(1, 4) %}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" + "{% do test.insert(1, 4) %}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("[1, 4, 2, 3]");
   }
 
   @Test
   public void itSupportsInsertOperationWithNegativeIndex() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{% do test.insert(-1, 4) %}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" + "{% do test.insert(-1, 4) %}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("[1, 2, 4, 3]");
   }
 
   @Test
   public void itSupportsInsertOperationWithLargeNegativeIndex() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{% do test.insert(-99, 4) %}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" + "{% do test.insert(-99, 4) %}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("[4, 1, 2, 3]");
   }
 
@@ -89,33 +89,33 @@ public class PyMapTest extends BaseJinjavaTest {
   @Test
   public void itSupportsPopOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{{ test.pop() }}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" + "{{ test.pop() }}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("3[1, 2]");
   }
 
   @Test
   public void itSupportsPopAtIndexOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{{ test.pop(1) }}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" + "{{ test.pop(1) }}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("2[1, 3]");
   }
 
   @Test
   public void itSupportsPopAtNegativeIndexOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{{ test.pop(-1) }}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" + "{{ test.pop(-1) }}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("3[1, 2]");
   }
 
@@ -148,91 +148,91 @@ public class PyMapTest extends BaseJinjavaTest {
   @Test
   public void itSupportsClearOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{% do test.clear() %}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" + "{% do test.clear() %}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("[]");
   }
 
   @Test
   public void itSupportsCountOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 1, 2, 2, 2, 3] %}" + "{{ test.count(2) }}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 1, 2, 2, 2, 3] %}" + "{{ test.count(2) }}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("3[1, 1, 2, 2, 2, 3]");
   }
 
   @Test
   public void itSupportsReverseOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" + "{% do test.reverse() %}" + "{{ test }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" + "{% do test.reverse() %}" + "{{ test }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("[3, 2, 1]");
   }
 
   @Test
   public void itSupportsCopyOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [1, 2, 3] %}" +
-          "{% set test2 = test.copy() %}" +
-          "{% do test.append(4) %}" +
-          "{{ test }}{{test2}}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [1, 2, 3] %}" +
+        "{% set test2 = test.copy() %}" +
+        "{% do test.append(4) %}" +
+        "{{ test }}{{test2}}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("[1, 2, 3, 4][1, 2, 3]");
   }
 
   @Test
   public void itSupportsIndexOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [10, 20, 30, 10, 20, 30] %}" + "{{ test.index(20) }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [10, 20, 30, 10, 20, 30] %}" + "{{ test.index(20) }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("1");
   }
 
   @Test
   public void itSupportsIndexWithinBoundsOperation() {
     assertThat(
-        jinjava.render(
-          "{% set test = [10, 20, 30, 10, 20, 30] %}" + "{{ test.index(20, 2, 6) }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [10, 20, 30, 10, 20, 30] %}" + "{{ test.index(20, 2, 6) }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("4");
   }
 
   @Test
   public void itReturnsNegativeOneForMissingObjectForIndex() {
     assertThat(
-        jinjava.render(
-          "{% set test = [10, 20, 30, 10, 20, 30] %}" + "{{ test.index(999) }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [10, 20, 30, 10, 20, 30] %}" + "{{ test.index(999) }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("-1");
   }
 
   @Test
   public void itReturnsNegativeOneForMissingObjectForIndexWithinBounds() {
     assertThat(
-        jinjava.render(
-          "{% set test = [10, 20, 30, 10, 20, 30] %}" + "{{ test.index(999, 1, 5) }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = [10, 20, 30, 10, 20, 30] %}" + "{{ test.index(999, 1, 5) }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("-1");
   }
 
@@ -263,26 +263,26 @@ public class PyMapTest extends BaseJinjavaTest {
   @Test
   public void itUpdatesKeysWithStaticName() {
     assertThat(
-        jinjava.render(
-          "{% set test = {\"key1\": \"value1\"} %}" +
-          "{% do test.update({\"key1\": \"value2\"}) %}" +
-          "{{ test[\"key1\"] }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = {\"key1\": \"value1\"} %}" +
+        "{% do test.update({\"key1\": \"value2\"}) %}" +
+        "{{ test[\"key1\"] }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("value2");
   }
 
   @Test
   public void itDoesntSetKeysWithVariableNameByDefault() {
     assertThat(
-        jinjava.render(
-          "{% set keyName = \"key1\" %}" +
-          "{% set test = {keyName: \"value1\"} %}" +
-          "{{ test['keyName'] }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set keyName = \"key1\" %}" +
+        "{% set test = {keyName: \"value1\"} %}" +
+        "{{ test['keyName'] }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("value1");
   }
 
@@ -299,51 +299,51 @@ public class PyMapTest extends BaseJinjavaTest {
       );
 
     assertThat(
-        jinjava.render(
-          "{% set keyName = \"key1\" %}" +
-          "{% set test = {keyName: \"value1\"} %}" +
-          "{{ test[keyName] }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set keyName = \"key1\" %}" +
+        "{% set test = {keyName: \"value1\"} %}" +
+        "{{ test[keyName] }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("value1");
   }
 
   @Test
   public void itGetsKeysWithVariableName() {
     assertThat(
-        jinjava.render(
-          "{% set test = {\"key1\": \"value1\"} %}" +
-          "{% set keyName = \"key1\" %}" +
-          "{{ test[keyName] }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = {\"key1\": \"value1\"} %}" +
+        "{% set keyName = \"key1\" %}" +
+        "{{ test[keyName] }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("value1");
   }
 
   @Test
   public void itFallsBackUnknownVariableNameToString() {
     assertThat(
-        jinjava.render(
-          "{% set test = {keyName: \"value1\"} %}" + "{{ test[\"keyName\"] }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = {keyName: \"value1\"} %}" + "{{ test[\"keyName\"] }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("value1");
   }
 
   @Test
   public void itDoesntUpdateKeysWithVariableNameByDefault() {
     assertThat(
-        jinjava.render(
-          "{% set test = {\"key1\": \"value1\"} %}" +
-          "{% set keyName = \"key1\" %}" +
-          "{% do test.update({keyName: \"value2\"}) %}" +
-          "{{ test['key1'] }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = {\"key1\": \"value1\"} %}" +
+        "{% set keyName = \"key1\" %}" +
+        "{% do test.update({keyName: \"value2\"}) %}" +
+        "{{ test['key1'] }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("value1");
   }
 
@@ -359,14 +359,14 @@ public class PyMapTest extends BaseJinjavaTest {
           .build()
       );
     assertThat(
-        jinjava.render(
-          "{% set test = {\"key1\": \"value1\"} %}" +
-          "{% set keyName = \"key1\" %}" +
-          "{% do test.update({keyName: \"value2\"}) %}" +
-          "{{ test[keyName] }}",
-          Collections.emptyMap()
-        )
+      jinjava.render(
+        "{% set test = {\"key1\": \"value1\"} %}" +
+        "{% set keyName = \"key1\" %}" +
+        "{% do test.update({keyName: \"value2\"}) %}" +
+        "{{ test[keyName] }}",
+        Collections.emptyMap()
       )
+    )
       .isEqualTo("value2");
   }
 

--- a/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/date/StrftimeFormatterTest.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class StrftimeFormatterTest {
+
   ZonedDateTime d;
 
   @Before
@@ -117,8 +118,8 @@ public class StrftimeFormatterTest {
     ZonedDateTime zonedDateTime = ZonedDateTime.parse("2019-06-06T14:22:00.000+00:00");
 
     assertThat(
-        StrftimeFormatter.format(zonedDateTime, "%OB", Locale.forLanguageTag("ru"))
-      )
+      StrftimeFormatter.format(zonedDateTime, "%OB", Locale.forLanguageTag("ru"))
+    )
       .isIn("Июнь", "июнь");
   }
 

--- a/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/serialization/PyishObjectMapperTest.java
@@ -122,10 +122,10 @@ public class PyishObjectMapperTest {
   @Test
   public void itSerializesToSnakeCaseAccessibleMapWhenInMapEntry() {
     assertThat(
-        PyishObjectMapper.getAsPyishString(
-          new AbstractMap.SimpleImmutableEntry<>("foo", new Foo("bar"))
-        )
+      PyishObjectMapper.getAsPyishString(
+        new AbstractMap.SimpleImmutableEntry<>("foo", new Foo("bar"))
       )
+    )
       .isEqualTo("fn:map_entry('foo', {'fooBar': 'bar'} |allow_snake_case)");
   }
 
@@ -169,6 +169,7 @@ public class PyishObjectMapperTest {
   }
 
   static class Foo {
+
     private final String bar;
 
     public Foo(String bar) {

--- a/src/test/java/com/hubspot/jinjava/tree/FailOnUnknownTokensTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/FailOnUnknownTokensTest.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class FailOnUnknownTokensTest {
+
   private static Jinjava jinjava;
 
   @Before

--- a/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
@@ -138,7 +138,7 @@ public class TreeParserTest extends BaseInterpretingTest {
       new Jinjava(
         JinjavaConfig.newBuilder().withLstripBlocks(true).withTrimBlocks(true).build()
       )
-      .newInterpreter();
+        .newInterpreter();
 
     assertThat(interpreter.render(parse("parse/tokenizer/whitespace-tags.jinja")))
       .isEqualTo("<div>\n" + "        yay\n" + "</div>\n");
@@ -242,7 +242,7 @@ public class TreeParserTest extends BaseInterpretingTest {
           )
           .build()
       )
-      .newInterpreter();
+        .newInterpreter();
     final Node newTree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(newTree)).isEqualTo("AB");
   }
@@ -264,7 +264,7 @@ public class TreeParserTest extends BaseInterpretingTest {
           )
           .build()
       )
-      .newInterpreter();
+        .newInterpreter();
     final Node newTree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(newTree)).isEqualTo("A\n");
   }
@@ -286,7 +286,7 @@ public class TreeParserTest extends BaseInterpretingTest {
           )
           .build()
       )
-      .newInterpreter();
+        .newInterpreter();
     final Node newTree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(newTree)).isEqualTo("A\n{{ ");
   }
@@ -308,7 +308,7 @@ public class TreeParserTest extends BaseInterpretingTest {
           )
           .build()
       )
-      .newInterpreter();
+        .newInterpreter();
     final Node newTree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(newTree)).isEqualTo("A\n{% ");
   }
@@ -337,7 +337,7 @@ public class TreeParserTest extends BaseInterpretingTest {
           )
           .build()
       )
-      .newInterpreter();
+        .newInterpreter();
     final Node newTree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(newTree)).isEqualTo("ABC");
   }
@@ -356,7 +356,7 @@ public class TreeParserTest extends BaseInterpretingTest {
           )
           .build()
       )
-      .newInterpreter();
+        .newInterpreter();
     final Node overriddenTree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(overriddenTree)).isEqualTo("A\nB");
   }
@@ -367,7 +367,7 @@ public class TreeParserTest extends BaseInterpretingTest {
         interpreter,
         Resources.toString(Resources.getResource(fixture), StandardCharsets.UTF_8)
       )
-      .buildTree();
+        .buildTree();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/com/hubspot/jinjava/tree/parse/CustomTokenScannerSymbolsTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/parse/CustomTokenScannerSymbolsTest.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class CustomTokenScannerSymbolsTest {
+
   private Jinjava jinjava;
   private JinjavaConfig config;
 
@@ -33,25 +34,25 @@ public class CustomTokenScannerSymbolsTest {
   @Test
   public void itRendersFiltersWithCustomTokens() {
     assertThat(
-        jinjava.render(
-          "<% set d=d | default(\"some random value\") %><< d >>",
-          new HashMap<>()
-        )
+      jinjava.render(
+        "<% set d=d | default(\"some random value\") %><< d >>",
+        new HashMap<>()
       )
+    )
       .isEqualTo("some random value");
     assertThat(jinjava.render("<< [1, 2, 3, 3]|union(null) >>", new HashMap<>()))
       .isEqualTo("[1, 2, 3]");
     assertThat(jinjava.render("<< numbers|select('equalto', 3) >>", new HashMap<>()))
       .isEqualTo("[3]");
     assertThat(
-        jinjava.render(
-          "<< users|map(attribute='username')|join(', ') >>",
-          ImmutableMap.of(
-            "users",
-            (Object) Lists.newArrayList(new User("foo"), new User("bar"))
-          )
+      jinjava.render(
+        "<< users|map(attribute='username')|join(', ') >>",
+        ImmutableMap.of(
+          "users",
+          (Object) Lists.newArrayList(new User("foo"), new User("bar"))
         )
       )
+    )
       .isEqualTo("foo, bar");
   }
 

--- a/src/test/java/com/hubspot/jinjava/tree/parse/TagTokenTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/parse/TagTokenTest.java
@@ -7,6 +7,7 @@ import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import org.junit.Test;
 
 public class TagTokenTest {
+
   private static final TokenScannerSymbols SYMBOLS = new DefaultTokenScannerSymbols();
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/tree/parse/TokenScannerTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/parse/TokenScannerTest.java
@@ -16,6 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TokenScannerTest {
+
   private JinjavaConfig config;
   private String script;
 
@@ -208,10 +209,10 @@ public class TokenScannerTest {
     assertThat(tokens).hasSize(2);
     assertThat(tokens.get(tokens.size() - 1)).isInstanceOf(TextToken.class);
     assertThat(
-        StringUtils
-          .substringBetween(tokens.get(tokens.size() - 1).toString(), "{~", "~}")
-          .trim()
-      )
+      StringUtils
+        .substringBetween(tokens.get(tokens.size() - 1).toString(), "{~", "~}")
+        .trim()
+    )
       .isEqualTo("and here's some extra.");
   }
 

--- a/src/test/java/com/hubspot/jinjava/util/DeferredValueUtilsTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/DeferredValueUtilsTest.java
@@ -47,9 +47,8 @@ public class DeferredValueUtilsTest {
     Set<String> deferredProperties = context
       .getDeferredNodes()
       .stream()
-      .flatMap(
-        node ->
-          DeferredValueUtils.findAndMarkDeferredProperties(finalContext, node).stream()
+      .flatMap(node ->
+        DeferredValueUtils.findAndMarkDeferredProperties(finalContext, node).stream()
       )
       .collect(Collectors.toSet());
 
@@ -66,8 +65,8 @@ public class DeferredValueUtilsTest {
     Set<String> deferredProperties = context
       .getDeferredNodes()
       .stream()
-      .flatMap(
-        node -> DeferredValueUtils.findAndMarkDeferredProperties(context, node).stream()
+      .flatMap(node ->
+        DeferredValueUtils.findAndMarkDeferredProperties(context, node).stream()
       )
       .collect(Collectors.toSet());
     assertThat(deferredProperties).contains("array");
@@ -83,8 +82,8 @@ public class DeferredValueUtilsTest {
     Set<String> deferredProperties = context
       .getDeferredNodes()
       .stream()
-      .flatMap(
-        node -> DeferredValueUtils.findAndMarkDeferredProperties(context, node).stream()
+      .flatMap(node ->
+        DeferredValueUtils.findAndMarkDeferredProperties(context, node).stream()
       )
       .collect(Collectors.toSet());
     assertThat(deferredProperties).contains("dict");
@@ -111,8 +110,8 @@ public class DeferredValueUtilsTest {
     Context finalContext = context;
     context
       .getDeferredNodes()
-      .forEach(
-        node -> DeferredValueUtils.findAndMarkDeferredProperties(finalContext, node)
+      .forEach(node ->
+        DeferredValueUtils.findAndMarkDeferredProperties(finalContext, node)
       );
     assertThat(context.containsKey("java_bean")).isTrue();
     assertThat(context.get("java_bean")).isInstanceOf(DeferredValue.class);
@@ -180,9 +179,8 @@ public class DeferredValueUtilsTest {
     context.put("java_bean_undeferred", javaBean);
     context.put("nested_map_undeferred", nestedMap);
 
-    HashMap<String, Object> result = DeferredValueUtils.getDeferredContextWithOriginalValues(
-      context
-    );
+    HashMap<String, Object> result =
+      DeferredValueUtils.getDeferredContextWithOriginalValues(context);
     assertThat(result).contains(entry("simple_var", "SimpleVar"));
     assertThat(result).contains(entry("java_bean", javaBean));
     assertThat(result).contains(entry("simple_bool", true));
@@ -202,9 +200,8 @@ public class DeferredValueUtilsTest {
     context.put("simple_var", DeferredValue.instance());
     context.put("java_bean", DeferredValue.instance());
 
-    HashMap<String, Object> result = DeferredValueUtils.getDeferredContextWithOriginalValues(
-      context
-    );
+    HashMap<String, Object> result =
+      DeferredValueUtils.getDeferredContextWithOriginalValues(context);
     assertThat(result).isEmpty();
   }
 
@@ -306,6 +303,7 @@ public class DeferredValueUtilsTest {
   }
 
   private class JavaBean {
+
     String propertyOne;
     String propertyTwo;
 

--- a/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
@@ -42,6 +42,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class EagerExpressionResolverTest {
+
   private static final TokenScannerSymbols SYMBOLS = new DefaultTokenScannerSymbols();
 
   private JinjavaInterpreter interpreter;
@@ -320,10 +321,10 @@ public class EagerExpressionResolverTest {
       " %}"
     );
     assertThat(
-        (
-          (PyishDate) ((Map<String, Object>) interpreter.getContext().get("foo")).get("a")
-        ).toDateTime()
-      )
+      (
+        (PyishDate) ((Map<String, Object>) interpreter.getContext().get("foo")).get("a")
+      ).toDateTime()
+    )
       .isEqualTo(date.toDateTime());
   }
 
@@ -371,14 +372,14 @@ public class EagerExpressionResolverTest {
   @Test
   public void itOutputsEmptyForVoidFunctions() throws Exception {
     assertThat(
-        WhitespaceUtils.unquoteAndUnescape(interpreter.render("{{ void_function(2) }}"))
-      )
+      WhitespaceUtils.unquoteAndUnescape(interpreter.render("{{ void_function(2) }}"))
+    )
       .isEmpty();
     assertThat(
-        WhitespaceUtils.unquoteAndUnescape(
-          eagerResolveExpression("void_function(2)").toString()
-        )
+      WhitespaceUtils.unquoteAndUnescape(
+        eagerResolveExpression("void_function(2)").toString()
       )
+    )
       .isEmpty();
   }
 
@@ -571,10 +572,10 @@ public class EagerExpressionResolverTest {
   public void itHandlesPyishSerializable() {
     context.put("foo", new SomethingPyish("yes"));
     assertThat(
-        interpreter.render(
-          String.format("{{ %s.name }}", eagerResolveExpression("foo").toString())
-        )
+      interpreter.render(
+        String.format("{{ %s.name }}", eagerResolveExpression("foo").toString())
       )
+    )
       .isEqualTo("yes");
   }
 
@@ -736,7 +737,6 @@ public class EagerExpressionResolverTest {
       new PyList(
         Collections.singletonList(
           new AbstractCallableMethod("echo", map) {
-
             @Override
             public Object doEvaluate(
               Map<String, Object> argMap,
@@ -758,10 +758,10 @@ public class EagerExpressionResolverTest {
   @Test
   public void itHandlesOrOperator() {
     assertThat(
-        WhitespaceUtils.unquoteAndUnescape(
-          eagerResolveExpression("false == true || (true) ? 'yes' : 'no'").toString()
-        )
+      WhitespaceUtils.unquoteAndUnescape(
+        eagerResolveExpression("false == true || (true) ? 'yes' : 'no'").toString()
       )
+    )
       .isEqualTo("yes");
   }
 
@@ -870,6 +870,7 @@ public class EagerExpressionResolverTest {
   }
 
   private static class Foo {
+
     private final String bar;
 
     Foo(String bar) {
@@ -886,6 +887,7 @@ public class EagerExpressionResolverTest {
   }
 
   public class SomethingPyish implements PyishSerializable {
+
     private String name;
 
     public SomethingPyish(String name) {
@@ -898,6 +900,7 @@ public class EagerExpressionResolverTest {
   }
 
   public class SomethingExceptionallyPyish implements PyishSerializable {
+
     private String name;
 
     public SomethingExceptionallyPyish(String name) {

--- a/src/test/java/com/hubspot/jinjava/util/EagerReconstructionUtilsTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerReconstructionUtilsTest.java
@@ -43,6 +43,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EagerReconstructionUtilsTest extends BaseInterpretingTest {
+
   private static final long MAX_OUTPUT_SIZE = 50L;
 
   @Before
@@ -77,8 +78,8 @@ public class EagerReconstructionUtilsTest extends BaseInterpretingTest {
         }
       ),
       interpreter,
-      EagerContextWatcher
-        .EagerChildContextConfig.newBuilder()
+      EagerContextWatcher.EagerChildContextConfig
+        .newBuilder()
         .withTakeNewValue(true)
         .withForceDeferredExecutionMode(true)
         .withCheckForContextChanges(true)
@@ -108,8 +109,8 @@ public class EagerReconstructionUtilsTest extends BaseInterpretingTest {
         }
       ),
       interpreter,
-      EagerContextWatcher
-        .EagerChildContextConfig.newBuilder()
+      EagerContextWatcher.EagerChildContextConfig
+        .newBuilder()
         .withForceDeferredExecutionMode(true)
         .withCheckForContextChanges(true)
         .build()
@@ -197,11 +198,12 @@ public class EagerReconstructionUtilsTest extends BaseInterpretingTest {
 
   @Test
   public void itBuildsSetTagForDeferredAndRegisters() {
-    String result = EagerReconstructionUtils.buildBlockOrInlineSetTagAndRegisterDeferredToken(
-      "foo",
-      "bar",
-      interpreter
-    );
+    String result =
+      EagerReconstructionUtils.buildBlockOrInlineSetTagAndRegisterDeferredToken(
+        "foo",
+        "bar",
+        interpreter
+      );
     assertThat(result).isEqualTo("{% set foo = 'bar' %}");
     assertThat(context.getDeferredTokens()).hasSize(1);
     DeferredToken deferredToken = context
@@ -250,13 +252,12 @@ public class EagerReconstructionUtilsTest extends BaseInterpretingTest {
     for (int i = 0; i < MAX_OUTPUT_SIZE; i++) {
       tooLong.append(i);
     }
-    assertThatThrownBy(
-        () ->
-          EagerReconstructionUtils.buildBlockOrInlineSetTagAndRegisterDeferredToken(
-            "foo",
-            tooLong.toString(),
-            interpreter
-          )
+    assertThatThrownBy(() ->
+        EagerReconstructionUtils.buildBlockOrInlineSetTagAndRegisterDeferredToken(
+          "foo",
+          tooLong.toString(),
+          interpreter
+        )
       )
       .isInstanceOf(OutputTooBigException.class);
   }
@@ -269,11 +270,11 @@ public class EagerReconstructionUtilsTest extends BaseInterpretingTest {
       .withExecutionMode(PreserveRawExecutionMode.instance())
       .build();
     assertThat(
-        EagerReconstructionUtils.wrapInRawIfNeeded(
-          toWrap,
-          new JinjavaInterpreter(jinjava, context, preserveRawConfig)
-        )
+      EagerReconstructionUtils.wrapInRawIfNeeded(
+        toWrap,
+        new JinjavaInterpreter(jinjava, context, preserveRawConfig)
       )
+    )
       .isEqualTo(String.format("{%% raw %%}%s{%% endraw %%}", toWrap));
   }
 
@@ -285,11 +286,11 @@ public class EagerReconstructionUtilsTest extends BaseInterpretingTest {
       .withExecutionMode(PreserveRawExecutionMode.instance())
       .build();
     assertThat(
-        EagerReconstructionUtils.wrapInRawIfNeeded(
-          toWrap,
-          new JinjavaInterpreter(jinjava, context, preserveRawConfig)
-        )
+      EagerReconstructionUtils.wrapInRawIfNeeded(
+        toWrap,
+        new JinjavaInterpreter(jinjava, context, preserveRawConfig)
       )
+    )
       .isEqualTo(toWrap);
   }
 
@@ -301,11 +302,11 @@ public class EagerReconstructionUtilsTest extends BaseInterpretingTest {
       .build();
     String toWrap = "{{ foo }}";
     assertThat(
-        EagerReconstructionUtils.wrapInRawIfNeeded(
-          toWrap,
-          new JinjavaInterpreter(jinjava, context, defaultConfig)
-        )
+      EagerReconstructionUtils.wrapInRawIfNeeded(
+        toWrap,
+        new JinjavaInterpreter(jinjava, context, defaultConfig)
       )
+    )
       .isEqualTo(toWrap);
   }
 
@@ -340,11 +341,11 @@ public class EagerReconstructionUtilsTest extends BaseInterpretingTest {
       .getContext()
       .put(Context.IMPORT_RESOURCE_ALIAS_KEY, DeferredValue.instance());
     assertThat(
-        EagerReconstructionUtils.reconstructFromContextBeforeDeferring(
-          Collections.singleton(Context.IMPORT_RESOURCE_ALIAS_KEY),
-          interpreter
-        )
+      EagerReconstructionUtils.reconstructFromContextBeforeDeferring(
+        Collections.singleton(Context.IMPORT_RESOURCE_ALIAS_KEY),
+        interpreter
       )
+    )
       .isEmpty();
   }
 
@@ -382,24 +383,25 @@ public class EagerReconstructionUtilsTest extends BaseInterpretingTest {
         return EagerExpressionResult.fromString("");
       },
       interpreter,
-      EagerContextWatcher
-        .EagerChildContextConfig.newBuilder()
+      EagerContextWatcher.EagerChildContextConfig
+        .newBuilder()
         .withDiscardSessionBindings(false)
         .withCheckForContextChanges(true)
         .build()
     );
-    EagerExecutionResult withoutSessionBindings = EagerContextWatcher.executeInChildContext(
-      eagerInterpreter -> {
-        interpreter.getContext().put("foo", "foobar");
-        return EagerExpressionResult.fromString("");
-      },
-      interpreter,
-      EagerContextWatcher
-        .EagerChildContextConfig.newBuilder()
-        .withDiscardSessionBindings(true)
-        .withCheckForContextChanges(true)
-        .build()
-    );
+    EagerExecutionResult withoutSessionBindings =
+      EagerContextWatcher.executeInChildContext(
+        eagerInterpreter -> {
+          interpreter.getContext().put("foo", "foobar");
+          return EagerExpressionResult.fromString("");
+        },
+        interpreter,
+        EagerContextWatcher.EagerChildContextConfig
+          .newBuilder()
+          .withDiscardSessionBindings(true)
+          .withCheckForContextChanges(true)
+          .build()
+      );
     assertThat(withSessionBindings.getSpeculativeBindings())
       .containsEntry("foo", "foobar");
     assertThat(withoutSessionBindings.getSpeculativeBindings()).doesNotContainKey("foo");
@@ -412,8 +414,8 @@ public class EagerReconstructionUtilsTest extends BaseInterpretingTest {
       eagerInterpreter ->
         EagerExpressionResult.fromString(interpreter.render("{% set foo = 'bar' %}")),
       interpreter,
-      EagerContextWatcher
-        .EagerChildContextConfig.newBuilder()
+      EagerContextWatcher.EagerChildContextConfig
+        .newBuilder()
         .withDiscardSessionBindings(false)
         .withCheckForContextChanges(true)
         .withTakeNewValue(true)

--- a/src/test/java/com/hubspot/jinjava/util/ForLoopTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ForLoopTest.java
@@ -23,9 +23,11 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class ForLoopTest {
+
   private static final int NULL_VAL = Integer.MIN_VALUE;
 
   public static class AIterator implements Iterator<String> {
+
     int i = 0;
 
     @Override

--- a/src/test/java/com/hubspot/jinjava/util/HelperStringTokenizerTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/HelperStringTokenizerTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 public class HelperStringTokenizerTest {
+
   private HelperStringTokenizer tk;
 
   @Test
@@ -104,10 +105,10 @@ public class HelperStringTokenizerTest {
   @Test
   public void itDoesntReturnTrailingNull() {
     assertThat(
-        new HelperStringTokenizer("product in collections.frontpage.products   ")
-          .splitComma(true)
-          .allTokens()
-      )
+      new HelperStringTokenizer("product in collections.frontpage.products   ")
+        .splitComma(true)
+        .allTokens()
+    )
       .containsExactly("product", "in", "collections.frontpage.products")
       .doesNotContainNull();
   }

--- a/src/test/java/com/hubspot/jinjava/util/ObjectIteratorTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ObjectIteratorTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.junit.Test;
 
 public class ObjectIteratorTest {
+
   private Object items = null;
   private ForLoop loop = null;
 

--- a/src/test/java/com/hubspot/jinjava/util/ObjectTruthValueTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ObjectTruthValueTest.java
@@ -45,6 +45,7 @@ public class ObjectTruthValueTest {
   }
 
   private class TestObject implements HasObjectTruthValue {
+
     private boolean objectTruthValue = false;
 
     public TestObject setObjectTruthValue(boolean objectTruthValue) {

--- a/src/test/java/com/hubspot/jinjava/util/RenderLimitUtilsTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/RenderLimitUtilsTest.java
@@ -10,33 +10,33 @@ public class RenderLimitUtilsTest {
   @Test
   public void itPicksLowerLimitWhenConfigIsSet() {
     assertThat(
-        RenderLimitUtils.clampProvidedRenderLimitToConfig(100, configWithOutputSize(10))
-      )
+      RenderLimitUtils.clampProvidedRenderLimitToConfig(100, configWithOutputSize(10))
+    )
       .isEqualTo(10);
   }
 
   @Test
   public void itKeepsConfigLimitWhenConfigSetAndUnlimitedProvided() {
     assertThat(
-        RenderLimitUtils.clampProvidedRenderLimitToConfig(0, configWithOutputSize(10))
-      )
+      RenderLimitUtils.clampProvidedRenderLimitToConfig(0, configWithOutputSize(10))
+    )
       .isEqualTo(10);
     assertThat(
-        RenderLimitUtils.clampProvidedRenderLimitToConfig(-10, configWithOutputSize(10))
-      )
+      RenderLimitUtils.clampProvidedRenderLimitToConfig(-10, configWithOutputSize(10))
+    )
       .isEqualTo(10);
   }
 
   @Test
   public void itUsesProvidedLimitWhenConfigIsUnlimited() {
     assertThat(
-        RenderLimitUtils.clampProvidedRenderLimitToConfig(10, configWithOutputSize(0))
-      )
+      RenderLimitUtils.clampProvidedRenderLimitToConfig(10, configWithOutputSize(0))
+    )
       .isEqualTo(10);
 
     assertThat(
-        RenderLimitUtils.clampProvidedRenderLimitToConfig(10, configWithOutputSize(-10))
-      )
+      RenderLimitUtils.clampProvidedRenderLimitToConfig(10, configWithOutputSize(-10))
+    )
       .isEqualTo(10);
   }
 

--- a/src/test/java/com/hubspot/jinjava/util/ScopeMapTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ScopeMapTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class ScopeMapTest {
+
   Map<String, String> a, b, c;
 
   @Before


### PR DESCRIPTION
Upgrades to latest basepom and prettier-java to 2.1.0, which includes a lot of formatting changes unfortunately (probably easier to review [without whitespace changes](https://github.com/HubSpot/jinjava/pull/1145/files?w=1))

@jasmith-hs @boulter 