### PR TITLE
Do not require arguement to unixtimestamp function

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/DateTimeFormatFilter.java
@@ -15,7 +15,6 @@ import com.hubspot.jinjava.objects.date.StrftimeFormatter;
   value = "Formats a date object",
   input = @JinjavaParam(
     value = "value",
-    defaultValue = "current time",
     desc = "The date variable or UNIX timestamp to format",
     required = true
   ),

--- a/src/main/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/UnixTimestampFilter.java
@@ -1,19 +1,20 @@
 package com.hubspot.jinjava.lib.filter;
 
+import static com.hubspot.jinjava.lib.filter.time.DateTimeFormatHelper.FIXED_DATE_TIME_FILTER_NULL_ARG;
+
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
+import com.hubspot.jinjava.features.DateTimeFeatureActivationStrategy;
+import com.hubspot.jinjava.features.FeatureActivationStrategy;
+import com.hubspot.jinjava.interpret.InvalidArgumentException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateError;
 import com.hubspot.jinjava.lib.fn.Functions;
 
 @JinjavaDoc(
   value = "Gets the UNIX timestamp value (in milliseconds) of a date object",
-  input = @JinjavaParam(
-    value = "value",
-    defaultValue = "current time",
-    desc = "The date variable",
-    required = true
-  ),
+  input = @JinjavaParam(value = "value", desc = "The date variable", required = true),
   snippets = { @JinjavaSnippet(code = "{% mydatetime|unixtimestamp %}") }
 )
 public class UnixTimestampFilter implements Filter {
@@ -25,6 +26,27 @@ public class UnixTimestampFilter implements Filter {
 
   @Override
   public Object filter(Object var, JinjavaInterpreter interpreter, String... args) {
+    if (var == null) {
+      interpreter.addError(
+        TemplateError.fromMissingFilterArgException(
+          new InvalidArgumentException(
+            interpreter,
+            "unixtimestamp",
+            "unixtimestamp filter called with null datetime"
+          )
+        )
+      );
+
+      FeatureActivationStrategy feat = interpreter
+        .getConfig()
+        .getFeatures()
+        .getActivationStrategy(FIXED_DATE_TIME_FILTER_NULL_ARG);
+
+      if (feat.isActive(interpreter.getContext())) {
+        var = ((DateTimeFeatureActivationStrategy) feat).getActivateAt();
+      }
+    }
+
     return Functions.unixtimestamp(var);
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/Functions.java
@@ -182,7 +182,7 @@ public class Functions {
   @JinjavaDoc(
     value = "formats a date to a string",
     params = {
-      @JinjavaParam(value = "var", type = "date", defaultValue = "current time"),
+      @JinjavaParam(value = "var", type = "date", required = true),
       @JinjavaParam(
         value = "format",
         defaultValue = StrftimeFormatter.DEFAULT_DATE_FORMAT
@@ -310,35 +310,10 @@ public class Functions {
 
   @JinjavaDoc(
     value = "gets the unix timestamp milliseconds value of a datetime",
-    params = {
-      @JinjavaParam(value = "var", type = "date", defaultValue = "current time"),
-    }
+    params = { @JinjavaParam(value = "var", type = "date", required = true) }
   )
   public static long unixtimestamp(Object... var) {
     Object filterVar = var == null || var.length == 0 ? null : var[0];
-
-    if (filterVar == null) {
-      JinjavaInterpreter interpreter = JinjavaInterpreter.getCurrent();
-
-      interpreter.addError(
-        TemplateError.fromMissingFilterArgException(
-          new InvalidArgumentException(
-            interpreter,
-            "unixtimestamp",
-            "unixtimestamp filter called with null datetime"
-          )
-        )
-      );
-
-      FeatureActivationStrategy feat = interpreter
-        .getConfig()
-        .getFeatures()
-        .getActivationStrategy(FIXED_DATE_TIME_FILTER_NULL_ARG);
-
-      if (feat.isActive(interpreter.getContext())) {
-        filterVar = ((DateTimeFeatureActivationStrategy) feat).getActivateAt();
-      }
-    }
 
     ZonedDateTime d = getDateTimeArg(filterVar, ZoneOffset.UTC);
 

--- a/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/UnixTimestampFunctionTest.java
@@ -28,13 +28,12 @@ public class UnixTimestampFunctionTest {
 
   @Test
   public void itGetsUnixTimestamps() {
-    JinjavaInterpreter.pushCurrent(
-      new JinjavaInterpreter(
-        new Jinjava(),
-        new Context(),
-        JinjavaConfig.newBuilder().build()
-      )
+    JinjavaInterpreter jinjavaInterpreter = new JinjavaInterpreter(
+      new Jinjava(),
+      new Context(),
+      JinjavaConfig.newBuilder().build()
     );
+    JinjavaInterpreter.pushCurrent(jinjavaInterpreter);
     assertThat(Functions.unixtimestamp())
       .isGreaterThan(0)
       .isLessThanOrEqualTo(System.currentTimeMillis());
@@ -42,6 +41,7 @@ public class UnixTimestampFunctionTest {
     assertThat(Functions.unixtimestamp(d)).isEqualTo(epochMilliseconds);
     assertThat(Functions.unixtimestamp((Object) null))
       .isCloseTo(System.currentTimeMillis(), Offset.offset(1000L));
+    assertThat(jinjavaInterpreter.getErrors()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
In https://github.com/HubSpot/jinjava/pull/1064, the intention was to require arguments for the unixtimestamp filter, but not the function. The unixtimestamp filter just calls the function though, so the requirement was incorrectly applied to both.