### PR TITLE
add support for numeric keys in map literal

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
@@ -50,7 +50,7 @@ public class AstDict extends AstLiteral {
         // This is a hack to treat numeric keys as string keys in the dictionary.
         // In most cases this is adequate since the keys are typically treated as
         // strings.
-        key = entryKey.eval(bindings, context).toString();
+        key = Objects.toString(entryKey.eval(bindings, context));
       } else {
         throw new TemplateStateException(
           "Dict key must be a string, or identifier, or a  number, was: " + entryKey

--- a/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
@@ -7,6 +7,7 @@ import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstIdentifier;
 import de.odysseus.el.tree.impl.ast.AstLiteral;
 import de.odysseus.el.tree.impl.ast.AstNode;
+import de.odysseus.el.tree.impl.ast.AstNumber;
 import de.odysseus.el.tree.impl.ast.AstString;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -45,6 +46,11 @@ public class AstDict extends AstLiteral {
         } else {
           key = ((AstIdentifier) entryKey).getName();
         }
+      } else if (entryKey instanceof AstNumber) {
+        // This is a hack to treat numeric keys as string keys in the dictionary.
+        // In most cases this is adequate since the keys are typically treated as
+        // strings.
+        key = entryKey.eval(bindings, context).toString();
       } else {
         throw new TemplateStateException(
           "Dict key must be a string or identifier, was: " + entryKey

--- a/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AstDict.java
@@ -53,7 +53,7 @@ public class AstDict extends AstLiteral {
         key = entryKey.eval(bindings, context).toString();
       } else {
         throw new TemplateStateException(
-          "Dict key must be a string or identifier, was: " + entryKey
+          "Dict key must be a string, or identifier, or a  number, was: " + entryKey
         );
       }
 

--- a/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
@@ -188,6 +188,11 @@ public class ExtendedSyntaxBuilderTest {
   }
 
   @Test
+  public void mapLiteralWithNumericKey() {
+    assertThat((Map<String, Object>) val("{0:'test'}")).contains(entry("0", "test"));
+  }
+
+  @Test
   public void itParsesDictWithVariableRefs() {
     List<?> theList = Lists.newArrayList(1L, 2L, 3L);
     context.put("the_list", theList);


### PR DESCRIPTION
This supercedes #934 (rebased, and then addresses the review comment), and fixes #1090. Note that I verified Python Jinja accepts numbers as dict keys:

```python
>>> from jinja2 import Environment
>>> env = Environment()
>>> expr = env.compile_expression("{0:'test'}[0]")
>>> expr()
'test'
```