### PR TITLE
Reconstruct current path of blocks/extends roots

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/output/DynamicRenderedOutputNode.java
+++ b/src/main/java/com/hubspot/jinjava/tree/output/DynamicRenderedOutputNode.java
@@ -1,0 +1,33 @@
+package com.hubspot.jinjava.tree.output;
+
+import com.google.common.base.Charsets;
+import java.nio.charset.Charset;
+
+/**
+ * An OutputNode that can be modified after already being added to the OutputList
+ */
+public class DynamicRenderedOutputNode implements OutputNode {
+
+  protected String output = "";
+
+  public void setValue(String output) {
+    this.output = output;
+  }
+
+  @Override
+  public String getValue() {
+    return output;
+  }
+
+  @Override
+  public long getSize() {
+    return output == null
+      ? 0
+      : output.getBytes(Charset.forName(Charsets.UTF_8.name())).length;
+  }
+
+  @Override
+  public String toString() {
+    return getValue();
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1556,4 +1556,20 @@ public class EagerTest {
       "reconstructs-block-path-when-deferred/test.expected"
     );
   }
+
+  @Test
+  public void itReconstructsBlockPathWhenDeferredNested() {
+    interpreter.getContext().getCurrentPathStack().push("Child path", 0, 0);
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "reconstructs-block-path-when-deferred-nested/test"
+    );
+  }
+
+  @Test
+  public void itReconstructsBlockPathWhenDeferredNestedSecondPass() {
+    interpreter.getContext().put("deferred", "resolved");
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "reconstructs-block-path-when-deferred-nested/test.expected"
+    );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1540,4 +1540,20 @@ public class EagerTest {
       "reconstructs-aliased-macro.expected"
     );
   }
+
+  @Test
+  public void itReconstructsBlockPathWhenDeferred() {
+    interpreter.getContext().getCurrentPathStack().push("Child path", 0, 0);
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "reconstructs-block-path-when-deferred/test"
+    );
+  }
+
+  @Test
+  public void itReconstructsBlockPathWhenDeferredSecondPass() {
+    interpreter.getContext().put("deferred", "resolved");
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "reconstructs-block-path-when-deferred/test.expected"
+    );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1544,7 +1544,7 @@ public class EagerTest {
   @Test
   public void itReconstructsBlockPathWhenDeferred() {
     interpreter.getContext().getCurrentPathStack().push("Child path", 0, 0);
-    expectedTemplateInterpreter.assertExpectedOutput(
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
       "reconstructs-block-path-when-deferred/test"
     );
   }
@@ -1560,7 +1560,7 @@ public class EagerTest {
   @Test
   public void itReconstructsBlockPathWhenDeferredNested() {
     interpreter.getContext().getCurrentPathStack().push("Child path", 0, 0);
-    expectedTemplateInterpreter.assertExpectedOutput(
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
       "reconstructs-block-path-when-deferred-nested/test"
     );
   }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerExtendsTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerExtendsTagTest.java
@@ -8,6 +8,7 @@ import com.hubspot.jinjava.LegacyOverrides;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.ExtendsTagTest;
+import com.hubspot.jinjava.loader.RelativePathResolver;
 import com.hubspot.jinjava.mode.EagerExecutionMode;
 import java.io.IOException;
 import org.junit.After;
@@ -46,7 +47,9 @@ public class EagerExtendsTagTest extends ExtendsTagTest {
 
   @Test
   public void itDefersBlockInExtendsChild() {
-    expectedTemplateInterpreter.assertExpectedOutput("defers-block-in-extends-child");
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
+      "defers-block-in-extends-child"
+    );
   }
 
   @Test
@@ -55,6 +58,7 @@ public class EagerExtendsTagTest extends ExtendsTagTest {
     expectedTemplateInterpreter.assertExpectedOutput(
       "defers-block-in-extends-child.expected"
     );
+    context.remove(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY);
     expectedTemplateInterpreter.assertExpectedNonEagerOutput(
       "defers-block-in-extends-child.expected"
     );
@@ -62,7 +66,9 @@ public class EagerExtendsTagTest extends ExtendsTagTest {
 
   @Test
   public void itDefersSuperBlockWithDeferred() {
-    expectedTemplateInterpreter.assertExpectedOutput("defers-super-block-with-deferred");
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
+      "defers-super-block-with-deferred"
+    );
   }
 
   @Test
@@ -71,6 +77,7 @@ public class EagerExtendsTagTest extends ExtendsTagTest {
     expectedTemplateInterpreter.assertExpectedOutput(
       "defers-super-block-with-deferred.expected"
     );
+    context.remove(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY);
     expectedTemplateInterpreter.assertExpectedNonEagerOutput(
       "defers-super-block-with-deferred.expected"
     );
@@ -90,6 +97,7 @@ public class EagerExtendsTagTest extends ExtendsTagTest {
     expectedTemplateInterpreter.assertExpectedOutput(
       "reconstructs-deferred-outside-block.expected"
     );
+    context.remove(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY);
     expectedTemplateInterpreter.assertExpectedNonEagerOutput(
       "reconstructs-deferred-outside-block.expected"
     );

--- a/src/test/resources/eager/reconstructs-block-path-when-deferred-nested/base.jinja
+++ b/src/test/resources/eager/reconstructs-block-path-when-deferred-nested/base.jinja
@@ -1,0 +1,11 @@
+{% set prefix = deferred ? "current" : "current" %}
+Parent's current path is: {{ '{{' + prefix + '_path }}' }}
+-----Pre-First-----
+{% block first -%}
+{%- endblock %}
+-----Post-First-----
+-----Pre-Second-----
+{% block second -%}
+{%- endblock %}
+-----Post-Second-----
+Parent's current path is: {{ '{{' + prefix + '_path }}' }}

--- a/src/test/resources/eager/reconstructs-block-path-when-deferred-nested/middle.jinja
+++ b/src/test/resources/eager/reconstructs-block-path-when-deferred-nested/middle.jinja
@@ -1,0 +1,10 @@
+{% extends '../../eager/reconstructs-block-path-when-deferred-nested/base.jinja' %}
+{% block first %}
+{%- set prefix = deferred ? "current" : "current" -%}
+Middle's first current path is: {{ '{{' + prefix + '_path }}' }}
+{% endblock %}
+
+{% block second %}
+{%- set prefix = deferred ? "current" : "current" -%}
+Middle's second current path is: {{ '{{' + prefix + '_path }}' }}
+{% endblock %}

--- a/src/test/resources/eager/reconstructs-block-path-when-deferred-nested/test.expected.expected.jinja
+++ b/src/test/resources/eager/reconstructs-block-path-when-deferred-nested/test.expected.expected.jinja
@@ -1,0 +1,10 @@
+Parent's current path is: ../../eager/reconstructs-block-path-when-deferred-nested/base.jinja
+-----Pre-First-----
+Child's first current path is: Child path
+
+-----Post-First-----
+-----Pre-Second-----
+Middle's second current path is: ../../eager/reconstructs-block-path-when-deferred-nested/middle.jinja
+
+-----Post-Second-----
+Parent's current path is: ../../eager/reconstructs-block-path-when-deferred-nested/base.jinja

--- a/src/test/resources/eager/reconstructs-block-path-when-deferred-nested/test.expected.jinja
+++ b/src/test/resources/eager/reconstructs-block-path-when-deferred-nested/test.expected.jinja
@@ -1,0 +1,11 @@
+{% set current_path = '../../eager/reconstructs-block-path-when-deferred-nested/base.jinja' %}{% set prefix = deferred ? 'current' : 'current' %}
+Parent's current path is: {{ '{{' + prefix + '_path }}' }}
+-----Pre-First-----
+{% set temp_current_path_586961858 = current_path %}{% set current_path = 'Child path' %}{% set prefix = deferred ? 'current' : 'current' %}Child's first current path is: {{ '{{' + prefix + '_path }}' }}
+{% set current_path = temp_current_path_586961858 %}
+-----Post-First-----
+-----Pre-Second-----
+{% set temp_current_path_435835221 = current_path %}{% set current_path = '../../eager/reconstructs-block-path-when-deferred-nested/middle.jinja' %}{% set prefix = deferred ? 'current' : 'current' %}Middle's second current path is: {{ '{{' + prefix + '_path }}' }}
+{% set current_path = temp_current_path_435835221 %}
+-----Post-Second-----
+Parent's current path is: {{ '{{' + prefix + '_path }}' }}

--- a/src/test/resources/eager/reconstructs-block-path-when-deferred-nested/test.jinja
+++ b/src/test/resources/eager/reconstructs-block-path-when-deferred-nested/test.jinja
@@ -1,0 +1,5 @@
+{% extends '../../eager/reconstructs-block-path-when-deferred-nested/middle.jinja' %}
+{% block first %}
+{%- set prefix = deferred ? "current" : "current" -%}
+Child's first current path is: {{ '{{' + prefix + '_path }}' }}
+{% endblock %}

--- a/src/test/resources/eager/reconstructs-block-path-when-deferred/base.jinja
+++ b/src/test/resources/eager/reconstructs-block-path-when-deferred/base.jinja
@@ -1,0 +1,7 @@
+{% set prefix = deferred ? "current" : "current" %}
+Parent's current path is: {{ '{{' + prefix + '_path }}' }}
+-----Pre-Block-----
+{% block body -%}
+{%- endblock %}
+-----Post-Block-----
+Parent's current path is: {{ '{{' + prefix + '_path }}' }}

--- a/src/test/resources/eager/reconstructs-block-path-when-deferred/test.expected.expected.jinja
+++ b/src/test/resources/eager/reconstructs-block-path-when-deferred/test.expected.expected.jinja
@@ -1,0 +1,6 @@
+Parent's current path is: ../../eager/reconstructs-block-path-when-deferred/base.jinja
+-----Pre-Block-----
+Block's current path is: Child path
+
+-----Post-Block-----
+Parent's current path is: ../../eager/reconstructs-block-path-when-deferred/base.jinja

--- a/src/test/resources/eager/reconstructs-block-path-when-deferred/test.expected.jinja
+++ b/src/test/resources/eager/reconstructs-block-path-when-deferred/test.expected.jinja
@@ -5,4 +5,3 @@ Parent's current path is: {{ '{{' + prefix + '_path }}' }}
 {% set current_path = temp_current_path_586961858 %}
 -----Post-Block-----
 Parent's current path is: {{ '{{' + prefix + '_path }}' }}
-{% set current_path = '../../eager/reconstructs-block-path-when-deferred/base.jinja' %}

--- a/src/test/resources/eager/reconstructs-block-path-when-deferred/test.expected.jinja
+++ b/src/test/resources/eager/reconstructs-block-path-when-deferred/test.expected.jinja
@@ -1,0 +1,8 @@
+{% set current_path = '../../eager/reconstructs-block-path-when-deferred/base.jinja' %}{% set prefix = deferred ? 'current' : 'current' %}
+Parent's current path is: {{ '{{' + prefix + '_path }}' }}
+-----Pre-Block-----
+{% set temp_current_path_586961858 = current_path %}{% set current_path = 'Child path' %}{% set prefix = deferred ? 'current' : 'current' %}Block's current path is: {{ '{{' + prefix + '_path }}' }}
+{% set current_path = temp_current_path_586961858 %}
+-----Post-Block-----
+Parent's current path is: {{ '{{' + prefix + '_path }}' }}
+{% set current_path = '../../eager/reconstructs-block-path-when-deferred/base.jinja' %}

--- a/src/test/resources/eager/reconstructs-block-path-when-deferred/test.jinja
+++ b/src/test/resources/eager/reconstructs-block-path-when-deferred/test.jinja
@@ -1,0 +1,5 @@
+{% extends '../../eager/reconstructs-block-path-when-deferred/base.jinja' %}
+{% block body %}
+{%- set prefix = deferred ? "current" : "current" -%}
+Block's current path is: {{ '{{' + prefix + '_path }}' }}
+{% endblock %}

--- a/src/test/resources/tags/eager/extendstag/defers-block-in-extends-child.expected.jinja
+++ b/src/test/resources/tags/eager/extendstag/defers-block-in-extends-child.expected.jinja
@@ -1,8 +1,9 @@
-<html>
+{% set current_path = '../eager/extendstag/base.html' %}<html>
 <body>
 <div class="sidebar">
-<h3>Table Of Contents</h3>
-{{ deferred }}
+{% set temp_current_path_743889914 = current_path %}{% set current_path = '' %}<h3>Table Of Contents</h3>
+{{ deferred }}{% set current_path = temp_current_path_743889914 %}
 </div>
 </body>
 </html>
+

--- a/src/test/resources/tags/eager/extendstag/defers-super-block-with-deferred.expected.jinja
+++ b/src/test/resources/tags/eager/extendstag/defers-super-block-with-deferred.expected.jinja
@@ -1,10 +1,10 @@
-<html>
+{% set current_path = '../eager/extendstag/base-deferred.html' %}<html>
 <body>
 <div class="sidebar">
-<h3>Table Of Contents</h3>
+{% set temp_current_path_743889914 = current_path %}{% set current_path = '' %}<h3>Table Of Contents</h3>
 
 <p>this is a {{ deferred }}.</p>
-
+{% set current_path = temp_current_path_743889914 %}
 </div>
 </body>
 </html>

--- a/src/test/resources/tags/eager/extendstag/reconstructs-deferred-outside-block.expected.jinja
+++ b/src/test/resources/tags/eager/extendstag/reconstructs-deferred-outside-block.expected.jinja
@@ -3,11 +3,11 @@
 {% set foo = 'yes' %}
 {% else %}
 {% set foo = 'no' %}
-{% endif %}{% enddo %}{# End Label:  ignored_output_from_extends #}<html>
+{% endif %}{% enddo %}{# End Label:  ignored_output_from_extends #}{% set current_path = '../eager/extendstag/base.html' %}<html>
 <body>
 <div class="sidebar">
-<h3>Table Of Contents</h3>
-<p>{{ foo }}.</p>
+{% set temp_current_path_743889914 = current_path %}{% set current_path = '' %}<h3>Table Of Contents</h3>
+<p>{{ foo }}.</p>{% set current_path = temp_current_path_743889914 %}
 </div>
 </body>
 </html>


### PR DESCRIPTION
When reconstructing output from an extends root, the current path won't be tracked correctly. This PR fixes that issue by reconstructing the current path when there are deferred tokens when evaluating the extends roots and resolving blocks.

If there is something deferred in the base, then the current path will end up being the child template's path unless we reconstruct it like we're doing in this PR. See new test cases for examples.