### PR TITLE
Fix no such element issue.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperator.java
@@ -48,7 +48,8 @@ public class CollectionMembershipOperator extends SimpleOperator {
 
     if (Map.class.isAssignableFrom(o2.getClass())) {
       Map map = (Map) o2;
-      if (map.isEmpty()) {
+      // An implementation of Map can override isEmpty() to false, but return empty keySet.
+      if (map.isEmpty() || map.keySet().isEmpty()) {
         return Boolean.FALSE;
       }
       Iterator iterator = map.keySet().iterator();

--- a/src/test/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperatorTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/CollectionMembershipOperatorTest.java
@@ -4,12 +4,33 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import java.util.AbstractMap;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 
 public class CollectionMembershipOperatorTest {
+
+  static class NoKeySetMap<K, V> extends AbstractMap<K, V> {
+
+    @Override
+    public boolean isEmpty() {
+      return false;
+    }
+
+    @Override
+    public Set<K> keySet() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+      return Collections.emptySet();
+    }
+  }
 
   private JinjavaInterpreter interpreter;
 
@@ -48,5 +69,13 @@ public class CollectionMembershipOperatorTest {
     assertThat(interpreter.resolveELExpression("'a' in map", -1)).isEqualTo(true);
     assertThat(interpreter.resolveELExpression("null in map", -1)).isEqualTo(true);
     assertThat(interpreter.resolveELExpression("'b' in map", -1)).isEqualTo(false);
+  }
+
+  @Test
+  public void itCheckEmptyKeySet() {
+    // The map is "not" empty, but keySet() is empty.
+    Map<String, Object> map = new NoKeySetMap<>();
+    interpreter.getContext().put("map", map);
+    assertThat(interpreter.resolveELExpression("'a' in map", -1)).isEqualTo(false);
   }
 }


### PR DESCRIPTION
An implementation of Map can override isEmpty() to false, but return empty keySet.