### PR TITLE
Remove Guava dependency with no direct use in codebase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,10 +110,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
     </dependency>


### PR DESCRIPTION
I found no direct use of Guava library in library codebase. Why should we have it in dependencies? Use the jininja often clashes with project`s Guava library version.