### PR TITLE
Add InvalidInput error when ArithmeticException is thrown when resolving expression

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/el/ExpressionResolver.java
@@ -188,6 +188,20 @@ public class ExpressionResolver {
       interpreter.addError(TemplateError.fromInvalidInputException(e));
     } catch (InvalidArgumentException e) {
       interpreter.addError(TemplateError.fromInvalidArgumentException(e));
+    } catch (ArithmeticException e) {
+      interpreter.addError(
+        TemplateError.fromInvalidInputException(
+          new InvalidInputException(
+            interpreter,
+            ExpressionResolver.class.getName(),
+            String.format(
+              "ArithmeticException when resolving expression [%s]: " +
+              getRootCauseMessage(e),
+              expression
+            )
+          )
+        )
+      );
     } catch (Exception e) {
       interpreter.addError(
         TemplateError.fromException(

--- a/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExpressionResolverTest.java
@@ -664,6 +664,17 @@ public class ExpressionResolverTest {
       );
   }
 
+  @Test
+  public void itAddsInvalidInputErrorWhenArithmeticExceptionIsThrown() {
+    String render = interpreter.render("{% set n = 12/0|round %}{{n}}");
+    assertThat(interpreter.getErrors().get(0).getMessage())
+      .contains(
+        "ArithmeticException when resolving expression [[ 12/0|round ]]: ArithmeticException: / by zero"
+      );
+    assertThat(interpreter.getErrors().get(0).getReason())
+      .isEqualTo(ErrorReason.INVALID_INPUT);
+  }
+
   public String result(String value, TestClass testClass) {
     testClass.touch();
     return value;


### PR DESCRIPTION
Currently, when an `ArithmeticException` is thrown when resolving expression, we are adding a `TemplateError` with `ErrorReason.EXCEPTION` to the interpreter.

Since `ArithmeticException` is caused by users' input errors, this PR changes to add a `TemplateError` with `ErrorReason.INVALID_INPUT` when `ArithmeticException` is caught.