### PR TITLE
Do not add broken JSON to resolved expressions.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -87,16 +87,24 @@ public class ExpressionResolver {
     }
     expression = expression.trim();
     if (addToResolvedExpressions) {
+      if (WhitespaceUtils.isWrappedWith(expression, "[", "]")) {
+        String commaSeparatedExpress = expression
+          .substring(1, expression.length() - 1)
+          .trim();
+        // Over-simplified way to detect JSON format, avoid to break it for adding resolved expressions.
+        if (
+          !commaSeparatedExpress.startsWith("{") || !commaSeparatedExpress.endsWith("}")
+        ) {
+          Arrays
+            .stream(commaSeparatedExpress.split(","))
+            .forEach(substring ->
+              interpreter.getContext().addResolvedExpression(substring.trim())
+            );
+        }
+      }
       interpreter.getContext().addResolvedExpression(expression);
     }
 
-    if (WhitespaceUtils.isWrappedWith(expression, "[", "]")) {
-      Arrays
-        .stream(expression.substring(1, expression.length() - 1).split(","))
-        .forEach(substring ->
-          interpreter.getContext().addResolvedExpression(substring.trim())
-        );
-    }
     try {
       String elExpression = EXPRESSION_START_TOKEN + expression + EXPRESSION_END_TOKEN;
       ValueExpression valueExp = expressionFactory.createValueExpression(

--- a/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
@@ -773,6 +773,21 @@ public class EagerExpressionResolverTest {
   }
 
   @Test
+  public void itDoesNotSplitJsonResolvedExpression() {
+    eagerResolveExpression("{'a': 1, 'b': 2}");
+    assertThat(context.getResolvedExpressions())
+      .containsExactlyInAnyOrder("{'a': 1, 'b': 2}");
+  }
+
+  @Test
+  public void itDoesNotSplitJsonInArrayResolvedExpression() {
+    // It should not add the broke JSON `{'a': 1` to resolved expressions.
+    eagerResolveExpression("[{'a': 1, 'b': 2}]");
+    assertThat(context.getResolvedExpressions())
+      .containsExactlyInAnyOrder("[{'a': 1, 'b': 2}]");
+  }
+
+  @Test
   public void itHandlesRandom() {
     assertThat(eagerResolveExpression("range(1)|random").toString())
       .isEqualTo("filter:random.filter(range(1), ____int3rpr3t3r____)");


### PR DESCRIPTION
When we resolve an expression as a "JSON" object, we should not break it out into broken pieces.
For example, `expr = {'a': 1, 'b': 2} `, we should not add `{'a': 1` to resolved expressions.
