### PR TITLE
Upgrade basepom to 59.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>56.2</version>
+    <version>59.3-SNAPSHOT</version>
   </parent>
 
   <groupId>com.hubspot.jinjava</groupId>
@@ -14,7 +14,9 @@
   <description>Jinja templating engine implemented in Java</description>
 
   <properties>
-    <dep.javassist.version>3.24.1-GA</dep.javassist.version>
+    <project.build.targetJdk>8</project.build.targetJdk>
+    <project.build.releaseJdk>8</project.build.releaseJdk>
+
     <dep.plugin.jacoco.version>0.8.3</dep.plugin.jacoco.version>
     <dep.plugin.javadoc.version>3.0.1</dep.plugin.javadoc.version>
     <dep.guava.version>31.1-jre</dep.guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>59.3-SNAPSHOT</version>
+    <version>59.4</version>
   </parent>
 
   <groupId>com.hubspot.jinjava</groupId>
@@ -19,10 +19,6 @@
 
     <dep.plugin.jacoco.version>0.8.3</dep.plugin.jacoco.version>
     <dep.plugin.javadoc.version>3.0.1</dep.plugin.javadoc.version>
-    <dep.guava.version>31.1-jre</dep.guava.version>
-    <dep.error-prone.version>2.19.1</dep.error-prone.version>
-
-    <dep.logback.version>1.2.3</dep.logback.version>
 
     <basepom.test.add.opens>
       --add-opens=java.base/java.lang=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>59.5</version>
+    <version>59.7</version>
   </parent>
 
   <groupId>com.hubspot.jinjava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>59.4</version>
+    <version>59.5</version>
   </parent>
 
   <groupId>com.hubspot.jinjava</groupId>

--- a/src/test/java/com/hubspot/jinjava/lib/filter/StripTagsFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/StripTagsFilterTest.java
@@ -19,7 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StripTagsFilterTest {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/TruncateFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/TruncateFilterTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TruncateFilterTest {

--- a/src/test/java/com/hubspot/jinjava/lib/tag/IncludeTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/IncludeTagTest.java
@@ -31,7 +31,7 @@ public class IncludeTagTest extends BaseInterpretingTest {
       ),
       new HashMap<String, Object>()
     );
-    assertThat(result).containsSequence("hello world", "hello world");
+    assertThat(result).containsSubsequence("hello world", "hello world");
   }
 
   @Test
@@ -43,7 +43,7 @@ public class IncludeTagTest extends BaseInterpretingTest {
       ),
       new HashMap<String, Object>()
     );
-    assertThat(result).containsSequence("A", "B");
+    assertThat(result).containsSubsequence("A", "B");
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/lib/tag/ValidationModeTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/ValidationModeTest.java
@@ -21,7 +21,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ValidationModeTest {

--- a/src/test/java/com/hubspot/jinjava/loader/CascadingResourceLocatorTest.java
+++ b/src/test/java/com/hubspot/jinjava/loader/CascadingResourceLocatorTest.java
@@ -9,7 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("unchecked")


### PR DESCRIPTION
This PR updates basepom to 59.5, which aligns dependency version overrides with our downstream parent. It also sets the default target jdk to 11, so I've pinned it to 8 here.

One of the dependency updates is mockito, from v4 to v5, shown in some of the code changes.
