### PR TITLE
Debug Undefined Feature to echo back Uknown tokens.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/expression/DefaultExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/DefaultExpressionStrategy.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.expression;
 
+import com.hubspot.jinjava.features.FeatureActivationStrategy;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.filter.EscapeFilter;
 import com.hubspot.jinjava.objects.SafeString;
@@ -11,6 +12,7 @@ import org.apache.commons.lang3.StringUtils;
 public class DefaultExpressionStrategy implements ExpressionStrategy {
 
   private static final long serialVersionUID = 436239440273704843L;
+  public static final String ECHO_UNDEFINED = "echoUndefined";
 
   public RenderedOutputNode interpretOutput(
     ExpressionToken master,
@@ -41,6 +43,14 @@ public class DefaultExpressionStrategy implements ExpressionStrategy {
     if (interpreter.getContext().isAutoEscape() && !(var instanceof SafeString)) {
       result = EscapeFilter.escapeHtmlEntities(result);
     }
+    final FeatureActivationStrategy feat = interpreter
+          .getConfig()
+          .getFeatures()
+          .getActivationStrategy(ECHO_UNDEFINED);
+
+  if (result.isEmpty() && feat.isActive(interpreter.getContext())){
+      result = master.getImage();
+  }
 
     return new RenderedOutputNode(result);
   }

--- a/src/main/java/com/hubspot/jinjava/lib/expression/DefaultExpressionStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/expression/DefaultExpressionStrategy.java
@@ -22,6 +22,16 @@ public class DefaultExpressionStrategy implements ExpressionStrategy {
       master.getExpr(),
       master.getLineNumber()
     );
+
+    final FeatureActivationStrategy feat = interpreter
+      .getConfig()
+      .getFeatures()
+      .getActivationStrategy(ECHO_UNDEFINED);
+
+    if (var == null && feat.isActive(interpreter.getContext())) {
+      return new RenderedOutputNode(master.getImage());
+    }
+
     String result = interpreter.getAsString(var);
 
     if (interpreter.getConfig().isNestedInterpretationEnabled()) {
@@ -43,14 +53,6 @@ public class DefaultExpressionStrategy implements ExpressionStrategy {
     if (interpreter.getContext().isAutoEscape() && !(var instanceof SafeString)) {
       result = EscapeFilter.escapeHtmlEntities(result);
     }
-    final FeatureActivationStrategy feat = interpreter
-          .getConfig()
-          .getFeatures()
-          .getActivationStrategy(ECHO_UNDEFINED);
-
-  if (result.isEmpty() && feat.isActive(interpreter.getContext())){
-      result = master.getImage();
-  }
 
     return new RenderedOutputNode(result);
   }

--- a/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
@@ -133,24 +133,26 @@ public class ExpressionNodeTest extends BaseInterpretingTest {
   }
 
   @Test
-  public void itRenderDebugUndefined() {
-
+  public void itRenderEchoUndefined() {
     final JinjavaConfig config = JinjavaConfig
-            .newBuilder()
-            .withFeatureConfig(FeatureConfig
-                    .newBuilder()
-                    .add(ECHO_UNDEFINED, FeatureStrategies.ACTIVE).build())
-            .build();
+      .newBuilder()
+      .withFeatureConfig(
+        FeatureConfig.newBuilder().add(ECHO_UNDEFINED, FeatureStrategies.ACTIVE).build()
+      )
+      .build();
     final JinjavaInterpreter jinjavaInterpreter = new Jinjava(config).newInterpreter();
     jinjavaInterpreter.getContext().put("subject", "this");
 
-    String template = "{{ subject | capitalize() }} expression {{ testing.template('hello_world') }} " +
-            "has a {{ unknown | lower() }} " +
-            "token but {{ unknown | default(\"replaced\") }}";
+    String template =
+      "{{ subject | capitalize() }} expression {{ testing.template('hello_world') }} " +
+      "has a {{ unknown | lower() }} " +
+      "token but {{ unknown | default(\"replaced\") }} and empty {{ '' }}";
     Node node = new TreeParser(jinjavaInterpreter, template).buildTree();
     assertThat(jinjavaInterpreter.render(node))
-            .isEqualTo("This expression {{ testing.template('hello_world') }} " +
-                    "has a {{ unknown | lower() }} token but replaced");
+      .isEqualTo(
+        "This expression {{ testing.template('hello_world') }} " +
+        "has a {{ unknown | lower() }} token but replaced and empty "
+      );
   }
 
   @Test


### PR DESCRIPTION
Inspired by this [PR - Render back unresolved tokens](https://github.com/HubSpot/jinjava/pull/1072). Implemented instead with features as suggested by @jasmith-hs and named `ECHO_UNDEFINED` . I originally wanted to call it DEBUG_UNDEFINED to get close to this [feature in jinja2](https://github.com/pallets/jinja/blob/3fd91e4d11bdd131d8c12805177dbe74d85e7b82/tests/test_api.py#L354), but that offers a bit more. 