### PR TITLE
Fix NPE for loop tuple vars of null.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -215,6 +215,17 @@ public class ForTag implements Tag {
         } else {
           for (int loopVarIndex = 0; loopVarIndex < loopVars.size(); loopVarIndex++) {
             String loopVar = loopVars.get(loopVarIndex);
+            if (val == null) {
+              if (
+                interpreter.getContext().get(loopVar) != null &&
+                interpreter.getConfig().getLegacyOverrides().isKeepNullableLoopValues()
+              ) {
+                interpreter.getContext().put(loopVar, NullValue.INSTANCE);
+              } else {
+                interpreter.getContext().put(loopVar, null);
+              }
+              continue;
+            }
             if (Entry.class.isAssignableFrom(val.getClass())) {
               Entry<String, Object> entry = (Entry<String, Object>) val;
               Object entryVal = null;

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ForTagTest.java
@@ -391,6 +391,21 @@ public class ForTagTest extends BaseInterpretingTest {
     assertThat(result).isEqualTo(" 1  2  null  null  null ");
   }
 
+  @Test
+  public void forLoopTupleWithNullValues() {
+    context.put("number", -1);
+    context.put("the_list", Lists.newArrayList(1L, 2L, null, null, null));
+    String template = "{% for number,name in the_list %} {{ number }} {% endfor %}";
+    TagNode tagNode = (TagNode) new TreeParser(interpreter, template)
+      .buildTree()
+      .getChildren()
+      .getFirst();
+    String result = tag.interpret(tagNode, interpreter);
+    // This is quite intuitive, if the value cannot be assigned to the loop var,
+    // the outer value of number is used as in the loop, number is not assigned if val is not null.
+    assertThat(result).isEqualTo(" -1  -1  null  null  null ");
+  }
+
   public static boolean inForLoop() {
     JinjavaInterpreter interpreter = JinjavaInterpreter.getCurrent();
     return interpreter.getContext().isInForLoop();


### PR DESCRIPTION
If the a loop value is null, we should not try to get the `.getClass()` of it. It throws a NPE. We fixed this for single var loops, did not expect this also happens for tuples.

A bad jinjava tag can trigger it:
```
{% for  for row in module.specific_projects  %}
```