### PR TITLE
Add custom serializer for NullValue.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/NullValue.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/NullValue.java
@@ -1,13 +1,41 @@
 package com.hubspot.jinjava.interpret;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.hubspot.jinjava.interpret.NullValue.NullValueSerializer;
+import java.io.IOException;
+
 /**
  * Marker object of a `null` value. A null value in the map is usually considered
  * the key does not exist. For example map = {"a": null}, if map.get("a") == null,
  * we treat it as the there is not key "a" in the map.
  */
+@JsonSerialize(using = NullValueSerializer.class)
 public final class NullValue {
 
   public static final NullValue INSTANCE = new NullValue();
+
+  public static class NullValueSerializer extends StdSerializer<NullValue> {
+
+    public NullValueSerializer() {
+      this(null);
+    }
+
+    protected NullValueSerializer(Class<NullValue> t) {
+      super(t);
+    }
+
+    @Override
+    public void serialize(
+      NullValue value,
+      JsonGenerator jgen,
+      SerializerProvider provider
+    ) throws IOException {
+      jgen.writeNull();
+    }
+  }
 
   private NullValue() {}
 

--- a/src/test/java/com/hubspot/jinjava/interpret/NullValueTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/NullValueTest.java
@@ -1,0 +1,23 @@
+package com.hubspot.jinjava.interpret;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+public class NullValueTest {
+
+  @Test
+  public void itSerializesUnderlyingValue() throws JsonProcessingException {
+    LazyExpression expression = LazyExpression.of(
+      () -> ImmutableMap.of("test", "hello", "test2", NullValue.instance()),
+      "{}"
+    );
+    Object evaluated = expression.get();
+    assertThat(evaluated).isNotNull();
+    assertThat(new ObjectMapper().writeValueAsString(expression))
+      .isEqualTo("{\"test\":\"hello\",\"test2\":null}");
+  }
+}


### PR DESCRIPTION
We need to serialize NullValue.
```
No serializer found for class com.hubspot.jinjava.interpret.NullValue and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS)
```