### PR TITLE
Revert "Fix date-time format with configured timezone."

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -213,8 +213,6 @@ public class Functions {
       zoneOffset = ((ZonedDateTime) var).getZone();
     } else if (var instanceof PyishDate) {
       zoneOffset = ((PyishDate) var).toDateTime().getZone();
-    } else if (interpreter != null) {
-      zoneOffset = interpreter.getConfig().getTimeZone();
     }
 
     if (var == null) {

--- a/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilterTest.java
@@ -204,24 +204,4 @@ public class DateTimeFormatFilterTest extends BaseInterpretingTest {
       JinjavaInterpreter.popCurrent();
     }
   }
-
-  @Test
-  public void itUsesTimezoneFromConfigToFormatString() {
-    Jinjava jinjava = new Jinjava(
-      JinjavaConfig
-        .newBuilder()
-        .withTimeZone(ZoneOffset.ofHours(+2))
-        .withLocale(new Locale("da"))
-        .build()
-    );
-    JinjavaInterpreter interpreter = jinjava.newInterpreter();
-    JinjavaInterpreter.pushCurrent(interpreter);
-    try {
-      long timestamp = 1718920800000L; // 2024-06-20 22:00:00 UTC
-      assertThat(filter.filter(timestamp, interpreter, "%b %d, %Y, at %I:%M %p"))
-        .isEqualTo("jun. 21, 2024, at 12:00 AM");
-    } finally {
-      JinjavaInterpreter.popCurrent();
-    }
-  }
 }


### PR DESCRIPTION
Reverts HubSpot/jinjava#1188

Too many pages depends on this date timezone not used from the config.