### PR TITLE
Mark @JinjavaDoc as @Inherited

### DIFF
--- a/src/main/java/com/hubspot/jinjava/doc/annotations/JinjavaDoc.java
+++ b/src/main/java/com/hubspot/jinjava/doc/annotations/JinjavaDoc.java
@@ -1,12 +1,14 @@
 package com.hubspot.jinjava.doc.annotations;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.METHOD })
+@Inherited
 public @interface JinjavaDoc {
   String value() default "";
 


### PR DESCRIPTION
If a tag/function/filter is overridden, but a new `@JinjavaDoc` isn't specified, the annotation of the parent should be inherited to ensure comprehensive documentation, rather than absent documentation.