### PR TITLE
Condense overrideable options in Context to ContextConfiguration immutable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,16 @@
         <artifactId>jackson-datatype-jdk8</artifactId>
         <version>2.14.0</version>
       </dependency>
+      <dependency>
+        <groupId>com.hubspot.immutables</groupId>
+        <artifactId>hubspot-style</artifactId>
+        <version>${dep.hubspot-immutables.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.hubspot.immutables</groupId>
+        <artifactId>immutables-exceptions</artifactId>
+        <version>${dep.hubspot-immutables.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -197,7 +207,10 @@
     <dependency>
       <groupId>com.hubspot.immutables</groupId>
       <artifactId>hubspot-style</artifactId>
-      <version>${dep.hubspot-immutables.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.hubspot.immutables</groupId>
+      <artifactId>immutables-exceptions</artifactId>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,8 @@
 
     <dep.plugin.jacoco.version>0.8.3</dep.plugin.jacoco.version>
     <dep.plugin.javadoc.version>3.0.1</dep.plugin.javadoc.version>
+    <dep.hubspot-immutables.version>1.9</dep.hubspot-immutables.version>
+
 
     <basepom.test.add.opens>
       --add-opens=java.base/java.lang=ALL-UNNAMED
@@ -186,6 +188,16 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.hubspot.immutables</groupId>
+      <artifactId>hubspot-style</artifactId>
+      <version>${dep.hubspot-immutables.version}</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,7 @@
     <dependency>
       <groupId>com.hubspot.immutables</groupId>
       <artifactId>hubspot-style</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.hubspot.immutables</groupId>

--- a/src/main/java/com/hubspot/jinjava/interpret/ContextConfigurationIF.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/ContextConfigurationIF.java
@@ -1,0 +1,50 @@
+package com.hubspot.jinjava.interpret;
+
+import com.hubspot.immutables.style.HubSpotImmutableStyle;
+import com.hubspot.jinjava.lib.expression.DefaultExpressionStrategy;
+import com.hubspot.jinjava.lib.expression.ExpressionStrategy;
+import javax.annotation.Nullable;
+import org.immutables.value.Value.Default;
+import org.immutables.value.Value.Immutable;
+
+@Immutable(singleton = true)
+@HubSpotImmutableStyle
+public interface ContextConfigurationIF {
+  @Default
+  default ExpressionStrategy getExpressionStrategy() {
+    return new DefaultExpressionStrategy();
+  }
+
+  @Nullable
+  DynamicVariableResolver getDynamicVariableResolver();
+
+  @Default
+  default boolean isValidationMode() {
+    return false;
+  }
+
+  @Default
+  default boolean isDeferredExecutionMode() {
+    return false;
+  }
+
+  @Default
+  default boolean isDeferLargeObjects() {
+    return false;
+  }
+
+  @Default
+  default boolean isThrowInterpreterErrors() {
+    return false;
+  }
+
+  @Default
+  default boolean isPartialMacroEvaluation() {
+    return false;
+  }
+
+  @Default
+  default boolean isUnwrapRawOverride() {
+    return false;
+  }
+}


### PR DESCRIPTION
The overrideable flags within `Context` are getting a bit out of hand so I'm grouping these with an immutable class `ContextConfiguration`. I'm planning on adding a new flag in a coming PR and having `Context` directly have so many responsibilities is somewhat off-putting