### PR TITLE
Update to lastest version of basepom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>56.2</version>
+    <version>56.3</version>
   </parent>
 
   <groupId>com.hubspot.jinjava</groupId>
@@ -16,7 +16,6 @@
   <properties>
     <dep.javassist.version>3.24.1-GA</dep.javassist.version>
     <dep.plugin.jacoco.version>0.8.3</dep.plugin.jacoco.version>
-    <dep.plugin.javadoc.version>3.0.1</dep.plugin.javadoc.version>
     <dep.guava.version>31.1-jre</dep.guava.version>
     <dep.error-prone.version>2.19.1</dep.error-prone.version>
 


### PR DESCRIPTION
This changes the version of basepom to `56.3`. This fixes the mismatch between the `targetJdk` and use of javadoc here. Incidentally, it includes an update to the `maven-release-plugin`, which should make your release flow easier (you shouldn't need to manually go to Sonatype anymore 🙂 )