### PR TITLE
add X-HubSpot-Target-Jdk attribute to jar manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,13 @@
                   <shadedPattern>jinjava.org.jsoup</shadedPattern>
                 </relocation>
               </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <X-HubSpot-Target-Jdk>${project.build.targetJdk}</X-HubSpot-Target-Jdk>
+                  </manifestEntries>
+                </transformer>
+              </transformers>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
this will work with our `RequireMatchingDependencyTargetJdk` build validator which enforces all hubspot dependencies have built with target JDK <= current module runtime JDK.
