### PR TITLE
Fix date-time format with configured timezone.

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -213,6 +213,8 @@ public class Functions {
       zoneOffset = ((ZonedDateTime) var).getZone();
     } else if (var instanceof PyishDate) {
       zoneOffset = ((PyishDate) var).toDateTime().getZone();
+    } else if (interpreter != null) {
+      zoneOffset = interpreter.getConfig().getTimeZone();
     }
 
     if (var == null) {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
@@ -204,4 +204,24 @@ public class DateTimeFormatFilterTest extends BaseInterpretingTest {
       JinjavaInterpreter.popCurrent();
     }
   }
+
+  @Test
+  public void itUsesTimezoneFromConfigToFormatString() {
+    Jinjava jinjava = new Jinjava(
+      JinjavaConfig
+        .newBuilder()
+        .withTimeZone(ZoneOffset.ofHours(+2))
+        .withLocale(new Locale("da"))
+        .build()
+    );
+    JinjavaInterpreter interpreter = jinjava.newInterpreter();
+    JinjavaInterpreter.pushCurrent(interpreter);
+    try {
+      long timestamp = 1718920800000L; // 2024-06-20 22:00:00 UTC
+      assertThat(filter.filter(timestamp, interpreter, "%b %d, %Y, at %I:%M %p"))
+        .isEqualTo("jun. 21, 2024, at 12:00 AM");
+    } finally {
+      JinjavaInterpreter.popCurrent();
+    }
+  }
 }


### PR DESCRIPTION
When the interpreter is configured to use a specific timezone, we should use that zone when formatting the date-time if the zone is not determine from the args already.