### PR TITLE
Add a feature to output template error when the variable is undefined

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -593,7 +593,7 @@ public class JinjavaInterpreter implements PyishSerializable {
         getConfig()
           .getFeatures()
           .getActivationStrategy(OUTPUT_UNDEFINED_VARIABLES_ERROR)
-          .isActive(getContext())
+          .isActive(context)
       ) {
         addError(
           new TemplateError(

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -78,6 +78,9 @@ public class JinjavaInterpreter implements PyishSerializable {
 
   public static final String IGNORED_OUTPUT_FROM_EXTENDS_NOTE =
     "ignored_output_from_extends";
+
+  public static final String OUTPUT_UNDEFINED_VARIABLES_ERROR =
+    "OUTPUT_UNDEFINED_VARIABLES_ERROR";
   private final Multimap<String, BlockInfo> blocks = ArrayListMultimap.create();
   private final LinkedList<Node> extendParentRoots = new LinkedList<>();
   private final Map<String, RevertibleObject> revertibleObjects = new HashMap<>();
@@ -585,6 +588,28 @@ public class JinjavaInterpreter implements PyishSerializable {
         }
       }
       obj = var.resolve(obj);
+    } else {
+      if (
+        getConfig()
+          .getFeatures()
+          .getActivationStrategy(OUTPUT_UNDEFINED_VARIABLES_ERROR)
+          .isActive(getContext())
+      ) {
+        addError(
+          new TemplateError(
+            ErrorType.WARNING,
+            ErrorReason.UNKNOWN,
+            ErrorItem.TOKEN,
+            "Undefined variable: '" + variable + "'",
+            null,
+            lineNumber,
+            startPosition,
+            null,
+            BasicTemplateErrorCategory.UNKNOWN,
+            ImmutableMap.of("variable", variable)
+          )
+        );
+      }
     }
     return obj;
   }


### PR DESCRIPTION
This PR adds a feature `OUTPUT_UNDEFINED_VARIABLES_ERROR`. When enabled, a template error (severity=WARNING) will be added when trying to resolve an undefined variable.