### PR TITLE
Add more lenient coercing

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/TruthyTypeConverter.java
+++ b/src/main/java/com/hubspot/jinjava/el/TruthyTypeConverter.java
@@ -140,11 +140,19 @@ public class TruthyTypeConverter extends TypeConverterImpl {
     if (!value.contains(",")) {
       return value;
     }
+
+    if (value.matches(".*\\..*,.*")) {
+      return value;
+    }
     return value.replaceAll(",", "");
   }
 
   private String trimDecimal(String value) {
     if (!value.contains(".")) {
+      return value;
+    }
+
+    if (!value.matches("\\d*\\.\\d*")) {
       return value;
     }
     return value.substring(0, value.indexOf("."));

--- a/src/main/java/com/hubspot/jinjava/el/TruthyTypeConverter.java
+++ b/src/main/java/com/hubspot/jinjava/el/TruthyTypeConverter.java
@@ -33,6 +33,12 @@ public class TruthyTypeConverter extends TypeConverterImpl {
     if (value instanceof DummyObject) {
       return BigDecimal.ZERO;
     }
+
+    if (value instanceof String) {
+      String sanitizedValue = trimDecimal(trimCommas((String) value));
+      return super.coerceToBigDecimal(sanitizedValue);
+    }
+
     return super.coerceToBigDecimal(value);
   }
 
@@ -41,6 +47,12 @@ public class TruthyTypeConverter extends TypeConverterImpl {
     if (value instanceof DummyObject) {
       return BigInteger.ZERO;
     }
+
+    if (value instanceof String) {
+      String sanitizedValue = trimDecimal(trimCommas((String) value));
+      return super.coerceToBigInteger(sanitizedValue);
+    }
+
     return super.coerceToBigInteger(value);
   }
 
@@ -49,6 +61,12 @@ public class TruthyTypeConverter extends TypeConverterImpl {
     if (value instanceof DummyObject) {
       return 0d;
     }
+
+    if (value instanceof String) {
+      String sanitizedValue = trimCommas((String) value);
+      return super.coerceToDouble(sanitizedValue);
+    }
+
     return super.coerceToDouble(value);
   }
 
@@ -57,6 +75,12 @@ public class TruthyTypeConverter extends TypeConverterImpl {
     if (value instanceof DummyObject) {
       return 0f;
     }
+
+    if (value instanceof String) {
+      String sanitizedValue = trimDecimal(trimCommas((String) value));
+      return super.coerceToFloat(sanitizedValue);
+    }
+
     return super.coerceToFloat(value);
   }
 
@@ -65,13 +89,37 @@ public class TruthyTypeConverter extends TypeConverterImpl {
     if (value instanceof DummyObject) {
       return 0L;
     }
+
+    if (value instanceof String) {
+      String sanitizedValue = trimDecimal(trimCommas((String) value));
+      return super.coerceToLong(sanitizedValue);
+    }
     return super.coerceToLong(value);
+  }
+
+  private String trimCommas(String value) {
+    if (!value.contains(",")) {
+      return value;
+    }
+    return value.replaceAll(",", "");
+  }
+
+  private String trimDecimal(String value) {
+    if (!value.contains(".")) {
+      return value;
+    }
+    return value.substring(0, value.indexOf("."));
   }
 
   @Override
   protected Integer coerceToInteger(Object value) {
     if (value instanceof DummyObject) {
       return 0;
+    }
+
+    if (value instanceof String) {
+      String sanitizedValue = trimDecimal(trimCommas((String) value));
+      return super.coerceToInteger(sanitizedValue);
     }
     return super.coerceToInteger(value);
   }
@@ -81,6 +129,11 @@ public class TruthyTypeConverter extends TypeConverterImpl {
     if (value instanceof DummyObject) {
       return 0;
     }
+
+    if (value instanceof String) {
+      String sanitizedValue = trimDecimal(trimCommas((String) value));
+      return super.coerceToShort(sanitizedValue);
+    }
     return super.coerceToShort(value);
   }
 
@@ -89,6 +142,11 @@ public class TruthyTypeConverter extends TypeConverterImpl {
     if (value instanceof DummyObject) {
       return 0;
     }
+    if (value instanceof String) {
+      String sanitizedValue = trimDecimal(trimCommas((String) value));
+      return super.coerceToByte(sanitizedValue);
+    }
+
     return super.coerceToByte(value);
   }
 

--- a/src/main/java/com/hubspot/jinjava/el/TruthyTypeConverter.java
+++ b/src/main/java/com/hubspot/jinjava/el/TruthyTypeConverter.java
@@ -35,7 +35,7 @@ public class TruthyTypeConverter extends TypeConverterImpl {
     }
 
     if (value instanceof String) {
-      String sanitizedValue = trimDecimal(trimCommas((String) value));
+      String sanitizedValue = trimCommas((String) value);
       return super.coerceToBigDecimal(sanitizedValue);
     }
 
@@ -77,7 +77,7 @@ public class TruthyTypeConverter extends TypeConverterImpl {
     }
 
     if (value instanceof String) {
-      String sanitizedValue = trimDecimal(trimCommas((String) value));
+      String sanitizedValue = trimCommas((String) value);
       return super.coerceToFloat(sanitizedValue);
     }
 
@@ -95,20 +95,6 @@ public class TruthyTypeConverter extends TypeConverterImpl {
       return super.coerceToLong(sanitizedValue);
     }
     return super.coerceToLong(value);
-  }
-
-  private String trimCommas(String value) {
-    if (!value.contains(",")) {
-      return value;
-    }
-    return value.replaceAll(",", "");
-  }
-
-  private String trimDecimal(String value) {
-    if (!value.contains(".")) {
-      return value;
-    }
-    return value.substring(0, value.indexOf("."));
   }
 
   @Override
@@ -148,6 +134,20 @@ public class TruthyTypeConverter extends TypeConverterImpl {
     }
 
     return super.coerceToByte(value);
+  }
+
+  private String trimCommas(String value) {
+    if (!value.contains(",")) {
+      return value;
+    }
+    return value.replaceAll(",", "");
+  }
+
+  private String trimDecimal(String value) {
+    if (!value.contains(".")) {
+      return value;
+    }
+    return value.substring(0, value.indexOf("."));
   }
 
   @Override

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/ComparisonExpTestsTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/ComparisonExpTestsTest.java
@@ -66,4 +66,15 @@ public class ComparisonExpTestsTest extends BaseJinjavaTest {
     assertThat(jinjava.render("{{ 4 is >= 5 }}", new HashMap<>())).isEqualTo("false");
     assertThat(jinjava.render("{{ 4 is != 5 }}", new HashMap<>())).isEqualTo("true");
   }
+
+  @Test
+  public void testFormattedStringParsing() {
+    assertThat(jinjava.render("{{ \"1,050.25\" is ge 4 }}", new HashMap<>()))
+      .isEqualTo("true");
+    assertThat(jinjava.render("{{ \"4.1\" is gt 4 }}", new HashMap<>()))
+      .isEqualTo("false");
+    assertThat(jinjava.render("{{ 4.0 is le 5.00 }}", new HashMap<>())).isEqualTo("true");
+    assertThat(jinjava.render("{{ \"4,500.75\" is le 10000.00 }}", new HashMap<>()))
+      .isEqualTo("true");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/exptest/ComparisonExpTestsTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/exptest/ComparisonExpTestsTest.java
@@ -1,13 +1,17 @@
 package com.hubspot.jinjava.lib.exptest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.BaseJinjavaTest;
+import com.hubspot.jinjava.interpret.FatalTemplateErrorsException;
 import com.hubspot.jinjava.objects.date.PyishDate;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import javax.el.ELException;
+import javax.el.MethodNotFoundException;
 import org.junit.Test;
 
 public class ComparisonExpTestsTest extends BaseJinjavaTest {
@@ -68,7 +72,7 @@ public class ComparisonExpTestsTest extends BaseJinjavaTest {
   }
 
   @Test
-  public void testFormattedStringParsing() {
+  public void itParsesFormattedNumbers() {
     assertThat(jinjava.render("{{ \"1,050.25\" is ge 4 }}", new HashMap<>()))
       .isEqualTo("true");
     assertThat(jinjava.render("{{ \"4.1\" is gt 4 }}", new HashMap<>()))
@@ -76,5 +80,17 @@ public class ComparisonExpTestsTest extends BaseJinjavaTest {
     assertThat(jinjava.render("{{ 4.0 is le 5.00 }}", new HashMap<>())).isEqualTo("true");
     assertThat(jinjava.render("{{ \"4,500.75\" is le 10000.00 }}", new HashMap<>()))
       .isEqualTo("true");
+  }
+
+  @Test
+  public void itDoesNotAllowCommasAfterDecimalPointInNumbers() {
+    assertThat(
+      jinjava.renderForResult("{{ \"150.25,0\" is ge 4 }}", new HashMap<>()).getErrors()
+    )
+      .isNotEmpty();
+    assertThat(
+      jinjava.renderForResult("{{ \"150.25,0\" is ge 4.0 }}", new HashMap<>()).getErrors()
+    )
+      .isNotEmpty();
   }
 }


### PR DESCRIPTION
strings can be implicitly coerced to numeric values, so comparisons like:
```
{% if "1000" > 5%}
```
works. However evaluating:
```
{% if "1,000" > 5%}
```
or:
```
{% if "1000.25" > 5%}
```
throws an error. This adds some additional cleaning to allow formatted number strings to be parsed.
Notably it does not remove decimals when comparing to floats, since those are valuable and:
```
{% if "1000.25" > 50.0 %}
```
already works.

It also only removes characters after decimals if its a properly formatted decimal number (so containing no non-digit characters and only one decimal point)