### PR TITLE
Make fixture test templates "pretty"

### DIFF
--- a/src/test/java/com/hubspot/jinjava/ExpectedNodeInterpreter.java
+++ b/src/test/java/com/hubspot/jinjava/ExpectedNodeInterpreter.java
@@ -26,7 +26,8 @@ public class ExpectedNodeInterpreter {
   public String assertExpectedOutput(String name) {
     TagNode tagNode = (TagNode) fixture(name);
     String output = tag.interpret(tagNode, interpreter);
-    assertThat(output.trim()).isEqualTo(expected(name).trim());
+    assertThat(ExpectedTemplateInterpreter.prettify(output.trim()))
+      .isEqualTo(ExpectedTemplateInterpreter.prettify(expected(name).trim()));
     return output;
   }
 
@@ -34,9 +35,11 @@ public class ExpectedNodeInterpreter {
     try {
       return new TreeParser(
         interpreter,
-        Resources.toString(
-          Resources.getResource(String.format("%s/%s.jinja", path, name)),
-          StandardCharsets.UTF_8
+        ExpectedTemplateInterpreter.simplify(
+          Resources.toString(
+            Resources.getResource(String.format("%s/%s.jinja", path, name)),
+            StandardCharsets.UTF_8
+          )
         )
       )
         .buildTree()
@@ -49,9 +52,11 @@ public class ExpectedNodeInterpreter {
 
   public String expected(String name) {
     try {
-      return Resources.toString(
-        Resources.getResource(String.format("%s/%s.expected.jinja", path, name)),
-        StandardCharsets.UTF_8
+      return ExpectedTemplateInterpreter.simplify(
+        Resources.toString(
+          Resources.getResource(String.format("%s/%s.expected.jinja", path, name)),
+          StandardCharsets.UTF_8
+        )
       );
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/src/test/java/com/hubspot/jinjava/ExpectedTemplateInterpreter.java
+++ b/src/test/java/com/hubspot/jinjava/ExpectedTemplateInterpreter.java
@@ -135,7 +135,7 @@ public class ExpectedTemplateInterpreter {
     return output;
   }
 
-  private String prettify(String string) {
+  static String prettify(String string) {
     return string.replaceAll("([}%]})([^\\s])", "$1\\\\\n$2");
   }
 
@@ -172,7 +172,7 @@ public class ExpectedTemplateInterpreter {
     }
   }
 
-  private String simplify(String prettified) {
+  static String simplify(String prettified) {
     return prettified.replaceAll("\\\\\n\\s*", "");
   }
 

--- a/src/test/resources/eager/allows-deferred-lazy-reference-to-get-overridden.expected.jinja
+++ b/src/test/resources/eager/allows-deferred-lazy-reference-to-get-overridden.expected.jinja
@@ -1,6 +1,12 @@
-{% set a_list = ['a', 'b'] %}{% for __ignored__ in [0] %}
-{% set b_list = a_list %}{% if deferred %}
+{% set a_list = ['a', 'b'] %}\
+{% for __ignored__ in [0] %}
+{% set b_list = a_list %}\
+{% if deferred %}
 {% set b_list = [deferred] %}
-{% endif %}{% do b_list.append(deferred ? 'B' : '') %}
-B: {{ b_list }}.{% endfor %}{% do a_list.append(deferred ? 'A' : '') %}
-A: {{ a_list }}.
+{% endif %}\
+{% do b_list.append(deferred ? 'B' : '') %}
+B: {{ b_list }}\
+.{% endfor %}\
+{% do a_list.append(deferred ? 'A' : '') %}
+A: {{ a_list }}\
+.

--- a/src/test/resources/eager/allows-meta-context-var-overriding.expected.jinja
+++ b/src/test/resources/eager/allows-meta-context-var-overriding.expected.jinja
@@ -1,9 +1,11 @@
 0
 META
 {% for meta in deferred %}
-{{ meta }}{% endfor %}
+{{ meta }}\
+{% endfor %}
 META
-{% set meta = [] %}{% if deferred %}
+{% set meta = [] %}\
+{% if deferred %}
 {% do meta.append(1) %}
 {% endif %}
 {{ meta }}

--- a/src/test/resources/eager/allows-variable-sharing-alias-name.expected.jinja
+++ b/src/test/resources/eager/allows-variable-sharing-alias-name.expected.jinja
@@ -1,7 +1,17 @@
-{% do %}{% set current_path = 'filters.jinja' %}{% set __temp_import_alias_854547461__ = {}  %}{% for __ignored__ in [0] %}
-{% set bar = deferred %}{% do __temp_import_alias_854547461__.update({'bar': bar}) %}
+{% do %}\
+{% set current_path = 'filters.jinja' %}\
+{% set __temp_import_alias_854547461__ = {}  %}\
+{% for __ignored__ in [0] %}
+{% set bar = deferred %}\
+{% do __temp_import_alias_854547461__.update({'bar': bar}) %}
 
-{% set filters = {}  %}{% do __temp_import_alias_854547461__.update({'filters': filters}) %}{% do filters.update(deferred) %}
-{% do __temp_import_alias_854547461__.update({'bar': bar,'foo': 123,'import_resource_path': 'filters.jinja','filters': filters}) %}{% endfor %}{% set filters = __temp_import_alias_854547461__ %}{% set current_path = '' %}{% enddo %}
+{% set filters = {}  %}\
+{% do __temp_import_alias_854547461__.update({'filters': filters}) %}\
+{% do filters.update(deferred) %}
+{% do __temp_import_alias_854547461__.update({'bar': bar,'foo': 123,'import_resource_path': 'filters.jinja','filters': filters}) %}\
+{% endfor %}\
+{% set filters = __temp_import_alias_854547461__ %}\
+{% set current_path = '' %}\
+{% enddo %}
 
 {{ filters }}

--- a/src/test/resources/eager/commits-variables-from-do-tag-when-partially-resolved.expected.jinja
+++ b/src/test/resources/eager/commits-variables-from-do-tag-when-partially-resolved.expected.jinja
@@ -1,7 +1,11 @@
-{% do %}{% set list1 = ['b'] %}{% set list0 = ['a'] %}{% set list2 = ['c'] %}
+{% do %}\
+{% set list1 = ['b'] %}\
+{% set list0 = ['a'] %}\
+{% set list2 = ['c'] %}
 
 
-{% set list2 = ['c'] %}{% do list2.append(deferred) %}
+{% set list2 = ['c'] %}\
+{% do list2.append(deferred) %}
 {% unless deferred %}
 {% set list0 = ['a', 'a'] %}
 {% endunless %}

--- a/src/test/resources/eager/correctly-defers-with-multiple-loops.expected.jinja
+++ b/src/test/resources/eager/correctly-defers-with-multiple-loops.expected.jinja
@@ -1,4 +1,5 @@
-{% set my_list = [] %}{% for __ignored__ in [0] %}
+{% set my_list = [] %}\
+{% for __ignored__ in [0] %}
 {% for j in deferred %}
 {% do my_list.append(0) %}
 {% endfor %}

--- a/src/test/resources/eager/defers-call-tag-with-deferred-argument.expected.jinja
+++ b/src/test/resources/eager/defers-call-tag-with-deferred-argument.expected.jinja
@@ -1,12 +1,14 @@
 {% macro repeat(val) %}
 {{ val }}
 {{ caller() }}
-{% endmacro %}{% call repeat(deferred) %}
+{% endmacro %}\
+{% call repeat(deferred) %}
 macro 1
 {% macro repeat(val) %}
 {{ val }}
 {{ caller() }}
-{% endmacro %}{% call repeat(deferred + 1) %}
+{% endmacro %}\
+{% call repeat(deferred + 1) %}
 macro2
 {% endcall %}
 {% endcall %}

--- a/src/test/resources/eager/defers-caller.expected.jinja
+++ b/src/test/resources/eager/defers-caller.expected.jinja
@@ -1,2 +1,3 @@
 Jack says:
-How do I get a {{ deferred }}?
+How do I get a {{ deferred }}\
+?

--- a/src/test/resources/eager/defers-changes-within-deferred-set-block.expected.jinja
+++ b/src/test/resources/eager/defers-changes-within-deferred-set-block.expected.jinja
@@ -1,6 +1,10 @@
 1
-{% set bar = [1] %}{% set foo = '1' %}{% if deferred %}
-{% set foo %}2{% do bar.append(2) %}{% endset %}
+{% set bar = [1] %}\
+{% set foo = '1' %}\
+{% if deferred %}
+{% set foo %}\
+2{% do bar.append(2) %}\
+{% endset %}
 {% endif %}
 Bar: {{ bar }}
 Foo: {{ foo }}

--- a/src/test/resources/eager/defers-loop-setting-meta-context-var.expected.jinja
+++ b/src/test/resources/eager/defers-loop-setting-meta-context-var.expected.jinja
@@ -1,5 +1,17 @@
 {% for __ignored__ in [0] %}
-{% macro render(content, query) %}{% if query %}{{ content.foo }}{% endif %}{% endmacro %}{% set content = {'foo': 'a'}  %}{{ render(content, deferred) }}
+{% macro render(content, query) %}\
+{% if query %}\
+{{ content.foo }}\
+{% endif %}\
+{% endmacro %}\
+{% set content = {'foo': 'a'}  %}\
+{{ render(content, deferred) }}
 
-{% macro render(content, query) %}{% if query %}{{ content.foo }}{% endif %}{% endmacro %}{% set content = {'foo': 'b'}  %}{{ render(content, deferred) }}
+{% macro render(content, query) %}\
+{% if query %}\
+{{ content.foo }}\
+{% endif %}\
+{% endmacro %}\
+{% set content = {'foo': 'b'}  %}\
+{{ render(content, deferred) }}
 {% endfor %}

--- a/src/test/resources/eager/defers-macro-for-do-and-print.expected.jinja
+++ b/src/test/resources/eager/defers-macro-for-do-and-print.expected.jinja
@@ -1,5 +1,15 @@
 Is ([]),
 Macro: [10]
-Is ([10]),{% set my_list = [10] %}{% macro macro_append(num) %}{% do my_list.append(num) %}Macro: {{ my_list }}{% endmacro %}{% do macro_append(deferred) %}
-Is ({{ my_list }}),
-{% macro macro_append(num) %}{% do my_list.append(num) %}Macro: {{ my_list }}{% endmacro %}{% print macro_append(deferred2) %}
+Is ([10]),{% set my_list = [10] %}\
+{% macro macro_append(num) %}\
+{% do my_list.append(num) %}\
+Macro: {{ my_list }}\
+{% endmacro %}\
+{% do macro_append(deferred) %}
+Is ({{ my_list }}\
+),
+{% macro macro_append(num) %}\
+{% do my_list.append(num) %}\
+Macro: {{ my_list }}\
+{% endmacro %}\
+{% print macro_append(deferred2) %}

--- a/src/test/resources/eager/defers-macro-in-expression.expected.jinja
+++ b/src/test/resources/eager/defers-macro-in-expression.expected.jinja
@@ -1,3 +1,10 @@
 2
-{% macro plus(foo, add) %}{{ foo + (filter:int.filter(add, ____int3rpr3t3r____)) }}{% endmacro %}{{ plus(deferred, 1.1) }}{% set deferred = deferred + 2 %}
-{% macro plus(foo, add) %}{{ foo + (filter:int.filter(add, ____int3rpr3t3r____)) }}{% endmacro %}{{ plus(deferred, 3.1) }}
+{% macro plus(foo, add) %}\
+{{ foo + (filter:int.filter(add, ____int3rpr3t3r____)) }}\
+{% endmacro %}\
+{{ plus(deferred, 1.1) }}\
+{% set deferred = deferred + 2 %}
+{% macro plus(foo, add) %}\
+{{ foo + (filter:int.filter(add, ____int3rpr3t3r____)) }}\
+{% endmacro %}\
+{{ plus(deferred, 3.1) }}

--- a/src/test/resources/eager/defers-macro-in-for.expected.jinja
+++ b/src/test/resources/eager/defers-macro-in-for.expected.jinja
@@ -1,3 +1,8 @@
-{% set my_list = [] %}{% macro macro_append(num) %}{% do my_list.append(num) %}{{ my_list }}{% endmacro %}{% for item in filter:split.filter(macro_append(deferred), ____int3rpr3t3r____, ',', 2) %}
+{% set my_list = [] %}\
+{% macro macro_append(num) %}\
+{% do my_list.append(num) %}\
+{{ my_list }}\
+{% endmacro %}\
+{% for item in filter:split.filter(macro_append(deferred), ____int3rpr3t3r____, ',', 2) %}
 {{ item }}
 {% endfor %}

--- a/src/test/resources/eager/defers-macro-in-if.expected.jinja
+++ b/src/test/resources/eager/defers-macro-in-if.expected.jinja
@@ -1,3 +1,8 @@
-{% set my_list = [] %}{% macro macro_append(num) %}{% do my_list.append(num) %}{{ my_list }}{% endmacro %}{% if [] == filter:split.filter(macro_append(deferred), ____int3rpr3t3r____, ',', 2) %}
+{% set my_list = [] %}\
+{% macro macro_append(num) %}\
+{% do my_list.append(num) %}\
+{{ my_list }}\
+{% endmacro %}\
+{% if [] == filter:split.filter(macro_append(deferred), ____int3rpr3t3r____, ',', 2) %}
 {{ my_list }}
 {% endif %}

--- a/src/test/resources/eager/defers-on-immutable-mode.expected.jinja
+++ b/src/test/resources/eager/defers-on-immutable-mode.expected.jinja
@@ -1,10 +1,13 @@
-{% set foo = 1 %}{% if deferred %}
+{% set foo = 1 %}\
+{% if deferred %}
 {% set foo = 2 %}
 {% else %}
 {% set foo = 3 %}
 {% endif %}
 {{ foo }}
 
-{% for __ignored__ in [0] %}{% set bar = 1 + deferred %}
+{% for __ignored__ in [0] %}\
+{% set bar = 1 + deferred %}
 {% set bar = bar + deferred %}
-{% endfor %}1
+{% endfor %}\
+1

--- a/src/test/resources/eager/does-not-override-import-modification-in-for.expected.jinja
+++ b/src/test/resources/eager/does-not-override-import-modification-in-for.expected.jinja
@@ -1,40 +1,81 @@
-{% set foo = 'start' %}{% for __ignored__ in [0] %}
-{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set __temp_import_alias_3016318__ = {}  %}{% for __ignored__ in [0] %}{% if deferred %}
+{% set foo = 'start' %}\
+{% for __ignored__ in [0] %}
+{% do %}\
+{% set current_path = 'deferred-modification.jinja' %}\
+{% set __temp_import_alias_3016318__ = {}  %}\
+{% for __ignored__ in [0] %}\
+{% if deferred %}
 
-{% set foo = 'starta' %}{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
+{% set foo = 'starta' %}\
+{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
 
 {% endif %}
 
-{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
-{% do __temp_import_alias_3016318__.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set bar1 = __temp_import_alias_3016318__ %}{% set current_path = '' %}{% enddo %}
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}\
+{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
+{% do __temp_import_alias_3016318__.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}\
+{% endfor %}\
+{% set bar1 = __temp_import_alias_3016318__ %}\
+{% set current_path = '' %}\
+{% enddo %}
 {{ bar1.foo }}
-{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set __temp_import_alias_3016319__ = {}  %}{% for __ignored__ in [0] %}{% if deferred %}
+{% do %}\
+{% set current_path = 'deferred-modification.jinja' %}\
+{% set __temp_import_alias_3016319__ = {}  %}\
+{% for __ignored__ in [0] %}\
+{% if deferred %}
 
-{% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
+{% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}\
+{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
 
 {% endif %}
 
-{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
-{% do __temp_import_alias_3016319__.update({'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set bar2 = __temp_import_alias_3016319__ %}{% set current_path = '' %}{% enddo %}
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}\
+{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
+{% do __temp_import_alias_3016319__.update({'import_resource_path': 'deferred-modification.jinja'}) %}\
+{% endfor %}\
+{% set bar2 = __temp_import_alias_3016319__ %}\
+{% set current_path = '' %}\
+{% enddo %}
 {{ bar2.foo }}
 
-{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set __temp_import_alias_3016318__ = {}  %}{% for __ignored__ in [0] %}{% if deferred %}
+{% do %}\
+{% set current_path = 'deferred-modification.jinja' %}\
+{% set __temp_import_alias_3016318__ = {}  %}\
+{% for __ignored__ in [0] %}\
+{% if deferred %}
 
-{% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
+{% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}\
+{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
 
 {% endif %}
 
-{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
-{% do __temp_import_alias_3016318__.update({'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set bar1 = __temp_import_alias_3016318__ %}{% set current_path = '' %}{% enddo %}
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}\
+{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
+{% do __temp_import_alias_3016318__.update({'import_resource_path': 'deferred-modification.jinja'}) %}\
+{% endfor %}\
+{% set bar1 = __temp_import_alias_3016318__ %}\
+{% set current_path = '' %}\
+{% enddo %}
 {{ bar1.foo }}
-{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set __temp_import_alias_3016319__ = {}  %}{% for __ignored__ in [0] %}{% if deferred %}
+{% do %}\
+{% set current_path = 'deferred-modification.jinja' %}\
+{% set __temp_import_alias_3016319__ = {}  %}\
+{% for __ignored__ in [0] %}\
+{% if deferred %}
 
-{% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
+{% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}\
+{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
 
 {% endif %}
 
-{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
-{% do __temp_import_alias_3016319__.update({'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set bar2 = __temp_import_alias_3016319__ %}{% set current_path = '' %}{% enddo %}
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}\
+{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
+{% do __temp_import_alias_3016319__.update({'import_resource_path': 'deferred-modification.jinja'}) %}\
+{% endfor %}\
+{% set bar2 = __temp_import_alias_3016319__ %}\
+{% set current_path = '' %}\
+{% enddo %}
 {{ bar2.foo }}
 {% endfor %}
 {{ foo }}

--- a/src/test/resources/eager/does-not-reconstruct-variable-in-set-in-wrong-scope.expected.jinja
+++ b/src/test/resources/eager/does-not-reconstruct-variable-in-set-in-wrong-scope.expected.jinja
@@ -1,4 +1,6 @@
-{% set my_list = [] %}{% set foo %}
-{% do my_list.append(deferred) %}a
+{% set my_list = [] %}\
+{% set foo %}
+{% do my_list.append(deferred) %}\
+a
 {% endset %}
 {{ my_list }}

--- a/src/test/resources/eager/does-not-reconstruct-variable-in-wrong-scope.expected.jinja
+++ b/src/test/resources/eager/does-not-reconstruct-variable-in-wrong-scope.expected.jinja
@@ -1,12 +1,16 @@
-{% set my_list = ['a'] %}{% if deferred %}
+{% set my_list = ['a'] %}\
+{% if deferred %}
 {% set __macro_append_stuff_153654787_temp_variable_0__ %}
 {% set __macro_foo_97643642_temp_variable_1__ %}
 {% do my_list.append('b') %}
-{% endset %}{{ __macro_foo_97643642_temp_variable_1__ }}
+{% endset %}\
+{{ __macro_foo_97643642_temp_variable_1__ }}
 {% set __macro_foo_97643642_temp_variable_2__ %}
 {% do my_list.append('c') %}
-{% endset %}{{ __macro_foo_97643642_temp_variable_2__ }}
-{% endset %}{{ __macro_append_stuff_153654787_temp_variable_0__ }}
+{% endset %}\
+{{ __macro_foo_97643642_temp_variable_2__ }}
+{% endset %}\
+{{ __macro_append_stuff_153654787_temp_variable_0__ }}
 {% endif %}
 
 {% do my_list.append('d') %}

--- a/src/test/resources/eager/doesnt-affect-parent-from-eager-if.expected.jinja
+++ b/src/test/resources/eager/doesnt-affect-parent-from-eager-if.expected.jinja
@@ -1,4 +1,5 @@
-{% set foo = 1 %}{% if deferred %}
+{% set foo = 1 %}\
+{% if deferred %}
 {% set foo = 2 %}
 {% else %}
 {% set foo = 3 %}

--- a/src/test/resources/eager/doesnt-double-append-in-deferred-if-tag.expected.jinja
+++ b/src/test/resources/eager/doesnt-double-append-in-deferred-if-tag.expected.jinja
@@ -1,4 +1,5 @@
-{% set foo = [0, 1] %}{% if deferred == true %}
+{% set foo = [0, 1] %}\
+{% if deferred == true %}
 [0, 1]
 {% do foo.append(2) %}
 {% else %}

--- a/src/test/resources/eager/doesnt-double-append-in-deferred-macro.expected.jinja
+++ b/src/test/resources/eager/doesnt-double-append-in-deferred-macro.expected.jinja
@@ -1,7 +1,10 @@
-{% set my_list = ['a'] %}{% set __macro_foo_97643642_temp_variable_0__ %}
+{% set my_list = ['a'] %}\
+{% set __macro_foo_97643642_temp_variable_0__ %}
 a
 {% if deferred %}
-{% do my_list.append('b') %}b
+{% do my_list.append('b') %}\
+b
 {% endif %}
-{% endset %}{{ __macro_foo_97643642_temp_variable_0__ }}
+{% endset %}\
+{{ __macro_foo_97643642_temp_variable_0__ }}
 {{ my_list }}

--- a/src/test/resources/eager/doesnt-double-append-in-deferred-set.expected.jinja
+++ b/src/test/resources/eager/doesnt-double-append-in-deferred-set.expected.jinja
@@ -1,7 +1,9 @@
-{% set my_list = ['a'] %}{% set foo %}
+{% set my_list = ['a'] %}\
+{% set foo %}
 a
 {% if deferred %}
-{% do my_list.append('b') %}b
+{% do my_list.append('b') %}\
+b
 {% endif %}
 {% endset %}
 {{ my_list }}

--- a/src/test/resources/eager/doesnt-overwrite-elif.expected.jinja
+++ b/src/test/resources/eager/doesnt-overwrite-elif.expected.jinja
@@ -1,2 +1,6 @@
-{% set foo = [0] %}{% if false %}{% elif deferred && foo.append(1) %}1{% elif deferred && foo.append(2) %}2{% endif %}
+{% set foo = [0] %}\
+{% if false %}\
+{% elif deferred && foo.append(1) %}\
+1{% elif deferred && foo.append(2) %}\
+2{% endif %}
 {{ foo }}

--- a/src/test/resources/eager/eagerly-defers-macro.expected.jinja
+++ b/src/test/resources/eager/eagerly-defers-macro.expected.jinja
@@ -1,6 +1,12 @@
 {% set __macro_big_guy_1311704000_temp_variable_0__ %}
-{% if deferred %}I am foo{% else %}I am bar{% endif %}
-{% endset %}{% print __macro_big_guy_1311704000_temp_variable_0__ %}
+{% if deferred %}\
+I am foo{% else %}\
+I am bar{% endif %}
+{% endset %}\
+{% print __macro_big_guy_1311704000_temp_variable_0__ %}
 {% set __macro_big_guy_1311704000_temp_variable_1__ %}
-{% if deferred %}No more foo{% else %}I am bar{% endif %}
-{% endset %}{% print __macro_big_guy_1311704000_temp_variable_1__ %}
+{% if deferred %}\
+No more foo{% else %}\
+I am bar{% endif %}
+{% endset %}\
+{% print __macro_big_guy_1311704000_temp_variable_1__ %}

--- a/src/test/resources/eager/fully-defers-filtered-macro.expected.jinja
+++ b/src/test/resources/eager/fully-defers-filtered-macro.expected.jinja
@@ -1,6 +1,15 @@
-{% macro flashy(foo) %}{{ filter:upper.filter(foo, ____int3rpr3t3r____) }}
-  A flashy {{ deferred }}.{% endmacro %}{% set __macro_flashy_1625622909_temp_variable_0__ %}BAR
-  A flashy {{ deferred }}.{% endset %}{{ flashy(__macro_flashy_1625622909_temp_variable_0__) }}
+{% macro flashy(foo) %}\
+{{ filter:upper.filter(foo, ____int3rpr3t3r____) }}
+  A flashy {{ deferred }}\
+.{% endmacro %}\
+{% set __macro_flashy_1625622909_temp_variable_0__ %}\
+BAR
+  A flashy {{ deferred }}\
+.{% endset %}\
+{{ flashy(__macro_flashy_1625622909_temp_variable_0__) }}
 ---
 
-{% set __macro_silly_2092874071_temp_variable_0__ %}A silly {{ deferred }}.{% endset %}{{ filter:upper.filter(__macro_silly_2092874071_temp_variable_0__, ____int3rpr3t3r____) }}
+{% set __macro_silly_2092874071_temp_variable_0__ %}\
+A silly {{ deferred }}\
+.{% endset %}\
+{{ filter:upper.filter(__macro_silly_2092874071_temp_variable_0__, ____int3rpr3t3r____) }}

--- a/src/test/resources/eager/handles-auto-escape.expected.jinja
+++ b/src/test/resources/eager/handles-auto-escape.expected.jinja
@@ -1,4 +1,8 @@
 1. foo < bar (Only expression nodes get escaped currently)
-2. {% autoescape %}{% print deferred %}{% endautoescape %}
+2. {% autoescape %}\
+{% print deferred %}\
+{% endautoescape %}
 3. foo &lt; bar
-4. {% autoescape %}{{ deferred }}{% endautoescape %}
+4. {% autoescape %}\
+{{ deferred }}\
+{% endautoescape %}

--- a/src/test/resources/eager/handles-block-set-in-deferred-if.expected.jinja
+++ b/src/test/resources/eager/handles-block-set-in-deferred-if.expected.jinja
@@ -1,4 +1,7 @@
-{% set foo = 'empty' %}{% if deferred %}
-{% set foo %}i am iron man{% endset %}{% set foo = 'I AM IRON MAN' %}
+{% set foo = 'empty' %}\
+{% if deferred %}
+{% set foo %}\
+i am iron man{% endset %}\
+{% set foo = 'I AM IRON MAN' %}
 {% endif %}
 {{ foo }}

--- a/src/test/resources/eager/handles-clashing-name-in-macro.expected.jinja
+++ b/src/test/resources/eager/handles-clashing-name-in-macro.expected.jinja
@@ -1,4 +1,5 @@
 {% macro func(foo) %}
 {{ foo }}
-{% endmacro %}{{ func(foo=deferred) }}
+{% endmacro %}\
+{{ func(foo=deferred) }}
 1

--- a/src/test/resources/eager/handles-complex-raw.expected.jinja
+++ b/src/test/resources/eager/handles-complex-raw.expected.jinja
@@ -1,4 +1,8 @@
 1
-{% raw %}{{ 2 }}{% endraw %}
+{% raw %}\
+{{ 2 }}\
+{% endraw %}
 3
-{% raw %}{{ 4 }}{% endraw %}
+{% raw %}\
+{{ 4 }}\
+{% endraw %}

--- a/src/test/resources/eager/handles-cycle-in-deferred-for.expected.jinja
+++ b/src/test/resources/eager/handles-cycle-in-deferred-for.expected.jinja
@@ -1,3 +1,4 @@
 {% for item in deferred %}
 {% cycle '1','2','3' %}
-{% cycle '1','2','3' %}{% endfor %}
+{% cycle '1','2','3' %}\
+{% endfor %}

--- a/src/test/resources/eager/handles-deferred-cycle-as.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-cycle-as.expected.jinja
@@ -1,7 +1,20 @@
 {% for __ignored__ in [0] %}
 {% set c = [1, deferred] %}
-{% if exptest:iterable.evaluate(c, ____int3rpr3t3r____) %}{{ c[0 % filter:length.filter(c, ____int3rpr3t3r____)] }}{% else %}{{ c }}{% endif %}
+{% if exptest:iterable.evaluate(c, ____int3rpr3t3r____) %}\
+{{ c[0 % filter:length.filter(c, ____int3rpr3t3r____)] }}\
+{% else %}\
+{{ c }}\
+{% endif %}
 {% set c = [2, deferred] %}
-{% if exptest:iterable.evaluate(c, ____int3rpr3t3r____) %}{{ c[1 % filter:length.filter(c, ____int3rpr3t3r____)] }}{% else %}{{ c }}{% endif %}
+{% if exptest:iterable.evaluate(c, ____int3rpr3t3r____) %}\
+{{ c[1 % filter:length.filter(c, ____int3rpr3t3r____)] }}\
+{% else %}\
+{{ c }}\
+{% endif %}
 {% set c = [3, deferred] %}
-{% if exptest:iterable.evaluate(c, ____int3rpr3t3r____) %}{{ c[2 % filter:length.filter(c, ____int3rpr3t3r____)] }}{% else %}{{ c }}{% endif %}{% endfor %}
+{% if exptest:iterable.evaluate(c, ____int3rpr3t3r____) %}\
+{{ c[2 % filter:length.filter(c, ____int3rpr3t3r____)] }}\
+{% else %}\
+{{ c }}\
+{% endif %}\
+{% endfor %}

--- a/src/test/resources/eager/handles-deferred-for-loop-var-from-macro.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-for-loop-var-from-macro.expected.jinja
@@ -4,10 +4,13 @@
 {% for __ignored__ in [0] %}
 {% set __macro_doIt_1327224118_temp_variable_0__ %}
 {{ deferred ~ '{\"a\":\"a\"}' }}
-{% endset %}{{ filter:upper.filter(__macro_doIt_1327224118_temp_variable_0__, ____int3rpr3t3r____) }}
+{% endset %}\
+{{ filter:upper.filter(__macro_doIt_1327224118_temp_variable_0__, ____int3rpr3t3r____) }}
 
 {% set __macro_doIt_1327224118_temp_variable_1__ %}
 {{ deferred ~ '{\"b\":\"b\"}' }}
-{% endset %}{{ filter:upper.filter(__macro_doIt_1327224118_temp_variable_1__, ____int3rpr3t3r____) }}
+{% endset %}\
+{{ filter:upper.filter(__macro_doIt_1327224118_temp_variable_1__, ____int3rpr3t3r____) }}
 {% endfor %}
-{% endset %}{{ filter:upper.filter(__macro_getData_357124436_temp_variable_0__, ____int3rpr3t3r____) }}
+{% endset %}\
+{{ filter:upper.filter(__macro_getData_357124436_temp_variable_0__, ____int3rpr3t3r____) }}

--- a/src/test/resources/eager/handles-deferred-from-import-as.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-from-import-as.expected.jinja
@@ -1,5 +1,8 @@
-{% set myname = deferred + 7 %}{% do %}
+{% set myname = deferred + 7 %}\
+{% do %}
 {% set bar = myname + 19 %}
 Hello {{ myname }}
-{% set from_bar = bar %}{% enddo %}from_foo: Hello {{ myname }}
+{% set from_bar = bar %}\
+{% enddo %}\
+from_foo: Hello {{ myname }}
 from_bar: {{ from_bar }}

--- a/src/test/resources/eager/handles-deferred-import-vars.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-import-vars.expected.jinja
@@ -1,11 +1,28 @@
-{% set myname = deferred + 3 %}{% do %}
+{% set myname = deferred + 3 %}\
+{% do %}
 {% set bar = myname + 19 %}
 Hello {{ myname }}
-{% enddo %}foo: Hello {{ myname }}
+{% enddo %}\
+foo: Hello {{ myname }}
 bar: {{ bar }}
 ---
-{% set myname = deferred + 7 %}{% do %}{% set current_path = 'macro-and-set.jinja' %}{% set __temp_import_alias_902286926__ = {}  %}{% for __ignored__ in [0] %}
-{% set bar = myname + 19 %}{% do __temp_import_alias_902286926__.update({'bar': bar}) %}
+{% set myname = deferred + 7 %}\
+{% do %}\
+{% set current_path = 'macro-and-set.jinja' %}\
+{% set __temp_import_alias_902286926__ = {}  %}\
+{% for __ignored__ in [0] %}
+{% set bar = myname + 19 %}\
+{% do __temp_import_alias_902286926__.update({'bar': bar}) %}
 Hello {{ myname }}
-{% do __temp_import_alias_902286926__.update({'import_resource_path': 'macro-and-set.jinja'}) %}{% endfor %}{% set simple = __temp_import_alias_902286926__ %}{% set current_path = '' %}{% enddo %}simple.foo: {% set deferred_import_resource_path = 'macro-and-set.jinja' %}{% macro simple.foo() %}Hello {{ myname }}{% endmacro %}{% set deferred_import_resource_path = null %}{{ simple.foo() }}
+{% do __temp_import_alias_902286926__.update({'import_resource_path': 'macro-and-set.jinja'}) %}\
+{% endfor %}\
+{% set simple = __temp_import_alias_902286926__ %}\
+{% set current_path = '' %}\
+{% enddo %}\
+simple.foo: {% set deferred_import_resource_path = 'macro-and-set.jinja' %}\
+{% macro simple.foo() %}\
+Hello {{ myname }}\
+{% endmacro %}\
+{% set deferred_import_resource_path = null %}\
+{{ simple.foo() }}
 simple.bar: {{ simple.bar }}

--- a/src/test/resources/eager/handles-deferred-in-ifchanged.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-in-ifchanged.expected.jinja
@@ -1,1 +1,5 @@
-{% for __ignored__ in [0] %}{{ deferred[1] }}{{ deferred[2] }}{{ deferred[1] }}{% endfor %}
+{% for __ignored__ in [0] %}\
+{{ deferred[1] }}\
+{{ deferred[2] }}\
+{{ deferred[1] }}\
+{% endfor %}

--- a/src/test/resources/eager/handles-deferred-in-namespace.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-in-namespace.expected.jinja
@@ -1,5 +1,7 @@
-{% set ns2 = namespace({} ) %}{% do ns2.update({'a': deferred}) %}
-{% set ns1 = namespace({'a': false} ) %}{% if deferred %}
+{% set ns2 = namespace({} ) %}\
+{% do ns2.update({'a': deferred}) %}
+{% set ns1 = namespace({'a': false} ) %}\
+{% if deferred %}
   {% set ns1.a = true %}
 {% endif %}
 {{ ns1.a }}

--- a/src/test/resources/eager/handles-deferred-modification-in-caller.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-modification-in-caller.expected.jinja
@@ -1,2 +1,11 @@
-{% set my_list = ['a', 'b'] %}{% set __macro_callerino_729568755_temp_variable_0__ %}{% do my_list.append(deferred) %}{{ my_list }}{% do my_list.append('d') %}{% endset %}{% call __macro_callerino_729568755_temp_variable_0__ %}{% do my_list.append(deferred) %}{{ my_list }}{% endcall %}
+{% set my_list = ['a', 'b'] %}\
+{% set __macro_callerino_729568755_temp_variable_0__ %}\
+{% do my_list.append(deferred) %}\
+{{ my_list }}\
+{% do my_list.append('d') %}\
+{% endset %}\
+{% call __macro_callerino_729568755_temp_variable_0__ %}\
+{% do my_list.append(deferred) %}\
+{{ my_list }}\
+{% endcall %}
 {{ my_list }}

--- a/src/test/resources/eager/handles-deferring-loop-variable.expected.jinja
+++ b/src/test/resources/eager/handles-deferring-loop-variable.expected.jinja
@@ -1,14 +1,17 @@
 {% for __ignored__ in [0] %}
-{% if deferred && true %}first time!
+{% if deferred && true %}\
+first time!
 {% endif %}
 1
 
-{% if deferred && false %}first time!
+{% if deferred && false %}\
+first time!
 {% endif %}
 2
 {% endfor %}
 {% for i in [0, 1] %}
-{% if deferred && loop.isLast() %}last time!
+{% if deferred && loop.isLast() %}\
+last time!
 {% endif %}
 {{ loop.index }}
 {% endfor %}

--- a/src/test/resources/eager/handles-double-import-modification.expected.jinja
+++ b/src/test/resources/eager/handles-double-import-modification.expected.jinja
@@ -1,20 +1,40 @@
-{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set __temp_import_alias_3016318__ = {}  %}{% for __ignored__ in [0] %}{% if deferred %}
+{% do %}\
+{% set current_path = 'deferred-modification.jinja' %}\
+{% set __temp_import_alias_3016318__ = {}  %}\
+{% for __ignored__ in [0] %}\
+{% if deferred %}
 
-{% set foo = 'a' %}{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
+{% set foo = 'a' %}\
+{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
 
 {% endif %}
 
-{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
-{% do __temp_import_alias_3016318__.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set bar1 = __temp_import_alias_3016318__ %}{% set current_path = '' %}{% enddo %}
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}\
+{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
+{% do __temp_import_alias_3016318__.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}\
+{% endfor %}\
+{% set bar1 = __temp_import_alias_3016318__ %}\
+{% set current_path = '' %}\
+{% enddo %}
 ---
-{% do %}{% set current_path = 'deferred-modification.jinja' %}{% set __temp_import_alias_3016319__ = {}  %}{% for __ignored__ in [0] %}{% if deferred %}
+{% do %}\
+{% set current_path = 'deferred-modification.jinja' %}\
+{% set __temp_import_alias_3016319__ = {}  %}\
+{% for __ignored__ in [0] %}\
+{% if deferred %}
 
-{% set foo = 'a' %}{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
+{% set foo = 'a' %}\
+{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
 
 {% endif %}
 
-{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
-{% do __temp_import_alias_3016319__.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}{% endfor %}{% set bar2 = __temp_import_alias_3016319__ %}{% set current_path = '' %}{% enddo %}
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}\
+{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
+{% do __temp_import_alias_3016319__.update({'foo': foo,'import_resource_path': 'deferred-modification.jinja'}) %}\
+{% endfor %}\
+{% set bar2 = __temp_import_alias_3016319__ %}\
+{% set current_path = '' %}\
+{% enddo %}
 ---
 {{ bar1.foo }}
 {{ bar2.foo }}

--- a/src/test/resources/eager/handles-duplicate-variable-reference-modification/test.expected.jinja
+++ b/src/test/resources/eager/handles-duplicate-variable-reference-modification/test.expected.jinja
@@ -1,9 +1,16 @@
-{% set the_list = [] %}{% set __macro_appender_2138849093_temp_variable_0__ %}{% set some_list = the_list %}{% if deferred %}
+{% set the_list = [] %}\
+{% set __macro_appender_2138849093_temp_variable_0__ %}\
+{% set some_list = the_list %}\
+{% if deferred %}
 {% do some_list.append(deferred) %}
-{% endif %}{% endset %}{{ __macro_appender_2138849093_temp_variable_0__ }}
+{% endif %}\
+{% endset %}\
+{{ __macro_appender_2138849093_temp_variable_0__ }}
 {{ the_list }}
 
 
-{% set foo = [1] %}{% do foo.append(deferred) %}
+{% set foo = [1] %}\
+{% do foo.append(deferred) %}
 {% do foo.append(2) %}
-{% set bar = foo %}{{ foo ~ 'and' ~ bar }}
+{% set bar = foo %}\
+{{ foo ~ 'and' ~ bar }}

--- a/src/test/resources/eager/handles-duplicate-variable-reference-speculative-modification/test.expected.jinja
+++ b/src/test/resources/eager/handles-duplicate-variable-reference-speculative-modification/test.expected.jinja
@@ -1,4 +1,6 @@
-{% set foo = ['a', 1] %}{% set bar = foo %}{% if deferred %}
+{% set foo = ['a', 1] %}\
+{% set bar = foo %}\
+{% if deferred %}
 {% do bar.append(2) %}
 {% endif %}
 {% do bar.append(3) %}

--- a/src/test/resources/eager/handles-higher-scope-reference-modification.expected.jinja
+++ b/src/test/resources/eager/handles-higher-scope-reference-modification.expected.jinja
@@ -1,10 +1,35 @@
-{% set a_list = ['a'] %}{% set __macro_b_125206_temp_variable_0__ %}{% set b_list = a_list %}{% do b_list.append(deferred ? 'b' : '') %}
-{% macro c(c_list) %}{% do c_list.append(deferred ? 'c' : '') %}
-C: {{ c_list }}.{% endmacro %}{{ c(b_list) }}{% do b_list.append(deferred ? 'B' : '') %}
-B: {{ b_list }}.{% endset %}{{ __macro_b_125206_temp_variable_0__ }}{% do a_list.append(deferred ? 'A' : '') %}
-A: {{ a_list }}.
+{% set a_list = ['a'] %}\
+{% set __macro_b_125206_temp_variable_0__ %}\
+{% set b_list = a_list %}\
+{% do b_list.append(deferred ? 'b' : '') %}
+{% macro c(c_list) %}\
+{% do c_list.append(deferred ? 'c' : '') %}
+C: {{ c_list }}\
+.{% endmacro %}\
+{{ c(b_list) }}\
+{% do b_list.append(deferred ? 'B' : '') %}
+B: {{ b_list }}\
+.{% endset %}\
+{{ __macro_b_125206_temp_variable_0__ }}\
+{% do a_list.append(deferred ? 'A' : '') %}
+A: {{ a_list }}\
+.
 ---
-{% set a_list = ['a', 'b'] %}{% for __ignored__ in [0] %}{% set b_list = a_list %}{% for __ignored__ in [0] %}{% set c_list = a_list %}{% if !deferred %}{% do c_list.append(deferred ? 'c' : '') %}{% else %}{% do c_list.append(deferred ? 'c' : '') %}{% endif %}
-C: {{ c_list }}.{% endfor %}{% do b_list.append(deferred ? 'B' : '') %}
-B: {{ b_list }}.{% endfor %}{% do a_list.append(deferred ? 'A' : '') %}
-A: {{ a_list }}.
+{% set a_list = ['a', 'b'] %}\
+{% for __ignored__ in [0] %}\
+{% set b_list = a_list %}\
+{% for __ignored__ in [0] %}\
+{% set c_list = a_list %}\
+{% if !deferred %}\
+{% do c_list.append(deferred ? 'c' : '') %}\
+{% else %}\
+{% do c_list.append(deferred ? 'c' : '') %}\
+{% endif %}
+C: {{ c_list }}\
+.{% endfor %}\
+{% do b_list.append(deferred ? 'B' : '') %}
+B: {{ b_list }}\
+.{% endfor %}\
+{% do a_list.append(deferred ? 'A' : '') %}
+A: {{ a_list }}\
+.

--- a/src/test/resources/eager/handles-import-in-deferred-if.expected.jinja
+++ b/src/test/resources/eager/handles-import-in-deferred-if.expected.jinja
@@ -1,7 +1,22 @@
-{% set primary_line_height = 100 %}{% if deferred %}
-{% do %}{% set current_path = '../settag/set-val.jinja' %}{% set __temp_import_alias_902286926__ = {}  %}{% for __ignored__ in [0] %}{% set primary_line_height = 42 %}{% do __temp_import_alias_902286926__.update({'primary_line_height': primary_line_height}) %}{% do __temp_import_alias_902286926__.update({'primary_line_height': 42,'import_resource_path': '../settag/set-val.jinja'}) %}{% endfor %}{% set simple = __temp_import_alias_902286926__ %}{% set current_path = '' %}{% enddo %}
+{% set primary_line_height = 100 %}\
+{% if deferred %}
+{% do %}\
+{% set current_path = '../settag/set-val.jinja' %}\
+{% set __temp_import_alias_902286926__ = {}  %}\
+{% for __ignored__ in [0] %}\
+{% set primary_line_height = 42 %}\
+{% do __temp_import_alias_902286926__.update({'primary_line_height': primary_line_height}) %}\
+{% do __temp_import_alias_902286926__.update({'primary_line_height': 42,'import_resource_path': '../settag/set-val.jinja'}) %}\
+{% endfor %}\
+{% set simple = __temp_import_alias_902286926__ %}\
+{% set current_path = '' %}\
+{% enddo %}
 {% else %}
-{% do %}{% set current_path = '../settag/set-val.jinja' %}{% set primary_line_height = 42 %}{% set current_path = '' %}{% enddo %}
+{% do %}\
+{% set current_path = '../settag/set-val.jinja' %}\
+{% set primary_line_height = 42 %}\
+{% set current_path = '' %}\
+{% enddo %}
 {% endif %}
 simple.primary_line_height (deferred): {{ simple.primary_line_height }}
 primary_line_height (deferred): {{ primary_line_height }}

--- a/src/test/resources/eager/handles-loop-var-against-deferred-in-loop.expected.jinja
+++ b/src/test/resources/eager/handles-loop-var-against-deferred-in-loop.expected.jinja
@@ -1,4 +1,11 @@
-{% for __ignored__ in [0] %}item1 {{ deferred }}.{% set temp = 'item1' ~ deferred %}{{ temp }}
-item2 {{ deferred }}.{% set temp = 'item2' ~ deferred %}{{ temp }}
-item3 {{ deferred }}.{% set temp = 'item3' ~ deferred %}{{ temp }}
+{% for __ignored__ in [0] %}\
+item1 {{ deferred }}\
+.{% set temp = 'item1' ~ deferred %}\
+{{ temp }}
+item2 {{ deferred }}\
+.{% set temp = 'item2' ~ deferred %}\
+{{ temp }}
+item3 {{ deferred }}\
+.{% set temp = 'item3' ~ deferred %}\
+{{ temp }}
 {% endfor %}

--- a/src/test/resources/eager/handles-reference-modification-when-source-is-lost.expected.jinja
+++ b/src/test/resources/eager/handles-reference-modification-when-source-is-lost.expected.jinja
@@ -1,13 +1,18 @@
-{% set a_list = ['a'] %}{% for __ignored__ in [0] %}{% set b_list = a_list %}{% do b_list.append(deferred) %}
+{% set a_list = ['a'] %}\
+{% for __ignored__ in [0] %}\
+{% set b_list = a_list %}\
+{% do b_list.append(deferred) %}
 {% endfor %}
 {{ a_list }}
 ---
 {% for __ignored__ in [0] %}
 
-{% set a_list = [] %}{% for __ignored__ in [0] %}
+{% set a_list = [] %}\
+{% for __ignored__ in [0] %}
 {% if deferred %}
 {% set b_list = [] %}
-{% set b_list = a_list %}{% do b_list.append(1) %}
+{% set b_list = a_list %}\
+{% do b_list.append(1) %}
 {% endif %}
 {% endfor %}
 {{ a_list }}

--- a/src/test/resources/eager/handles-same-name-import-var.expected.jinja
+++ b/src/test/resources/eager/handles-same-name-import-var.expected.jinja
@@ -1,10 +1,39 @@
 {% if deferred %}
-{% do %}{% set current_path = '../settag/set-var-and-deferred.jinja' %}{% set __temp_import_alias_1059697132__ = {}  %}{% for __ignored__ in [0] %}{% if deferred %}
-{% do %}{% set path = '' %}{% do __temp_import_alias_1059697132__.update({'path': path}) %}{% set my_var = {'my_var': {'foo': 'bar'} }  %}{% do __temp_import_alias_1059697132__.update({'my_var': my_var}) %}{% set path = '../settag/set-var-and-deferred.jinja' %}{% do __temp_import_alias_1059697132__.update({'path': path}) %}{% set value = null %}{% do __temp_import_alias_1059697132__.update({'value': value}) %}{% set my_var = {}  %}{% do __temp_import_alias_1059697132__.update({'my_var': my_var}) %}{% set my_var = {'foo': 'bar'}  %}{% do __temp_import_alias_1059697132__.update({'my_var': my_var}) %}{% set my_var = {'my_var': {'foo': 'bar'} }  %}{% do __temp_import_alias_1059697132__.update({'my_var': my_var}) %}
-{% set value = deferred %}{% do __temp_import_alias_1059697132__.update({'value': value}) %}{% set my_var = {'my_var': {'foo': 'bar'} }  %}{% do __temp_import_alias_1059697132__.update({'my_var': my_var}) %}{% do my_var.update({'value': value}) %}
-{% do my_var.update({'import_resource_path': '../settag/set-var-and-deferred.jinja', 'value': value}) %}{% set path = '' %}{% do __temp_import_alias_1059697132__.update({'path': path}) %}{% enddo %}
+{% do %}\
+{% set current_path = '../settag/set-var-and-deferred.jinja' %}\
+{% set __temp_import_alias_1059697132__ = {}  %}\
+{% for __ignored__ in [0] %}\
+{% if deferred %}
+{% do %}\
+{% set path = '' %}\
+{% do __temp_import_alias_1059697132__.update({'path': path}) %}\
+{% set my_var = {'my_var': {'foo': 'bar'} }  %}\
+{% do __temp_import_alias_1059697132__.update({'my_var': my_var}) %}\
+{% set path = '../settag/set-var-and-deferred.jinja' %}\
+{% do __temp_import_alias_1059697132__.update({'path': path}) %}\
+{% set value = null %}\
+{% do __temp_import_alias_1059697132__.update({'value': value}) %}\
+{% set my_var = {}  %}\
+{% do __temp_import_alias_1059697132__.update({'my_var': my_var}) %}\
+{% set my_var = {'foo': 'bar'}  %}\
+{% do __temp_import_alias_1059697132__.update({'my_var': my_var}) %}\
+{% set my_var = {'my_var': {'foo': 'bar'} }  %}\
+{% do __temp_import_alias_1059697132__.update({'my_var': my_var}) %}
+{% set value = deferred %}\
+{% do __temp_import_alias_1059697132__.update({'value': value}) %}\
+{% set my_var = {'my_var': {'foo': 'bar'} }  %}\
+{% do __temp_import_alias_1059697132__.update({'my_var': my_var}) %}\
+{% do my_var.update({'value': value}) %}
+{% do my_var.update({'import_resource_path': '../settag/set-var-and-deferred.jinja', 'value': value}) %}\
+{% set path = '' %}\
+{% do __temp_import_alias_1059697132__.update({'path': path}) %}\
+{% enddo %}
 {{ my_var }}
 {% endif %}
-{% do __temp_import_alias_1059697132__.update({'path': path,'import_resource_path': '../settag/set-var-and-deferred.jinja','value': value}) %}{% endfor %}{% set my_var = __temp_import_alias_1059697132__ %}{% set current_path = '' %}{% enddo %}
+{% do __temp_import_alias_1059697132__.update({'path': path,'import_resource_path': '../settag/set-var-and-deferred.jinja','value': value}) %}\
+{% endfor %}\
+{% set my_var = __temp_import_alias_1059697132__ %}\
+{% set current_path = '' %}\
+{% enddo %}
 {{ filter:dictsort.filter(my_var, ____int3rpr3t3r____, false, 'key') }}
 {% endif %}

--- a/src/test/resources/eager/handles-set-and-modified-in-for.expected.jinja
+++ b/src/test/resources/eager/handles-set-and-modified-in-for.expected.jinja
@@ -1,4 +1,5 @@
-{% set list = [] %}{% for item in deferred %}
+{% set list = [] %}\
+{% for item in deferred %}
 {% unless count %}
 {% set count = 0 %}
 {% endunless %}

--- a/src/test/resources/eager/handles-set-in-for.expected.jinja
+++ b/src/test/resources/eager/handles-set-in-for.expected.jinja
@@ -1,4 +1,5 @@
-{% set list = [] %}{% for item in deferred %}
+{% set list = [] %}\
+{% for item in deferred %}
 {% set count = 0 %}
 {% do list.append(0) %}
 {% set count = 1 %}

--- a/src/test/resources/eager/handles-value-modified-in-macro.expected.jinja
+++ b/src/test/resources/eager/handles-value-modified-in-macro.expected.jinja
@@ -4,7 +4,8 @@
 {{ counter(foo) }}
 {% endif %}
 {{ level }}
-{% endmacro %}{{ counter(deferred) }}
+{% endmacro %}\
+{{ counter(deferred) }}
 
 {% macro counter(foo) %}
 {% set level = level + 2 %}
@@ -12,4 +13,5 @@
 {{ counter(foo) }}
 {% endif %}
 {{ level }}
-{% endmacro %}{{ counter(2) }}
+{% endmacro %}\
+{{ counter(2) }}

--- a/src/test/resources/eager/has-proper-line-stripping.expected.jinja
+++ b/src/test/resources/eager/has-proper-line-stripping.expected.jinja
@@ -1,3 +1,8 @@
 1
 2
-3{% if deferred > 0 %}{{ deferred }}{% elif deferred == 0 %}null{% else %}{{ deferred }}{% endif %}
+3{% if deferred > 0 %}\
+{{ deferred }}\
+{% elif deferred == 0 %}\
+null{% else %}\
+{{ deferred }}\
+{% endif %}

--- a/src/test/resources/eager/keeps-macro-modifications-in-scope.expected.jinja
+++ b/src/test/resources/eager/keeps-macro-modifications-in-scope.expected.jinja
@@ -1,10 +1,35 @@
-{% set list = [] %}{% if deferred %}
+{% set list = [] %}\
+{% if deferred %}
 
-{% set __macro_inc_100372882_temp_variable_0__ %}{% do list.append(1) %}1{% set depth = 2 %}
-{% set __macro_inc_100372882_temp_variable_1__ %}{% do list.append(2) %}2{% set depth = 3 %}
-{% set __macro_inc_100372882_temp_variable_2__ %}{% do list.append(3) %}3{% endset %}{{ __macro_inc_100372882_temp_variable_2__ }}
-{% set __macro_inc_100372882_temp_variable_3__ %}{% do list.append(3) %}3{% endset %}{{ __macro_inc_100372882_temp_variable_3__ }}{% endset %}{{ __macro_inc_100372882_temp_variable_1__ }}
-{% set __macro_inc_100372882_temp_variable_4__ %}{% do list.append(2) %}2{% set depth = 3 %}
-{% set __macro_inc_100372882_temp_variable_5__ %}{% do list.append(3) %}3{% endset %}{{ __macro_inc_100372882_temp_variable_5__ }}
-{% set __macro_inc_100372882_temp_variable_6__ %}{% do list.append(3) %}3{% endset %}{{ __macro_inc_100372882_temp_variable_6__ }}{% endset %}{{ __macro_inc_100372882_temp_variable_4__ }}{% endset %}{{ __macro_inc_100372882_temp_variable_0__ }}
+{% set __macro_inc_100372882_temp_variable_0__ %}\
+{% do list.append(1) %}\
+1{% set depth = 2 %}
+{% set __macro_inc_100372882_temp_variable_1__ %}\
+{% do list.append(2) %}\
+2{% set depth = 3 %}
+{% set __macro_inc_100372882_temp_variable_2__ %}\
+{% do list.append(3) %}\
+3{% endset %}\
+{{ __macro_inc_100372882_temp_variable_2__ }}
+{% set __macro_inc_100372882_temp_variable_3__ %}\
+{% do list.append(3) %}\
+3{% endset %}\
+{{ __macro_inc_100372882_temp_variable_3__ }}\
+{% endset %}\
+{{ __macro_inc_100372882_temp_variable_1__ }}
+{% set __macro_inc_100372882_temp_variable_4__ %}\
+{% do list.append(2) %}\
+2{% set depth = 3 %}
+{% set __macro_inc_100372882_temp_variable_5__ %}\
+{% do list.append(3) %}\
+3{% endset %}\
+{{ __macro_inc_100372882_temp_variable_5__ }}
+{% set __macro_inc_100372882_temp_variable_6__ %}\
+{% do list.append(3) %}\
+3{% endset %}\
+{{ __macro_inc_100372882_temp_variable_6__ }}\
+{% endset %}\
+{{ __macro_inc_100372882_temp_variable_4__ }}\
+{% endset %}\
+{{ __macro_inc_100372882_temp_variable_0__ }}
 {% endif %}

--- a/src/test/resources/eager/keeps-meta-context-variables-through-import/test.expected.jinja
+++ b/src/test/resources/eager/keeps-meta-context-variables-through-import/test.expected.jinja
@@ -1,4 +1,5 @@
 {% set list = deferred %}
 
-{% set meta = ['overridden'] %}{% do list.append(meta) %}
+{% set meta = ['overridden'] %}\
+{% do list.append(meta) %}
 {{ list }}

--- a/src/test/resources/eager/modifies-variable-in-deferred-macro.expected.jinja
+++ b/src/test/resources/eager/modifies-variable-in-deferred-macro.expected.jinja
@@ -1,14 +1,20 @@
 {% macro my_macro(list, other) %}
 {% do list.append(other) %}
-{% endmacro %}{% set list = [] %}{% do my_macro(list, deferred) %}
+{% endmacro %}\
+{% set list = [] %}\
+{% do my_macro(list, deferred) %}
 {{ list }}
 
 {% macro my_macro(list, other) %}
 {% do list.append(other) %}
-{% endmacro %}{% set var = [] %}{% do my_macro(var, deferred) %}
+{% endmacro %}\
+{% set var = [] %}\
+{% do my_macro(var, deferred) %}
 {{ var }}
 
 {% macro my_macro(list, other) %}
 {% do list.append(other) %}
-{% endmacro %}{% set var2 = [] %}{% do my_macro(var2, 1) %}
+{% endmacro %}\
+{% set var2 = [] %}\
+{% do my_macro(var2, 1) %}
 {{ var2 }}

--- a/src/test/resources/eager/only-defers-loop-item-on-current-context.expected.jinja
+++ b/src/test/resources/eager/only-defers-loop-item-on-current-context.expected.jinja
@@ -1,7 +1,9 @@
-{% set outer_val = 'start' %}{% for def in deferred %}
+{% set outer_val = 'start' %}\
+{% for def in deferred %}
 {% set outer_list = [{'a': ['b']} ] %}
 {% for __ignored__ in [0] %}
-{% set map = {'a': ['b']}  %}{% set inner_list = map.a %}
+{% set map = {'a': ['b']}  %}\
+{% set inner_list = map.a %}
 {% for x in inner_list %}
 
 {% set outer_val = outer_val ~ '-' %}

--- a/src/test/resources/eager/prepends-set-if-state-changes.expected.jinja
+++ b/src/test/resources/eager/prepends-set-if-state-changes.expected.jinja
@@ -1,4 +1,5 @@
-{% set foo = [0] %}{% set deferred = deferred && foo.append(1) %}
+{% set foo = [0] %}\
+{% set deferred = deferred && foo.append(1) %}
 {% do foo.append(2) %}
 {% set deferred = deferred && foo.append(3) %}
 {% print foo.append(4) %}

--- a/src/test/resources/eager/preserves-raw-inside-deferred-set-block.expected.jinja
+++ b/src/test/resources/eager/preserves-raw-inside-deferred-set-block.expected.jinja
@@ -1,6 +1,8 @@
 {% set foo %}
 {% if deferred %}
-{% raw %}{{ 'fire' }}{% endraw %}
+{% raw %}\
+{{ 'fire' }}\
+{% endraw %}
 {% else %}
 water
 {% endif %}

--- a/src/test/resources/eager/preserves-value-set-in-if.expected.jinja
+++ b/src/test/resources/eager/preserves-value-set-in-if.expected.jinja
@@ -1,5 +1,6 @@
 2
-{% set foo = 2 %}{% if deferred %}
+{% set foo = 2 %}\
+{% if deferred %}
 {% set foo = deferred %}
 {% endif %}
 {{ foo }}

--- a/src/test/resources/eager/puts-deferred-fromed-macro-in-output.expected.jinja
+++ b/src/test/resources/eager/puts-deferred-fromed-macro-in-output.expected.jinja
@@ -1,1 +1,5 @@
-{% set myname = deferred + 3 %}{% set __macro_getPath_331491059_temp_variable_1__ %}Hello {{ myname }}{% endset %}{% print __macro_getPath_331491059_temp_variable_1__ %}
+{% set myname = deferred + 3 %}\
+{% set __macro_getPath_331491059_temp_variable_1__ %}\
+Hello {{ myname }}\
+{% endset %}\
+{% print __macro_getPath_331491059_temp_variable_1__ %}

--- a/src/test/resources/eager/puts-deferred-imported-macro-in-output.expected.jinja
+++ b/src/test/resources/eager/puts-deferred-imported-macro-in-output.expected.jinja
@@ -1,1 +1,5 @@
-{% set myname = deferred + 3 %}{% set __macro_getPath_331491059_temp_variable_1__ %}Hello {{ myname }}{% endset %}{% print __macro_getPath_331491059_temp_variable_1__ %}
+{% set myname = deferred + 3 %}\
+{% set __macro_getPath_331491059_temp_variable_1__ %}\
+Hello {{ myname }}\
+{% endset %}\
+{% print __macro_getPath_331491059_temp_variable_1__ %}

--- a/src/test/resources/eager/reconstructs-aliased-macro.expected.jinja
+++ b/src/test/resources/eager/reconstructs-aliased-macro.expected.jinja
@@ -1,4 +1,9 @@
-{% set myname = deferred + 3 %}{% set deferred_import_resource_path = 'eager/takes-param.jinja' %}{% macro macros.takes_param(foo) %}{% set bar = 'bar' %}
+{% set myname = deferred + 3 %}\
+{% set deferred_import_resource_path = 'eager/takes-param.jinja' %}\
+{% macro macros.takes_param(foo) %}\
+{% set bar = 'bar' %}
 {% print foo %}
-{% endmacro %}{% set deferred_import_resource_path = null %}{% set answer = macros.takes_param(myname) %}
+{% endmacro %}\
+{% set deferred_import_resource_path = null %}\
+{% set answer = macros.takes_param(myname) %}
 {{ answer }}

--- a/src/test/resources/eager/reconstructs-block-path-when-deferred-nested/test.expected.jinja
+++ b/src/test/resources/eager/reconstructs-block-path-when-deferred-nested/test.expected.jinja
@@ -1,11 +1,22 @@
-{% set current_path = '../../eager/reconstructs-block-path-when-deferred-nested/base.jinja' %}{% set prefix = deferred ? 'current' : 'current' %}
-Parent's current path is: {{ '{{' + prefix + '_path }}' }}
+{% set current_path = '../../eager/reconstructs-block-path-when-deferred-nested/base.jinja' %}\
+{% set prefix = deferred ? 'current' : 'current' %}
+Parent's current path is: {{ '{{' + prefix + '_path }}\
+' }}
 -----Pre-First-----
-{% set temp_current_path_586961858 = current_path %}{% set current_path = 'Child path' %}{% set prefix = deferred ? 'current' : 'current' %}Child's first current path is: {{ '{{' + prefix + '_path }}' }}
+{% set temp_current_path_586961858 = current_path %}\
+{% set current_path = 'Child path' %}\
+{% set prefix = deferred ? 'current' : 'current' %}\
+Child's first current path is: {{ '{{' + prefix + '_path }}\
+' }}
 {% set current_path = temp_current_path_586961858 %}
 -----Post-First-----
 -----Pre-Second-----
-{% set temp_current_path_435835221 = current_path %}{% set current_path = '../../eager/reconstructs-block-path-when-deferred-nested/middle.jinja' %}{% set prefix = deferred ? 'current' : 'current' %}Middle's second current path is: {{ '{{' + prefix + '_path }}' }}
+{% set temp_current_path_435835221 = current_path %}\
+{% set current_path = '../../eager/reconstructs-block-path-when-deferred-nested/middle.jinja' %}\
+{% set prefix = deferred ? 'current' : 'current' %}\
+Middle's second current path is: {{ '{{' + prefix + '_path }}\
+' }}
 {% set current_path = temp_current_path_435835221 %}
 -----Post-Second-----
-Parent's current path is: {{ '{{' + prefix + '_path }}' }}
+Parent's current path is: {{ '{{' + prefix + '_path }}\
+' }}

--- a/src/test/resources/eager/reconstructs-block-path-when-deferred/test.expected.jinja
+++ b/src/test/resources/eager/reconstructs-block-path-when-deferred/test.expected.jinja
@@ -1,7 +1,14 @@
-{% set current_path = '../../eager/reconstructs-block-path-when-deferred/base.jinja' %}{% set prefix = deferred ? 'current' : 'current' %}
-Parent's current path is: {{ '{{' + prefix + '_path }}' }}
+{% set current_path = '../../eager/reconstructs-block-path-when-deferred/base.jinja' %}\
+{% set prefix = deferred ? 'current' : 'current' %}
+Parent's current path is: {{ '{{' + prefix + '_path }}\
+' }}
 -----Pre-Block-----
-{% set temp_current_path_586961858 = current_path %}{% set current_path = 'Child path' %}{% set prefix = deferred ? 'current' : 'current' %}Block's current path is: {{ '{{' + prefix + '_path }}' }}
+{% set temp_current_path_586961858 = current_path %}\
+{% set current_path = 'Child path' %}\
+{% set prefix = deferred ? 'current' : 'current' %}\
+Block's current path is: {{ '{{' + prefix + '_path }}\
+' }}
 {% set current_path = temp_current_path_586961858 %}
 -----Post-Block-----
-Parent's current path is: {{ '{{' + prefix + '_path }}' }}
+Parent's current path is: {{ '{{' + prefix + '_path }}\
+' }}

--- a/src/test/resources/eager/reconstructs-block-set-variables-in-for-loop.expected.jinja
+++ b/src/test/resources/eager/reconstructs-block-set-variables-in-for-loop.expected.jinja
@@ -1,5 +1,6 @@
 {% for i in range(deferred) %}
 {% set __macro_foo_97643642_temp_variable_0__ %}
 {{ deferred }}
-{% endset %}{{ filter:int.filter(__macro_foo_97643642_temp_variable_0__, ____int3rpr3t3r____) + 3 }}
+{% endset %}\
+{{ filter:int.filter(__macro_foo_97643642_temp_variable_0__, ____int3rpr3t3r____) + 3 }}
 {% endfor %}

--- a/src/test/resources/eager/reconstructs-deferred-variable-eventually.expected.jinja
+++ b/src/test/resources/eager/reconstructs-deferred-variable-eventually.expected.jinja
@@ -1,13 +1,17 @@
-{% set my_list = [] %}{% set __macro_append_stuff_153654787_temp_variable_0__ %}
+{% set my_list = [] %}\
+{% set __macro_append_stuff_153654787_temp_variable_0__ %}
 {% if deferred %}
 
 {% set __macro_foo_97643642_temp_variable_0__ %}
 {% do my_list.append('b') %}
-{% endset %}{{ __macro_foo_97643642_temp_variable_0__ }}
+{% endset %}\
+{{ __macro_foo_97643642_temp_variable_0__ }}
 {% set __macro_foo_97643642_temp_variable_1__ %}
 {% do my_list.append('c') %}
-{% endset %}{{ __macro_foo_97643642_temp_variable_1__ }}
+{% endset %}\
+{{ __macro_foo_97643642_temp_variable_1__ }}
 {% endif %}
-{% endset %}{{ __macro_append_stuff_153654787_temp_variable_0__ }}
+{% endset %}\
+{{ __macro_append_stuff_153654787_temp_variable_0__ }}
 
 {{ my_list }}

--- a/src/test/resources/eager/reconstructs-map-node.expected.jinja
+++ b/src/test/resources/eager/reconstructs-map-node.expected.jinja
@@ -1,11 +1,16 @@
 {% if deferred %}
 {% set foo = [fn:map_entry('foo', 'ff'), fn:map_entry('bar', 'bb')] %}
 {% endif %}
-{% set my_list = [] %}{% for key, val in foo %}{% do my_list.append(deferred) %}
-{{ key ~ ' ' ~ val }}{% endfor %}
+{% set my_list = [] %}\
+{% for key, val in foo %}\
+{% do my_list.append(deferred) %}
+{{ key ~ ' ' ~ val }}\
+{% endfor %}
 {{ my_list }}
 
-{% set my_list = [] %}{% for __ignored__ in [0] %}{% do my_list.append(deferred) %}
+{% set my_list = [] %}\
+{% for __ignored__ in [0] %}\
+{% do my_list.append(deferred) %}
 foo{% do my_list.append(deferred) %}
 bar{% endfor %}
 {{ my_list }}

--- a/src/test/resources/eager/reconstructs-namespace-for-set-tags-using-period.expected.jinja
+++ b/src/test/resources/eager/reconstructs-namespace-for-set-tags-using-period.expected.jinja
@@ -1,7 +1,11 @@
-{% set ns1 = namespace({'a': 'aa'} ) %}{% set ns1.b = 'b ' ~ deferred %}
+{% set ns1 = namespace({'a': 'aa'} ) %}\
+{% set ns1.b = 'b ' ~ deferred %}
 
 
-{% set ns2 = namespace({'c': 'cc'} ) %}{% set ns2.d %}d {{ deferred }}{% endset %}
+{% set ns2 = namespace({'c': 'cc'} ) %}\
+{% set ns2.d %}\
+d {{ deferred }}\
+{% endset %}
 
 {{ ns1 }}
 {{ ns2 }}

--- a/src/test/resources/eager/reconstructs-nested-value-in-string-representation.expected.jinja
+++ b/src/test/resources/eager/reconstructs-nested-value-in-string-representation.expected.jinja
@@ -1,15 +1,30 @@
-{% set i_am = 'I am' %}{% set bar = '{{ i_am }} bar' %}{% set foo = '{{ i_am }} foo' %}{% set map_with_vals = {'foo': 'Foo is {{ foo }}.'}  %}{% if deferred %}
-{% do map_with_vals.put('bar', 'Bar is {{ bar }}.') %}
+{% set i_am = 'I am' %}\
+{% set bar = '{{ i_am }} bar' %}\
+{% set foo = '{{ i_am }} foo' %}\
+{% set map_with_vals = {'foo': 'Foo is {{ foo }}\
+.'}  %}\
+{% if deferred %}
+{% do map_with_vals.put('bar', 'Bar is {{ bar }}\
+.') %}
 {% endif %}
 map.foo: {{ map_with_vals.foo }}
 map.bar: {{ map_with_vals.bar }}
 
-{% set a = 'a' %}{% set aa = '{{ a }}' %}{% if deferred %}
-{% set aaa = '{{ aa }}' %}
+{% set a = 'a' %}\
+{% set aa = '{{ a }}\
+' %}\
+{% if deferred %}
+{% set aaa = '{{ aa }}\
+' %}
 {{ aa }}
 {% endif %}
 
-{% set b = 'b' %}{% set bb = '{{ b }}' %}{% if deferred %}
-{% set bbb = {'b': '{{ bb }}'}  %}
-{'b': '{{ bb }}'}
+{% set b = 'b' %}\
+{% set bb = '{{ b }}\
+' %}\
+{% if deferred %}
+{% set bbb = {'b': '{{ bb }}\
+'}  %}
+{'b': '{{ bb }}\
+'}
 {% endif %}

--- a/src/test/resources/eager/reconstructs-null-variables-in-deferred-caller.expected.jinja
+++ b/src/test/resources/eager/reconstructs-null-variables-in-deferred-caller.expected.jinja
@@ -1,9 +1,11 @@
 {% if deferred %}
 {% macro foo(var) %}
 {% set second_list = [] %}
-{% set second_list = [] %}{% do second_list.append(var) %}
+{% set second_list = [] %}\
+{% do second_list.append(var) %}
 {{ caller() }}
-{% endmacro %}{% call foo(deferred) %}
+{% endmacro %}\
+{% call foo(deferred) %}
 []
 {{ second_list }}
 {% endcall %}

--- a/src/test/resources/eager/reconstructs-value-used-in-deferred-imported-macro.expected.jinja
+++ b/src/test/resources/eager/reconstructs-value-used-in-deferred-imported-macro.expected.jinja
@@ -1,10 +1,27 @@
-{% do %}{% set current_path = 'uses-deferred-value-in-macro.jinja' %}{% set __temp_import_alias_1081745881__ = {}  %}{% for __ignored__ in [0] %}{% set value = deferred %}{% do __temp_import_alias_1081745881__.update({'value': value}) %}
+{% do %}\
+{% set current_path = 'uses-deferred-value-in-macro.jinja' %}\
+{% set __temp_import_alias_1081745881__ = {}  %}\
+{% for __ignored__ in [0] %}\
+{% set value = deferred %}\
+{% do __temp_import_alias_1081745881__.update({'value': value}) %}
 
-{% do __temp_import_alias_1081745881__.update({'import_resource_path': 'uses-deferred-value-in-macro.jinja','value': value}) %}{% endfor %}{% set macros = __temp_import_alias_1081745881__ %}{% set current_path = '' %}{% enddo %}
+{% do __temp_import_alias_1081745881__.update({'import_resource_path': 'uses-deferred-value-in-macro.jinja','value': value}) %}\
+{% endfor %}\
+{% set macros = __temp_import_alias_1081745881__ %}\
+{% set current_path = '' %}\
+{% enddo %}
 
-{% set deferred_import_resource_path = 'uses-deferred-value-in-macro.jinja' %}{% macro macros.getValueAnd(other) %}{% set value = macros.value %}
+{% set deferred_import_resource_path = 'uses-deferred-value-in-macro.jinja' %}\
+{% macro macros.getValueAnd(other) %}\
+{% set value = macros.value %}
 {{ value ~ ' ' ~ other }}
-{% endmacro %}{% set deferred_import_resource_path = null %}{{ macros.getValueAnd(1) }}
-{% set deferred_import_resource_path = 'uses-deferred-value-in-macro.jinja' %}{% macro macros.getValueAnd(other) %}{% set value = macros.value %}
+{% endmacro %}\
+{% set deferred_import_resource_path = null %}\
+{{ macros.getValueAnd(1) }}
+{% set deferred_import_resource_path = 'uses-deferred-value-in-macro.jinja' %}\
+{% macro macros.getValueAnd(other) %}\
+{% set value = macros.value %}
 {{ value ~ ' ' ~ other }}
-{% endmacro %}{% set deferred_import_resource_path = null %}{{ macros.getValueAnd(deferred) }}
+{% endmacro %}\
+{% set deferred_import_resource_path = null %}\
+{{ macros.getValueAnd(deferred) }}

--- a/src/test/resources/eager/reconstructs-with-multiple-loops.expected.jinja
+++ b/src/test/resources/eager/reconstructs-with-multiple-loops.expected.jinja
@@ -1,6 +1,8 @@
 [][]
 [0][0]
-{% set alpha = [0] %}{% set beta = [0] %}{% for i in deferred %}
+{% set alpha = [0] %}\
+{% set beta = [0] %}\
+{% for i in deferred %}
   {% if deferred %}
     {% for j in deferred %}
       {% if deferred %}

--- a/src/test/resources/eager/reconstructs-words-from-inside-nested-expressions.expected.jinja
+++ b/src/test/resources/eager/reconstructs-words-from-inside-nested-expressions.expected.jinja
@@ -1,3 +1,5 @@
-{% set foo = 'a' %}{% do deferred.append('{{ foo }}') %}
+{% set foo = 'a' %}\
+{% do deferred.append('{{ foo }}\
+') %}
 {{ deferred[0] }}
 {% print deferred[0] %}

--- a/src/test/resources/eager/reverts-modification-with-deferred-loop.expected.jinja
+++ b/src/test/resources/eager/reverts-modification-with-deferred-loop.expected.jinja
@@ -1,4 +1,5 @@
-{% set my_list = [] %}{% for __ignored__ in [0] %}
+{% set my_list = [] %}\
+{% for __ignored__ in [0] %}
 {% for j in deferred %}
 {% if loop.first %}
 {% do my_list.append(1) %}

--- a/src/test/resources/eager/reverts-simple.expected.jinja
+++ b/src/test/resources/eager/reverts-simple.expected.jinja
@@ -1,5 +1,6 @@
 {% for __ignored__ in [0] %}
-  {% set my_list = [0, 1] %}{% if deferred %}
+  {% set my_list = [0, 1] %}\
+{% if deferred %}
     {% do my_list.append(2) %}
   {% endif %}
   {% do my_list.append(3) %}

--- a/src/test/resources/eager/runs-macro-function-in-deferred-execution-mode.expected.jinja
+++ b/src/test/resources/eager/runs-macro-function-in-deferred-execution-mode.expected.jinja
@@ -1,7 +1,9 @@
-{% set holder = {'val': -1}  %}{% for i in range(deferred) %}
+{% set holder = {'val': -1}  %}\
+{% for i in range(deferred) %}
 {% set __macro_modify_615470226_temp_variable_1__ %}
 {% do holder.update({'val': holder.val + 1}) %}
-{% endset %}{% do __macro_modify_615470226_temp_variable_1__ %}
+{% endset %}\
+{% do __macro_modify_615470226_temp_variable_1__ %}
 {% if holder.val >= 1 %}
 {{ i }}
 {% endif %}

--- a/src/test/resources/eager/scopes-resetting-bindings.expected.jinja
+++ b/src/test/resources/eager/scopes-resetting-bindings.expected.jinja
@@ -1,4 +1,5 @@
-{% set my_list = [0] %}{% for i in deferred %}
+{% set my_list = [0] %}\
+{% for i in deferred %}
 {% for j in deferred %}
 {% if deferred %}
 {% do my_list.append(1) %}

--- a/src/test/resources/eager/sets-multiple-vars-deferred-in-child.expected.jinja
+++ b/src/test/resources/eager/sets-multiple-vars-deferred-in-child.expected.jinja
@@ -1,2 +1,8 @@
-1 & 2{% set bar = 2 %}{% set foo = 3 %}{% if deferred %}{% set bar = 4 %}{% else %}{% set foo = 5 %}{% endif %}
+1 & 2{% set bar = 2 %}\
+{% set foo = 3 %}\
+{% if deferred %}\
+{% set bar = 4 %}\
+{% else %}\
+{% set foo = 5 %}\
+{% endif %}
 {{ foo }} & {{ bar }}

--- a/src/test/resources/eager/uses-unique-macro-names.expected.jinja
+++ b/src/test/resources/eager/uses-unique-macro-names.expected.jinja
@@ -2,9 +2,15 @@
 
 {% set __macro_foo_97643642_temp_variable_0__ %}
 Goodbye {{ myname }}
-{% endset %}{% set a = filter:upper.filter(__macro_foo_97643642_temp_variable_0__, ____int3rpr3t3r____) %}
-{% do %}{% set current_path = 'macro-with-filter.jinja' %}
-{% set __macro_foo_927217348_temp_variable_0__ %}Hello {{ myname }}{% endset %}{% set b = filter:upper.filter(__macro_foo_927217348_temp_variable_0__, ____int3rpr3t3r____) %}
-{% set current_path = '' %}{% enddo %}
+{% endset %}\
+{% set a = filter:upper.filter(__macro_foo_97643642_temp_variable_0__, ____int3rpr3t3r____) %}
+{% do %}\
+{% set current_path = 'macro-with-filter.jinja' %}
+{% set __macro_foo_927217348_temp_variable_0__ %}\
+Hello {{ myname }}\
+{% endset %}\
+{% set b = filter:upper.filter(__macro_foo_927217348_temp_variable_0__, ____int3rpr3t3r____) %}
+{% set current_path = '' %}\
+{% enddo %}
 {{ a }}
 {{ b }}

--- a/src/test/resources/eager/wraps-certain-output-in-raw.expected.jinja
+++ b/src/test/resources/eager/wraps-certain-output-in-raw.expected.jinja
@@ -1,8 +1,20 @@
-{% raw %}{{ bar }}{% endraw %}
-{% raw %}{{ bar }}{% endraw %}
-{% raw %}{% print foo %}{% endraw %}
-{% raw %}{% print foo %}{% endraw %}
-{% raw %}{% baz %}{% endraw %}
-{% raw %}{% baz %}{% endraw %}
+{% raw %}\
+{{ bar }}\
+{% endraw %}
+{% raw %}\
+{{ bar }}\
+{% endraw %}
+{% raw %}\
+{% print foo %}\
+{% endraw %}
+{% raw %}\
+{% print foo %}\
+{% endraw %}
+{% raw %}\
+{% baz %}\
+{% endraw %}
+{% raw %}\
+{% baz %}\
+{% endraw %}
 No raw
 No raw

--- a/src/test/resources/tags/eager/extendstag/defers-block-in-extends-child.expected.jinja
+++ b/src/test/resources/tags/eager/extendstag/defers-block-in-extends-child.expected.jinja
@@ -1,8 +1,12 @@
-{% set current_path = '../eager/extendstag/base.html' %}<html>
+{% set current_path = '../eager/extendstag/base.html' %}\
+<html>
 <body>
 <div class="sidebar">
-{% set temp_current_path_743889914 = current_path %}{% set current_path = '' %}<h3>Table Of Contents</h3>
-{{ deferred }}{% set current_path = temp_current_path_743889914 %}
+{% set temp_current_path_743889914 = current_path %}\
+{% set current_path = '' %}\
+<h3>Table Of Contents</h3>
+{{ deferred }}\
+{% set current_path = temp_current_path_743889914 %}
 </div>
 </body>
 </html>

--- a/src/test/resources/tags/eager/extendstag/defers-super-block-with-deferred.expected.jinja
+++ b/src/test/resources/tags/eager/extendstag/defers-super-block-with-deferred.expected.jinja
@@ -1,9 +1,13 @@
-{% set current_path = '../eager/extendstag/base-deferred.html' %}<html>
+{% set current_path = '../eager/extendstag/base-deferred.html' %}\
+<html>
 <body>
 <div class="sidebar">
-{% set temp_current_path_743889914 = current_path %}{% set current_path = '' %}<h3>Table Of Contents</h3>
+{% set temp_current_path_743889914 = current_path %}\
+{% set current_path = '' %}\
+<h3>Table Of Contents</h3>
 
-<p>this is a {{ deferred }}.</p>
+<p>this is a {{ deferred }}\
+.</p>
 {% set current_path = temp_current_path_743889914 %}
 </div>
 </body>

--- a/src/test/resources/tags/eager/extendstag/reconstructs-deferred-outside-block.expected.jinja
+++ b/src/test/resources/tags/eager/extendstag/reconstructs-deferred-outside-block.expected.jinja
@@ -3,11 +3,17 @@
 {% set foo = 'yes' %}
 {% else %}
 {% set foo = 'no' %}
-{% endif %}{% enddo %}{# End Label:  ignored_output_from_extends #}{% set current_path = '../eager/extendstag/base.html' %}<html>
+{% endif %}\
+{% enddo %}\
+{# End Label:  ignored_output_from_extends #}{% set current_path = '../eager/extendstag/base.html' %}\
+<html>
 <body>
 <div class="sidebar">
-{% set temp_current_path_743889914 = current_path %}{% set current_path = '' %}<h3>Table Of Contents</h3>
-<p>{{ foo }}.</p>{% set current_path = temp_current_path_743889914 %}
+{% set temp_current_path_743889914 = current_path %}\
+{% set current_path = '' %}\
+<h3>Table Of Contents</h3>
+<p>{{ foo }}\
+.</p>{% set current_path = temp_current_path_743889914 %}
 </div>
 </body>
 </html>

--- a/src/test/resources/tags/eager/fortag/handles-nested-deferred-for-loop.expected.jinja
+++ b/src/test/resources/tags/eager/fortag/handles-nested-deferred-for-loop.expected.jinja
@@ -1,13 +1,16 @@
 {% for __ignored__ in [0] %}
 {% for bar in deferred %}
-pastrami sandwich. {{ bar }}!
+pastrami sandwich. {{ bar }}\
+!
 {% endfor %}
 
 {% for bar in deferred %}
-pastrami salad. {{ bar }}!
+pastrami salad. {{ bar }}\
+!
 {% endfor %}
 
 {% for bar in deferred %}
-pastrami smoothie. {{ bar }}!
+pastrami smoothie. {{ bar }}\
+!
 {% endfor %}
 {% endfor %}

--- a/src/test/resources/tags/eager/iftag/handles-only-deferred-elif.expected.jinja
+++ b/src/test/resources/tags/eager/iftag/handles-only-deferred-elif.expected.jinja
@@ -1,4 +1,5 @@
-{% if false %}{% elif deferred > 0 %}
+{% if false %}\
+{% elif deferred > 0 %}
 Positive {{ deferred }}
 {% else %}
 Negative {{ deferred }}

--- a/src/test/resources/tags/eager/includetag/includes-deferred.expected.jinja
+++ b/src/test/resources/tags/eager/includetag/includes-deferred.expected.jinja
@@ -1,5 +1,7 @@
 Foo begins as: abc
-{% set current_path = 'sets-to-deferred.jinja' %}{% set foo = deferred %}
-foo is now {{ deferred }}.
+{% set current_path = 'sets-to-deferred.jinja' %}\
+{% set foo = deferred %}
+foo is now {{ deferred }}\
+.
 {% set current_path = '' %}
 Foo ends as: {{ foo }}


### PR DESCRIPTION
Allows fixture templates to be separated by newlines for easier readability.
Use `\` to escape the newlines similar to escaping in bash scripts.

Certainly this:
```
{% do __temp_import_alias_902286926__.update({'import_resource_path': 'macro-and-set.jinja'}) %}\
{% endfor %}\
{% set simple = __temp_import_alias_902286926__ %}\
{% set current_path = '' %}\
{% enddo %}\
simple.foo: {% set deferred_import_resource_path = 'macro-and-set.jinja' %}\
{% macro simple.foo() %}\
Hello {{ myname }}\
{% endmacro %}\
{% set deferred_import_resource_path = null %}\
{{ simple.foo() }}
```
Is easier to read than this:
```
{% do __temp_import_alias_902286926__.update({'import_resource_path': 'macro-and-set.jinja'}) %}{% endfor %}{% set simple = __temp_import_alias_902286926__ %}{% set current_path = '' %}{% enddo %}simple.foo: {% set deferred_import_resource_path = 'macro-and-set.jinja' %}{% macro simple.foo() %}Hello {{ myname }}{% endmacro %}{% set deferred_import_resource_path = null %}{{ simple.foo() }}
```
The actual output may not have any newlines in it, but for writing, understanding, and debugging test failures, splitting up the jinjava nodes with newlines is very helpful. And the `\` denotes that the pretty spacing is not actually part of the output.