### PR TITLE
Apply whitespace rules for LStrip and Trim to comment blocks, resolves #1218

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -170,14 +170,17 @@ public class TreeParser {
 
   private Node text(TextToken textToken) {
     if (interpreter.getConfig().isLstripBlocks()) {
-      if (scanner.hasNext() && scanner.peek().getType() == symbols.getTag()) {
-        textToken =
-          new TextToken(
-            StringUtils.stripEnd(textToken.getImage(), "\t "),
-            textToken.getLineNumber(),
-            textToken.getStartPosition(),
-            symbols
-          );
+      if (scanner.hasNext()) {
+        final int nextTokenType = scanner.peek().getType();
+        if (nextTokenType == symbols.getTag() || nextTokenType == symbols.getNote()) {
+          textToken =
+            new TextToken(
+              StringUtils.stripEnd(textToken.getImage(), "\t "),
+              textToken.getLineNumber(),
+              textToken.getStartPosition(),
+              symbols
+            );
+        }
       }
     }
 

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TokenScanner.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TokenScanner.java
@@ -253,13 +253,18 @@ public class TokenScanner extends AbstractIterator<Token> {
       lastStart - lastNewlinePos + 1
     );
 
-    if (t instanceof TagToken) {
-      if (config.isTrimBlocks() && currPost < length && is[currPost] == '\n') {
-        lastNewlinePos = currPost;
-        ++currPost;
-        ++tokenStart;
-      }
+    if (
+      (t instanceof TagToken || t instanceof NoteToken) &&
+      config.isTrimBlocks() &&
+      currPost < length &&
+      is[currPost] == '\n'
+    ) {
+      lastNewlinePos = currPost;
+      ++currPost;
+      ++tokenStart;
+    }
 
+    if (t instanceof TagToken) {
       TagToken tt = (TagToken) t;
       if ("raw".equals(tt.getTagName())) {
         inRaw = 1;

--- a/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
@@ -148,6 +148,18 @@ public class TreeParserTest extends BaseInterpretingTest {
   }
 
   @Test
+  public void trimAndLstripCommentBlocks() {
+    interpreter =
+      new Jinjava(
+        JinjavaConfig.newBuilder().withLstripBlocks(true).withTrimBlocks(true).build()
+      )
+        .newInterpreter();
+
+    assertThat(interpreter.render(parse("parse/tokenizer/whitespace-comment-tags.jinja")))
+      .isEqualTo("<div>\n" + "        yay\n" + "        whoop\n" + "</div>\n");
+  }
+
+  @Test
   public void itWarnsAgainstMissingStartTags() {
     String expression = "{% if true %} foo {% endif %} {% endif %}";
     final Node tree = new TreeParser(interpreter, expression).buildTree();

--- a/src/test/java/com/hubspot/jinjava/tree/parse/TokenWhitespaceTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/parse/TokenWhitespaceTest.java
@@ -21,6 +21,16 @@ public class TokenWhitespaceTest {
     assertThat(tokens.get(2).getImage()).isEqualTo("        yay\n    ");
   }
 
+  @Test
+  public void trimBlocksTrimsAfterCommentTag() {
+    List<Token> tokens = scanTokens(
+      "parse/tokenizer/whitespace-comment-tags.jinja",
+      trimBlocksConfig()
+    );
+    assertThat(tokens.get(2).getImage()).isEqualTo("        yay\n    ");
+    assertThat(tokens.get(4).getImage()).isEqualTo("        whoop\n</div>\n");
+  }
+
   private List<Token> scanTokens(String srcPath, JinjavaConfig config) {
     try {
       return Lists.newArrayList(

--- a/src/test/resources/parse/tokenizer/whitespace-comment-tags.jinja
+++ b/src/test/resources/parse/tokenizer/whitespace-comment-tags.jinja
@@ -1,0 +1,8 @@
+<div>
+    {# a comment #}
+        yay
+    {# another comment
+       This time, over multiple lines
+     #}
+        whoop
+</div>


### PR DESCRIPTION
Fixing bug: LStrip and Trim are not being applied consistently with other jinja engines when it comes to comment blocks.

Example python behaviour (Jinja2):
```
Python 3.10.12 (main, Sep 11 2024, 15:47:36) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from jinja2 import Environment
>>> env = Environment(trim_blocks=True, lstrip_blocks=True)
>>> template = env.from_string("""<div>
...     {# a comment #}
...         yay
...     {# another comment
...        This time, over multiple lines
...      #}
...         whoop
... </div>""")
>>> template.render()
'<div>\n        yay\n        whoop\n</div>'
>>> print(template.render())
<div>
        yay
        whoop
</div>
>>>
```