### PR TITLE
Only unwrap raw tags from set block when fully resolved

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/SetTag.java
@@ -19,7 +19,6 @@ import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.doc.annotations.JinjavaTextMateSnippet;
-import com.hubspot.jinjava.interpret.Context.TemporaryValueClosable;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
@@ -169,12 +168,8 @@ public class SetTag implements Tag, FlexibleTag {
   private static String renderChildren(TagNode tagNode, JinjavaInterpreter interpreter) {
     String result;
     StringBuilder sb = new StringBuilder();
-    try (
-      TemporaryValueClosable<Boolean> c = interpreter.getContext().withUnwrapRawOverride()
-    ) {
-      for (Node child : tagNode.getChildren()) {
-        sb.append(child.render(interpreter));
-      }
+    for (Node child : tagNode.getChildren()) {
+      sb.append(child.render(interpreter));
     }
     result = sb.toString();
     return result;

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1520,4 +1520,11 @@ public class EagerTest {
       "handles-deferred-modification-in-caller.expected"
     );
   }
+
+  @Test
+  public void itPreservesRawInsideDeferredSetBlock() {
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "preserves-raw-inside-deferred-set-block"
+    );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagTest.java
@@ -227,6 +227,24 @@ public class EagerSetTagTest extends SetTagTest {
   }
 
   @Test
+  public void itUnwrapsEmptyAdjacentRawTags() {
+    String template =
+      "{% set foo %}A{% raw %}{% endraw %}{% raw %}{% endraw %}B{% endset %}";
+    interpreter.render(template);
+    assertThat(interpreter.getContext().get("foo")).isEqualTo("AB");
+  }
+
+  @Test
+  public void itDoesNotDoExtraNestedInterpretationWhenUnwrappingRaw() {
+    String template =
+      "{% set foo %}{% print '{{ 1 + 1 }}' %}{% raw %}{% endraw %}{{ deferred }}B{% endset %}";
+    String result = interpreter.render(template);
+    interpreter.getContext().put("deferred", "resolved");
+    interpreter.render(result);
+    assertThat(interpreter.getContext().get("foo")).isEqualTo("{{ 1 + 1 }}resolvedB");
+  }
+
+  @Test
   @Override
   @Ignore
   public void itThrowsAndDefersVarWhenValContainsDeferred() {

--- a/src/test/resources/eager/preserves-raw-inside-deferred-set-block.expected.jinja
+++ b/src/test/resources/eager/preserves-raw-inside-deferred-set-block.expected.jinja
@@ -1,0 +1,8 @@
+{% set foo %}
+{% if deferred %}
+{% raw %}{{ 'fire' }}{% endraw %}
+{% else %}
+water
+{% endif %}
+{% endset %}
+{% print foo %}

--- a/src/test/resources/eager/preserves-raw-inside-deferred-set-block.jinja
+++ b/src/test/resources/eager/preserves-raw-inside-deferred-set-block.jinja
@@ -1,0 +1,8 @@
+{% set foo %}
+{% if deferred %}
+{% raw %}{{ 'fire' }}{% endraw %}
+{% else %}
+{{ 'water' }}
+{% endif %}
+{% endset %}
+{% print foo %}


### PR DESCRIPTION
When rendering a set block with eager execution, if it cannot be fully resolved, it must be deferred and reconstructed If there are raw tags inside of it when this happens, the reconstructed image will not be correct.

This input:
```
{% set foo %}
{% if deferred %}
{% raw %}{{ 'fire' }}{% endraw %}
{% endif %}
{% endset %}
{% print foo %}
```
Would incorrectly become:
```
{% set foo %}
{% if deferred %}
{{ 'fire' }}
{% endif %}
{% endset %}
{% print foo %}
```

To fix this, I've made it so that we solve the problem from https://github.com/HubSpot/jinjava/pull/1080 in a different manner, by only unwrapping the raw tags if the result has been fully resolved. The simplest way to unwrap the raw tags is by doing a `renderFlat`.