### PR TITLE
Count Optional as resolvable inside EagerExpressionResolver

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
@@ -335,6 +336,11 @@ public class EagerExpressionResolver {
         }
         return (Arrays.stream((Object[]) val)).filter(Objects::nonNull)
           .allMatch(item -> isResolvableObjectRec(item, depth + 1, maxDepth, maxSize));
+      } else if (val instanceof Optional) {
+        return ((Optional<?>) val).map(item ->
+            isResolvableObjectRec(item, depth + 1, maxDepth, maxSize)
+          )
+          .orElse(true);
       }
     } catch (DeferredValueException e) {
       if (!(val instanceof PartiallyDeferredValue)) {

--- a/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
@@ -954,4 +954,14 @@ public class EagerExpressionResolverTest {
     assertThat(EagerExpressionResolver.isResolvableObject(new BigDecimal("2.1E7")))
       .isTrue();
   }
+
+  @Test
+  public void itCountsOptionalAsResolvable() {
+    assertThat(
+      EagerExpressionResolver.isResolvableObject(
+        ImmutableList.of(Optional.of(123), Optional.empty())
+      )
+    )
+      .isTrue();
+  }
 }


### PR DESCRIPTION
With https://github.com/HubSpot/jinjava/pull/1175 which serializes `Optional` values correctly, we can count them as resolvable inside of EagerExpressionResolver, since we know how to reconstruct them now.