### PR TITLE
Defer BreakTag and ContinueTag if they're used in deferredExecutionMode

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/BreakTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/BreakTag.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.lib.tag;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaTextMateSnippet;
+import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.NotInLoopException;
 import com.hubspot.jinjava.tree.TagNode;
@@ -31,6 +32,9 @@ public class BreakTag implements Tag {
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     Object loop = interpreter.getContext().get(ForTag.LOOP);
     if (loop instanceof ForLoop) {
+      if (interpreter.getContext().isDeferredExecutionMode()) {
+        throw new DeferredValueException("Deferred break");
+      }
       ForLoop forLoop = (ForLoop) loop;
       forLoop.doBreak();
     } else {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ContinueTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ContinueTag.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.lib.tag;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaTextMateSnippet;
+import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.NotInLoopException;
 import com.hubspot.jinjava.tree.TagNode;
@@ -29,6 +30,9 @@ public class ContinueTag implements Tag {
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     Object loop = interpreter.getContext().get(ForTag.LOOP);
     if (loop instanceof ForLoop) {
+      if (interpreter.getContext().isDeferredExecutionMode()) {
+        throw new DeferredValueException("Deferred continue");
+      }
       ForLoop forLoop = (ForLoop) loop;
       forLoop.doContinue();
     } else {

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactory.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactory.java
@@ -5,7 +5,9 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.jinjava.lib.tag.BlockTag;
+import com.hubspot.jinjava.lib.tag.BreakTag;
 import com.hubspot.jinjava.lib.tag.CallTag;
+import com.hubspot.jinjava.lib.tag.ContinueTag;
 import com.hubspot.jinjava.lib.tag.CycleTag;
 import com.hubspot.jinjava.lib.tag.DoTag;
 import com.hubspot.jinjava.lib.tag.ElseIfTag;
@@ -54,6 +56,8 @@ public class EagerTagFactory {
     .add(ElseTag.class)
     .add(RawTag.class)
     .add(ExtendsTag.class) // TODO support reconstructing extends tags
+    .add(BreakTag.class) // TODO support eager break tag
+    .add(ContinueTag.class) // TODO support eager continue tag
     .build();
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1644,4 +1644,24 @@ public class EagerTest {
       "wraps-macro-that-would-change-current-path-in-child-scope/test"
     );
   }
+
+  @Test
+  public void itHandlesDeferredBreakInForLoop() {
+    String input = expectedTemplateInterpreter.getFixtureTemplate(
+      "handles-deferred-break-in-for-loop/test"
+    );
+    interpreter.render(input);
+    // We don't support this yet
+    assertThat(interpreter.getContext().getDeferredNodes()).isNotEmpty();
+  }
+
+  @Test
+  public void itHandlesDeferredContinueInForLoop() {
+    String input = expectedTemplateInterpreter.getFixtureTemplate(
+      "handles-deferred-continue-in-for-loop/test"
+    );
+    interpreter.render(input);
+    // We don't support this yet
+    assertThat(interpreter.getContext().getDeferredNodes()).isNotEmpty();
+  }
 }

--- a/src/test/resources/eager/handles-deferred-break-in-for-loop/test.jinja
+++ b/src/test/resources/eager/handles-deferred-break-in-for-loop/test.jinja
@@ -1,0 +1,8 @@
+Start loop
+{% for i in range(5) %}
+  {% if deferred %}
+    {% break %}
+  {% endif %}
+  i is: {{ i }}
+{% endfor %}
+End loop

--- a/src/test/resources/eager/handles-deferred-continue-in-for-loop/test.jinja
+++ b/src/test/resources/eager/handles-deferred-continue-in-for-loop/test.jinja
@@ -1,0 +1,8 @@
+Start loop
+{% for i in range(5) %}
+  {% if deferred %}
+    {% continue %}
+  {% endif %}
+  i is: {{ i }}
+{% endfor %}
+End loop


### PR DESCRIPTION

If we are running a for loop and cannot evaluate whether it will be "broken" or "continued", we'll need special logic to handle that and make sure that the for-loop is reconstructed properly and that the deferred execution mode is propagated to the for-loop.

For now, we can simply defer these nodes, which will make this change compatible with eager execution insofar as deferred nodes signify that something isn't supported.

Eventually, we can handle them, but I don't want to block getting this jinja feature out waiting on that.
