### PR TITLE
Overhaul current path reconstruction in eager execution

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
@@ -5,6 +5,7 @@ import com.hubspot.jinjava.el.ext.ExtendedParser;
 import com.hubspot.jinjava.el.ext.IdentifierPreservationStrategy;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.MetaContextVariables;
 import com.hubspot.jinjava.interpret.PartiallyDeferredValue;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
 import de.odysseus.el.tree.Bindings;
@@ -125,11 +126,12 @@ public interface EvalResultHolder {
         if (astNode instanceof AstIdentifier) {
           String name = ((AstIdentifier) astNode).getName();
           if (
-            ((JinjavaInterpreter) context
-                .getELResolver()
-                .getValue(context, null, ExtendedParser.INTERPRETER)).getContext()
-              .getComputedMetaContextVariables()
-              .contains(name)
+            MetaContextVariables.isMetaContextVariable(
+              name,
+              ((JinjavaInterpreter) context
+                  .getELResolver()
+                  .getValue(context, null, ExtendedParser.INTERPRETER)).getContext()
+            )
           ) {
             return name;
           }

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -337,6 +337,9 @@ public class Context extends ScopeMap<String, Object> {
     }
   }
 
+  /**
+   * @deprecated Use {@link MetaContextVariables#isMetaContextVariable(String, Context)}
+   */
   @Deprecated
   @Beta
   public Set<String> getMetaContextVariables() {
@@ -344,13 +347,17 @@ public class Context extends ScopeMap<String, Object> {
   }
 
   @Beta
-  public Set<String> getComputedMetaContextVariables() {
+  Set<String> getComputedMetaContextVariables() {
     return Sets.difference(metaContextVariables, overriddenNonMetaContextVariables);
   }
 
   @Beta
   public void addMetaContextVariables(Collection<String> variables) {
     metaContextVariables.addAll(variables);
+  }
+
+  Set<String> getNonMetaContextVariables() {
+    return overriddenNonMetaContextVariables;
   }
 
   @Beta

--- a/src/main/java/com/hubspot/jinjava/interpret/MetaContextVariables.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/MetaContextVariables.java
@@ -1,0 +1,52 @@
+package com.hubspot.jinjava.interpret;
+
+import com.google.common.annotations.Beta;
+import java.util.Objects;
+
+@Beta
+public class MetaContextVariables {
+
+  public static final String TEMPORARY_META_CONTEXT_PREFIX = "__temp_meta_";
+  private static final String TEMPORARY_IMPORT_ALIAS_PREFIX =
+    TEMPORARY_META_CONTEXT_PREFIX + "import_alias_";
+
+  private static final String TEMPORARY_IMPORT_ALIAS_FORMAT =
+    TEMPORARY_IMPORT_ALIAS_PREFIX + "%d__";
+  private static final String TEMP_CURRENT_PATH_PREFIX =
+    TEMPORARY_META_CONTEXT_PREFIX + "current_path_";
+  private static final String TEMP_CURRENT_PATH_FORMAT =
+    TEMP_CURRENT_PATH_PREFIX + "%d__";
+
+  public static boolean isMetaContextVariable(String varName, Context context) {
+    if (isTemporaryMetaContextVariable(varName)) {
+      return true;
+    }
+    return (
+      context.getMetaContextVariables().contains(varName) &&
+      !context.getNonMetaContextVariables().contains(varName)
+    );
+  }
+
+  private static boolean isTemporaryMetaContextVariable(String varName) {
+    return varName.startsWith(TEMPORARY_META_CONTEXT_PREFIX);
+  }
+
+  public static boolean isTemporaryImportAlias(String varName) {
+    // This is just faster than checking a regex
+    return varName.startsWith(TEMPORARY_IMPORT_ALIAS_PREFIX);
+  }
+
+  public static String getTemporaryImportAlias(String fullAlias) {
+    return String.format(
+      TEMPORARY_IMPORT_ALIAS_FORMAT,
+      Math.abs(Objects.hashCode(fullAlias))
+    );
+  }
+
+  public static String getTemporaryCurrentPathVarName(String newPath) {
+    return String.format(
+      TEMP_CURRENT_PATH_FORMAT,
+      Math.abs(Objects.hash(newPath, TEMPORARY_META_CONTEXT_PREFIX) >> 1)
+    );
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -127,6 +127,11 @@ public class MacroFunction extends AbstractCallableMethod {
             );
         } else {
           if (!alreadyDeferredInEarlierCall(scopeEntry.getKey(), interpreter)) {
+            if (
+              interpreter.getContext().get(scopeEntry.getKey()) == scopeEntry.getValue()
+            ) {
+              continue; // don't override if it's the same object
+            }
             interpreter.getContext().put(scopeEntry.getKey(), scopeEntry.getValue());
           }
         }

--- a/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
@@ -126,6 +126,12 @@ public class EagerMacroFunction extends MacroFunction {
         );
       throw new DeferredInvocationResolutionException(tempVarName);
     }
+    if (!eagerExecutionResult.getResult().isFullyResolved()) {
+      return EagerReconstructionUtils.wrapInChildScope(
+        eagerExecutionResult.getResult().toString(true),
+        interpreter
+      );
+    }
     return eagerExecutionResult.getResult().toString(true);
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/DeferredToken.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/DeferredToken.java
@@ -10,6 +10,7 @@ import com.hubspot.jinjava.interpret.DeferredMacroValueImpl;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueShadow;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.MetaContextVariables;
 import com.hubspot.jinjava.tree.parse.Token;
 import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
 import com.hubspot.jinjava.util.EagerExpressionResolver;
@@ -376,7 +377,7 @@ public class DeferredToken {
         }
         return !(val instanceof DeferredValue);
       })
-      .filter(prop -> !context.getComputedMetaContextVariables().contains(prop))
+      .filter(prop -> !MetaContextVariables.isMetaContextVariable(prop, context))
       .filter(prop -> {
         DeferredValue deferredValue = convertToDeferredValue(context, prop);
         context.put(prop, deferredValue);

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerBlockSetTagStrategy.java
@@ -170,7 +170,7 @@ public class EagerBlockSetTagStrategy extends EagerSetTagStrategy {
             .build()
         )
       );
-    String suffixToPreserveState = getSuffixToPreserveState(variables[0], interpreter);
+    String suffixToPreserveState = getSuffixToPreserveState(variables, interpreter);
     return Triple.of(
       prefixToPreserveState.toString(),
       joiner.toString(),

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -38,8 +38,6 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
       importingData
     );
 
-    final String newPathSetter;
-
     Optional<String> maybeTemplateFile;
     try {
       maybeTemplateFile =
@@ -53,7 +51,6 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
     String templateFile = maybeTemplateFile.get();
     try {
       Node node = ImportTag.parseTemplateAsNode(interpreter, templateFile);
-      newPathSetter = EagerImportingStrategyFactory.getSetTagForCurrentPath(interpreter);
 
       JinjavaInterpreter child = interpreter
         .getConfig()
@@ -96,7 +93,11 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
         return "";
       }
       return EagerReconstructionUtils.wrapInTag(
-        eagerImportingStrategy.getFinalOutput(newPathSetter, output, child),
+        EagerReconstructionUtils.wrapPathAroundText(
+          eagerImportingStrategy.getFinalOutput(output, child),
+          templateFile,
+          interpreter
+        ),
         DoTag.TAG_NAME,
         interpreter,
         true

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
@@ -3,7 +3,6 @@ package com.hubspot.jinjava.lib.tag.eager;
 import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.IncludeTag;
-import com.hubspot.jinjava.lib.tag.eager.importing.EagerImportingStrategyFactory;
 import com.hubspot.jinjava.loader.RelativePathResolver;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
@@ -30,14 +29,16 @@ public class EagerIncludeTag extends EagerTagDecorator<IncludeTag> {
         tagNode.getStartPosition()
       );
       templateFile = interpreter.resolveResourceLocation(templateFile);
-      final String initialPathSetter =
-        EagerImportingStrategyFactory.getSetTagForCurrentPath(interpreter);
       final String newPathSetter = EagerReconstructionUtils.buildBlockOrInlineSetTag(
         RelativePathResolver.CURRENT_PATH_CONTEXT_KEY,
         templateFile,
         interpreter
       );
-      return newPathSetter + output + initialPathSetter;
+      return EagerReconstructionUtils.wrapPathAroundText(
+        output,
+        templateFile,
+        interpreter
+      );
     }
     return output;
   }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerIncludeTag.java
@@ -3,7 +3,6 @@ package com.hubspot.jinjava.lib.tag.eager;
 import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.tag.IncludeTag;
-import com.hubspot.jinjava.loader.RelativePathResolver;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.HelperStringTokenizer;
@@ -29,11 +28,6 @@ public class EagerIncludeTag extends EagerTagDecorator<IncludeTag> {
         tagNode.getStartPosition()
       );
       templateFile = interpreter.resolveResourceLocation(templateFile);
-      final String newPathSetter = EagerReconstructionUtils.buildBlockOrInlineSetTag(
-        RelativePathResolver.CURRENT_PATH_CONTEXT_KEY,
-        templateFile,
-        interpreter
-      );
       return EagerReconstructionUtils.wrapPathAroundText(
         output,
         templateFile,

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerInlineSetTagStrategy.java
@@ -101,10 +101,7 @@ public class EagerInlineSetTagStrategy extends EagerSetTagStrategy {
           .build()
       )
     );
-    String suffixToPreserveState = getSuffixToPreserveState(
-      String.join(",", Arrays.asList(variables)),
-      interpreter
-    );
+    String suffixToPreserveState = getSuffixToPreserveState(variables, interpreter);
     return Triple.of(
       prefixToPreserveState.toString(),
       joiner.toString(),

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagStrategy.java
@@ -3,8 +3,8 @@ package com.hubspot.jinjava.lib.tag.eager;
 import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.MetaContextVariables;
 import com.hubspot.jinjava.lib.tag.SetTag;
-import com.hubspot.jinjava.lib.tag.eager.importing.AliasedEagerImportingStrategy;
 import com.hubspot.jinjava.tree.TagNode;
 import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.PrefixToPreserveState;
@@ -180,16 +180,17 @@ public abstract class EagerSetTagStrategy {
     JinjavaInterpreter interpreter
   ) {
     StringBuilder suffixToPreserveState = new StringBuilder();
-    Optional<String> maybeTemporaryImportAlias =
-      AliasedEagerImportingStrategy.getTemporaryImportAlias(interpreter.getContext());
+    Optional<String> maybeTemporaryImportAlias = interpreter
+      .getContext()
+      .getImportResourceAlias()
+      .map(MetaContextVariables::getTemporaryImportAlias);
     if (maybeTemporaryImportAlias.isPresent()) {
       boolean stillInsideImportTag = interpreter
         .getContext()
         .containsKey(maybeTemporaryImportAlias.get());
       List<String> filteredVars = varStream
-        .filter(var -> !AliasedEagerImportingStrategy.isTemporaryImportAlias(var))
         .filter(var ->
-          !interpreter.getContext().getComputedMetaContextVariables().contains(var)
+          !MetaContextVariables.isMetaContextVariable(var, interpreter.getContext())
         )
         .peek(var -> {
           if (!stillInsideImportTag) {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/AliasedEagerImportingStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/AliasedEagerImportingStrategy.java
@@ -127,14 +127,9 @@ public class AliasedEagerImportingStrategy implements EagerImportingStrategy {
   }
 
   @Override
-  public String getFinalOutput(
-    String newPathSetter,
-    String output,
-    JinjavaInterpreter child
-  ) {
+  public String getFinalOutput(String output, JinjavaInterpreter child) {
     String temporaryImportAlias = getTemporaryImportAlias(fullImportAlias);
     return (
-      newPathSetter +
       EagerReconstructionUtils.buildBlockOrInlineSetTag(
         temporaryImportAlias,
         Collections.emptyMap(),
@@ -153,8 +148,7 @@ public class AliasedEagerImportingStrategy implements EagerImportingStrategy {
         ImmutableMap.of(currentImportAlias, temporaryImportAlias),
         importingData.getOriginalInterpreter(),
         true
-      ) +
-      importingData.getInitialPathSetter()
+      )
     );
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/AliasedEagerImportingStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/AliasedEagerImportingStrategy.java
@@ -7,6 +7,7 @@ import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.MetaContextVariables;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
 import com.hubspot.jinjava.lib.tag.eager.DeferredToken;
 import com.hubspot.jinjava.objects.collections.PyMap;
@@ -16,34 +17,11 @@ import com.hubspot.jinjava.util.PrefixToPreserveState;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.stream.Stream;
 
 public class AliasedEagerImportingStrategy implements EagerImportingStrategy {
-
-  private static final String TEMPORARY_IMPORT_ALIAS_PREFIX = "__temp_import_alias_";
-  private static final String TEMPORARY_IMPORT_ALIAS_FORMAT =
-    TEMPORARY_IMPORT_ALIAS_PREFIX + "%d__";
-
-  public static Optional<String> getTemporaryImportAlias(Context context) {
-    return context
-      .getImportResourceAlias()
-      .map(AliasedEagerImportingStrategy::getTemporaryImportAlias);
-  }
-
-  public static boolean isTemporaryImportAlias(String varName) {
-    // This is just faster than checking a regex
-    return varName.startsWith(TEMPORARY_IMPORT_ALIAS_PREFIX);
-  }
-
-  private static String getTemporaryImportAlias(String fullAlias) {
-    return String.format(
-      TEMPORARY_IMPORT_ALIAS_FORMAT,
-      Math.abs(Objects.hashCode(fullAlias))
-    );
-  }
 
   private final ImportingData importingData;
   private final String currentImportAlias;
@@ -95,7 +73,10 @@ public class AliasedEagerImportingStrategy implements EagerImportingStrategy {
     importingData
       .getOriginalInterpreter()
       .getContext()
-      .put(getTemporaryImportAlias(fullImportAlias), DeferredValue.instance());
+      .put(
+        MetaContextVariables.getTemporaryImportAlias(fullImportAlias),
+        DeferredValue.instance()
+      );
   }
 
   @Override
@@ -108,7 +89,9 @@ public class AliasedEagerImportingStrategy implements EagerImportingStrategy {
     }
     Map<String, Object> childBindings = child.getContext().getSessionBindings();
     childBindings.putAll(child.getContext().getGlobalMacros());
-    String temporaryImportAlias = getTemporaryImportAlias(fullImportAlias);
+    String temporaryImportAlias = MetaContextVariables.getTemporaryImportAlias(
+      fullImportAlias
+    );
     Map<String, Object> mapForCurrentContextAlias = getMapForCurrentContextAlias(
       currentImportAlias,
       child
@@ -128,7 +111,9 @@ public class AliasedEagerImportingStrategy implements EagerImportingStrategy {
 
   @Override
   public String getFinalOutput(String output, JinjavaInterpreter child) {
-    String temporaryImportAlias = getTemporaryImportAlias(fullImportAlias);
+    String temporaryImportAlias = MetaContextVariables.getTemporaryImportAlias(
+      fullImportAlias
+    );
     return (
       EagerReconstructionUtils.buildBlockOrInlineSetTag(
         temporaryImportAlias,
@@ -237,7 +222,9 @@ public class AliasedEagerImportingStrategy implements EagerImportingStrategy {
     JinjavaInterpreter child
   ) {
     StringJoiner keyValueJoiner = new StringJoiner(",");
-    String temporaryImportAlias = getTemporaryImportAlias(fullImportAlias);
+    String temporaryImportAlias = MetaContextVariables.getTemporaryImportAlias(
+      fullImportAlias
+    );
     Map<String, Object> currentAliasMap = getMapForCurrentContextAlias(
       currentImportAlias,
       child

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/EagerImportingStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/EagerImportingStrategy.java
@@ -12,7 +12,7 @@ public interface EagerImportingStrategy {
   void setup(JinjavaInterpreter child);
 
   void integrateChild(JinjavaInterpreter child);
-  String getFinalOutput(String newPathSetter, String output, JinjavaInterpreter child);
+  String getFinalOutput(String output, JinjavaInterpreter child);
 
   static String getSetTagForDeferredChildBindings(
     JinjavaInterpreter interpreter,

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/EagerImportingStrategyFactory.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/EagerImportingStrategyFactory.java
@@ -30,15 +30,7 @@ public class EagerImportingStrategyFactory {
   public static String getSetTagForCurrentPath(JinjavaInterpreter interpreter) {
     return EagerReconstructionUtils.buildBlockOrInlineSetTag(
       RelativePathResolver.CURRENT_PATH_CONTEXT_KEY,
-      interpreter
-        .getContext()
-        .getCurrentPathStack()
-        .peek()
-        .orElseGet(() ->
-          (String) interpreter
-            .getContext()
-            .getOrDefault(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY, "")
-        ),
+      RelativePathResolver.getCurrentPathFromStackOrKey(interpreter),
       interpreter
     );
   }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/FlatEagerImportingStrategy.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/importing/FlatEagerImportingStrategy.java
@@ -63,11 +63,7 @@ public class FlatEagerImportingStrategy implements EagerImportingStrategy {
   }
 
   @Override
-  public String getFinalOutput(
-    String newPathSetter,
-    String output,
-    JinjavaInterpreter child
-  ) {
+  public String getFinalOutput(String output, JinjavaInterpreter child) {
     if (importingData.getOriginalInterpreter().getContext().isDeferredExecutionMode()) {
       Set<String> metaContextVariables = importingData
         .getOriginalInterpreter()
@@ -90,14 +86,12 @@ public class FlatEagerImportingStrategy implements EagerImportingStrategy {
       );
     }
     return (
-      newPathSetter +
       EagerImportingStrategy.getSetTagForDeferredChildBindings(
         importingData.getOriginalInterpreter(),
         null,
         child.getContext().getSessionBindings()
       ) +
-      output +
-      importingData.getInitialPathSetter()
+      output
     );
   }
 }

--- a/src/main/java/com/hubspot/jinjava/loader/RelativePathResolver.java
+++ b/src/main/java/com/hubspot/jinjava/loader/RelativePathResolver.java
@@ -11,13 +11,7 @@ public class RelativePathResolver implements LocationResolver {
   @Override
   public String resolve(String path, JinjavaInterpreter interpreter) {
     if (path.startsWith("./") || path.startsWith("../")) {
-      String parentPath = interpreter
-        .getContext()
-        .getCurrentPathStack()
-        .peek()
-        .orElseGet(() ->
-          (String) interpreter.getContext().getOrDefault(CURRENT_PATH_CONTEXT_KEY, "")
-        );
+      String parentPath = getCurrentPathFromStackOrKey(interpreter);
 
       Path templatePath = Paths.get(parentPath);
       Path folderPath = templatePath.getParent() != null
@@ -28,5 +22,15 @@ public class RelativePathResolver implements LocationResolver {
       }
     }
     return path;
+  }
+
+  public static String getCurrentPathFromStackOrKey(JinjavaInterpreter interpreter) {
+    return interpreter
+      .getContext()
+      .getCurrentPathStack()
+      .peek()
+      .orElseGet(() ->
+        (String) interpreter.getContext().getOrDefault(CURRENT_PATH_CONTEXT_KEY, "")
+      );
   }
 }

--- a/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/DeferredValueUtils.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Sets;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.MetaContextVariables;
 import com.hubspot.jinjava.interpret.PartiallyDeferredValue;
 import com.hubspot.jinjava.lib.tag.SetTag;
 import com.hubspot.jinjava.tree.ExpressionNode;
@@ -119,7 +120,7 @@ public class DeferredValueUtils {
     props
       .stream()
       .filter(prop -> !(context.get(prop) instanceof DeferredValue))
-      .filter(prop -> !context.getComputedMetaContextVariables().contains(prop))
+      .filter(prop -> !MetaContextVariables.isMetaContextVariable(prop, context))
       .forEach(prop -> {
         Object value = context.get(prop);
         if (value != null) {

--- a/src/main/java/com/hubspot/jinjava/util/EagerContextWatcher.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerContextWatcher.java
@@ -2,11 +2,13 @@ package com.hubspot.jinjava.util;
 
 import com.google.common.annotations.Beta;
 import com.hubspot.jinjava.interpret.CannotReconstructValueException;
+import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
 import com.hubspot.jinjava.interpret.LazyExpression;
+import com.hubspot.jinjava.interpret.MetaContextVariables;
 import com.hubspot.jinjava.interpret.OneTimeReconstructible;
 import com.hubspot.jinjava.interpret.RevertibleObject;
 import com.hubspot.jinjava.lib.tag.eager.EagerExecutionResult;
@@ -15,6 +17,7 @@ import com.hubspot.jinjava.objects.collections.PyMap;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.util.EagerExpressionResolver.EagerExpressionResult;
 import java.util.AbstractMap;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -48,16 +51,13 @@ public class EagerContextWatcher {
     JinjavaInterpreter interpreter,
     EagerChildContextConfig eagerChildContextConfig
   ) {
-    final Set<String> metaContextVariables = interpreter
-      .getContext()
-      .getComputedMetaContextVariables();
     final EagerExecutionResult initialResult;
     final Map<String, Object> speculativeBindings;
     if (eagerChildContextConfig.checkForContextChanges) {
       final Set<Entry<String, Object>> entrySet = interpreter.getContext().entrySet();
       final Map<String, Object> initiallyResolvedHashes = getInitiallyResolvedHashes(
         entrySet,
-        metaContextVariables
+        interpreter.getContext()
       );
       final Map<String, String> initiallyResolvedAsStrings =
         getInitiallyResolvedAsStrings(interpreter, entrySet, initiallyResolvedHashes);
@@ -66,15 +66,13 @@ public class EagerContextWatcher {
         getAllSpeculativeBindings(
           interpreter,
           eagerChildContextConfig,
-          metaContextVariables,
           initiallyResolvedHashes,
           initiallyResolvedAsStrings,
           initialResult
         );
     } else {
-      Set<String> ignoredKeys = getKeysToIgnore(
+      Set<String> ignoredKeys = getAdditionalKeysToIgnore(
         interpreter,
-        metaContextVariables,
         eagerChildContextConfig
       );
       initialResult = applyFunction(function, interpreter, eagerChildContextConfig);
@@ -140,12 +138,14 @@ public class EagerContextWatcher {
 
   private static Map<String, Object> getInitiallyResolvedHashes(
     Set<Entry<String, Object>> entrySet,
-    Set<String> metaContextVariables
+    Context context
   ) {
     Map<String, Object> mapOfHashes = new HashMap<>();
     entrySet
       .stream()
-      .filter(entry -> !metaContextVariables.contains(entry.getKey()))
+      .filter(entry ->
+        !MetaContextVariables.isMetaContextVariable(entry.getKey(), context)
+      )
       .filter(entry ->
         !(entry.getValue() instanceof DeferredValue) && entry.getValue() != null
       )
@@ -155,9 +155,8 @@ public class EagerContextWatcher {
     return mapOfHashes;
   }
 
-  private static Set<String> getKeysToIgnore(
+  private static Set<String> getAdditionalKeysToIgnore(
     JinjavaInterpreter interpreter,
-    Set<String> metaContextVariables,
     EagerChildContextConfig eagerChildContextConfig
   ) {
     // We don't need to reconstruct already deferred keys.
@@ -166,18 +165,14 @@ public class EagerContextWatcher {
         interpreter.getContext().isDeferredExecutionMode() &&
         !eagerChildContextConfig.takeNewValue
       )
-      ? Stream
-        .concat(
-          metaContextVariables.stream(),
-          interpreter
-            .getContext()
-            .entrySet()
-            .stream()
-            .filter(entry -> entry.getValue() instanceof DeferredValue)
-            .map(Entry::getKey)
-        )
+      ? interpreter
+        .getContext()
+        .entrySet()
+        .stream()
+        .filter(entry -> entry.getValue() instanceof DeferredValue)
+        .map(Entry::getKey)
         .collect(Collectors.toSet())
-      : metaContextVariables;
+      : Collections.emptySet();
   }
 
   private static Map<String, Object> getBasicSpeculativeBindings(
@@ -209,6 +204,12 @@ public class EagerContextWatcher {
       .getSpeculativeBindings()
       .entrySet()
       .stream()
+      .filter(entry ->
+        !MetaContextVariables.isMetaContextVariable(
+          entry.getKey(),
+          interpreter.getContext()
+        )
+      )
       .filter(entry -> !ignoredKeys.contains(entry.getKey()))
       .filter(entry -> !"loop".equals(entry.getKey()))
       .map(entry -> {
@@ -245,7 +246,6 @@ public class EagerContextWatcher {
   private static Map<String, Object> getAllSpeculativeBindings(
     JinjavaInterpreter interpreter,
     EagerChildContextConfig eagerChildContextConfig,
-    Set<String> metaContextVariables,
     Map<String, Object> initiallyResolvedHashes,
     Map<String, String> initiallyResolvedAsStrings,
     EagerExecutionResult eagerExecutionResult
@@ -295,7 +295,12 @@ public class EagerContextWatcher {
       speculativeBindings
         .entrySet()
         .stream()
-        .filter(entry -> !metaContextVariables.contains(entry.getKey()))
+        .filter(entry ->
+          !MetaContextVariables.isMetaContextVariable(
+            entry.getKey(),
+            interpreter.getContext()
+          )
+        )
         .filter(entry -> entry.getValue() != null)
         .filter(entry -> !isDeferredWithOriginalValueNull(entry.getValue()))
         .collect(Collectors.toMap(Entry::getKey, Entry::getValue));

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1634,4 +1634,14 @@ public class EagerTest {
       "keeps-meta-context-variables-through-import/test"
     );
   }
+
+  @Test
+  public void itWrapsMacroThatWouldChangeCurrentPathInChildScope() {
+    interpreter
+      .getContext()
+      .put(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY, "starting path");
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
+      "wraps-macro-that-would-change-current-path-in-child-scope/test"
+    );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/ExpectedTemplateInterpreter.java
+++ b/src/test/java/com/hubspot/jinjava/ExpectedTemplateInterpreter.java
@@ -6,6 +6,7 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
+import com.hubspot.jinjava.loader.RelativePathResolver;
 import com.hubspot.jinjava.mode.DefaultExecutionMode;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -147,6 +148,12 @@ public class ExpectedTemplateInterpreter {
           .getContext()
           .getCurrentPathStack()
           .push(String.format("%s/%s.jinja", path, name), 0, 0);
+        interpreter
+          .getContext()
+          .put(
+            RelativePathResolver.CURRENT_PATH_CONTEXT_KEY,
+            String.format("%s/%s.jinja", path, name)
+          );
       }
       return simplify(
         Resources.toString(

--- a/src/test/java/com/hubspot/jinjava/interpret/ContextTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/ContextTest.java
@@ -6,6 +6,9 @@ import static org.assertj.core.api.Assertions.fail;
 import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.Jinjava;
 import com.hubspot.jinjava.lib.fn.ELFunctionDefinition;
+import com.hubspot.jinjava.loader.RelativePathResolver;
+import com.hubspot.jinjava.mode.EagerExecutionMode;
+import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -91,6 +94,30 @@ public class ContextTest {
     } finally {
       JinjavaInterpreter.popCurrent();
     }
+  }
+
+  @Test
+  public void itRemovesOtherMetaContextVariables() {
+    String variableName = "foo";
+    EagerExecutionMode.instance().prepareContext(context);
+    context.addMetaContextVariables(Collections.singleton(variableName));
+    assertThat(context.getComputedMetaContextVariables()).contains(variableName);
+    context.addNonMetaContextVariables(Collections.singleton(variableName));
+    assertThat(context.getComputedMetaContextVariables()).doesNotContain(variableName);
+    context.removeNonMetaContextVariables(Collections.singleton(variableName));
+    assertThat(context.getComputedMetaContextVariables()).contains(variableName);
+  }
+
+  @Test
+  public void itDoesNotRemoveStaticMetaContextVariables() {
+    EagerExecutionMode.instance().prepareContext(context);
+    assertThat(context.getComputedMetaContextVariables())
+      .contains(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY);
+    context.addNonMetaContextVariables(
+      Collections.singleton(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY)
+    );
+    assertThat(context.getComputedMetaContextVariables())
+      .contains(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY);
   }
 
   public static void throwException() {

--- a/src/test/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunctionTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunctionTest.java
@@ -111,7 +111,7 @@ public class EagerMacroFunctionTest extends BaseInterpretingTest {
       .isInstanceOf(DeferredValueException.class);
     try (TemporaryValueClosable<Boolean> ignored = context.withPartialMacroEvaluation()) {
       assertThat(eagerMacroFunction.evaluate("Bar"))
-        .isEqualTo("It's: Bar, {{ deferred }}");
+        .isEqualTo("{% for __ignored__ in [0] %}It's: Bar, {{ deferred }}{% endfor %}");
     }
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -376,11 +376,11 @@ public class EagerImportTagTest extends ImportTagTest {
     );
     assertThat(result)
       .isEqualTo(
-        "{% if deferred %}{% do %}{% set current_path = 'import-tree-b.jinja' %}{% set __temp_import_alias_98__ = {}  %}{% for __ignored__ in [0] %}{% do %}{% set current_path = 'import-tree-a.jinja' %}{% set __temp_import_alias_95701__ = {}  %}{% for __ignored__ in [0] %}{% set something = 'somn' %}{% do __temp_import_alias_95701__.update({'something': something}) %}\n" +
-        "{% set foo_a = 'a' %}{% do __temp_import_alias_95701__.update({'foo_a': foo_a}) %}\n" +
-        "{% do __temp_import_alias_95701__.update({'foo_a': 'a','import_resource_path': 'import-tree-a.jinja','something': 'somn'}) %}{% endfor %}{% set a = __temp_import_alias_95701__ %}{% set current_path = 'import-tree-b.jinja' %}{% enddo %}\n" +
-        "{% set foo_b = 'b' + a.foo_a %}{% do __temp_import_alias_98__.update({'foo_b': foo_b}) %}\n" +
-        "{% do __temp_import_alias_98__.update({'a': a,'foo_b': foo_b,'import_resource_path': 'import-tree-b.jinja'}) %}{% endfor %}{% set b = __temp_import_alias_98__ %}{% set current_path = '' %}{% enddo %}{% endif %}"
+        "{% if deferred %}{% do %}{% set __temp_meta_current_path_930119534__,current_path = current_path,'import-tree-b.jinja' %}{% set __temp_meta_import_alias_98__ = {}  %}{% for __ignored__ in [0] %}{% do %}{% set __temp_meta_current_path_58714367__,current_path = current_path,'import-tree-a.jinja' %}{% set __temp_meta_import_alias_95701__ = {}  %}{% for __ignored__ in [0] %}{% set something = 'somn' %}{% do __temp_meta_import_alias_95701__.update({'something': something}) %}\n" +
+        "{% set foo_a = 'a' %}{% do __temp_meta_import_alias_95701__.update({'foo_a': foo_a}) %}\n" +
+        "{% do __temp_meta_import_alias_95701__.update({'foo_a': 'a','import_resource_path': 'import-tree-a.jinja','something': 'somn'}) %}{% endfor %}{% set a = __temp_meta_import_alias_95701__ %}{% set current_path,__temp_meta_current_path_58714367__ = __temp_meta_current_path_58714367__,null %}{% enddo %}\n" +
+        "{% set foo_b = 'b' + a.foo_a %}{% do __temp_meta_import_alias_98__.update({'foo_b': foo_b}) %}\n" +
+        "{% do __temp_meta_import_alias_98__.update({'a': a,'foo_b': foo_b,'import_resource_path': 'import-tree-b.jinja'}) %}{% endfor %}{% set b = __temp_meta_import_alias_98__ %}{% set current_path,__temp_meta_current_path_930119534__ = __temp_meta_current_path_930119534__,null %}{% enddo %}{% endif %}"
       );
 
     removeDeferredContextKeys();
@@ -641,15 +641,15 @@ public class EagerImportTagTest extends ImportTagTest {
         "{% set vars = {'foo': 'a', 'import_resource_path': 'var-a.jinja'}  %}" +
         "{% if deferred %}" +
         "{% do %}" +
-        "{% set temp_current_path_1033239083,current_path = current_path,'var-b.jinja' %}" +
-        "{% set __temp_import_alias_3612204__ = {}  %}" +
+        "{% set __temp_meta_current_path_299252430__,current_path = current_path,'var-b.jinja' %}" +
+        "{% set __temp_meta_import_alias_3612204__ = {}  %}" +
         "{% for __ignored__ in [0] %}" +
         "{% set foo = 'b' %}" +
-        "{% do __temp_import_alias_3612204__.update({'foo': foo}) %}\n" +
-        "{% do __temp_import_alias_3612204__.update({'foo': 'b','import_resource_path': 'var-b.jinja'}) %}" +
+        "{% do __temp_meta_import_alias_3612204__.update({'foo': foo}) %}\n" +
+        "{% do __temp_meta_import_alias_3612204__.update({'foo': 'b','import_resource_path': 'var-b.jinja'}) %}" +
         "{% endfor %}" +
-        "{% set vars = __temp_import_alias_3612204__ %}" +
-        "{% set current_path,temp_current_path_1033239083 = temp_current_path_1033239083,null %}" +
+        "{% set vars = __temp_meta_import_alias_3612204__ %}" +
+        "{% set current_path,__temp_meta_current_path_299252430__ = __temp_meta_current_path_299252430__,null %}" +
         "{% enddo %}" +
         "{% endif %}" +
         "{{ vars.foo }}"
@@ -678,9 +678,9 @@ public class EagerImportTagTest extends ImportTagTest {
         "{% set foo = 'a' %}" +
         "{% if deferred %}" +
         "{% do %}" +
-        "{% set temp_current_path_1033239083,current_path = current_path,'var-b.jinja' %}" +
+        "{% set __temp_meta_current_path_299252430__,current_path = current_path,'var-b.jinja' %}" +
         "{% set foo = 'b' %}\n" +
-        "{% set current_path,temp_current_path_1033239083 = temp_current_path_1033239083,null %}" +
+        "{% set current_path,__temp_meta_current_path_299252430__ = __temp_meta_current_path_299252430__,null %}" +
         "{% enddo %}" +
         "{% endif %}" +
         "{{ foo }}"
@@ -699,10 +699,10 @@ public class EagerImportTagTest extends ImportTagTest {
     assertThat(result)
       .isEqualTo(
         "{% do %}" +
-        "{% set temp_current_path_184309715,current_path = current_path,'set-two-variables.jinja' %}" +
+        "{% set __temp_meta_current_path_549676938__,current_path = current_path,'set-two-variables.jinja' %}" +
         "{% set foo = deferred %}\n" +
         "\n" +
-        "{% set current_path,temp_current_path_184309715 = temp_current_path_184309715,null %}" +
+        "{% set current_path,__temp_meta_current_path_549676938__ = __temp_meta_current_path_549676938__,null %}" +
         "{% enddo %}" +
         "{{ foo }} bar"
       );

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -562,10 +562,16 @@ public class EagerImportTagTest extends ImportTagTest {
     );
     assertThat(result.trim())
       .isEqualTo(
-        "{% set var = [] %}{% do var.append('a' ~ deferred) %}" +
-        "a\n" +
+        "{% set var = [] %}" +
+        "{% set __macro_adjust_108896029_temp_variable_0__ %}" +
+        "{% do var.append('a' ~ deferred) %}" +
+        "a" +
+        "{% endset %}" +
+        "{{ __macro_adjust_108896029_temp_variable_0__ }}\n" +
+        "{% for __ignored__ in [0] %}" +
         "{% do var.append('b' ~ deferred) %}" +
-        "b\n" +
+        "b" +
+        "{% endfor %}\n" +
         "c{{ var }}"
       );
     context.put("deferred", "resolved");

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -638,9 +638,19 @@ public class EagerImportTagTest extends ImportTagTest {
     assertThat(result)
       .isEqualTo(
         "a" +
-        "{% set vars = {'foo': 'a', 'import_resource_path': 'var-a.jinja'}  %}{% if deferred %}" +
-        "{% do %}{% set current_path = 'var-b.jinja' %}{% set __temp_import_alias_3612204__ = {}  %}{% for __ignored__ in [0] %}{% set foo = 'b' %}{% do __temp_import_alias_3612204__.update({'foo': foo}) %}\n" +
-        "{% do __temp_import_alias_3612204__.update({'foo': 'b','import_resource_path': 'var-b.jinja'}) %}{% endfor %}{% set vars = __temp_import_alias_3612204__ %}{% set current_path = '' %}{% enddo %}" +
+        "{% set vars = {'foo': 'a', 'import_resource_path': 'var-a.jinja'}  %}" +
+        "{% if deferred %}" +
+        "{% do %}" +
+        "{% set temp_current_path_1033239083,current_path = current_path,'var-b.jinja' %}" +
+        "{% set __temp_import_alias_3612204__ = {}  %}" +
+        "{% for __ignored__ in [0] %}" +
+        "{% set foo = 'b' %}" +
+        "{% do __temp_import_alias_3612204__.update({'foo': foo}) %}\n" +
+        "{% do __temp_import_alias_3612204__.update({'foo': 'b','import_resource_path': 'var-b.jinja'}) %}" +
+        "{% endfor %}" +
+        "{% set vars = __temp_import_alias_3612204__ %}" +
+        "{% set current_path,temp_current_path_1033239083 = temp_current_path_1033239083,null %}" +
+        "{% enddo %}" +
         "{% endif %}" +
         "{{ vars.foo }}"
       );
@@ -665,9 +675,13 @@ public class EagerImportTagTest extends ImportTagTest {
     assertThat(result)
       .isEqualTo(
         "a" +
-        "{% set foo = 'a' %}{% if deferred %}" +
-        "{% do %}{% set current_path = 'var-b.jinja' %}{% set foo = 'b' %}\n" +
-        "{% set current_path = '' %}{% enddo %}" +
+        "{% set foo = 'a' %}" +
+        "{% if deferred %}" +
+        "{% do %}" +
+        "{% set temp_current_path_1033239083,current_path = current_path,'var-b.jinja' %}" +
+        "{% set foo = 'b' %}\n" +
+        "{% set current_path,temp_current_path_1033239083 = temp_current_path_1033239083,null %}" +
+        "{% enddo %}" +
         "{% endif %}" +
         "{{ foo }}"
       );
@@ -684,9 +698,13 @@ public class EagerImportTagTest extends ImportTagTest {
       .trim();
     assertThat(result)
       .isEqualTo(
-        "{% do %}{% set current_path = 'set-two-variables.jinja' %}{% set foo = deferred %}\n" +
+        "{% do %}" +
+        "{% set temp_current_path_184309715,current_path = current_path,'set-two-variables.jinja' %}" +
+        "{% set foo = deferred %}\n" +
         "\n" +
-        "{% set current_path = '' %}{% enddo %}{{ foo }} bar"
+        "{% set current_path,temp_current_path_184309715 = temp_current_path_184309715,null %}" +
+        "{% enddo %}" +
+        "{{ foo }} bar"
       );
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -331,6 +331,7 @@ public class EagerImportTagTest extends ImportTagTest {
     removeDeferredContextKeys();
     context.put("a_val", "a");
     // There are some extras due to deferred values copying up the context stack.
+    context.getDeferredTokens().clear();
     assertThat(interpreter.render(result).trim())
       .isEqualTo(
         interpreter.render(
@@ -363,6 +364,7 @@ public class EagerImportTagTest extends ImportTagTest {
     removeDeferredContextKeys();
 
     context.put("a_val", "a");
+    context.getDeferredTokens().clear();
     assertThat(interpreter.render(result).trim()).isEqualTo("12345 cbaabaaba");
   }
 
@@ -655,6 +657,7 @@ public class EagerImportTagTest extends ImportTagTest {
         "{{ vars.foo }}"
       );
     interpreter.getContext().put("deferred", "resolved");
+    context.getDeferredTokens().clear();
     assertThat(interpreter.render(result)).isEqualTo("ab");
   }
 
@@ -687,6 +690,7 @@ public class EagerImportTagTest extends ImportTagTest {
       );
 
     interpreter.getContext().put("deferred", "resolved");
+    context.getDeferredTokens().clear();
     assertThat(interpreter.render(result)).isEqualTo("ab");
   }
 

--- a/src/test/java/com/hubspot/jinjava/util/EagerReconstructionUtilsTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerReconstructionUtilsTest.java
@@ -18,7 +18,6 @@ import com.hubspot.jinjava.lib.fn.MacroFunction;
 import com.hubspot.jinjava.lib.fn.eager.EagerMacroFunction;
 import com.hubspot.jinjava.lib.tag.eager.DeferredToken;
 import com.hubspot.jinjava.lib.tag.eager.EagerExecutionResult;
-import com.hubspot.jinjava.loader.RelativePathResolver;
 import com.hubspot.jinjava.mode.DefaultExecutionMode;
 import com.hubspot.jinjava.mode.EagerExecutionMode;
 import com.hubspot.jinjava.mode.PreserveRawExecutionMode;
@@ -341,37 +340,6 @@ public class EagerReconstructionUtilsTest extends BaseInterpretingTest {
       )
     )
       .isEmpty();
-  }
-
-  @Test
-  public void itRemovesOtherMetaContextVariables() {
-    String variableName = "foo";
-    interpreter.getContext().addMetaContextVariables(Collections.singleton(variableName));
-    assertThat(interpreter.getContext().getComputedMetaContextVariables())
-      .contains(variableName);
-    interpreter
-      .getContext()
-      .addNonMetaContextVariables(Collections.singleton(variableName));
-    assertThat(interpreter.getContext().getComputedMetaContextVariables())
-      .doesNotContain(variableName);
-    interpreter
-      .getContext()
-      .removeNonMetaContextVariables(Collections.singleton(variableName));
-    assertThat(interpreter.getContext().getComputedMetaContextVariables())
-      .contains(variableName);
-  }
-
-  @Test
-  public void itDoesNotRemoveStaticMetaContextVariables() {
-    assertThat(interpreter.getContext().getComputedMetaContextVariables())
-      .contains(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY);
-    interpreter
-      .getContext()
-      .addNonMetaContextVariables(
-        Collections.singleton(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY)
-      );
-    assertThat(interpreter.getContext().getComputedMetaContextVariables())
-      .contains(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY);
   }
 
   @Test

--- a/src/test/resources/eager/allows-variable-sharing-alias-name/test.expected.jinja
+++ b/src/test/resources/eager/allows-variable-sharing-alias-name/test.expected.jinja
@@ -1,17 +1,17 @@
 {% do %}\
-{% set temp_current_path_934833828,current_path = current_path,'eager/allows-variable-sharing-alias-name/filters.jinja' %}\
-{% set __temp_import_alias_854547461__ = {}  %}\
+{% set __temp_meta_current_path_200847175__,current_path = current_path,'eager/allows-variable-sharing-alias-name/filters.jinja' %}\
+{% set __temp_meta_import_alias_854547461__ = {}  %}\
 {% for __ignored__ in [0] %}
 {% set bar = deferred %}\
-{% do __temp_import_alias_854547461__.update({'bar': bar}) %}
+{% do __temp_meta_import_alias_854547461__.update({'bar': bar}) %}
 
 {% set filters = {}  %}\
-{% do __temp_import_alias_854547461__.update({'filters': filters}) %}\
+{% do __temp_meta_import_alias_854547461__.update({'filters': filters}) %}\
 {% do filters.update(deferred) %}
-{% do __temp_import_alias_854547461__.update({'bar': bar,'foo': 123,'import_resource_path': 'eager/allows-variable-sharing-alias-name/filters.jinja','filters': filters}) %}\
+{% do __temp_meta_import_alias_854547461__.update({'bar': bar,'foo': 123,'import_resource_path': 'eager/allows-variable-sharing-alias-name/filters.jinja','filters': filters}) %}\
 {% endfor %}\
-{% set filters = __temp_import_alias_854547461__ %}\
-{% set current_path,temp_current_path_934833828 = temp_current_path_934833828,null %}\
+{% set filters = __temp_meta_import_alias_854547461__ %}\
+{% set current_path,__temp_meta_current_path_200847175__ = __temp_meta_current_path_200847175__,null %}\
 {% enddo %}
 
 {{ filters }}

--- a/src/test/resources/eager/allows-variable-sharing-alias-name/test.expected.jinja
+++ b/src/test/resources/eager/allows-variable-sharing-alias-name/test.expected.jinja
@@ -1,5 +1,5 @@
 {% do %}\
-{% set current_path = 'eager/allows-variable-sharing-alias-name/filters.jinja' %}\
+{% set temp_current_path_934833828,current_path = current_path,'eager/allows-variable-sharing-alias-name/filters.jinja' %}\
 {% set __temp_import_alias_854547461__ = {}  %}\
 {% for __ignored__ in [0] %}
 {% set bar = deferred %}\
@@ -11,7 +11,7 @@
 {% do __temp_import_alias_854547461__.update({'bar': bar,'foo': 123,'import_resource_path': 'eager/allows-variable-sharing-alias-name/filters.jinja','filters': filters}) %}\
 {% endfor %}\
 {% set filters = __temp_import_alias_854547461__ %}\
-{% set current_path = 'eager/allows-variable-sharing-alias-name/test.jinja' %}\
+{% set current_path,temp_current_path_934833828 = temp_current_path_934833828,null %}\
 {% enddo %}
 
 {{ filters }}

--- a/src/test/resources/eager/defers-caller/test.expected.jinja
+++ b/src/test/resources/eager/defers-caller/test.expected.jinja
@@ -1,3 +1,4 @@
+{% for __ignored__ in [0] %}\
 Jack says:
 How do I get a {{ deferred }}\
-?
+?{% endfor %}

--- a/src/test/resources/eager/does-not-override-import-modification-in-for/test.expected.jinja
+++ b/src/test/resources/eager/does-not-override-import-modification-in-for/test.expected.jinja
@@ -1,80 +1,80 @@
 {% set foo = 'start' %}\
 {% for __ignored__ in [0] %}
 {% do %}\
-{% set temp_current_path_952361846,current_path = current_path,'eager/supplements/deferred-modification.jinja' %}\
-{% set __temp_import_alias_3016318__ = {}  %}\
+{% set __temp_meta_current_path_461135149__,current_path = current_path,'eager/supplements/deferred-modification.jinja' %}\
+{% set __temp_meta_import_alias_3016318__ = {}  %}\
 {% for __ignored__ in [0] %}\
 {% if deferred %}
 
 {% set foo = 'starta' %}\
-{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
+{% do __temp_meta_import_alias_3016318__.update({'foo': foo}) %}
 
 {% endif %}
 
 {% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}\
-{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
-{% do __temp_import_alias_3016318__.update({'foo': foo,'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
+{% do __temp_meta_import_alias_3016318__.update({'foo': foo}) %}
+{% do __temp_meta_import_alias_3016318__.update({'foo': foo,'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
 {% endfor %}\
-{% set bar1 = __temp_import_alias_3016318__ %}\
-{% set current_path,temp_current_path_952361846 = temp_current_path_952361846,null %}\
+{% set bar1 = __temp_meta_import_alias_3016318__ %}\
+{% set current_path,__temp_meta_current_path_461135149__ = __temp_meta_current_path_461135149__,null %}\
 {% enddo %}
 {{ bar1.foo }}
 {% do %}\
-{% set temp_current_path_952361846,current_path = current_path,'eager/supplements/deferred-modification.jinja' %}\
-{% set __temp_import_alias_3016319__ = {}  %}\
+{% set __temp_meta_current_path_461135149__,current_path = current_path,'eager/supplements/deferred-modification.jinja' %}\
+{% set __temp_meta_import_alias_3016319__ = {}  %}\
 {% for __ignored__ in [0] %}\
 {% if deferred %}
 
 {% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}\
-{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
+{% do __temp_meta_import_alias_3016319__.update({'foo': foo}) %}
 
 {% endif %}
 
 {% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}\
-{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
-{% do __temp_import_alias_3016319__.update({'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
+{% do __temp_meta_import_alias_3016319__.update({'foo': foo}) %}
+{% do __temp_meta_import_alias_3016319__.update({'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
 {% endfor %}\
-{% set bar2 = __temp_import_alias_3016319__ %}\
-{% set current_path,temp_current_path_952361846 = temp_current_path_952361846,null %}\
+{% set bar2 = __temp_meta_import_alias_3016319__ %}\
+{% set current_path,__temp_meta_current_path_461135149__ = __temp_meta_current_path_461135149__,null %}\
 {% enddo %}
 {{ bar2.foo }}
 
 {% do %}\
-{% set temp_current_path_952361846,current_path = current_path,'eager/supplements/deferred-modification.jinja' %}\
-{% set __temp_import_alias_3016318__ = {}  %}\
+{% set __temp_meta_current_path_461135149__,current_path = current_path,'eager/supplements/deferred-modification.jinja' %}\
+{% set __temp_meta_import_alias_3016318__ = {}  %}\
 {% for __ignored__ in [0] %}\
 {% if deferred %}
 
 {% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}\
-{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
+{% do __temp_meta_import_alias_3016318__.update({'foo': foo}) %}
 
 {% endif %}
 
 {% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}\
-{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
-{% do __temp_import_alias_3016318__.update({'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
+{% do __temp_meta_import_alias_3016318__.update({'foo': foo}) %}
+{% do __temp_meta_import_alias_3016318__.update({'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
 {% endfor %}\
-{% set bar1 = __temp_import_alias_3016318__ %}\
-{% set current_path,temp_current_path_952361846 = temp_current_path_952361846,null %}\
+{% set bar1 = __temp_meta_import_alias_3016318__ %}\
+{% set current_path,__temp_meta_current_path_461135149__ = __temp_meta_current_path_461135149__,null %}\
 {% enddo %}
 {{ bar1.foo }}
 {% do %}\
-{% set temp_current_path_952361846,current_path = current_path,'eager/supplements/deferred-modification.jinja' %}\
-{% set __temp_import_alias_3016319__ = {}  %}\
+{% set __temp_meta_current_path_461135149__,current_path = current_path,'eager/supplements/deferred-modification.jinja' %}\
+{% set __temp_meta_import_alias_3016319__ = {}  %}\
 {% for __ignored__ in [0] %}\
 {% if deferred %}
 
 {% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}\
-{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
+{% do __temp_meta_import_alias_3016319__.update({'foo': foo}) %}
 
 {% endif %}
 
 {% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}\
-{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
-{% do __temp_import_alias_3016319__.update({'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
+{% do __temp_meta_import_alias_3016319__.update({'foo': foo}) %}
+{% do __temp_meta_import_alias_3016319__.update({'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
 {% endfor %}\
-{% set bar2 = __temp_import_alias_3016319__ %}\
-{% set current_path,temp_current_path_952361846 = temp_current_path_952361846,null %}\
+{% set bar2 = __temp_meta_import_alias_3016319__ %}\
+{% set current_path,__temp_meta_current_path_461135149__ = __temp_meta_current_path_461135149__,null %}\
 {% enddo %}
 {{ bar2.foo }}
 {% endfor %}

--- a/src/test/resources/eager/does-not-override-import-modification-in-for/test.expected.jinja
+++ b/src/test/resources/eager/does-not-override-import-modification-in-for/test.expected.jinja
@@ -1,7 +1,7 @@
 {% set foo = 'start' %}\
 {% for __ignored__ in [0] %}
 {% do %}\
-{% set current_path = 'eager/supplements/deferred-modification.jinja' %}\
+{% set temp_current_path_952361846,current_path = current_path,'eager/supplements/deferred-modification.jinja' %}\
 {% set __temp_import_alias_3016318__ = {}  %}\
 {% for __ignored__ in [0] %}\
 {% if deferred %}
@@ -16,11 +16,11 @@
 {% do __temp_import_alias_3016318__.update({'foo': foo,'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
 {% endfor %}\
 {% set bar1 = __temp_import_alias_3016318__ %}\
-{% set current_path = 'eager/does-not-override-import-modification-in-for/test.jinja' %}\
+{% set current_path,temp_current_path_952361846 = temp_current_path_952361846,null %}\
 {% enddo %}
 {{ bar1.foo }}
 {% do %}\
-{% set current_path = 'eager/supplements/deferred-modification.jinja' %}\
+{% set temp_current_path_952361846,current_path = current_path,'eager/supplements/deferred-modification.jinja' %}\
 {% set __temp_import_alias_3016319__ = {}  %}\
 {% for __ignored__ in [0] %}\
 {% if deferred %}
@@ -35,12 +35,12 @@
 {% do __temp_import_alias_3016319__.update({'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
 {% endfor %}\
 {% set bar2 = __temp_import_alias_3016319__ %}\
-{% set current_path = 'eager/does-not-override-import-modification-in-for/test.jinja' %}\
+{% set current_path,temp_current_path_952361846 = temp_current_path_952361846,null %}\
 {% enddo %}
 {{ bar2.foo }}
 
 {% do %}\
-{% set current_path = 'eager/supplements/deferred-modification.jinja' %}\
+{% set temp_current_path_952361846,current_path = current_path,'eager/supplements/deferred-modification.jinja' %}\
 {% set __temp_import_alias_3016318__ = {}  %}\
 {% for __ignored__ in [0] %}\
 {% if deferred %}
@@ -55,11 +55,11 @@
 {% do __temp_import_alias_3016318__.update({'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
 {% endfor %}\
 {% set bar1 = __temp_import_alias_3016318__ %}\
-{% set current_path = 'eager/does-not-override-import-modification-in-for/test.jinja' %}\
+{% set current_path,temp_current_path_952361846 = temp_current_path_952361846,null %}\
 {% enddo %}
 {{ bar1.foo }}
 {% do %}\
-{% set current_path = 'eager/supplements/deferred-modification.jinja' %}\
+{% set temp_current_path_952361846,current_path = current_path,'eager/supplements/deferred-modification.jinja' %}\
 {% set __temp_import_alias_3016319__ = {}  %}\
 {% for __ignored__ in [0] %}\
 {% if deferred %}
@@ -74,7 +74,7 @@
 {% do __temp_import_alias_3016319__.update({'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
 {% endfor %}\
 {% set bar2 = __temp_import_alias_3016319__ %}\
-{% set current_path = 'eager/does-not-override-import-modification-in-for/test.jinja' %}\
+{% set current_path,temp_current_path_952361846 = temp_current_path_952361846,null %}\
 {% enddo %}
 {{ bar2.foo }}
 {% endfor %}

--- a/src/test/resources/eager/does-not-reconstruct-variable-in-wrong-scope/test.expected.jinja
+++ b/src/test/resources/eager/does-not-reconstruct-variable-in-wrong-scope/test.expected.jinja
@@ -12,8 +12,8 @@
 {% endset %}\
 {{ __macro_append_stuff_153654787_temp_variable_0__ }}
 {% endif %}
-
+{% for __ignored__ in [0] %}
 {% do my_list.append('d') %}
-
+{% endfor %}
 
 {{ my_list }}

--- a/src/test/resources/eager/handles-deferred-from-import-as/test.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-from-import-as/test.expected.jinja
@@ -1,7 +1,9 @@
 {% set myname = deferred + 7 %}\
 {% do %}
 {% set bar = myname + 19 %}
-Hello {{ myname }}
+{% for __ignored__ in [0] %}\
+Hello {{ myname }}\
+{% endfor %}
 {% set from_bar = bar %}\
 {% enddo %}\
 from_foo: Hello {{ myname }}

--- a/src/test/resources/eager/handles-deferred-import-vars/test.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-import-vars/test.expected.jinja
@@ -12,18 +12,18 @@ bar: {{ bar }}
 ---
 {% set myname = deferred + 7 %}\
 {% do %}\
-{% set temp_current_path_88106455,current_path = current_path,'eager/supplements/macro-and-set.jinja' %}\
-{% set __temp_import_alias_902286926__ = {}  %}\
+{% set __temp_meta_current_path_822093108__,current_path = current_path,'eager/supplements/macro-and-set.jinja' %}\
+{% set __temp_meta_import_alias_902286926__ = {}  %}\
 {% for __ignored__ in [0] %}
 {% set bar = myname + 19 %}\
-{% do __temp_import_alias_902286926__.update({'bar': bar}) %}
+{% do __temp_meta_import_alias_902286926__.update({'bar': bar}) %}
 {% for __ignored__ in [0] %}\
 Hello {{ myname }}\
 {% endfor %}
-{% do __temp_import_alias_902286926__.update({'import_resource_path': 'eager/supplements/macro-and-set.jinja'}) %}\
+{% do __temp_meta_import_alias_902286926__.update({'import_resource_path': 'eager/supplements/macro-and-set.jinja'}) %}\
 {% endfor %}\
-{% set simple = __temp_import_alias_902286926__ %}\
-{% set current_path,temp_current_path_88106455 = temp_current_path_88106455,null %}\
+{% set simple = __temp_meta_import_alias_902286926__ %}\
+{% set current_path,__temp_meta_current_path_822093108__ = __temp_meta_current_path_822093108__,null %}\
 {% enddo %}\
 simple.foo: {% set deferred_import_resource_path = 'eager/supplements/macro-and-set.jinja' %}\
 {% macro simple.foo() %}\

--- a/src/test/resources/eager/handles-deferred-import-vars/test.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-import-vars/test.expected.jinja
@@ -1,9 +1,13 @@
 {% set myname = deferred + 3 %}\
 {% do %}
 {% set bar = myname + 19 %}
-Hello {{ myname }}
+{% for __ignored__ in [0] %}\
+Hello {{ myname }}\
+{% endfor %}
 {% enddo %}\
-foo: Hello {{ myname }}
+foo: {% for __ignored__ in [0] %}\
+Hello {{ myname }}\
+{% endfor %}
 bar: {{ bar }}
 ---
 {% set myname = deferred + 7 %}\
@@ -13,7 +17,9 @@ bar: {{ bar }}
 {% for __ignored__ in [0] %}
 {% set bar = myname + 19 %}\
 {% do __temp_import_alias_902286926__.update({'bar': bar}) %}
-Hello {{ myname }}
+{% for __ignored__ in [0] %}\
+Hello {{ myname }}\
+{% endfor %}
 {% do __temp_import_alias_902286926__.update({'import_resource_path': 'eager/supplements/macro-and-set.jinja'}) %}\
 {% endfor %}\
 {% set simple = __temp_import_alias_902286926__ %}\

--- a/src/test/resources/eager/handles-deferred-import-vars/test.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-import-vars/test.expected.jinja
@@ -12,7 +12,7 @@ bar: {{ bar }}
 ---
 {% set myname = deferred + 7 %}\
 {% do %}\
-{% set current_path = 'eager/supplements/macro-and-set.jinja' %}\
+{% set temp_current_path_88106455,current_path = current_path,'eager/supplements/macro-and-set.jinja' %}\
 {% set __temp_import_alias_902286926__ = {}  %}\
 {% for __ignored__ in [0] %}
 {% set bar = myname + 19 %}\
@@ -23,7 +23,7 @@ Hello {{ myname }}\
 {% do __temp_import_alias_902286926__.update({'import_resource_path': 'eager/supplements/macro-and-set.jinja'}) %}\
 {% endfor %}\
 {% set simple = __temp_import_alias_902286926__ %}\
-{% set current_path = 'eager/handles-deferred-import-vars/test.jinja' %}\
+{% set current_path,temp_current_path_88106455 = temp_current_path_88106455,null %}\
 {% enddo %}\
 simple.foo: {% set deferred_import_resource_path = 'eager/supplements/macro-and-set.jinja' %}\
 {% macro simple.foo() %}\

--- a/src/test/resources/eager/handles-double-import-modification/test.expected.jinja
+++ b/src/test/resources/eager/handles-double-import-modification/test.expected.jinja
@@ -1,5 +1,5 @@
 {% do %}\
-{% set current_path = 'eager/supplements/deferred-modification.jinja' %}\
+{% set temp_current_path_952361846,current_path = current_path,'eager/supplements/deferred-modification.jinja' %}\
 {% set __temp_import_alias_3016318__ = {}  %}\
 {% for __ignored__ in [0] %}\
 {% if deferred %}
@@ -14,11 +14,11 @@
 {% do __temp_import_alias_3016318__.update({'foo': foo,'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
 {% endfor %}\
 {% set bar1 = __temp_import_alias_3016318__ %}\
-{% set current_path = 'eager/handles-double-import-modification/test.jinja' %}\
+{% set current_path,temp_current_path_952361846 = temp_current_path_952361846,null %}\
 {% enddo %}
 ---
 {% do %}\
-{% set current_path = 'eager/supplements/deferred-modification.jinja' %}\
+{% set temp_current_path_952361846,current_path = current_path,'eager/supplements/deferred-modification.jinja' %}\
 {% set __temp_import_alias_3016319__ = {}  %}\
 {% for __ignored__ in [0] %}\
 {% if deferred %}
@@ -33,7 +33,7 @@
 {% do __temp_import_alias_3016319__.update({'foo': foo,'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
 {% endfor %}\
 {% set bar2 = __temp_import_alias_3016319__ %}\
-{% set current_path = 'eager/handles-double-import-modification/test.jinja' %}\
+{% set current_path,temp_current_path_952361846 = temp_current_path_952361846,null %}\
 {% enddo %}
 ---
 {{ bar1.foo }}

--- a/src/test/resources/eager/handles-double-import-modification/test.expected.jinja
+++ b/src/test/resources/eager/handles-double-import-modification/test.expected.jinja
@@ -1,39 +1,39 @@
 {% do %}\
-{% set temp_current_path_952361846,current_path = current_path,'eager/supplements/deferred-modification.jinja' %}\
-{% set __temp_import_alias_3016318__ = {}  %}\
+{% set __temp_meta_current_path_461135149__,current_path = current_path,'eager/supplements/deferred-modification.jinja' %}\
+{% set __temp_meta_import_alias_3016318__ = {}  %}\
 {% for __ignored__ in [0] %}\
 {% if deferred %}
 
 {% set foo = 'a' %}\
-{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
+{% do __temp_meta_import_alias_3016318__.update({'foo': foo}) %}
 
 {% endif %}
 
 {% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}\
-{% do __temp_import_alias_3016318__.update({'foo': foo}) %}
-{% do __temp_import_alias_3016318__.update({'foo': foo,'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
+{% do __temp_meta_import_alias_3016318__.update({'foo': foo}) %}
+{% do __temp_meta_import_alias_3016318__.update({'foo': foo,'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
 {% endfor %}\
-{% set bar1 = __temp_import_alias_3016318__ %}\
-{% set current_path,temp_current_path_952361846 = temp_current_path_952361846,null %}\
+{% set bar1 = __temp_meta_import_alias_3016318__ %}\
+{% set current_path,__temp_meta_current_path_461135149__ = __temp_meta_current_path_461135149__,null %}\
 {% enddo %}
 ---
 {% do %}\
-{% set temp_current_path_952361846,current_path = current_path,'eager/supplements/deferred-modification.jinja' %}\
-{% set __temp_import_alias_3016319__ = {}  %}\
+{% set __temp_meta_current_path_461135149__,current_path = current_path,'eager/supplements/deferred-modification.jinja' %}\
+{% set __temp_meta_import_alias_3016319__ = {}  %}\
 {% for __ignored__ in [0] %}\
 {% if deferred %}
 
 {% set foo = 'a' %}\
-{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
+{% do __temp_meta_import_alias_3016319__.update({'foo': foo}) %}
 
 {% endif %}
 
 {% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}\
-{% do __temp_import_alias_3016319__.update({'foo': foo}) %}
-{% do __temp_import_alias_3016319__.update({'foo': foo,'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
+{% do __temp_meta_import_alias_3016319__.update({'foo': foo}) %}
+{% do __temp_meta_import_alias_3016319__.update({'foo': foo,'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
 {% endfor %}\
-{% set bar2 = __temp_import_alias_3016319__ %}\
-{% set current_path,temp_current_path_952361846 = temp_current_path_952361846,null %}\
+{% set bar2 = __temp_meta_import_alias_3016319__ %}\
+{% set current_path,__temp_meta_current_path_461135149__ = __temp_meta_current_path_461135149__,null %}\
 {% enddo %}
 ---
 {{ bar1.foo }}

--- a/src/test/resources/eager/handles-import-in-deferred-if/test.expected.jinja
+++ b/src/test/resources/eager/handles-import-in-deferred-if/test.expected.jinja
@@ -1,7 +1,7 @@
 {% set primary_line_height = 100 %}\
 {% if deferred %}
 {% do %}\
-{% set current_path = 'eager/supplements/set-val.jinja' %}\
+{% set temp_current_path_9523988,current_path = current_path,'eager/supplements/set-val.jinja' %}\
 {% set __temp_import_alias_902286926__ = {}  %}\
 {% for __ignored__ in [0] %}\
 {% set primary_line_height = 42 %}\
@@ -9,13 +9,13 @@
 {% do __temp_import_alias_902286926__.update({'primary_line_height': 42,'import_resource_path': 'eager/supplements/set-val.jinja'}) %}\
 {% endfor %}\
 {% set simple = __temp_import_alias_902286926__ %}\
-{% set current_path = 'eager/handles-import-in-deferred-if/test.jinja' %}\
+{% set current_path,temp_current_path_9523988 = temp_current_path_9523988,null %}\
 {% enddo %}
 {% else %}
 {% do %}\
-{% set current_path = 'eager/supplements/set-val.jinja' %}\
+{% set temp_current_path_9523988,current_path = current_path,'eager/supplements/set-val.jinja' %}\
 {% set primary_line_height = 42 %}\
-{% set current_path = 'eager/handles-import-in-deferred-if/test.jinja' %}\
+{% set current_path,temp_current_path_9523988 = temp_current_path_9523988,null %}\
 {% enddo %}
 {% endif %}
 simple.primary_line_height (deferred): {{ simple.primary_line_height }}

--- a/src/test/resources/eager/handles-import-in-deferred-if/test.expected.jinja
+++ b/src/test/resources/eager/handles-import-in-deferred-if/test.expected.jinja
@@ -1,21 +1,21 @@
 {% set primary_line_height = 100 %}\
 {% if deferred %}
 {% do %}\
-{% set temp_current_path_9523988,current_path = current_path,'eager/supplements/set-val.jinja' %}\
-{% set __temp_import_alias_902286926__ = {}  %}\
+{% set __temp_meta_current_path_724462665__,current_path = current_path,'eager/supplements/set-val.jinja' %}\
+{% set __temp_meta_import_alias_902286926__ = {}  %}\
 {% for __ignored__ in [0] %}\
 {% set primary_line_height = 42 %}\
-{% do __temp_import_alias_902286926__.update({'primary_line_height': primary_line_height}) %}\
-{% do __temp_import_alias_902286926__.update({'primary_line_height': 42,'import_resource_path': 'eager/supplements/set-val.jinja'}) %}\
+{% do __temp_meta_import_alias_902286926__.update({'primary_line_height': primary_line_height}) %}\
+{% do __temp_meta_import_alias_902286926__.update({'primary_line_height': 42,'import_resource_path': 'eager/supplements/set-val.jinja'}) %}\
 {% endfor %}\
-{% set simple = __temp_import_alias_902286926__ %}\
-{% set current_path,temp_current_path_9523988 = temp_current_path_9523988,null %}\
+{% set simple = __temp_meta_import_alias_902286926__ %}\
+{% set current_path,__temp_meta_current_path_724462665__ = __temp_meta_current_path_724462665__,null %}\
 {% enddo %}
 {% else %}
 {% do %}\
-{% set temp_current_path_9523988,current_path = current_path,'eager/supplements/set-val.jinja' %}\
+{% set __temp_meta_current_path_724462665__,current_path = current_path,'eager/supplements/set-val.jinja' %}\
 {% set primary_line_height = 42 %}\
-{% set current_path,temp_current_path_9523988 = temp_current_path_9523988,null %}\
+{% set current_path,__temp_meta_current_path_724462665__ = __temp_meta_current_path_724462665__,null %}\
 {% enddo %}
 {% endif %}
 simple.primary_line_height (deferred): {{ simple.primary_line_height }}

--- a/src/test/resources/eager/handles-same-name-import-var/test.expected.jinja
+++ b/src/test/resources/eager/handles-same-name-import-var/test.expected.jinja
@@ -1,6 +1,6 @@
 {% if deferred %}
 {% do %}\
-{% set current_path = 'eager/handles-same-name-import-var/set-var-and-deferred.jinja' %}\
+{% set temp_current_path_210763896,current_path = current_path,'eager/handles-same-name-import-var/set-var-and-deferred.jinja' %}\
 {% set __temp_import_alias_1059697132__ = {}  %}\
 {% for __ignored__ in [0] %}\
 {% if deferred %}
@@ -33,7 +33,7 @@
 {% do __temp_import_alias_1059697132__.update({'path': path,'import_resource_path': 'eager/handles-same-name-import-var/set-var-and-deferred.jinja','value': value}) %}\
 {% endfor %}\
 {% set my_var = __temp_import_alias_1059697132__ %}\
-{% set current_path = 'eager/handles-same-name-import-var/test.jinja' %}\
+{% set current_path,temp_current_path_210763896 = temp_current_path_210763896,null %}\
 {% enddo %}
 {{ filter:dictsort.filter(my_var, ____int3rpr3t3r____, false, 'key') }}
 {% endif %}

--- a/src/test/resources/eager/handles-same-name-import-var/test.expected.jinja
+++ b/src/test/resources/eager/handles-same-name-import-var/test.expected.jinja
@@ -1,39 +1,39 @@
 {% if deferred %}
 {% do %}\
-{% set temp_current_path_210763896,current_path = current_path,'eager/handles-same-name-import-var/set-var-and-deferred.jinja' %}\
-{% set __temp_import_alias_1059697132__ = {}  %}\
+{% set __temp_meta_current_path_944750549__,current_path = current_path,'eager/handles-same-name-import-var/set-var-and-deferred.jinja' %}\
+{% set __temp_meta_import_alias_1059697132__ = {}  %}\
 {% for __ignored__ in [0] %}\
 {% if deferred %}
 {% do %}\
 {% set path = '' %}\
-{% do __temp_import_alias_1059697132__.update({'path': path}) %}\
+{% do __temp_meta_import_alias_1059697132__.update({'path': path}) %}\
 {% set my_var = {'my_var': {'foo': 'bar'} }  %}\
-{% do __temp_import_alias_1059697132__.update({'my_var': my_var}) %}\
+{% do __temp_meta_import_alias_1059697132__.update({'my_var': my_var}) %}\
 {% set path = 'eager/handles-same-name-import-var/set-var-and-deferred.jinja' %}\
-{% do __temp_import_alias_1059697132__.update({'path': path}) %}\
+{% do __temp_meta_import_alias_1059697132__.update({'path': path}) %}\
 {% set value = null %}\
-{% do __temp_import_alias_1059697132__.update({'value': value}) %}\
+{% do __temp_meta_import_alias_1059697132__.update({'value': value}) %}\
 {% set my_var = {}  %}\
-{% do __temp_import_alias_1059697132__.update({'my_var': my_var}) %}\
+{% do __temp_meta_import_alias_1059697132__.update({'my_var': my_var}) %}\
 {% set my_var = {'foo': 'bar'}  %}\
-{% do __temp_import_alias_1059697132__.update({'my_var': my_var}) %}\
+{% do __temp_meta_import_alias_1059697132__.update({'my_var': my_var}) %}\
 {% set my_var = {'my_var': {'foo': 'bar'} }  %}\
-{% do __temp_import_alias_1059697132__.update({'my_var': my_var}) %}
+{% do __temp_meta_import_alias_1059697132__.update({'my_var': my_var}) %}
 {% set value = deferred %}\
-{% do __temp_import_alias_1059697132__.update({'value': value}) %}\
+{% do __temp_meta_import_alias_1059697132__.update({'value': value}) %}\
 {% set my_var = {'my_var': {'foo': 'bar'} }  %}\
-{% do __temp_import_alias_1059697132__.update({'my_var': my_var}) %}\
+{% do __temp_meta_import_alias_1059697132__.update({'my_var': my_var}) %}\
 {% do my_var.update({'value': value}) %}
 {% do my_var.update({'import_resource_path': 'eager/handles-same-name-import-var/set-var-and-deferred.jinja', 'value': value}) %}\
 {% set path = '' %}\
-{% do __temp_import_alias_1059697132__.update({'path': path}) %}\
+{% do __temp_meta_import_alias_1059697132__.update({'path': path}) %}\
 {% enddo %}
 {{ my_var }}
 {% endif %}
-{% do __temp_import_alias_1059697132__.update({'path': path,'import_resource_path': 'eager/handles-same-name-import-var/set-var-and-deferred.jinja','value': value}) %}\
+{% do __temp_meta_import_alias_1059697132__.update({'path': path,'import_resource_path': 'eager/handles-same-name-import-var/set-var-and-deferred.jinja','value': value}) %}\
 {% endfor %}\
-{% set my_var = __temp_import_alias_1059697132__ %}\
-{% set current_path,temp_current_path_210763896 = temp_current_path_210763896,null %}\
+{% set my_var = __temp_meta_import_alias_1059697132__ %}\
+{% set current_path,__temp_meta_current_path_944750549__ = __temp_meta_current_path_944750549__,null %}\
 {% enddo %}
 {{ filter:dictsort.filter(my_var, ____int3rpr3t3r____, false, 'key') }}
 {% endif %}

--- a/src/test/resources/eager/reconstructs-block-path-when-deferred-nested/test.expected.jinja
+++ b/src/test/resources/eager/reconstructs-block-path-when-deferred-nested/test.expected.jinja
@@ -3,18 +3,18 @@
 Parent's current path is: {{ '{{' + prefix + '_path }}\
 ' }}
 -----Pre-First-----
-{% set temp_current_path_344089506,current_path = current_path,'eager/reconstructs-block-path-when-deferred-nested/test.jinja' %}\
+{% set __temp_meta_current_path_389897147__,current_path = current_path,'eager/reconstructs-block-path-when-deferred-nested/test.jinja' %}\
 {% set prefix = deferred ? 'current' : 'current' %}\
 Child's first current path is: {{ '{{' + prefix + '_path }}\
 ' }}
-{% set current_path,temp_current_path_344089506 = temp_current_path_344089506,null %}
+{% set current_path,__temp_meta_current_path_389897147__ = __temp_meta_current_path_389897147__,null %}
 -----Post-First-----
 -----Pre-Second-----
-{% set temp_current_path_535589872,current_path = current_path,'eager/reconstructs-block-path-when-deferred-nested/middle.jinja' %}\
+{% set __temp_meta_current_path_198396781__,current_path = current_path,'eager/reconstructs-block-path-when-deferred-nested/middle.jinja' %}\
 {% set prefix = deferred ? 'current' : 'current' %}\
 Middle's second current path is: {{ '{{' + prefix + '_path }}\
 ' }}
-{% set current_path,temp_current_path_535589872 = temp_current_path_535589872,null %}
+{% set current_path,__temp_meta_current_path_198396781__ = __temp_meta_current_path_198396781__,null %}
 -----Post-Second-----
 Parent's current path is: {{ '{{' + prefix + '_path }}\
 ' }}

--- a/src/test/resources/eager/reconstructs-block-path-when-deferred-nested/test.expected.jinja
+++ b/src/test/resources/eager/reconstructs-block-path-when-deferred-nested/test.expected.jinja
@@ -3,20 +3,18 @@
 Parent's current path is: {{ '{{' + prefix + '_path }}\
 ' }}
 -----Pre-First-----
-{% set temp_current_path_995476186 = current_path %}\
-{% set current_path = 'eager/reconstructs-block-path-when-deferred-nested/test.jinja' %}\
+{% set temp_current_path_344089506,current_path = current_path,'eager/reconstructs-block-path-when-deferred-nested/test.jinja' %}\
 {% set prefix = deferred ? 'current' : 'current' %}\
 Child's first current path is: {{ '{{' + prefix + '_path }}\
 ' }}
-{% set current_path = temp_current_path_995476186 %}
+{% set current_path,temp_current_path_344089506 = temp_current_path_344089506,null %}
 -----Post-First-----
 -----Pre-Second-----
-{% set temp_current_path_751498149 = current_path %}\
-{% set current_path = 'eager/reconstructs-block-path-when-deferred-nested/middle.jinja' %}\
+{% set temp_current_path_535589872,current_path = current_path,'eager/reconstructs-block-path-when-deferred-nested/middle.jinja' %}\
 {% set prefix = deferred ? 'current' : 'current' %}\
 Middle's second current path is: {{ '{{' + prefix + '_path }}\
 ' }}
-{% set current_path = temp_current_path_751498149 %}
+{% set current_path,temp_current_path_535589872 = temp_current_path_535589872,null %}
 -----Post-Second-----
 Parent's current path is: {{ '{{' + prefix + '_path }}\
 ' }}

--- a/src/test/resources/eager/reconstructs-block-path-when-deferred/test.expected.jinja
+++ b/src/test/resources/eager/reconstructs-block-path-when-deferred/test.expected.jinja
@@ -3,11 +3,11 @@
 Parent's current path is: {{ '{{' + prefix + '_path }}\
 ' }}
 -----Pre-Block-----
-{% set temp_current_path_404322609,current_path = current_path,'eager/reconstructs-block-path-when-deferred/test.jinja' %}\
+{% set __temp_meta_current_path_329664044__,current_path = current_path,'eager/reconstructs-block-path-when-deferred/test.jinja' %}\
 {% set prefix = deferred ? 'current' : 'current' %}\
 Block's current path is: {{ '{{' + prefix + '_path }}\
 ' }}
-{% set current_path,temp_current_path_404322609 = temp_current_path_404322609,null %}
+{% set current_path,__temp_meta_current_path_329664044__ = __temp_meta_current_path_329664044__,null %}
 -----Post-Block-----
 Parent's current path is: {{ '{{' + prefix + '_path }}\
 ' }}

--- a/src/test/resources/eager/reconstructs-block-path-when-deferred/test.expected.jinja
+++ b/src/test/resources/eager/reconstructs-block-path-when-deferred/test.expected.jinja
@@ -3,12 +3,11 @@
 Parent's current path is: {{ '{{' + prefix + '_path }}\
 ' }}
 -----Pre-Block-----
-{% set temp_current_path_802878910 = current_path %}\
-{% set current_path = 'eager/reconstructs-block-path-when-deferred/test.jinja' %}\
+{% set temp_current_path_404322609,current_path = current_path,'eager/reconstructs-block-path-when-deferred/test.jinja' %}\
 {% set prefix = deferred ? 'current' : 'current' %}\
 Block's current path is: {{ '{{' + prefix + '_path }}\
 ' }}
-{% set current_path = temp_current_path_802878910 %}
+{% set current_path,temp_current_path_404322609 = temp_current_path_404322609,null %}
 -----Post-Block-----
 Parent's current path is: {{ '{{' + prefix + '_path }}\
 ' }}

--- a/src/test/resources/eager/reconstructs-value-used-in-deferred-imported-macro/test.expected.jinja
+++ b/src/test/resources/eager/reconstructs-value-used-in-deferred-imported-macro/test.expected.jinja
@@ -1,14 +1,14 @@
 {% do %}\
-{% set temp_current_path_205806278,current_path = current_path,'eager/reconstructs-value-used-in-deferred-imported-macro/uses-deferred-value-in-macro.jinja' %}\
-{% set __temp_import_alias_1081745881__ = {}  %}\
+{% set __temp_meta_current_path_528180375__,current_path = current_path,'eager/reconstructs-value-used-in-deferred-imported-macro/uses-deferred-value-in-macro.jinja' %}\
+{% set __temp_meta_import_alias_1081745881__ = {}  %}\
 {% for __ignored__ in [0] %}\
 {% set value = deferred %}\
-{% do __temp_import_alias_1081745881__.update({'value': value}) %}
+{% do __temp_meta_import_alias_1081745881__.update({'value': value}) %}
 
-{% do __temp_import_alias_1081745881__.update({'import_resource_path': 'eager/reconstructs-value-used-in-deferred-imported-macro/uses-deferred-value-in-macro.jinja','value': value}) %}\
+{% do __temp_meta_import_alias_1081745881__.update({'import_resource_path': 'eager/reconstructs-value-used-in-deferred-imported-macro/uses-deferred-value-in-macro.jinja','value': value}) %}\
 {% endfor %}\
-{% set macros = __temp_import_alias_1081745881__ %}\
-{% set current_path,temp_current_path_205806278 = temp_current_path_205806278,null %}\
+{% set macros = __temp_meta_import_alias_1081745881__ %}\
+{% set current_path,__temp_meta_current_path_528180375__ = __temp_meta_current_path_528180375__,null %}\
 {% enddo %}
 
 {% set deferred_import_resource_path = 'eager/reconstructs-value-used-in-deferred-imported-macro/uses-deferred-value-in-macro.jinja' %}\

--- a/src/test/resources/eager/reconstructs-value-used-in-deferred-imported-macro/test.expected.jinja
+++ b/src/test/resources/eager/reconstructs-value-used-in-deferred-imported-macro/test.expected.jinja
@@ -1,5 +1,5 @@
 {% do %}\
-{% set current_path = 'eager/reconstructs-value-used-in-deferred-imported-macro/uses-deferred-value-in-macro.jinja' %}\
+{% set temp_current_path_205806278,current_path = current_path,'eager/reconstructs-value-used-in-deferred-imported-macro/uses-deferred-value-in-macro.jinja' %}\
 {% set __temp_import_alias_1081745881__ = {}  %}\
 {% for __ignored__ in [0] %}\
 {% set value = deferred %}\
@@ -8,7 +8,7 @@
 {% do __temp_import_alias_1081745881__.update({'import_resource_path': 'eager/reconstructs-value-used-in-deferred-imported-macro/uses-deferred-value-in-macro.jinja','value': value}) %}\
 {% endfor %}\
 {% set macros = __temp_import_alias_1081745881__ %}\
-{% set current_path = 'eager/reconstructs-value-used-in-deferred-imported-macro/test.jinja' %}\
+{% set current_path,temp_current_path_205806278 = temp_current_path_205806278,null %}\
 {% enddo %}
 
 {% set deferred_import_resource_path = 'eager/reconstructs-value-used-in-deferred-imported-macro/uses-deferred-value-in-macro.jinja' %}\

--- a/src/test/resources/eager/uses-unique-macro-names/test.expected.jinja
+++ b/src/test/resources/eager/uses-unique-macro-names/test.expected.jinja
@@ -5,12 +5,12 @@ Goodbye {{ myname }}
 {% endset %}\
 {% set a = filter:upper.filter(__macro_foo_97643642_temp_variable_0__, ____int3rpr3t3r____) %}
 {% do %}\
-{% set temp_current_path_530872119,current_path = current_path,'eager/uses-unique-macro-names/macro-with-filter.jinja' %}
+{% set __temp_meta_current_path_203114534__,current_path = current_path,'eager/uses-unique-macro-names/macro-with-filter.jinja' %}
 {% set __macro_foo_1717337666_temp_variable_0__ %}\
 Hello {{ myname }}\
 {% endset %}\
 {% set b = filter:upper.filter(__macro_foo_1717337666_temp_variable_0__, ____int3rpr3t3r____) %}
-{% set current_path,temp_current_path_530872119 = temp_current_path_530872119,null %}\
+{% set current_path,__temp_meta_current_path_203114534__ = __temp_meta_current_path_203114534__,null %}\
 {% enddo %}
 {{ a }}
 {{ b }}

--- a/src/test/resources/eager/uses-unique-macro-names/test.expected.jinja
+++ b/src/test/resources/eager/uses-unique-macro-names/test.expected.jinja
@@ -5,12 +5,12 @@ Goodbye {{ myname }}
 {% endset %}\
 {% set a = filter:upper.filter(__macro_foo_97643642_temp_variable_0__, ____int3rpr3t3r____) %}
 {% do %}\
-{% set current_path = 'eager/uses-unique-macro-names/macro-with-filter.jinja' %}
+{% set temp_current_path_530872119,current_path = current_path,'eager/uses-unique-macro-names/macro-with-filter.jinja' %}
 {% set __macro_foo_1717337666_temp_variable_0__ %}\
 Hello {{ myname }}\
 {% endset %}\
 {% set b = filter:upper.filter(__macro_foo_1717337666_temp_variable_0__, ____int3rpr3t3r____) %}
-{% set current_path = 'eager/uses-unique-macro-names/test.jinja' %}\
+{% set current_path,temp_current_path_530872119 = temp_current_path_530872119,null %}\
 {% enddo %}
 {{ a }}
 {{ b }}

--- a/src/test/resources/eager/wraps-macro-that-would-change-current-path-in-child-scope/dir1/macro.jinja
+++ b/src/test/resources/eager/wraps-macro-that-would-change-current-path-in-child-scope/dir1/macro.jinja
@@ -1,0 +1,4 @@
+{% macro foo_importer() -%}
+  {%- include "../dir2/included.jinja" -%}
+  {%- print foo -%}
+{%- endmacro %}

--- a/src/test/resources/eager/wraps-macro-that-would-change-current-path-in-child-scope/dir2/included.jinja
+++ b/src/test/resources/eager/wraps-macro-that-would-change-current-path-in-child-scope/dir2/included.jinja
@@ -1,0 +1,2 @@
+{% set foo = deferred %}
+{{ foo }}

--- a/src/test/resources/eager/wraps-macro-that-would-change-current-path-in-child-scope/test.expected.jinja
+++ b/src/test/resources/eager/wraps-macro-that-would-change-current-path-in-child-scope/test.expected.jinja
@@ -1,0 +1,8 @@
+Starting current_path: starting path
+Intermediate current_path: starting path
+{% for __ignored__ in [0] %}\
+{% set foo = deferred %}
+{{ foo }}\
+{% print foo %}\
+{% endfor %}
+Ending current_path: starting path

--- a/src/test/resources/eager/wraps-macro-that-would-change-current-path-in-child-scope/test.expected.jinja
+++ b/src/test/resources/eager/wraps-macro-that-would-change-current-path-in-child-scope/test.expected.jinja
@@ -1,8 +1,10 @@
-Starting current_path: starting path
-Intermediate current_path: starting path
+Starting current_path: eager/wraps-macro-that-would-change-current-path-in-child-scope/test.jinja
+Intermediate current_path: eager/wraps-macro-that-would-change-current-path-in-child-scope/test.jinja
 {% for __ignored__ in [0] %}\
+{% set __temp_meta_current_path_629250870__,current_path = 'eager/wraps-macro-that-would-change-current-path-in-child-scope/test.jinja', 'eager/wraps-macro-that-would-change-current-path-in-child-scope/dir2/included.jinja' %}\
 {% set foo = deferred %}
 {{ foo }}\
+{% set current_path,__temp_meta_current_path_629250870__ = 'eager/wraps-macro-that-would-change-current-path-in-child-scope/test.jinja', null %}\
 {% print foo %}\
 {% endfor %}
-Ending current_path: starting path
+Ending current_path: eager/wraps-macro-that-would-change-current-path-in-child-scope/test.jinja

--- a/src/test/resources/eager/wraps-macro-that-would-change-current-path-in-child-scope/test.jinja
+++ b/src/test/resources/eager/wraps-macro-that-would-change-current-path-in-child-scope/test.jinja
@@ -1,0 +1,5 @@
+Starting current_path: {{ current_path }}
+{% from "./dir1/macro.jinja" import foo_importer -%}
+Intermediate current_path: {{ current_path }}
+{{ foo_importer() }}
+Ending current_path: {{ current_path }}

--- a/src/test/resources/tags/eager/extendstag/defers-block-in-extends-child.expected.jinja
+++ b/src/test/resources/tags/eager/extendstag/defers-block-in-extends-child.expected.jinja
@@ -2,12 +2,10 @@
 <html>
 <body>
 <div class="sidebar">
-{% set temp_current_path_743889914 = current_path %}\
-{% set current_path = '' %}\
+{% set temp_current_path_709120875,current_path = current_path,'' %}\
 <h3>Table Of Contents</h3>
 {{ deferred }}\
-{% set current_path = temp_current_path_743889914 %}
+{% set current_path,temp_current_path_709120875 = temp_current_path_709120875,null %}
 </div>
 </body>
 </html>
-

--- a/src/test/resources/tags/eager/extendstag/defers-block-in-extends-child.expected.jinja
+++ b/src/test/resources/tags/eager/extendstag/defers-block-in-extends-child.expected.jinja
@@ -2,10 +2,10 @@
 <html>
 <body>
 <div class="sidebar">
-{% set temp_current_path_709120875,current_path = current_path,'' %}\
+{% set __temp_meta_current_path_704376120__,current_path = current_path,'' %}\
 <h3>Table Of Contents</h3>
 {{ deferred }}\
-{% set current_path,temp_current_path_709120875 = temp_current_path_709120875,null %}
+{% set current_path,__temp_meta_current_path_704376120__ = __temp_meta_current_path_704376120__,null %}
 </div>
 </body>
 </html>

--- a/src/test/resources/tags/eager/extendstag/defers-super-block-with-deferred.expected.jinja
+++ b/src/test/resources/tags/eager/extendstag/defers-super-block-with-deferred.expected.jinja
@@ -2,12 +2,12 @@
 <html>
 <body>
 <div class="sidebar">
-{% set temp_current_path_709120875,current_path = current_path,'' %}\
+{% set __temp_meta_current_path_704376120__,current_path = current_path,'' %}\
 <h3>Table Of Contents</h3>
 
 <p>this is a {{ deferred }}\
 .</p>
-{% set current_path,temp_current_path_709120875 = temp_current_path_709120875,null %}
+{% set current_path,__temp_meta_current_path_704376120__ = __temp_meta_current_path_704376120__,null %}
 </div>
 </body>
 </html>

--- a/src/test/resources/tags/eager/extendstag/defers-super-block-with-deferred.expected.jinja
+++ b/src/test/resources/tags/eager/extendstag/defers-super-block-with-deferred.expected.jinja
@@ -2,13 +2,12 @@
 <html>
 <body>
 <div class="sidebar">
-{% set temp_current_path_743889914 = current_path %}\
-{% set current_path = '' %}\
+{% set temp_current_path_709120875,current_path = current_path,'' %}\
 <h3>Table Of Contents</h3>
 
 <p>this is a {{ deferred }}\
 .</p>
-{% set current_path = temp_current_path_743889914 %}
+{% set current_path,temp_current_path_709120875 = temp_current_path_709120875,null %}
 </div>
 </body>
 </html>

--- a/src/test/resources/tags/eager/extendstag/reconstructs-deferred-outside-block.expected.jinja
+++ b/src/test/resources/tags/eager/extendstag/reconstructs-deferred-outside-block.expected.jinja
@@ -9,10 +9,10 @@
 <html>
 <body>
 <div class="sidebar">
-{% set temp_current_path_709120875,current_path = current_path,'' %}\
+{% set __temp_meta_current_path_704376120__,current_path = current_path,'' %}\
 <h3>Table Of Contents</h3>
 <p>{{ foo }}\
-.</p>{% set current_path,temp_current_path_709120875 = temp_current_path_709120875,null %}
+.</p>{% set current_path,__temp_meta_current_path_704376120__ = __temp_meta_current_path_704376120__,null %}
 </div>
 </body>
 </html>

--- a/src/test/resources/tags/eager/extendstag/reconstructs-deferred-outside-block.expected.jinja
+++ b/src/test/resources/tags/eager/extendstag/reconstructs-deferred-outside-block.expected.jinja
@@ -9,11 +9,10 @@
 <html>
 <body>
 <div class="sidebar">
-{% set temp_current_path_743889914 = current_path %}\
-{% set current_path = '' %}\
+{% set temp_current_path_709120875,current_path = current_path,'' %}\
 <h3>Table Of Contents</h3>
 <p>{{ foo }}\
-.</p>{% set current_path = temp_current_path_743889914 %}
+.</p>{% set current_path,temp_current_path_709120875 = temp_current_path_709120875,null %}
 </div>
 </body>
 </html>

--- a/src/test/resources/tags/eager/includetag/includes-deferred.expected.jinja
+++ b/src/test/resources/tags/eager/includetag/includes-deferred.expected.jinja
@@ -1,7 +1,7 @@
 Foo begins as: abc
-{% set temp_current_path_772637950,current_path = current_path,'sets-to-deferred.jinja' %}\
+{% set __temp_meta_current_path_38651297__,current_path = current_path,'sets-to-deferred.jinja' %}\
 {% set foo = deferred %}
 foo is now {{ deferred }}\
 .
-{% set current_path,temp_current_path_772637950 = temp_current_path_772637950,null %}
+{% set current_path,__temp_meta_current_path_38651297__ = __temp_meta_current_path_38651297__,null %}
 Foo ends as: {{ foo }}

--- a/src/test/resources/tags/eager/includetag/includes-deferred.expected.jinja
+++ b/src/test/resources/tags/eager/includetag/includes-deferred.expected.jinja
@@ -1,7 +1,7 @@
 Foo begins as: abc
-{% set current_path = 'sets-to-deferred.jinja' %}\
+{% set temp_current_path_772637950,current_path = current_path,'sets-to-deferred.jinja' %}\
 {% set foo = deferred %}
 foo is now {{ deferred }}\
 .
-{% set current_path = '' %}
+{% set current_path,temp_current_path_772637950 = temp_current_path_772637950,null %}
 Foo ends as: {{ foo }}


### PR DESCRIPTION
This PR takes the newer way of reconstructing the current_path, introduced in https://github.com/HubSpot/jinjava/pull/1177 and applies it to more places where we reconstruct the path by wrapping the initial and new path.

It also adds a new class for tracking the meta context variables `MetaContextVariables`, specifically causing the temporary variables for `current_path` and import resource alias to be considered as meta context variables.

This is a more comprehensive way of solving https://github.com/HubSpot/jinjava/pull/1199 and it also doesn't change non-eager execution code. It does that by wrapping the partially evaluated macro function output in a child scope (with `{% for __ignored__ in [0] %}`)

Several minor QOL improvements are made here too.
