### PR TITLE
Use renderFlat inside of the RenderFilter

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -238,6 +238,20 @@ public class JinjavaInterpreter implements PyishSerializable {
    * @return rendered result
    */
   public String renderFlat(String template) {
+    return renderFlat(template, config.getMaxOutputSize());
+  }
+
+  /**
+   * Parse the given string into a root Node, and then render it without processing any extend parents.
+   * This method should be used when the template is known to not have any extends or block tags.
+   *
+   * @param template
+   *          string to parse
+   * @param renderLimit
+   *          stop rendering once this output length is reached
+   * @return rendered result
+   */
+  public String renderFlat(String template, long renderLimit) {
     int depth = context.getRenderDepth();
 
     try {
@@ -246,7 +260,7 @@ public class JinjavaInterpreter implements PyishSerializable {
         return template;
       } else {
         context.setRenderDepth(depth + 1);
-        return render(parse(template), false);
+        return render(parse(template), false, renderLimit);
       }
     } finally {
       context.setRenderDepth(depth);
@@ -264,6 +278,15 @@ public class JinjavaInterpreter implements PyishSerializable {
     return render(template, config.getMaxOutputSize());
   }
 
+  /**
+   * Parse the given string into a root Node, and then renders it processing extend parents.
+   *
+   * @param template
+   *          string to parse
+   * @param renderLimit
+   *          stop rendering once this output length is reached
+   * @return rendered result
+   */
   public String render(String template, long renderLimit) {
     return render(parse(template), true, renderLimit);
   }
@@ -299,7 +322,7 @@ public class JinjavaInterpreter implements PyishSerializable {
    * @param processExtendRoots
    *          if true, also render all extend parents
    * @param renderLimit
-   *          the number of characters the result may contain
+   *          stop rendering once this output length is reached
    * @return rendered result
    */
   private String render(Node root, boolean processExtendRoots, long renderLimit) {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/RenderFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/RenderFilter.java
@@ -28,7 +28,7 @@ public class RenderFilter implements Filter {
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
     if (args.length > 0) {
       String firstArg = args[0];
-      return interpreter.render(
+      return interpreter.renderFlat(
         Objects.toString(var),
         NumberUtils.toLong(
           firstArg,
@@ -36,6 +36,6 @@ public class RenderFilter implements Filter {
         )
       );
     }
-    return interpreter.render(Objects.toString(var));
+    return interpreter.renderFlat(Objects.toString(var));
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RenderFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RenderFilterTest.java
@@ -59,4 +59,27 @@ public class RenderFilterTest extends BaseInterpretingTest {
     assertThat(filter.filter(stringToRender, interpreter, "17"))
       .isEqualTo("<p> Hello, world!");
   }
+
+  @Test
+  public void itDoesNotProcessExtendsRoots() {
+    String stringToRender =
+      "{% extends 'filter/render/base.jinja' %}\n" +
+      "{% set foo = '{{ 1 + 1}}'|render %}\n" +
+      "{% block body %}\n" +
+      "I am the extension body and foo is {% print foo %}\n" +
+      "{% endblock %}" +
+      "{% block footer %}\n" +
+      "I am the extension footer\n" +
+      "{% endblock %}";
+
+    assertThat(interpreter.render(stringToRender))
+      .isEqualTo(
+        "Body is: \n" +
+        "I am the extension body and foo is 2\n" +
+        "\n" +
+        "Footer is: \n" +
+        "I am the extension footer\n" +
+        "\n"
+      );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/filter/RenderFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/RenderFilterTest.java
@@ -63,11 +63,12 @@ public class RenderFilterTest extends BaseInterpretingTest {
   @Test
   public void itDoesNotProcessExtendsRoots() {
     String stringToRender =
-      "{% extends 'filter/render/base.jinja' %}\n" +
-      "{% set foo = '{{ 1 + 1}}'|render %}\n" +
+      "{% extends 'filter/render/base.jinja' -%}\n" +
       "{% block body %}\n" +
-      "I am the extension body and foo is {% print foo %}\n" +
+      "I am the extension body\n" +
       "{% endblock %}" +
+      "You should never see this text in the output!\n" +
+      "{%- set foo = '{{ 1 + 1}}'|render -%}\n" +
       "{% block footer %}\n" +
       "I am the extension footer\n" +
       "{% endblock %}";
@@ -75,7 +76,7 @@ public class RenderFilterTest extends BaseInterpretingTest {
     assertThat(interpreter.render(stringToRender))
       .isEqualTo(
         "Body is: \n" +
-        "I am the extension body and foo is 2\n" +
+        "I am the extension body\n" +
         "\n" +
         "Footer is: \n" +
         "I am the extension footer\n" +

--- a/src/test/resources/filter/render/base.jinja
+++ b/src/test/resources/filter/render/base.jinja
@@ -1,0 +1,6 @@
+Body is: {% block body %}
+Base body
+{% endblock %}
+Footer is: {% block footer %}
+Base footer
+{% endblock %}


### PR DESCRIPTION
So that extends roots are not prematurely processed. Similar to how expression nodes use `interpreter.renderFlat` when doing nested interpretation, the `RenderFilter` must do the same, otherwise it will process the extends roots early.
What this looks like is that the new test I added's output looks like this before this fix:
```
I am the extension body
You should never see this text in the output!
Base footer
```

### The reason this bug happens is because:
- We encounter the `{% extends 'filter/render/base.jinja' %}` tag, and add the `base.jinja` as an extends root
- We encounter the extended `{% block body %}`
- We use the `|render` filter
- We then try to process the extends root.
   - We find `{% block body %}` and `{% block footer %}` and resolve them to the extended `body` and the base `footer` as that is all we've seen at this point
   - We pop the extends root
   - We return the output of `base.jinja` with the extended `body` substituted in
 - We encounter the extended `{% block footer %}`
 - We try to process the extends root, there are none anymore so we act like our original template didn't extend anything and we output it, including its (previously resolved) blocks


### What should happen (what now happens after this PR) is:
- We encounter the `{% extends 'filter/render/base.jinja' %}` tag, and add the `base.jinja` as an extends root
- We encounter the extended `{% block body %}`
- We use the `|render` filter
- We encounter the extended `{% block footer %}`
- We try to process the extends root
   - We find `{% block body %}` and `{% block footer %}` and resolve them to the extended `body` and the extended `footer` as we've seen both of those already
   - We pop the extends root
   - We return the output of `base.jinja` with the extended `body` and `footer` substituted in