### PR TITLE
When not using eager execution, don't modify the non-meta context variables

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ForTag.java
@@ -163,7 +163,6 @@ public class ForTag implements Tag {
   ) {
     ForLoop loop = ObjectIterator.getLoop(collection);
 
-    interpreter.getContext().addNonMetaContextVariables(loopVars);
     try (InterpreterScopeClosable c = interpreter.enterScope()) {
       if (interpreter.isValidationMode() && !loop.hasNext()) {
         loop = ObjectIterator.getLoop(new DummyObject());
@@ -292,8 +291,6 @@ public class ForTag implements Tag {
         }
       }
       return checkLoopVariable(interpreter, buff);
-    } finally {
-      interpreter.getContext().removeNonMetaContextVariables(loopVars);
     }
   }
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerForTag.java
@@ -56,16 +56,26 @@ public class EagerForTag extends EagerTagDecorator<ForTag> {
       EagerExecutionResult result = EagerContextWatcher.executeInChildContext(
         eagerInterpreter -> {
           EagerExpressionResult expressionResult = EagerExpressionResult.fromSupplier(
-            () ->
-              getTag()
-                .renderForCollection(
-                  tagNode,
-                  eagerInterpreter,
-                  loopVarsAndExpression.getLeft(),
-                  !collectionResult.getResult().toList().isEmpty()
-                    ? collectionResult.getResult().toList().get(0)
-                    : Collections.emptyList()
-                ),
+            () -> {
+              try {
+                interpreter
+                  .getContext()
+                  .addNonMetaContextVariables(loopVarsAndExpression.getLeft());
+                return getTag()
+                  .renderForCollection(
+                    tagNode,
+                    eagerInterpreter,
+                    loopVarsAndExpression.getLeft(),
+                    !collectionResult.getResult().toList().isEmpty()
+                      ? collectionResult.getResult().toList().get(0)
+                      : Collections.emptyList()
+                  );
+              } finally {
+                interpreter
+                  .getContext()
+                  .removeNonMetaContextVariables(loopVarsAndExpression.getLeft());
+              }
+            },
             eagerInterpreter
           );
           addedTokens.addAll(eagerInterpreter.getContext().getDeferredTokens());


### PR DESCRIPTION
Fix https://github.com/HubSpot/jinjava/issues/1212

Default jinjava rendering has no use for this data so the functionality should be removed from `ForTag` and just applied in the `EagerForTag` decorator.

The existing tests verify that this change does not change the behaviour when using eager execution.