### PR TITLE
Intercept out of range ArrayIndexOutOfBoundsException with custom's one

### DIFF
--- a/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
@@ -53,7 +53,7 @@ public class PyList extends ForwardingList<Object> implements PyWrapper {
   }
 
   public Object pop() {
-    if (list.size() == 0) {
+    if (list.isEmpty()) {
       throw createOutOfRangeException(0);
     }
     return remove(list.size() - 1);
@@ -87,6 +87,14 @@ public class PyList extends ForwardingList<Object> implements PyWrapper {
     return indexOf(o);
   }
 
+  @Override
+  public Object get(int index) {
+    if (index < 0 || index >= list.size()) {
+      throw createOutOfRangeException(index);
+    }
+    return this.delegate().get(index);
+  }
+
   public int index(Object o, int begin, int end) {
     for (int i = begin; i < end; i++) {
       if (Objects.equals(o, get(i))) {
@@ -104,6 +112,7 @@ public class PyList extends ForwardingList<Object> implements PyWrapper {
 
   /**
    * This is not thread-safe
+   *
    * @return hashCode, preventing recursion
    */
   @Override

--- a/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
@@ -92,7 +92,7 @@ public class PyList extends ForwardingList<Object> implements PyWrapper {
     if (index < 0 || index >= list.size()) {
       throw createOutOfRangeException(index);
     }
-    return this.delegate().get(index);
+    return super.get(index);
   }
 
   public int index(Object o, int begin, int end) {

--- a/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
+++ b/src/main/java/com/hubspot/jinjava/objects/collections/PyList.java
@@ -53,7 +53,7 @@ public class PyList extends ForwardingList<Object> implements PyWrapper {
   }
 
   public Object pop() {
-    if (list.isEmpty()) {
+    if (list.size() == 0) {
       throw createOutOfRangeException(0);
     }
     return remove(list.size() - 1);
@@ -112,7 +112,6 @@ public class PyList extends ForwardingList<Object> implements PyWrapper {
 
   /**
    * This is not thread-safe
-   *
    * @return hashCode, preventing recursion
    */
   @Override

--- a/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
@@ -274,6 +274,18 @@ public class ExtendedSyntaxBuilderTest {
   }
 
   @Test
+  public void outOfRange() {
+    List<?> emptyList = Lists.newArrayList();
+    context.put("emptyList", emptyList);
+    assertThat(val("emptyList.get(0)")).isNull();
+    assertThat(val("emptyList.get(-1)")).isNull();
+
+    List<?> theList = Lists.newArrayList(1, 2, 3);
+    context.put("mylist", theList);
+    assertThat(val("myList.get(3)")).isNull();
+  }
+
+  @Test
   public void listRangeSyntaxNegativeIndices() {
     List<?> theList = Lists.newArrayList(1, 2, 3, 4, 5);
     context.put("mylist", theList);


### PR DESCRIPTION
The goal is to intercept runtime exception `ArrayIndexOutOfBoundsException` with jinjava's `IndexOutOfRangeException` so we can notify user with predicted root cause which would be our custom exception.  