### PR TITLE
Make output of map sorted by key in pprint.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/PrettyPrintFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/PrettyPrintFilter.java
@@ -10,6 +10,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.objects.date.PyishDate;
 import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
 
 @JinjavaDoc(
   value = "Pretty print a variable. Useful for debugging.",
@@ -45,10 +46,12 @@ public class PrettyPrintFilter implements Filter {
       var instanceof String ||
       var instanceof Number ||
       var instanceof PyishDate ||
-      var instanceof Iterable ||
-      var instanceof Map
+      var instanceof Iterable
     ) {
       varStr = Objects.toString(var);
+    } else if (var instanceof Map) {
+      TreeMap map = new TreeMap((Map) var);
+      varStr = Objects.toString(map);
     } else {
       try {
         varStr =

--- a/src/test/java/com/hubspot/jinjava/lib/filter/PrettyPrintFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/PrettyPrintFilterTest.java
@@ -52,8 +52,8 @@ public class PrettyPrintFilterTest {
 
   @Test
   public void ppMap() {
-    assertThat(f.filter(ImmutableMap.of("a", "foo", "b", "bar"), null))
-      .isEqualTo("{% raw %}(RegularImmutableMap: {a=foo, b=bar}){% endraw %}");
+    assertThat(f.filter(ImmutableMap.of("b", "foo", "a", "bar"), null))
+      .isEqualTo("{% raw %}(RegularImmutableMap: {a=bar, b=foo}){% endraw %}");
   }
 
   @Test


### PR DESCRIPTION
The output of a map should be stable -- not depending on what an entry is added. So sorting them be key before serialization makes it stable.