### PR TITLE
Manually set javadoc version to 3.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
   <properties>
     <dep.javassist.version>3.24.1-GA</dep.javassist.version>
     <dep.plugin.jacoco.version>0.8.3</dep.plugin.jacoco.version>
+    <dep.plugin.javadoc.version>3.0.1</dep.plugin.javadoc.version>
     <dep.guava.version>31.1-jre</dep.guava.version>
     <dep.error-prone.version>2.19.1</dep.error-prone.version>
 


### PR DESCRIPTION
This version from basepom 25 supports the "1.8" version string.
Just doing this to get the release out without a hitch, then we can change the target version to "8" which should mean the same thing as "1.8" everywhere, but isn't necessarily the case as javadoc 3.1.0+ only supports "8"