### PR TITLE
Keep meta context variables when importing

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
@@ -136,7 +136,7 @@ public interface EvalResultHolder {
                 .getELResolver()
                 .getValue(context, null, ExtendedParser.INTERPRETER)
             ).getContext()
-              .getMetaContextVariables()
+              .getComputedMetaContextVariables()
               .contains(name)
           ) {
             return name;

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -115,6 +115,7 @@ public class Context extends ScopeMap<String, Object> {
   private boolean throwInterpreterErrors = false;
   private boolean partialMacroEvaluation = false;
   private boolean unwrapRawOverride = false;
+  private boolean preparedByExecutionMode = false;
   private DynamicVariableResolver dynamicVariableResolver = null;
   private final Set<String> metaContextVariables; // These variable names aren't tracked in eager execution
   private Node currentNode;
@@ -217,6 +218,7 @@ public class Context extends ScopeMap<String, Object> {
       this.deferredExecutionMode = parent.deferredExecutionMode;
       this.deferLargeObjects = parent.deferLargeObjects;
       this.throwInterpreterErrors = parent.throwInterpreterErrors;
+      this.preparedByExecutionMode = parent.preparedByExecutionMode;
     }
   }
 
@@ -824,5 +826,13 @@ public class Context extends ScopeMap<String, Object> {
 
   public boolean isInForLoop() {
     return get(ForTag.LOOP) != null;
+  }
+
+  boolean isPreparedByExecutionMode() {
+    return preparedByExecutionMode;
+  }
+
+  void setPreparedByExecutionMode(boolean preparedByExecutionMode) {
+    this.preparedByExecutionMode = preparedByExecutionMode;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.Beta;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
 import com.hubspot.jinjava.lib.Importable;
 import com.hubspot.jinjava.lib.expression.DefaultExpressionStrategy;
 import com.hubspot.jinjava.lib.expression.ExpressionStrategy;
@@ -34,6 +35,7 @@ import com.hubspot.jinjava.lib.tag.ForTag;
 import com.hubspot.jinjava.lib.tag.Tag;
 import com.hubspot.jinjava.lib.tag.TagLibrary;
 import com.hubspot.jinjava.lib.tag.eager.DeferredToken;
+import com.hubspot.jinjava.mode.EagerExecutionMode;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.util.DeferredValueUtils;
 import com.hubspot.jinjava.util.ScopeMap;
@@ -115,9 +117,9 @@ public class Context extends ScopeMap<String, Object> {
   private boolean throwInterpreterErrors = false;
   private boolean partialMacroEvaluation = false;
   private boolean unwrapRawOverride = false;
-  private boolean preparedByExecutionMode = false;
   private DynamicVariableResolver dynamicVariableResolver = null;
   private final Set<String> metaContextVariables; // These variable names aren't tracked in eager execution
+  private final Set<String> overriddenNonMetaContextVariables;
   private Node currentNode;
 
   public Context() {
@@ -210,6 +212,8 @@ public class Context extends ScopeMap<String, Object> {
       new FunctionLibrary(parent == null, disabled.get(Library.FUNCTION));
     this.metaContextVariables =
       parent == null ? new HashSet<>() : parent.metaContextVariables;
+    this.overriddenNonMetaContextVariables =
+      parent == null ? new HashSet<>() : parent.overriddenNonMetaContextVariables;
     if (parent != null) {
       this.expressionStrategy = parent.expressionStrategy;
       this.partialMacroEvaluation = parent.partialMacroEvaluation;
@@ -218,7 +222,6 @@ public class Context extends ScopeMap<String, Object> {
       this.deferredExecutionMode = parent.deferredExecutionMode;
       this.deferLargeObjects = parent.deferLargeObjects;
       this.throwInterpreterErrors = parent.throwInterpreterErrors;
-      this.preparedByExecutionMode = parent.preparedByExecutionMode;
     }
   }
 
@@ -350,8 +353,35 @@ public class Context extends ScopeMap<String, Object> {
     }
   }
 
+  @Deprecated
+  @Beta
   public Set<String> getMetaContextVariables() {
     return metaContextVariables;
+  }
+
+  @Beta
+  public Set<String> getComputedMetaContextVariables() {
+    return Sets.difference(metaContextVariables, overriddenNonMetaContextVariables);
+  }
+
+  @Beta
+  public void addMetaContextVariables(Collection<String> variables) {
+    metaContextVariables.addAll(variables);
+  }
+
+  @Beta
+  public void addNonMetaContextVariables(Collection<String> variables) {
+    overriddenNonMetaContextVariables.addAll(
+      variables
+        .stream()
+        .filter(var -> !EagerExecutionMode.STATIC_META_CONTEXT_VARIABLES.contains(var))
+        .collect(Collectors.toList())
+    );
+  }
+
+  @Beta
+  public void removeNonMetaContextVariables(Collection<String> variables) {
+    overriddenNonMetaContextVariables.removeAll(variables);
   }
 
   public void handleDeferredNode(Node node) {
@@ -826,13 +856,5 @@ public class Context extends ScopeMap<String, Object> {
 
   public boolean isInForLoop() {
     return get(ForTag.LOOP) != null;
-  }
-
-  boolean isPreparedByExecutionMode() {
-    return preparedByExecutionMode;
-  }
-
-  void setPreparedByExecutionMode(boolean preparedByExecutionMode) {
-    this.preparedByExecutionMode = preparedByExecutionMode;
   }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -111,8 +111,10 @@ public class JinjavaInterpreter implements PyishSerializable {
     this.context = context;
     this.config = renderConfig;
     this.application = application;
-
-    this.config.getExecutionMode().prepareContext(this.context);
+    if (!this.context.isPreparedByExecutionMode()) {
+      this.config.getExecutionMode().prepareContext(this.context);
+      this.context.setPreparedByExecutionMode(true);
+    }
 
     switch (config.getRandomNumberGeneratorStrategy()) {
       case THREAD_LOCAL:

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -111,10 +111,7 @@ public class JinjavaInterpreter implements PyishSerializable {
     this.context = context;
     this.config = renderConfig;
     this.application = application;
-    if (!this.context.isPreparedByExecutionMode()) {
-      this.config.getExecutionMode().prepareContext(this.context);
-      this.context.setPreparedByExecutionMode(true);
-    }
+    this.config.getExecutionMode().prepareContext(this.context);
 
     switch (config.getRandomNumberGeneratorStrategy()) {
       case THREAD_LOCAL:

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -37,7 +37,6 @@ import com.hubspot.jinjava.tree.ExpressionNode;
 import com.hubspot.jinjava.tree.Node;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.tree.parse.TagToken;
-import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.ForLoop;
 import com.hubspot.jinjava.util.HelperStringTokenizer;
 import com.hubspot.jinjava.util.LengthLimitingStringBuilder;
@@ -48,7 +47,6 @@ import java.util.ConcurrentModificationException;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.tuple.Pair;
@@ -165,11 +163,7 @@ public class ForTag implements Tag {
   ) {
     ForLoop loop = ObjectIterator.getLoop(collection);
 
-    Set<String> removedMetaContextVariables =
-      EagerReconstructionUtils.removeMetaContextVariables(
-        loopVars.stream(),
-        interpreter.getContext()
-      );
+    interpreter.getContext().addNonMetaContextVariables(loopVars);
     try (InterpreterScopeClosable c = interpreter.enterScope()) {
       if (interpreter.isValidationMode() && !loop.hasNext()) {
         loop = ObjectIterator.getLoop(new DummyObject());
@@ -298,10 +292,7 @@ public class ForTag implements Tag {
       }
       return checkLoopVariable(interpreter, buff);
     } finally {
-      interpreter
-        .getContext()
-        .getMetaContextVariables()
-        .addAll(removedMetaContextVariables);
+      interpreter.getContext().removeNonMetaContextVariables(loopVars);
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/DeferredToken.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/DeferredToken.java
@@ -378,7 +378,7 @@ public class DeferredToken {
         }
         return !(val instanceof DeferredValue);
       })
-      .filter(prop -> !context.getMetaContextVariables().contains(prop))
+      .filter(prop -> !context.getComputedMetaContextVariables().contains(prop))
       .filter(prop -> {
         DeferredValue deferredValue = convertToDeferredValue(context, prop);
         context.put(prop, deferredValue);

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -185,11 +185,7 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
         List<String> loopVars = getTag()
           .getLoopVarsAndExpression((TagToken) tagNode.getMaster())
           .getLeft();
-        Set<String> removedMetaContextVariables =
-          EagerReconstructionUtils.removeMetaContextVariables(
-            loopVars.stream(),
-            interpreter.getContext()
-          );
+        interpreter.getContext().addNonMetaContextVariables(loopVars);
         loopVars.forEach(var ->
           interpreter.getContext().put(var, DeferredValue.instance())
         );
@@ -198,10 +194,7 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
             renderChildren(tagNode, eagerInterpreter)
           );
         } finally {
-          interpreter
-            .getContext()
-            .getMetaContextVariables()
-            .addAll(removedMetaContextVariables);
+          interpreter.getContext().removeNonMetaContextVariables(loopVars);
           if (clearDeferredWords) {
             interpreter
               .getContext()

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
@@ -40,11 +40,11 @@ public abstract class EagerSetTagStrategy {
       variables = new String[] { var };
       expression = tagNode.getHelpers();
     }
-
-    EagerReconstructionUtils.removeMetaContextVariables(
-      Arrays.stream(variables).map(String::trim),
-      interpreter.getContext()
-    );
+    interpreter
+      .getContext()
+      .addNonMetaContextVariables(
+        Arrays.stream(variables).map(String::trim).collect(Collectors.toList())
+      );
 
     EagerExecutionResult eagerExecutionResult = getEagerExecutionResult(
       tagNode,
@@ -167,7 +167,7 @@ public abstract class EagerSetTagStrategy {
     if (
       maybeTemporaryImportAlias.isPresent() &&
       !AliasedEagerImportingStrategy.isTemporaryImportAlias(variables) &&
-      !interpreter.getContext().getMetaContextVariables().contains(variables)
+      !interpreter.getContext().getComputedMetaContextVariables().contains(variables)
     ) {
       if (!interpreter.getContext().containsKey(maybeTemporaryImportAlias.get())) {
         if (

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/FlatEagerImportingStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/FlatEagerImportingStrategy.java
@@ -72,7 +72,7 @@ public class FlatEagerImportingStrategy implements EagerImportingStrategy {
       Set<String> metaContextVariables = importingData
         .getOriginalInterpreter()
         .getContext()
-        .getMetaContextVariables();
+        .getComputedMetaContextVariables();
       // defer imported variables
       EagerReconstructionUtils.buildSetTag(
         child

--- a/src/main/java/com/hubspot/jinjava/mode/EagerExecutionMode.java
+++ b/src/main/java/com/hubspot/jinjava/mode/EagerExecutionMode.java
@@ -53,6 +53,6 @@ public class EagerExecutionMode implements ExecutionMode {
       .filter(Optional::isPresent)
       .forEach(maybeEagerTag -> context.registerTag(maybeEagerTag.get()));
     context.setExpressionStrategy(new EagerExpressionStrategy());
-    context.getMetaContextVariables().addAll(STATIC_META_CONTEXT_VARIABLES);
+    context.addMetaContextVariables(STATIC_META_CONTEXT_VARIABLES);
   }
 }

--- a/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
@@ -119,7 +119,7 @@ public class DeferredValueUtils {
     props
       .stream()
       .filter(prop -> !(context.get(prop) instanceof DeferredValue))
-      .filter(prop -> !context.getMetaContextVariables().contains(prop))
+      .filter(prop -> !context.getComputedMetaContextVariables().contains(prop))
       .forEach(prop -> {
         Object value = context.get(prop);
         if (value != null) {

--- a/src/main/java/com/hubspot/jinjava/util/EagerContextWatcher.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerContextWatcher.java
@@ -50,7 +50,7 @@ public class EagerContextWatcher {
   ) {
     final Set<String> metaContextVariables = interpreter
       .getContext()
-      .getMetaContextVariables();
+      .getComputedMetaContextVariables();
     final EagerExecutionResult initialResult;
     final Map<String, Object> speculativeBindings;
     if (eagerChildContextConfig.checkForContextChanges) {

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -2,7 +2,6 @@ package com.hubspot.jinjava.util;
 
 import com.google.common.annotations.Beta;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Sets;
 import com.hubspot.jinjava.el.ext.AbstractCallableMethod;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.Context.Library;
@@ -25,7 +24,6 @@ import com.hubspot.jinjava.lib.tag.eager.EagerSetTagStrategy;
 import com.hubspot.jinjava.lib.tag.eager.importing.AliasedEagerImportingStrategy;
 import com.hubspot.jinjava.lib.tag.eager.importing.EagerImportingStrategyFactory;
 import com.hubspot.jinjava.loader.RelativePathResolver;
-import com.hubspot.jinjava.mode.EagerExecutionMode;
 import com.hubspot.jinjava.objects.serialization.PyishBlockSetSerializable;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.objects.serialization.PyishSerializable;
@@ -313,7 +311,9 @@ public class EagerReconstructionUtils {
     JinjavaInterpreter interpreter,
     int depth
   ) {
-    Set<String> metaContextVariables = interpreter.getContext().getMetaContextVariables();
+    Set<String> metaContextVariables = interpreter
+      .getContext()
+      .getComputedMetaContextVariables();
     deferredWords
       .stream()
       .filter(w -> !metaContextVariables.contains(w))
@@ -751,22 +751,6 @@ public class EagerReconstructionUtils {
         interpreter.getConfig().getTokenScannerSymbols().getExpressionEndWithTag()
       )
     );
-  }
-
-  public static Set<String> removeMetaContextVariables(
-    Stream<String> varStream,
-    Context context
-  ) {
-    Set<String> metaSetVars = Sets
-      .intersection(
-        context.getMetaContextVariables(),
-        varStream
-          .filter(var -> !EagerExecutionMode.STATIC_META_CONTEXT_VARIABLES.contains(var))
-          .collect(Collectors.toSet())
-      )
-      .immutableCopy();
-    context.getMetaContextVariables().removeAll(metaSetVars);
-    return metaSetVars;
   }
 
   public static Boolean isDeferredExecutionMode() {

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1572,4 +1572,21 @@ public class EagerTest {
       "reconstructs-block-path-when-deferred-nested/test.expected"
     );
   }
+
+  @Test
+  public void itKeepsMetaContextVariablesThroughImport() {
+    setupWithExecutionMode(
+      new EagerExecutionMode() {
+        @Override
+        public void prepareContext(Context context) {
+          super.prepareContext(context);
+          context.getMetaContextVariables().add("meta");
+        }
+      }
+    );
+    interpreter.getContext().put("meta", new ArrayList<>());
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "keeps-meta-context-variables-through-import/test"
+    );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -990,7 +991,7 @@ public class EagerTest {
 
   @Test
   public void itAllowsMetaContextVarOverriding() {
-    interpreter.getContext().getMetaContextVariables().add("meta");
+    interpreter.getContext().addMetaContextVariables(Collections.singleton("meta"));
     interpreter.getContext().put("meta", "META");
     expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
       "allows-meta-context-var-overriding"
@@ -1471,7 +1472,7 @@ public class EagerTest {
 
   @Test
   public void itDefersLoopSettingMetaContextVar() {
-    interpreter.getContext().getMetaContextVariables().add("content");
+    interpreter.getContext().addMetaContextVariables(Collections.singleton("content"));
     expectedTemplateInterpreter.assertExpectedOutput(
       "defers-loop-setting-meta-context-var"
     );
@@ -1480,7 +1481,7 @@ public class EagerTest {
   @Test
   public void itDefersLoopSettingMetaContextVarSecondPass() {
     interpreter.getContext().put("deferred", "resolved");
-    interpreter.getContext().getMetaContextVariables().add("content");
+    interpreter.getContext().addMetaContextVariables(Collections.singleton("content"));
     expectedTemplateInterpreter.assertExpectedOutput(
       "defers-loop-setting-meta-context-var.expected"
     );
@@ -1580,7 +1581,7 @@ public class EagerTest {
         @Override
         public void prepareContext(Context context) {
           super.prepareContext(context);
-          context.getMetaContextVariables().add("meta");
+          context.addMetaContextVariables(Collections.singleton("meta"));
         }
       }
     );

--- a/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethodTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethodTest.java
@@ -16,6 +16,7 @@ import com.hubspot.jinjava.objects.collections.PyList;
 import com.hubspot.jinjava.objects.collections.PyMap;
 import com.hubspot.jinjava.random.RandomNumberGeneratorStrategy;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -225,7 +226,7 @@ public class EagerAstMethodTest extends BaseInterpretingTest {
   @Test
   public void itPreservesUnresolvable() {
     interpreter.getContext().put("foo_object", new Foo());
-    interpreter.getContext().getMetaContextVariables().add("foo_object");
+    interpreter.getContext().addMetaContextVariables(Collections.singleton("foo_object"));
     try {
       interpreter.resolveELExpression("foo_object.deferred|upper", -1);
       fail("Should throw DeferredParsingException");

--- a/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
@@ -600,7 +600,7 @@ public class EagerExpressionResolverTest {
   @Test
   public void itHandlesPyishSerializableWithProcessingException() {
     context.put("foo", new SomethingExceptionallyPyish("yes"));
-    context.getMetaContextVariables().add("foo");
+    context.addMetaContextVariables(Collections.singleton("foo"));
     assertThat(interpreter.render("{{ deferred && (1 == 2 || foo) }}"))
       .isEqualTo("{{ deferred && (false || foo) }}");
   }

--- a/src/test/java/com/hubspot/jinjava/util/EagerReconstructionUtilsTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerReconstructionUtilsTest.java
@@ -2,8 +2,7 @@ package com.hubspot.jinjava.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -34,7 +33,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Stream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -350,27 +348,33 @@ public class EagerReconstructionUtilsTest extends BaseInterpretingTest {
   }
 
   @Test
-  public void itDoesNotRemoveStaticMetaContextVariables() {
+  public void itRemovesOtherMetaContextVariables() {
     String variableName = "foo";
-    interpreter.getContext().getMetaContextVariables().add(variableName);
-    assertThat(interpreter.getContext().getMetaContextVariables()).contains(variableName);
-    EagerReconstructionUtils.removeMetaContextVariables(
-      Stream.of(variableName),
-      interpreter.getContext()
-    );
-    assertThat(interpreter.getContext().getMetaContextVariables())
+    interpreter.getContext().addMetaContextVariables(Collections.singleton(variableName));
+    assertThat(interpreter.getContext().getComputedMetaContextVariables())
+      .contains(variableName);
+    interpreter
+      .getContext()
+      .addNonMetaContextVariables(Collections.singleton(variableName));
+    assertThat(interpreter.getContext().getComputedMetaContextVariables())
       .doesNotContain(variableName);
+    interpreter
+      .getContext()
+      .removeNonMetaContextVariables(Collections.singleton(variableName));
+    assertThat(interpreter.getContext().getComputedMetaContextVariables())
+      .contains(variableName);
   }
 
   @Test
-  public void itRemovesOtherMetaContextVariables() {
-    assertThat(interpreter.getContext().getMetaContextVariables())
+  public void itDoesNotRemoveStaticMetaContextVariables() {
+    assertThat(interpreter.getContext().getComputedMetaContextVariables())
       .contains(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY);
-    EagerReconstructionUtils.removeMetaContextVariables(
-      Stream.of(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY),
-      interpreter.getContext()
-    );
-    assertThat(interpreter.getContext().getMetaContextVariables())
+    interpreter
+      .getContext()
+      .addNonMetaContextVariables(
+        Collections.singleton(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY)
+      );
+    assertThat(interpreter.getContext().getComputedMetaContextVariables())
       .contains(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY);
   }
 

--- a/src/test/resources/eager/keeps-meta-context-variables-through-import/import-target.jinja
+++ b/src/test/resources/eager/keeps-meta-context-variables-through-import/import-target.jinja
@@ -1,0 +1,1 @@
+I am a boring import

--- a/src/test/resources/eager/keeps-meta-context-variables-through-import/test.expected.jinja
+++ b/src/test/resources/eager/keeps-meta-context-variables-through-import/test.expected.jinja
@@ -1,0 +1,4 @@
+{% set list = deferred %}
+
+{% set meta = ['overridden'] %}{% do list.append(meta) %}
+{{ list }}

--- a/src/test/resources/eager/keeps-meta-context-variables-through-import/test.jinja
+++ b/src/test/resources/eager/keeps-meta-context-variables-through-import/test.jinja
@@ -1,0 +1,5 @@
+{% set meta = ['overridden'] %}
+{% set list = deferred %}
+{% import '../../eager/keeps-meta-context-variables-through-import/import-target.jinja' %}
+{% do list.append(meta) %}
+{{ list }}


### PR DESCRIPTION
Meta context variables denote those which have special meaning outside the context of the Jinjava template. In HubL, this includes variables like `content`.

If these are manually overridden, such as inside a set tag or a for tag, then the lose their special functionality. This is mirrored by the set of `metaContextVariables` which can have keys removed inside of a set tag or for tag.

If a meta context variable is removed and then an import tag is run, the meta context variable will re-appear due to the `prepareContext` method getting run again, which is used to re-add meta context variables.

This PR adds a new method `getComputedMetaContextVariables()` and deprecates the old `getMetaContextVariables()` method. This allows overrides to be added and removed without affecting the core `metaContextVariables`. So running `prepareContext` again does not cause issues as the core set of `metaContextVariables` won't have had any elements removed since any previous `prepareContext` runs.