### PR TITLE
find first valid deferred words

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/DeferredToken.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/DeferredToken.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.lib.tag.eager;
 
 import com.google.common.annotations.Beta;
+import com.google.common.base.Strings;
 import com.hubspot.jinjava.interpret.CallStack;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredLazyReference;
@@ -13,9 +14,11 @@ import com.hubspot.jinjava.tree.parse.Token;
 import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -40,7 +43,8 @@ public class DeferredToken {
         token,
         usedDeferredWords != null
           ? usedDeferredWords
-            .map(prop -> prop.split("\\.", 2)[0])
+            .map(DeferredToken::splitToken)
+            .map(DeferredToken::getFirstNonEmptyToken)
             .distinct()
             .filter(word ->
               interpreter == null ||
@@ -50,7 +54,8 @@ public class DeferredToken {
           : Collections.emptySet(),
         setDeferredWords != null
           ? setDeferredWords
-            .map(prop -> prop.split("\\.", 2)[0])
+            .map(DeferredToken::splitToken)
+            .map(DeferredToken::getFirstNonEmptyToken)
             .collect(Collectors.toSet())
           : Collections.emptySet(),
         acquireImportResourcePath(),
@@ -413,10 +418,19 @@ public class DeferredToken {
       .orElse(null);
   }
 
+  private static String getFirstNonEmptyToken(List<String> strings) {
+    return Strings.isNullOrEmpty(strings.get(0)) ? strings.get(1) : strings.get(0);
+  }
+
+  public static List<String> splitToken(String token) {
+    return Arrays.asList(token.split("\\.", 2));
+  }
+
   public static Set<String> getBases(Set<String> original) {
     return original
       .stream()
-      .map(prop -> prop.split("\\.", 2)[0])
+      .map(DeferredToken::splitToken)
+      .map(prop -> prop.get(0))
       .collect(Collectors.toSet());
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/DeferredToken.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/DeferredToken.java
@@ -423,7 +423,7 @@ public class DeferredToken {
   }
 
   public static List<String> splitToken(String token) {
-    return Arrays.asList(token.split("\\.", 2));
+    return Arrays.asList(token.split("\\."));
   }
 
   public static Set<String> getBases(Set<String> original) {

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -518,27 +518,6 @@ public class EagerTest {
   }
 
   @Test
-  public void itDefersArrayAccess() {
-    expectedTemplateInterpreter.assertExpectedOutput("evaluates-non-eager-set");
-    assertThat(
-      localContext
-        .getDeferredTokens()
-        .stream()
-        .flatMap(deferredToken -> deferredToken.getSetDeferredWords().stream())
-        .collect(Collectors.toSet())
-    )
-      .isEmpty();
-    assertThat(
-      localContext
-        .getDeferredTokens()
-        .stream()
-        .flatMap(deferredToken -> deferredToken.getUsedDeferredWords().stream())
-        .collect(Collectors.toSet())
-    )
-      .contains("deferred");
-  }
-
-  @Test
   public void itDefersOnImmutableMode() {
     expectedTemplateInterpreter.assertExpectedOutput("defers-on-immutable-mode");
   }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -518,6 +518,27 @@ public class EagerTest {
   }
 
   @Test
+  public void itDefersArrayAccess() {
+    expectedTemplateInterpreter.assertExpectedOutput("evaluates-non-eager-set");
+    assertThat(
+      localContext
+        .getDeferredTokens()
+        .stream()
+        .flatMap(deferredToken -> deferredToken.getSetDeferredWords().stream())
+        .collect(Collectors.toSet())
+    )
+      .isEmpty();
+    assertThat(
+      localContext
+        .getDeferredTokens()
+        .stream()
+        .flatMap(deferredToken -> deferredToken.getUsedDeferredWords().stream())
+        .collect(Collectors.toSet())
+    )
+      .contains("deferred");
+  }
+
+  @Test
   public void itDefersOnImmutableMode() {
     expectedTemplateInterpreter.assertExpectedOutput("defers-on-immutable-mode");
   }

--- a/src/test/java/com/hubspot/jinjava/util/DeferredValueUtilsTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/DeferredValueUtilsTest.java
@@ -262,6 +262,22 @@ public class DeferredValueUtilsTest {
       .isEqualTo(ImmutableSet.of("deferred", "attribute2"));
   }
 
+  @Test
+  public void itFindsFirstValidDeferredWordsWithNestedAttributes() {
+    DeferredToken deferredToken = DeferredToken
+      .builderFromToken(
+        new ExpressionToken("{{ blah }}", 1, 1, new DefaultTokenScannerSymbols())
+      )
+      .addUsedDeferredWords(ImmutableSet.of("deferred", ".attribute1.ignore"))
+      .addSetDeferredWords(ImmutableSet.of("deferred", ".attribute2.ignoreme"))
+      .build();
+
+    assertThat(deferredToken.getUsedDeferredWords())
+      .isEqualTo(ImmutableSet.of("deferred", "attribute1"));
+    assertThat(deferredToken.getSetDeferredWords())
+      .isEqualTo(ImmutableSet.of("deferred", "attribute2"));
+  }
+
   private Context getContext(List<? extends Node> nodes) {
     return getContext(nodes, Optional.empty());
   }

--- a/src/test/java/com/hubspot/jinjava/util/DeferredValueUtilsTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/DeferredValueUtilsTest.java
@@ -246,6 +246,22 @@ public class DeferredValueUtilsTest {
     assertThat(context.containsKey("int")).isFalse();
   }
 
+  @Test
+  public void itFindsFirstValidDeferredWords() {
+    DeferredToken deferredToken = DeferredToken
+      .builderFromToken(
+        new ExpressionToken("{{ blah }}", 1, 1, new DefaultTokenScannerSymbols())
+      )
+      .addUsedDeferredWords(ImmutableSet.of("deferred", ".attribute1"))
+      .addSetDeferredWords(ImmutableSet.of("deferred", ".attribute2"))
+      .build();
+
+    assertThat(deferredToken.getUsedDeferredWords())
+      .isEqualTo(ImmutableSet.of("deferred", "attribute1"));
+    assertThat(deferredToken.getSetDeferredWords())
+      .isEqualTo(ImmutableSet.of("deferred", "attribute2"));
+  }
+
   private Context getContext(List<? extends Node> nodes) {
     return getContext(nodes, Optional.empty());
   }


### PR DESCRIPTION
We end up with a lot blank deferred words when they are attributes of array values. 

For example, `{{ deferred.results[0].attribute }}` will return the used tokens `deferred` and  `.attribute`. `.attribute` is treated a value of `attribute` with a base of (blank) because it splits on periods. This cleans up the general case, but the evaluated eager expressions could also be improved so we don't end up with words with leading periods.