### PR TITLE
limit length of strings in operators

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/AdditionOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AdditionOperator.java
@@ -3,14 +3,11 @@ package com.hubspot.jinjava.el.ext;
 import de.odysseus.el.misc.NumberOperations;
 import de.odysseus.el.misc.TypeConverter;
 import de.odysseus.el.tree.impl.ast.AstBinary;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
-public class AdditionOperator extends AstBinary.SimpleOperator {
+public class AdditionOperator
+  extends AstBinary.SimpleOperator
+  implements StringBuildingOperator {
 
   @SuppressWarnings("unchecked")
   @Override
@@ -33,7 +30,10 @@ public class AdditionOperator extends AstBinary.SimpleOperator {
     }
 
     if (o1 instanceof String || o2 instanceof String) {
-      return Objects.toString(o1).concat(Objects.toString(o2));
+      return getStringBuilder()
+        .append(Objects.toString(o1))
+        .append(Objects.toString(o2))
+        .toString();
     }
 
     return NumberOperations.add(converter, o1, o2);

--- a/src/main/java/com/hubspot/jinjava/el/ext/AdditionOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AdditionOperator.java
@@ -3,7 +3,12 @@ package com.hubspot.jinjava.el.ext;
 import de.odysseus.el.misc.NumberOperations;
 import de.odysseus.el.misc.TypeConverter;
 import de.odysseus.el.tree.impl.ast.AstBinary;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 public class AdditionOperator
   extends AstBinary.SimpleOperator

--- a/src/main/java/com/hubspot/jinjava/el/ext/StringBuildingOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/StringBuildingOperator.java
@@ -1,0 +1,16 @@
+package com.hubspot.jinjava.el.ext;
+
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
+
+public interface StringBuildingOperator {
+  default LengthLimitingStringBuilder getStringBuilder() {
+    JinjavaInterpreter interpreter = JinjavaInterpreter.getCurrent();
+
+    long maxSize = (interpreter == null || interpreter.getConfig() == null)
+      ? 0
+      : interpreter.getConfig().getMaxOutputSize();
+
+    return new LengthLimitingStringBuilder(maxSize);
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/el/ext/StringConcatOperator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/StringConcatOperator.java
@@ -9,14 +9,16 @@ import de.odysseus.el.tree.impl.ast.AstBinary;
 import de.odysseus.el.tree.impl.ast.AstBinary.SimpleOperator;
 import de.odysseus.el.tree.impl.ast.AstNode;
 
-public class StringConcatOperator extends SimpleOperator {
+public class StringConcatOperator
+  extends SimpleOperator
+  implements StringBuildingOperator {
 
   @Override
   protected Object apply(TypeConverter converter, Object o1, Object o2) {
     String o1s = converter.convert(o1, String.class);
     String o2s = converter.convert(o2, String.class);
 
-    return new StringBuilder(o1s).append(o2s).toString();
+    return getStringBuilder().append(o1s).append(o2s).toString();
   }
 
   @Override


### PR DESCRIPTION
There were a couple of places where we were not limiting the length of large strings, allowing users to create huge ones. This fixes both the `~` and `+` operators to limit string length based on the config value.