### PR TITLE
Fix aliased macro function in set tag and duplicate DeferredTokens

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -427,7 +427,6 @@ public class Context extends ScopeMap<String, Object> {
 
   @Beta
   public void removeDeferredTokens(Collection<DeferredToken> toRemove) {
-    deferredTokens.removeAll(toRemove);
     if (getParent() != null) {
       Context parent = getParent();
       //Ignore global context
@@ -435,6 +434,7 @@ public class Context extends ScopeMap<String, Object> {
         parent.removeDeferredTokens(toRemove);
       }
     }
+    deferredTokens.removeAll(toRemove);
   }
 
   @Beta

--- a/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
@@ -72,6 +72,9 @@ public class EagerMacroFunction extends MacroFunction {
           interpreter
         );
         if (!result.getResult().isFullyResolved()) {
+          interpreter
+            .getContext()
+            .removeDeferredTokens(interpreter.getContext().getDeferredTokens());
           result =
             eagerEvaluateInDeferredExecutionMode(
               () -> getEvaluationResultDirectly(argMap, kwargMap, varArgs, interpreter),

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -143,7 +143,7 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
       );
     }
 
-    EagerExecutionResult firstRunResult = runLoopOnce(tagNode, interpreter);
+    EagerExecutionResult firstRunResult = runLoopOnce(tagNode, interpreter, true);
     PrefixToPreserveState prefixToPreserveState = firstRunResult
       .getPrefixToPreserveState()
       .withAllInFront(
@@ -153,7 +153,7 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
         )
       );
     // Run for loop again now that the necessary values have been deferred
-    EagerExecutionResult secondRunResult = runLoopOnce(tagNode, interpreter);
+    EagerExecutionResult secondRunResult = runLoopOnce(tagNode, interpreter, false);
     if (
       secondRunResult
         .getSpeculativeBindings()
@@ -174,7 +174,8 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
 
   private EagerExecutionResult runLoopOnce(
     TagNode tagNode,
-    JinjavaInterpreter interpreter
+    JinjavaInterpreter interpreter,
+    boolean clearDeferredWords
   ) {
     return EagerContextWatcher.executeInChildContext(
       eagerInterpreter -> {
@@ -201,6 +202,11 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
             .getContext()
             .getMetaContextVariables()
             .addAll(removedMetaContextVariables);
+          if (clearDeferredWords) {
+            interpreter
+              .getContext()
+              .removeDeferredTokens(interpreter.getContext().getDeferredTokens());
+          }
         }
       },
       interpreter,

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
@@ -170,7 +170,6 @@ public abstract class EagerSetTagStrategy {
       !interpreter.getContext().getMetaContextVariables().contains(variables)
     ) {
       if (!interpreter.getContext().containsKey(maybeTemporaryImportAlias.get())) {
-        //        Object aliasObject = (interpreter.getContext().get(interpreter.getContext().getImportResourceAlias().get()));
         if (
           interpreter.resolveELExpressionSilently(
             String.format(
@@ -181,12 +180,6 @@ public abstract class EagerSetTagStrategy {
           ) !=
           null
         ) {
-          //        Context importTopLevelContext = interpreter.getContext();
-          //        while (!importTopLevelContext.getScope().containsKey(IMPORT_RESOURCE_ALIAS_KEY)) {
-          //          importTopLevelContext = importTopLevelContext.getParent();
-          //        }
-          //        Object contextValue = importTopLevelContext.get(variables);
-          //        if (contextValue != null && !(contextValue instanceof DeferredValue)) {
           throw new DeferredValueException(
             "Cannot modify temporary import alias outside of import tag"
           );

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Triple;
 
 @Beta
@@ -141,11 +140,14 @@ public abstract class EagerSetTagStrategy {
     }
     EagerReconstructionUtils.hydrateReconstructionFromContextBeforeDeferring(
       prefixToPreserveState,
-      Stream
-        .concat(
-          eagerExecutionResult.getResult().getDeferredWords().stream(),
-          Arrays.stream(variables).filter(var -> var.contains("."))
-        )
+      eagerExecutionResult.getResult().getDeferredWords(),
+      interpreter
+    );
+    EagerReconstructionUtils.hydrateReconstructionFromContextBeforeDeferring(
+      prefixToPreserveState,
+      Arrays
+        .stream(variables)
+        .filter(var -> var.contains("."))
         .collect(Collectors.toSet()),
       interpreter
     );
@@ -168,9 +170,27 @@ public abstract class EagerSetTagStrategy {
       !interpreter.getContext().getMetaContextVariables().contains(variables)
     ) {
       if (!interpreter.getContext().containsKey(maybeTemporaryImportAlias.get())) {
-        throw new DeferredValueException(
-          "Cannot modify temporary import alias outside of import tag"
-        );
+        //        Object aliasObject = (interpreter.getContext().get(interpreter.getContext().getImportResourceAlias().get()));
+        if (
+          interpreter.resolveELExpressionSilently(
+            String.format(
+              "%s.%s",
+              interpreter.getContext().getImportResourceAlias().get(),
+              variables
+            )
+          ) !=
+          null
+        ) {
+          //        Context importTopLevelContext = interpreter.getContext();
+          //        while (!importTopLevelContext.getScope().containsKey(IMPORT_RESOURCE_ALIAS_KEY)) {
+          //          importTopLevelContext = importTopLevelContext.getParent();
+          //        }
+          //        Object contextValue = importTopLevelContext.get(variables);
+          //        if (contextValue != null && !(contextValue instanceof DeferredValue)) {
+          throw new DeferredValueException(
+            "Cannot modify temporary import alias outside of import tag"
+          );
+        }
       }
       String updateString = getUpdateString(variables);
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
@@ -171,12 +171,13 @@ public abstract class EagerSetTagStrategy {
     ) {
       if (!interpreter.getContext().containsKey(maybeTemporaryImportAlias.get())) {
         if (
-          interpreter.resolveELExpressionSilently(
+          interpreter.retraceVariable(
             String.format(
               "%s.%s",
               interpreter.getContext().getImportResourceAlias().get(),
               variables
-            )
+            ),
+            -1
           ) !=
           null
         ) {

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1520,4 +1520,17 @@ public class EagerTest {
       "handles-deferred-modification-in-caller.expected"
     );
   }
+
+  @Test
+  public void itReconstructsAliasedMacro() {
+    expectedTemplateInterpreter.assertExpectedOutput("reconstructs-aliased-macro");
+  }
+
+  @Test
+  public void itReconstructsAliasedMacroSecondPass() {
+    interpreter.getContext().put("deferred", "resolved");
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "reconstructs-aliased-macro.expected"
+    );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -531,6 +531,18 @@ public class EagerImportTagTest extends ImportTagTest {
   }
 
   @Test
+  public void itKeepsDeferredImportAliasesInsideOwnScopeInSet() {
+    setupResourceLocator();
+    String result = interpreter.render(
+      "{% import 'printer-a.jinja' as printer %}{% import 'intermediate-b.jinja' as inter %}" +
+      "{% set foo = printer.print(deferred) %}{% set bar = inter.print(deferred) %}" +
+      "{{ foo }}-{{ bar }}"
+    );
+    context.put("deferred", "resolved");
+    assertThat(interpreter.render(result)).isEqualTo("A_resolved_A-B_resolved_B");
+  }
+
+  @Test
   public void itDefersWhenPathIsDeferred() {
     String input = "{% import deferred as foo %}";
     String output = interpreter.render(input);

--- a/src/test/resources/eager/reconstructs-aliased-macro.expected.expected.jinja
+++ b/src/test/resources/eager/reconstructs-aliased-macro.expected.expected.jinja
@@ -1,0 +1,1 @@
+resolved3

--- a/src/test/resources/eager/reconstructs-aliased-macro.expected.jinja
+++ b/src/test/resources/eager/reconstructs-aliased-macro.expected.jinja
@@ -1,3 +1,4 @@
-{%- import "takes-param.jinja" as macros -%}
-{%- set myname = deferred + (1 + 2) -%}
-{% print macros.takes_param(my_name) %}
+{% set myname = deferred + 3 %}{% set deferred_import_resource_path = 'eager/takes-param.jinja' %}{% macro macros.takes_param(foo) %}{% set bar = 'bar' %}
+{% print foo %}
+{% endmacro %}{% set deferred_import_resource_path = null %}{% set answer = macros.takes_param(myname) %}
+{{ answer }}

--- a/src/test/resources/eager/reconstructs-aliased-macro.expected.jinja
+++ b/src/test/resources/eager/reconstructs-aliased-macro.expected.jinja
@@ -1,0 +1,3 @@
+{%- import "takes-param.jinja" as macros -%}
+{%- set myname = deferred + (1 + 2) -%}
+{% print macros.takes_param(my_name) %}

--- a/src/test/resources/eager/reconstructs-aliased-macro.jinja
+++ b/src/test/resources/eager/reconstructs-aliased-macro.jinja
@@ -1,0 +1,3 @@
+{%- import "simple-with-call.jinja" as simple -%}
+{%- set myname = deferred + (1 + 2) -%}
+{% print simple.getPath() %}

--- a/src/test/resources/eager/reconstructs-aliased-macro.jinja
+++ b/src/test/resources/eager/reconstructs-aliased-macro.jinja
@@ -1,3 +1,4 @@
-{%- import "simple-with-call.jinja" as simple -%}
+{%- import "eager/takes-param.jinja" as macros -%}
 {%- set myname = deferred + (1 + 2) -%}
-{% print simple.getPath() %}
+{% set answer = macros.takes_param(myname) %}
+{{ answer }}

--- a/src/test/resources/tags/macrotag/eager/takes-param.jinja
+++ b/src/test/resources/tags/macrotag/eager/takes-param.jinja
@@ -1,0 +1,5 @@
+{% macro takes_param(foo) %}
+{% print foo %}
+{% endmacro %}
+
+{% set bar = 'bar' %}


### PR DESCRIPTION
Specifically in a set tag, we weren't properly removing deferred words from the `eagerExecutionResult.getResult().getDeferredWords()` because we were unioning those with the set tag's variable name.

Part of `hydrateReconstructionFromContextBeforeDeferring` will find the deferred macro functions which are marked as `usedDeferredWords` and hydrate their reconstruction within the `prefixToPreserveState`, and then they will get removed from `eagerExecutionResult.getResult().getDeferredWords()`, but since a new set was being created via:
```java
 Stream
  .concat(
    eagerExecutionResult.getResult().getDeferredWords().stream(),
    Arrays.stream(variables).filter(var -> var.contains("."))
  )
  .collect(Collectors.toSet())
```
We weren't removing the macro functions, which was causing the import alias to be fully deferred unnecessarily.