### PR TITLE
Target Java 17 with 2.8.0-SNAPSHOT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 17 ]
     name: jdk-${{ matrix.java }}
     steps:
       - uses: actions/checkout@v3

--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,12 @@
 
   <groupId>com.hubspot.jinjava</groupId>
   <artifactId>jinjava</artifactId>
-  <version>2.7.5-SNAPSHOT</version>
+  <version>2.8.0-SNAPSHOT</version>
   <description>Jinja templating engine implemented in Java</description>
 
   <properties>
-    <project.build.targetJdk>8</project.build.targetJdk>
-    <project.build.releaseJdk>8</project.build.releaseJdk>
+    <project.build.targetJdk>17</project.build.targetJdk>
+    <project.build.releaseJdk>17</project.build.releaseJdk>
 
     <dep.plugin.jacoco.version>0.8.3</dep.plugin.jacoco.version>
     <dep.plugin.javadoc.version>3.0.1</dep.plugin.javadoc.version>


### PR DESCRIPTION
Bump target version from `8` to `17`.
Removes the Java 11 workflow since targeting java 17 does not work in java 11.

We are preparing for this to be a major release as Jinjava will no longer work on JVMs running pre-17 versions of java.