### PR TITLE
Construct EagerMacroFunction when aliasing macro function from {% from %} tag

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -202,6 +202,10 @@ public class MacroFunction extends AbstractCallableMethod {
     );
   }
 
+  public MacroFunction cloneWithNewName(String name) {
+    return new MacroFunction(this, name);
+  }
+
   private boolean alreadyDeferredInEarlierCall(
     String key,
     JinjavaInterpreter interpreter

--- a/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
@@ -58,6 +58,10 @@ public class EagerMacroFunction extends MacroFunction {
     );
   }
 
+  EagerMacroFunction(MacroFunction source, String name) {
+    super(source, name);
+  }
+
   public Object doEvaluate(
     Map<String, Object> argMap,
     Map<String, Object> kwargMap,
@@ -333,5 +337,10 @@ public class EagerMacroFunction extends MacroFunction {
   @Override
   public int hashCode() {
     return super.hashCode();
+  }
+
+  @Override
+  public EagerMacroFunction cloneWithNewName(String name) {
+    return new EagerMacroFunction(this, name);
   }
 }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/FromTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/FromTag.java
@@ -170,7 +170,7 @@ public class FromTag implements Tag {
       if (val != null) {
         MacroFunction toImport = (MacroFunction) val;
         if (!importMapping.getKey().equals(importMapping.getValue())) {
-          toImport = new MacroFunction(toImport, importMapping.getValue());
+          toImport = toImport.cloneWithNewName(importMapping.getValue());
         }
         interpreter.getContext().addGlobalMacro(toImport);
       } else {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCallTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCallTag.java
@@ -7,6 +7,7 @@ import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter.InterpreterScopeClosable;
 import com.hubspot.jinjava.lib.expression.EagerExpressionStrategy;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
+import com.hubspot.jinjava.lib.fn.eager.EagerMacroFunction;
 import com.hubspot.jinjava.lib.tag.CallTag;
 import com.hubspot.jinjava.lib.tag.FlexibleTag;
 import com.hubspot.jinjava.tree.TagNode;
@@ -45,7 +46,7 @@ public class EagerCallTag extends EagerStateChangingTag<CallTag> {
     LengthLimitingStringJoiner joiner;
     try (InterpreterScopeClosable c = interpreter.enterNonStackingScope()) {
       caller =
-        new MacroFunction(
+        new EagerMacroFunction(
           tagNode.getChildren(),
           "caller",
           new LinkedHashMap<>(),

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTag.java
@@ -6,6 +6,7 @@ import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.InterpretException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.lib.fn.MacroFunction;
+import com.hubspot.jinjava.lib.fn.eager.EagerMacroFunction;
 import com.hubspot.jinjava.lib.tag.DoTag;
 import com.hubspot.jinjava.lib.tag.FromTag;
 import com.hubspot.jinjava.loader.RelativePathResolver;
@@ -41,7 +42,7 @@ public class EagerFromTag extends EagerStateChangingTag<FromTag> {
       imports
         .values()
         .forEach(value -> {
-          MacroFunction deferredMacro = new MacroFunction(
+          MacroFunction deferredMacro = new EagerMacroFunction(
             null,
             value,
             null,

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1634,4 +1634,9 @@ public class EagerTest {
       "keeps-meta-context-variables-through-import/test"
     );
   }
+
+  @Test
+  public void itReconstructsFromedMacro() {
+    expectedTemplateInterpreter.assertExpectedOutput("reconstructs-fromed-macro/test");
+  }
 }

--- a/src/test/resources/eager/defers-caller/test.expected.jinja
+++ b/src/test/resources/eager/defers-caller/test.expected.jinja
@@ -1,4 +1,6 @@
 {% for __ignored__ in [0] %}\
 Jack says:
+{% for __ignored__ in [0] %}\
 How do I get a {{ deferred }}\
-?{% endfor %}
+?{% endfor %}\
+{% endfor %}

--- a/src/test/resources/eager/handles-deferred-from-import-as/test.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-from-import-as/test.expected.jinja
@@ -6,5 +6,7 @@ Hello {{ myname }}\
 {% endfor %}
 {% set from_bar = bar %}\
 {% enddo %}\
-from_foo: Hello {{ myname }}
+from_foo: {% for __ignored__ in [0] %}\
+Hello {{ myname }}\
+{% endfor %}
 from_bar: {{ from_bar }}

--- a/src/test/resources/eager/handles-deferred-modification-in-caller/test.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-modification-in-caller/test.expected.jinja
@@ -1,7 +1,10 @@
 {% set my_list = ['a', 'b'] %}\
 {% set __macro_callerino_729568755_temp_variable_0__ %}\
+{% set __macro_caller_172086791_temp_variable_0__ %}\
 {% do my_list.append(deferred) %}\
 {{ my_list }}\
+{% endset %}\
+{{ __macro_caller_172086791_temp_variable_0__ }}\
 {% do my_list.append('d') %}\
 {% endset %}\
 {% call __macro_callerino_729568755_temp_variable_0__ %}\

--- a/src/test/resources/eager/reconstructs-fromed-macro/has-macro.jinja
+++ b/src/test/resources/eager/reconstructs-fromed-macro/has-macro.jinja
@@ -1,0 +1,3 @@
+{% macro upper(param) %}
+ {{ param|upper }}
+{% endmacro %}

--- a/src/test/resources/eager/reconstructs-fromed-macro/test.expected.jinja
+++ b/src/test/resources/eager/reconstructs-fromed-macro/test.expected.jinja
@@ -1,0 +1,6 @@
+{% set deferred_import_resource_path = 'eager/reconstructs-fromed-macro/has-macro.jinja' %}\
+{% macro to_upper(param) %}
+ {{ filter:upper.filter(param, ____int3rpr3t3r____) }}
+{% endmacro %}\
+{% set deferred_import_resource_path = null %}\
+{{ to_upper(deferred) }}

--- a/src/test/resources/eager/reconstructs-fromed-macro/test.jinja
+++ b/src/test/resources/eager/reconstructs-fromed-macro/test.jinja
@@ -1,0 +1,3 @@
+{% from './has-macro.jinja' import upper as to_upper %}
+
+{{ to_upper(deferred) }}


### PR DESCRIPTION
MacroFunctions made in tags used in eager execution should be EagerMacroFunctions. This was done for those created from the `{% macro %}` (EagerMacroTag) tag, but not from EagerCallTag or EagerFromTag.

Specifically, there's a ClassCastException that can happen due to the assumption that in eager execution all `MacroFunction` objects are `EagerMacroFunction` instances. This could happen when successfully importing a macro function using a `FromTag` with an alias, a bug I introduced with https://github.com/HubSpot/jinjava/pull/1117