### PR TITLE
Always try to resolve a PartiallyDeferredValue if possible

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
@@ -5,6 +5,7 @@ import com.hubspot.jinjava.el.ext.ExtendedParser;
 import com.hubspot.jinjava.el.ext.IdentifierPreservationStrategy;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.PartiallyDeferredValue;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
 import de.odysseus.el.tree.Bindings;
 import de.odysseus.el.tree.impl.ast.AstIdentifier;
@@ -106,7 +107,13 @@ public interface EvalResultHolder {
     }
     if (
       !preserveIdentifier.isPreserving() ||
-      (astNode.hasEvalResult() && EagerExpressionResolver.isPrimitive(evalResult))
+      (
+        astNode.hasEvalResult() &&
+        (
+          EagerExpressionResolver.isPrimitive(evalResult) ||
+          evalResult instanceof PartiallyDeferredValue
+        )
+      )
     ) {
       if (exceptionMatchesNode(exception, astNode)) {
         return exception.getDeferredEvalResult();

--- a/src/test/java/com/hubspot/jinjava/interpret/PartiallyDeferredValueTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/PartiallyDeferredValueTest.java
@@ -147,6 +147,26 @@ public class PartiallyDeferredValueTest extends BaseInterpretingTest {
     assertThat(interpreter.getContext().getDeferredNodes()).isEmpty();
   }
 
+  @Test
+  public void itSerializesPartiallyDeferredValueInsteadOfPreservingOriginalIdentifier() {
+    interpreter.getContext().put("foo", new GoodPyishSerializable());
+    assertThat(
+      interpreter.render(
+        "{% set list = [] %}{% set bar = foo %}{% do list.append(bar['resolved']) %}{% print list %}"
+      )
+    )
+      .isEqualTo("['resolved']");
+    assertThat(
+      interpreter.render(
+        "{% set list = [] %}{% set bar = foo %}{% do list.append(bar['deferred']) %}{% print list %}"
+      )
+    )
+      .isEqualTo(
+        "{% set list = [] %}{% do list.append(good['deferred']) %}{% print list %}"
+      );
+    assertThat(interpreter.getContext().getDeferredNodes()).isEmpty();
+  }
+
   public static class BadSerialization implements PartiallyDeferredValue {
 
     public String getDeferred() {


### PR DESCRIPTION
If we preserve the PartiallyDeferredValue's identifier, we'd end up with a result like:
```
{% set list = [] %}{% do list.append(bar['deferred']) %}{% print list %}
```
And we wouldn't know what `bar` refers to since it's a PartiallyDeferedValue, we'll never explicitly reconstruct it, so we have to try to resolve it to it's PyishSerializable value here.