### PR TITLE
hard max limit for slices

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
@@ -1,13 +1,12 @@
 package com.hubspot.jinjava.lib.filter;
 
-import static com.hubspot.jinjava.util.Logging.ENGINE_LOG;
-
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.InvalidReason;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.interpret.TemplateSyntaxException;
 import com.hubspot.jinjava.util.ForLoop;
 import com.hubspot.jinjava.util.ObjectIterator;
@@ -84,8 +83,17 @@ public class SliceFilter implements Filter {
         args[0]
       );
     } else if (slices > MAX_SLICES) {
-      ENGINE_LOG.warn(
-        "The limit input value is too large, it's been reduced to " + MAX_SLICES
+      interpreter.addError(
+        new TemplateError(
+          TemplateError.ErrorType.WARNING,
+          TemplateError.ErrorReason.OVER_LIMIT,
+          TemplateError.ErrorItem.FILTER,
+          "The limit input value is too large, it's been reduced to " + MAX_SLICES,
+          null,
+          interpreter.getLineNumber(),
+          interpreter.getPosition(),
+          null
+        )
       );
       slices = MAX_SLICES;
     }

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
@@ -90,8 +90,11 @@ public class SliceFilter implements Filter {
           TemplateError.ErrorType.WARNING,
           TemplateError.ErrorReason.OVER_LIMIT,
           TemplateError.ErrorItem.FILTER,
-          "The value of the 'slices' parameter is greater than " + MAX_SLICES + ". It's been reduced to " +
-          MAX_SLICES,
+          String.format(
+            "The value of the 'slices' parameter is greater than %d. It's been reduced to %d",
+            MAX_SLICES,
+            MAX_SLICES
+          ),
           null,
           interpreter.getLineNumber(),
           interpreter.getPosition(),

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
@@ -80,18 +80,24 @@ public class SliceFilter implements Filter {
         args[0]
       );
     }
-    List<List<Object>> result = new ArrayList<>();
 
-    List<Object> currentList = null;
+    List<List<Object>> result = new ArrayList<>();
+    List<Object> currentList = null; // lazy evaluation
+
     int i = 0;
     while (loop.hasNext()) {
-      Object next = loop.next();
       if (i % slices == 0) {
-        currentList = new ArrayList<>(slices);
-        result.add(currentList);
+        if (currentList != null) {
+          result.add(currentList);
+        }
+        currentList = new ArrayList<>();
       }
-      currentList.add(next);
+      currentList.add(loop.next());
       i++;
+    }
+
+    if (currentList != null && !currentList.isEmpty()) {
+      result.add(currentList);
     }
 
     if (args.length > 1 && currentList != null) {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
@@ -26,7 +26,11 @@ import org.apache.commons.lang3.math.NumberUtils;
     @JinjavaParam(
       value = "slices",
       type = "number",
-      desc = "Specifies how many items will be sliced",
+      desc = "Specifies how many items will be sliced." +
+      "Please note, the max limit is " +
+      SliceFilter.MAX_SLICES +
+      ". " +
+      "All values above this limit will be reduced.",
       required = true
     ),
     @JinjavaParam(
@@ -88,7 +92,8 @@ public class SliceFilter implements Filter {
           TemplateError.ErrorType.WARNING,
           TemplateError.ErrorReason.OVER_LIMIT,
           TemplateError.ErrorItem.FILTER,
-          "The limit input value is too large, it's been reduced to " + MAX_SLICES,
+          "The limit input value of 'slices' parameter is too large, it's been reduced to " +
+          MAX_SLICES,
           null,
           interpreter.getLineNumber(),
           interpreter.getPosition(),

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
@@ -26,11 +26,9 @@ import org.apache.commons.lang3.math.NumberUtils;
     @JinjavaParam(
       value = "slices",
       type = "number",
-      desc = "Specifies how many items will be sliced." +
-      "Please note, the max limit is " +
+      desc = "Specifies how many items will be sliced. Maximum value is " +
       SliceFilter.MAX_SLICES +
-      ". " +
-      "All values above this limit will be reduced.",
+      ". ",
       required = true
     ),
     @JinjavaParam(

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
@@ -90,7 +90,7 @@ public class SliceFilter implements Filter {
           TemplateError.ErrorType.WARNING,
           TemplateError.ErrorReason.OVER_LIMIT,
           TemplateError.ErrorItem.FILTER,
-          "The limit input value of 'slices' parameter is too large, it's been reduced to " +
+          "The value of the 'slices' parameter is greater than " + MAX_SLICES + ". It's been reduced to " +
           MAX_SLICES,
           null,
           interpreter.getLineNumber(),

--- a/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/SliceFilter.java
@@ -1,5 +1,7 @@
 package com.hubspot.jinjava.lib.filter;
 
+import static com.hubspot.jinjava.util.Logging.ENGINE_LOG;
+
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
@@ -53,6 +55,8 @@ import org.apache.commons.lang3.math.NumberUtils;
 )
 public class SliceFilter implements Filter {
 
+  public static final int MAX_SLICES = 1000;
+
   @Override
   public String getName() {
     return "slice";
@@ -79,10 +83,15 @@ public class SliceFilter implements Filter {
         0,
         args[0]
       );
+    } else if (slices > MAX_SLICES) {
+      ENGINE_LOG.warn(
+        "The limit input value is too large, it's been reduced to " + MAX_SLICES
+      );
+      slices = MAX_SLICES;
     }
 
     List<List<Object>> result = new ArrayList<>();
-    List<Object> currentList = null; // lazy evaluation
+    List<Object> currentList = null;
 
     int i = 0;
     while (loop.hasNext()) {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/SliceFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/SliceFilterTest.java
@@ -1,5 +1,6 @@
 package com.hubspot.jinjava.lib.filter;
 
+import static com.hubspot.jinjava.lib.filter.SliceFilter.MAX_SLICES;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
@@ -8,6 +9,9 @@ import com.google.common.io.Resources;
 import com.hubspot.jinjava.BaseJinjavaTest;
 import com.hubspot.jinjava.interpret.RenderResult;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.junit.Test;
@@ -33,6 +37,20 @@ public class SliceFilterTest extends BaseJinjavaTest {
     assertThat(dom.select(".columwrapper .column-1 li")).hasSize(3);
     assertThat(dom.select(".columwrapper .column-2 li")).hasSize(3);
     assertThat(dom.select(".columwrapper .column-3 li")).hasSize(1);
+  }
+
+  @Test
+  public void itSlicesToTheMaxLimit() throws Exception {
+    String result = jinjava.render(
+      Resources.toString(
+        Resources.getResource("filter/slice-filter-big.jinja"),
+        StandardCharsets.UTF_8
+      ),
+      ImmutableMap.of("items", Lists.newArrayList("a", "b", "c", "d", "e"))
+    );
+
+    assertThat(result).isNotEmpty();
+    assertThat(result.split("\n")).hasSize(MAX_SLICES + 2); // 1 for each slice, 1 for the newline
   }
 
   @Test

--- a/src/test/resources/filter/slice-filter-big.jinja
+++ b/src/test/resources/filter/slice-filter-big.jinja
@@ -1,0 +1,6 @@
+{%- for column in items|slice(999999999, 'hello') %}
+  {{ loop.index }}
+ {%- for item in column %}
+    {{ item }}
+  {%- endfor %}
+{%- endfor %}


### PR DESCRIPTION
In some cases using ForLoop can led to OOM when we deal with many elements because we start to create lists with huge capacity. 

In this PR we introduce MAX_SLICES limit. Additional improvement is to relax the heap usage by not copying elements to new `ArrayLists` rather reusing the one in `ForLoop` which has `Iterator<?>` it inside.