### PR TITLE
Discards disabled module errors in interpreter when using render filter

### DIFF
--- a/src/main/java/com/hubspot/jinjava/features/RemoveModuleDisabledErrorsActivationStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/features/RemoveModuleDisabledErrorsActivationStrategy.java
@@ -1,0 +1,20 @@
+package com.hubspot.jinjava.features;
+
+import com.hubspot.jinjava.interpret.Context;
+
+public class RemoveModuleDisabledErrorsActivationStrategy implements FeatureActivationStrategy{
+  private final boolean enabled;
+
+  public static RemoveModuleDisabledErrorsActivationStrategy of(boolean enabled) {
+    return new RemoveModuleDisabledErrorsActivationStrategy(enabled);
+  }
+  private RemoveModuleDisabledErrorsActivationStrategy(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+
+  @Override
+  public boolean isActive(Context context) {
+    return enabled;
+  }
+}


### PR DESCRIPTION
Includes a method for removing disabled modules from the interpreter when running the render filter.