### PR TITLE
Remove hubspot-style and immutables-exceptions dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,6 @@
 
     <dep.plugin.jacoco.version>0.8.3</dep.plugin.jacoco.version>
     <dep.plugin.javadoc.version>3.0.1</dep.plugin.javadoc.version>
-    <dep.hubspot-immutables.version>1.9</dep.hubspot-immutables.version>
 
 
     <basepom.test.add.opens>
@@ -90,16 +89,6 @@
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jdk8</artifactId>
         <version>2.14.0</version>
-      </dependency>
-      <dependency>
-        <groupId>com.hubspot.immutables</groupId>
-        <artifactId>hubspot-style</artifactId>
-        <version>${dep.hubspot-immutables.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.hubspot.immutables</groupId>
-        <artifactId>immutables-exceptions</artifactId>
-        <version>${dep.hubspot-immutables.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -203,15 +192,6 @@
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.hubspot.immutables</groupId>
-      <artifactId>hubspot-style</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.hubspot.immutables</groupId>
-      <artifactId>immutables-exceptions</artifactId>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/hubspot/jinjava/interpret/ContextConfigurationIF.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/ContextConfigurationIF.java
@@ -1,14 +1,14 @@
 package com.hubspot.jinjava.interpret;
 
-import com.hubspot.immutables.style.HubSpotImmutableStyle;
 import com.hubspot.jinjava.lib.expression.DefaultExpressionStrategy;
 import com.hubspot.jinjava.lib.expression.ExpressionStrategy;
+import com.hubspot.jinjava.style.JinjavaImmutableStyle;
 import javax.annotation.Nullable;
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 
 @Immutable(singleton = true)
-@HubSpotImmutableStyle
+@JinjavaImmutableStyle
 public interface ContextConfigurationIF {
   @Default
   default ExpressionStrategy getExpressionStrategy() {
@@ -49,7 +49,7 @@ public interface ContextConfigurationIF {
   }
 
   @Immutable(singleton = true)
-  @HubSpotImmutableStyle
+  @JinjavaImmutableStyle
   interface ErrorHandlingStrategyIF {
     @Default
     default TemplateErrorTypeHandlingStrategy getFatalErrorStrategy() {

--- a/src/main/java/com/hubspot/jinjava/style/JinjavaImmutableStyle.java
+++ b/src/main/java/com/hubspot/jinjava/style/JinjavaImmutableStyle.java
@@ -1,0 +1,25 @@
+package com.hubspot.jinjava.style;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.immutables.value.Value.Style;
+import org.immutables.value.Value.Style.ImplementationVisibility;
+
+@Target({ ElementType.PACKAGE, ElementType.TYPE })
+@Retention(RetentionPolicy.CLASS)
+@JsonSerialize
+@Style(
+  get = { "is*", "get*" },
+  init = "set*",
+  typeAbstract = { "Abstract*", "*IF" },
+  typeImmutable = "*",
+  optionalAcceptNullable = true,
+  forceJacksonPropertyNames = false,
+  visibility = ImplementationVisibility.SAME,
+  redactedMask = "**REDACTED**"
+)
+public @interface JinjavaImmutableStyle {
+}


### PR DESCRIPTION
As pointed out in https://github.com/HubSpot/jinjava/pull/1213, `immutables-exceptions` now has a guava dependency since https://github.com/HubSpot/hubspot-immutables/pull/40.

If we're going to start removing our guava usage, we can start here because it's certainly unnecessary.