### PR TITLE
Don't alter the current_path context key when getting the set tag for current path

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/EagerImportingStrategyFactory.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/EagerImportingStrategyFactory.java
@@ -34,12 +34,6 @@ public class EagerImportingStrategyFactory {
         .getContext()
         .getCurrentPathStack()
         .peek()
-        .map(c -> {
-          interpreter
-            .getContext()
-            .replace(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY, c);
-          return c;
-        })
         .orElseGet(() ->
           (String) interpreter
             .getContext()


### PR DESCRIPTION
This is a behaviour change that's not strictly necessary that I added in https://github.com/HubSpot/jinjava/pull/1199. I'm changing it back to the previous behaviour.