### PR TITLE
Not necessary to defer today().

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -169,8 +169,13 @@ public class Functions {
         );
       }
     }
-
-    ZonedDateTime dateTime = getDateTimeArg(System.currentTimeMillis(), zoneOffset);
+    long currentMillis = JinjavaInterpreter
+      .getCurrentMaybe()
+      .map(JinjavaInterpreter::getConfig)
+      .map(JinjavaConfig::getDateTimeProvider)
+      .map(DateTimeProvider::getCurrentTimeMillis)
+      .orElse(System.currentTimeMillis());
+    ZonedDateTime dateTime = getDateTimeArg(currentMillis, zoneOffset);
     return dateTime.toLocalDate().atStartOfDay(zoneOffset);
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -170,7 +170,7 @@ public class Functions {
       }
     }
 
-    ZonedDateTime dateTime = getDateTimeArg(null, zoneOffset);
+    ZonedDateTime dateTime = getDateTimeArg(System.currentTimeMillis(), zoneOffset);
     return dateTime.toLocalDate().atStartOfDay(zoneOffset);
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/fn/TodayFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/TodayFunctionTest.java
@@ -6,7 +6,6 @@ import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.interpret.Context;
-import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.mode.EagerExecutionMode;
@@ -65,7 +64,6 @@ public class TodayFunctionTest extends BaseInterpretingTest {
     assertThat(Functions.today((String) null).getZone()).isEqualTo(ZoneOffset.UTC);
   }
 
-  @Test(expected = DeferredValueException.class)
   public void itDefersWhenExecutingEagerly() {
     JinjavaInterpreter.pushCurrent(
       new JinjavaInterpreter(
@@ -77,10 +75,8 @@ public class TodayFunctionTest extends BaseInterpretingTest {
           .build()
       )
     );
-    try {
-      Functions.today(ZONE_NAME);
-    } finally {
-      JinjavaInterpreter.popCurrent();
-    }
+
+    ZonedDateTime today = Functions.today(ZONE_NAME);
+    assertThat(today.getYear()).isGreaterThan(2023);
   }
 }

--- a/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
@@ -773,13 +773,6 @@ public class EagerExpressionResolverTest {
   }
 
   @Test
-  public void itHandlesToday() {
-    context.put("foo", "bar");
-    assertThat(eagerResolveExpression("foo ~ today()").toString())
-      .isEqualTo("'bar' ~ today()");
-  }
-
-  @Test
   public void itHandlesRandom() {
     assertThat(eagerResolveExpression("range(1)|random").toString())
       .isEqualTo("filter:random.filter(range(1), ____int3rpr3t3r____)");


### PR DESCRIPTION
The value of today() does not change frequently, let make it not deferred.

Some users use `"today() | datetimeformat("%Y")"` for generate the Copyright year. They should have used the `year()` function.