### PR TITLE
Don't make new call stacks when interpreting a CallTag so that the max render depth is tracked properly

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/CallTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/CallTag.java
@@ -67,7 +67,7 @@ public class CallTag implements Tag {
   public String interpret(TagNode tagNode, JinjavaInterpreter interpreter) {
     String macroExpr = "{{" + tagNode.getHelpers().trim() + "}}";
 
-    try (InterpreterScopeClosable c = interpreter.enterScope()) {
+    try (InterpreterScopeClosable c = interpreter.enterNonStackingScope()) {
       LinkedHashMap<String, Object> args = new LinkedHashMap<>();
       MacroFunction caller = new MacroFunction(
         tagNode.getChildren(),

--- a/src/test/java/com/hubspot/jinjava/lib/tag/CallTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/CallTagTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.io.Resources;
 import com.hubspot.jinjava.BaseInterpretingTest;
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.JinjavaConfig;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.jsoup.Jsoup;
@@ -18,6 +21,28 @@ public class CallTagTest extends BaseInterpretingTest {
     assertThat(dom.select("div h2").text().trim()).isEqualTo("Hello World");
     assertThat(dom.select("div.contents").text().trim())
       .isEqualTo("This is a simple dialog rendered by using a macro and a call block.");
+  }
+
+  @Test
+  public void itDoesNotDoubleCountCallTagTowardsDepth() throws IOException {
+    interpreter =
+      new Jinjava(
+        JinjavaConfig
+          .newBuilder()
+          .withEnableRecursiveMacroCalls(true)
+          .withMaxMacroRecursionDepth(6) // There are 3 call tags, but a total of 6 "macro" calls happening in this file as each call to `caller()` counts too
+          .build()
+      )
+        .newInterpreter();
+    JinjavaInterpreter.pushCurrent(interpreter);
+
+    try {
+      String template = fixture("multiple");
+      interpreter.render(template);
+      assertThat(interpreter.getErrorsCopy()).isEmpty();
+    } finally {
+      JinjavaInterpreter.popCurrent();
+    }
   }
 
   private String fixture(String name) {

--- a/src/test/resources/tags/calltag/multiple.jinja
+++ b/src/test/resources/tags/calltag/multiple.jinja
@@ -1,0 +1,4 @@
+{% macro test1() %}1{{ caller() }}{% endmacro %}
+{% macro test2() %}2{{ caller() }}{% endmacro %}
+{% macro test3() %}3{{ caller() }}{% endmacro %}
+{% call test1() %}{% call test2() %}{% call test3() %}{% endcall %}{% endcall %}{% endcall %}


### PR DESCRIPTION
Minor bug in max macro depth recursion tracking: https://github.com/HubSpot/jinjava/pull/308

CallTags don't need to count towards the recursion depth, otherwise a use of a call tag with a macro function counts for 3 render depth, when it should really just count for 2.