### PR TITLE
Add feature to ignore parsing errors when doing nested interpretation

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -819,6 +819,23 @@ public class Context extends ScopeMap<String, Object> {
     return temporaryValueClosable;
   }
 
+  public boolean isIgnoreParseErrors() {
+    return contextConfiguration.isIgnoreParseErrors();
+  }
+
+  private void setIgnoreParseErrors(boolean ignoreParseErrors) {
+    contextConfiguration = contextConfiguration.withIgnoreParseErrors(ignoreParseErrors);
+  }
+
+  public TemporaryValueClosable<Boolean> withIgnoreParseErrors() {
+    TemporaryValueClosable<Boolean> temporaryValueClosable = new TemporaryValueClosable<>(
+      isIgnoreParseErrors(),
+      this::setIgnoreParseErrors
+    );
+    setIgnoreParseErrors(true);
+    return temporaryValueClosable;
+  }
+
   public static class TemporaryValueClosable<T> implements AutoCloseable {
 
     private final T previousValue;
@@ -829,9 +846,25 @@ public class Context extends ScopeMap<String, Object> {
       this.resetValueConsumer = resetValueConsumer;
     }
 
+    public static <T> TemporaryValueClosable<T> noOp() {
+      return new NoOpTemporaryValueClosable<>();
+    }
+
     @Override
     public void close() {
       resetValueConsumer.accept(previousValue);
+    }
+
+    private static class NoOpTemporaryValueClosable<T> extends TemporaryValueClosable<T> {
+
+      private NoOpTemporaryValueClosable() {
+        super(null, null);
+      }
+
+      @Override
+      public void close() {
+        // No-op
+      }
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/interpret/ContextConfigurationIF.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/ContextConfigurationIF.java
@@ -47,4 +47,12 @@ public interface ContextConfigurationIF {
   default boolean isUnwrapRawOverride() {
     return false;
   }
+
+  /**
+   * When trying nested interpretation, parsing errors are likely. This flag avoids propogating to differentiate between static and dynamic parsing errors.
+   */
+  @Default
+  default boolean isIgnoreParseErrors() {
+    return false;
+  }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/ContextConfigurationIF.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/ContextConfigurationIF.java
@@ -34,11 +34,6 @@ public interface ContextConfigurationIF {
   }
 
   @Default
-  default boolean isThrowInterpreterErrors() {
-    return false;
-  }
-
-  @Default
   default boolean isPartialMacroEvaluation() {
     return false;
   }
@@ -48,11 +43,42 @@ public interface ContextConfigurationIF {
     return false;
   }
 
-  /**
-   * When trying nested interpretation, parsing errors are likely. This flag avoids propogating to differentiate between static and dynamic parsing errors.
-   */
   @Default
-  default boolean isIgnoreParseErrors() {
-    return false;
+  default ErrorHandlingStrategy getErrorHandlingStrategy() {
+    return ErrorHandlingStrategy.of();
+  }
+
+  @Immutable(singleton = true)
+  @HubSpotImmutableStyle
+  interface ErrorHandlingStrategyIF {
+    @Default
+    default TemplateErrorTypeHandlingStrategy getFatalErrorStrategy() {
+      return TemplateErrorTypeHandlingStrategy.ADD_ERROR;
+    }
+
+    @Default
+    default TemplateErrorTypeHandlingStrategy getNonFatalErrorStrategy() {
+      return TemplateErrorTypeHandlingStrategy.ADD_ERROR;
+    }
+
+    enum TemplateErrorTypeHandlingStrategy {
+      IGNORE,
+      ADD_ERROR,
+      THROW_EXCEPTION,
+    }
+
+    static ErrorHandlingStrategy throwAll() {
+      return ErrorHandlingStrategy
+        .of()
+        .withFatalErrorStrategy(TemplateErrorTypeHandlingStrategy.THROW_EXCEPTION)
+        .withNonFatalErrorStrategy(TemplateErrorTypeHandlingStrategy.THROW_EXCEPTION);
+    }
+
+    static ErrorHandlingStrategy ignoreAll() {
+      return ErrorHandlingStrategy
+        .of()
+        .withFatalErrorStrategy(TemplateErrorTypeHandlingStrategy.IGNORE)
+        .withNonFatalErrorStrategy(TemplateErrorTypeHandlingStrategy.IGNORE);
+    }
   }
 }

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -849,6 +849,7 @@ public class JinjavaInterpreter implements PyishSerializable {
           templateError.getMessage()
         );
       case ADD_ERROR:
+      default: // Checkstyle
         // fix line numbers not matching up with source template
         if (!context.getCurrentPathStack().isEmpty()) {
           if (

--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -81,7 +81,7 @@ public class TreeParser {
 
     do {
       if (parent != root) {
-        maybeAddError(
+        interpreter.addError(
           TemplateError.fromException(
             new MissingEndTagException(
               ((TagNode) parent).getEndName(),
@@ -113,7 +113,7 @@ public class TreeParser {
 
     if (token.getType() == symbols.getFixed()) {
       if (token instanceof UnclosedToken) {
-        maybeAddError(
+        interpreter.addError(
           new TemplateError(
             ErrorType.WARNING,
             ErrorReason.SYNTAX_ERROR,
@@ -134,7 +134,7 @@ public class TreeParser {
     } else if (token.getType() == symbols.getNote()) {
       String commentClosed = symbols.getClosingComment();
       if (!token.getImage().endsWith(commentClosed)) {
-        maybeAddError(
+        interpreter.addError(
           new TemplateError(
             ErrorType.WARNING,
             ErrorReason.SYNTAX_ERROR,
@@ -148,7 +148,7 @@ public class TreeParser {
         );
       }
     } else {
-      maybeAddError(
+      interpreter.addError(
         TemplateError.fromException(
           new UnexpectedTokenException(
             token.getImage(),
@@ -237,11 +237,13 @@ public class TreeParser {
     try {
       tag = interpreter.getContext().getTag(tagToken.getTagName());
       if (tag == null) {
-        maybeAddError(TemplateError.fromException(new UnknownTagException(tagToken)));
+        interpreter.addError(
+          TemplateError.fromException(new UnknownTagException(tagToken))
+        );
         return null;
       }
     } catch (DisabledException e) {
-      maybeAddError(
+      interpreter.addError(
         new TemplateError(
           ErrorType.FATAL,
           ErrorReason.DISABLED,
@@ -290,7 +292,7 @@ public class TreeParser {
         hasMatchingStartTag = true;
         break;
       } else {
-        maybeAddError(
+        interpreter.addError(
           TemplateError.fromException(
             new TemplateSyntaxException(
               tagToken.getImage(),
@@ -303,7 +305,7 @@ public class TreeParser {
       }
     }
     if (!hasMatchingStartTag) {
-      maybeAddError(
+      interpreter.addError(
         new TemplateError(
           ErrorType.WARNING,
           ErrorReason.SYNTAX_ERROR,
@@ -323,12 +325,5 @@ public class TreeParser {
       return true;
     }
     return jinjavaConfig.getLegacyOverrides().isUseTrimmingForNotesAndExpressions();
-  }
-
-  private void maybeAddError(TemplateError templateError) {
-    if (interpreter.getContext().isIgnoreParseErrors()) {
-      return;
-    }
-    interpreter.addError(templateError);
   }
 }

--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -81,7 +81,7 @@ public class TreeParser {
 
     do {
       if (parent != root) {
-        interpreter.addError(
+        maybeAddError(
           TemplateError.fromException(
             new MissingEndTagException(
               ((TagNode) parent).getEndName(),
@@ -113,7 +113,7 @@ public class TreeParser {
 
     if (token.getType() == symbols.getFixed()) {
       if (token instanceof UnclosedToken) {
-        interpreter.addError(
+        maybeAddError(
           new TemplateError(
             ErrorType.WARNING,
             ErrorReason.SYNTAX_ERROR,
@@ -134,7 +134,7 @@ public class TreeParser {
     } else if (token.getType() == symbols.getNote()) {
       String commentClosed = symbols.getClosingComment();
       if (!token.getImage().endsWith(commentClosed)) {
-        interpreter.addError(
+        maybeAddError(
           new TemplateError(
             ErrorType.WARNING,
             ErrorReason.SYNTAX_ERROR,
@@ -148,7 +148,7 @@ public class TreeParser {
         );
       }
     } else {
-      interpreter.addError(
+      maybeAddError(
         TemplateError.fromException(
           new UnexpectedTokenException(
             token.getImage(),
@@ -237,13 +237,11 @@ public class TreeParser {
     try {
       tag = interpreter.getContext().getTag(tagToken.getTagName());
       if (tag == null) {
-        interpreter.addError(
-          TemplateError.fromException(new UnknownTagException(tagToken))
-        );
+        maybeAddError(TemplateError.fromException(new UnknownTagException(tagToken)));
         return null;
       }
     } catch (DisabledException e) {
-      interpreter.addError(
+      maybeAddError(
         new TemplateError(
           ErrorType.FATAL,
           ErrorReason.DISABLED,
@@ -292,7 +290,7 @@ public class TreeParser {
         hasMatchingStartTag = true;
         break;
       } else {
-        interpreter.addError(
+        maybeAddError(
           TemplateError.fromException(
             new TemplateSyntaxException(
               tagToken.getImage(),
@@ -305,7 +303,7 @@ public class TreeParser {
       }
     }
     if (!hasMatchingStartTag) {
-      interpreter.addError(
+      maybeAddError(
         new TemplateError(
           ErrorType.WARNING,
           ErrorReason.SYNTAX_ERROR,
@@ -325,5 +323,12 @@ public class TreeParser {
       return true;
     }
     return jinjavaConfig.getLegacyOverrides().isUseTrimmingForNotesAndExpressions();
+  }
+
+  private void maybeAddError(TemplateError templateError) {
+    if (interpreter.getContext().isIgnoreParseErrors()) {
+      return;
+    }
+    interpreter.addError(templateError);
   }
 }

--- a/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/ExpressionNodeTest.java
@@ -236,6 +236,28 @@ public class ExpressionNodeTest extends BaseInterpretingTest {
     assertThat(val("{{ a }}")).isEqualTo("foo &lt; bar");
   }
 
+  @Test
+  public void itIgnoresParseErrorsWhenFeatureIsEnabled() {
+    final JinjavaConfig config = JinjavaConfig
+      .newBuilder()
+      .withFeatureConfig(
+        FeatureConfig
+          .newBuilder()
+          .add(JinjavaInterpreter.IGNORE_NESTED_INTERPRETATION_PARSE_ERRORS, c -> true)
+          .build()
+      )
+      .build();
+    JinjavaInterpreter interpreter = new Jinjava(config).newInterpreter();
+    Context context = interpreter.getContext();
+    context.put("myvar", "hello {% if");
+    context.put("place", "world");
+
+    ExpressionNode node = fixture("simplevar");
+
+    assertThat(node.render(interpreter).toString()).isEqualTo("hello {% if");
+    assertThat(interpreter.getErrors()).isEmpty();
+  }
+
   private String val(String jinja) {
     return parse(jinja).render(interpreter).getValue();
   }

--- a/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
@@ -8,6 +8,8 @@ import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.LegacyOverrides;
 import com.hubspot.jinjava.interpret.Context.TemporaryValueClosable;
+import com.hubspot.jinjava.interpret.ContextConfigurationIF.ErrorHandlingStrategyIF;
+import com.hubspot.jinjava.interpret.ErrorHandlingStrategy;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import java.nio.charset.StandardCharsets;
 import org.junit.Test;
@@ -365,7 +367,9 @@ public class TreeParserTest extends BaseInterpretingTest {
   @Test
   public void itDoesNotAddErrorWhenParseErrorsAreIgnored() {
     try (
-      TemporaryValueClosable<Boolean> c = interpreter.getContext().withIgnoreParseErrors()
+      TemporaryValueClosable<ErrorHandlingStrategy> c = interpreter
+        .getContext()
+        .withErrorHandlingStrategy(ErrorHandlingStrategyIF.ignoreAll())
     ) {
       String expression = "{% if ";
       final Node tree = new TreeParser(interpreter, expression).buildTree();

--- a/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
@@ -7,6 +7,7 @@ import com.hubspot.jinjava.BaseInterpretingTest;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.JinjavaConfig;
 import com.hubspot.jinjava.LegacyOverrides;
+import com.hubspot.jinjava.interpret.Context.TemporaryValueClosable;
 import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import java.nio.charset.StandardCharsets;
 import org.junit.Test;
@@ -359,6 +360,20 @@ public class TreeParserTest extends BaseInterpretingTest {
         .newInterpreter();
     final Node overriddenTree = new TreeParser(interpreter, expression).buildTree();
     assertThat(interpreter.render(overriddenTree)).isEqualTo("A\nB");
+  }
+
+  @Test
+  public void itDoesNotAddErrorWhenParseErrorsAreIgnored() {
+    try (
+      TemporaryValueClosable<Boolean> c = interpreter.getContext().withIgnoreParseErrors()
+    ) {
+      String expression = "{% if ";
+      final Node tree = new TreeParser(interpreter, expression).buildTree();
+      assertThat(tree.getChildren()).hasSize(1);
+      assertThat(tree.getChildren().get(0).toTreeString())
+        .isEqualToIgnoringWhitespace(" {~ {% if  ~}");
+    }
+    assertThat(interpreter.getErrors()).isEmpty();
   }
 
   Node parse(String fixture) {


### PR DESCRIPTION
This builds off the `ContextConfiguration` immutable object I added in https://github.com/HubSpot/jinjava/pull/1195.

Nested interpretation is cancerous.
I can write an entirely well-formatted template:
```
Check this out: {{ my_var }}
```
And get `SYNTAX_ERROR`s if `my_var` is `{% if`.

Also, disabled tags which are attempted to be rendered in nested interpretation produce errors. It's probably better to just ignore the tags.
This functionality is behind the feature `IGNORE_NESTED_INTERPRETATION_PARSE_ERRORS`, which is disabled by default.

This PR accomplishes what https://github.com/HubSpot/jinjava/pull/1151 aims to do, plus the added bonus of ignoring any parsing errors when using nested interpretation.