### PR TITLE
bump basepom to 63, add required pom metadata fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>63.0</version>
+    <version>63.4</version>
   </parent>
 
   <groupId>com.hubspot.jinjava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,14 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>59.11</version>
+    <version>63.0</version>
   </parent>
 
   <groupId>com.hubspot.jinjava</groupId>
   <artifactId>jinjava</artifactId>
   <version>2.8.1-SNAPSHOT</version>
+
+  <name>${project.groupId}:${project.artifactId}</name>
   <description>Jinja templating engine implemented in Java</description>
 
   <properties>
@@ -329,6 +331,13 @@
 
   <url>https://github.com/HubSpot/jinjava</url>
 
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
   <developers>
     <developer>
       <id>jaredstehler</id>
@@ -349,7 +358,7 @@
 
   <profiles>
     <profile>
-      <id>basepom.oss-release</id>
+      <id>basepom.central-release</id>
       <properties>
         <basepom.check.skip-pom-lint>true</basepom.check.skip-pom-lint>
         <basepom.check.skip-dependency-management>true</basepom.check.skip-dependency-management>

--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedScanner.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedScanner.java
@@ -1,6 +1,7 @@
 package com.hubspot.jinjava.el.ext;
 
 import de.odysseus.el.tree.impl.Scanner;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -58,6 +59,10 @@ public class ExtendedScanner extends Scanner {
     }
   }
 
+  @SuppressFBWarnings(
+    value = "HSM_HIDING_METHOD",
+    justification = "Purposefully overriding to use static method instance of this class."
+  )
   protected static void addKeyToken(Token token) {
     try {
       ADD_KEY_TOKEN_METHOD.invoke(null, token);

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -59,7 +59,6 @@ import com.hubspot.jinjava.util.EagerReconstructionUtils;
 import com.hubspot.jinjava.util.RenderLimitUtils;
 import com.hubspot.jinjava.util.Variable;
 import com.hubspot.jinjava.util.WhitespaceUtils;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -526,10 +525,6 @@ public class JinjavaInterpreter implements PyishSerializable {
     );
   }
 
-  @SuppressFBWarnings(
-    justification = "Iterables#getFirst DOES allow null for default value",
-    value = "NP_NONNULL_PARAM_VIOLATION"
-  )
   private void resolveBlockStubs(OutputList output, Stack<String> blockNames) {
     for (BlockPlaceholderOutputNode blockPlaceholder : output.getBlocks()) {
       if (!blockNames.contains(blockPlaceholder.getBlockName())) {

--- a/src/main/java/com/hubspot/jinjava/lib/filter/AbstractFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/AbstractFilter.java
@@ -21,7 +21,6 @@ import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaParam;
 import com.hubspot.jinjava.interpret.InvalidInputException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -69,10 +68,6 @@ public abstract class AbstractFilter implements Filter {
     return filter(var, interpreter, args, Collections.emptyMap());
   }
 
-  @SuppressFBWarnings(
-    value = "UC_USELESS_OBJECT",
-    justification = "FB bug prevents forEach() method call counting `namedArgs` as used (fixed in next release)"
-  )
   public Object filter(
     Object var,
     JinjavaInterpreter interpreter,

--- a/src/main/java/com/hubspot/jinjava/mode/NonRevertingEagerExecutionMode.java
+++ b/src/main/java/com/hubspot/jinjava/mode/NonRevertingEagerExecutionMode.java
@@ -1,11 +1,17 @@
 package com.hubspot.jinjava.mode;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public class NonRevertingEagerExecutionMode extends EagerExecutionMode {
 
   private static final ExecutionMode INSTANCE = new NonRevertingEagerExecutionMode();
 
   protected NonRevertingEagerExecutionMode() {}
 
+  @SuppressFBWarnings(
+    value = "HSM_HIDING_METHOD",
+    justification = "Purposefully overriding to return static instance of this class."
+  )
   public static ExecutionMode instance() {
     return INSTANCE;
   }


### PR DESCRIPTION
Also fixes new findbugs errors:

```
[ERROR] Medium: The method 'addKeyToken(Scanner$Token)' in class 'ExtendedScanner' hides a method in class 'Scanner'. Declare the respective methods non-static or private to eradicate the problem. [com.hubspot.jinjava.el.ext.ExtendedScanner] At ExtendedScanner.java:[line 63] HSM_HIDING_METHOD
[ERROR] Medium: Suppressing annotation on the method com.hubspot.jinjava.interpret.JinjavaInterpreter.resolveBlockStubs(OutputList, Stack) is unnecessary [com.hubspot.jinjava.interpret.JinjavaInterpreter] At JinjavaInterpreter.java:[lines 534-597] US_USELESS_SUPPRESSION_ON_METHOD
[ERROR] Medium: Suppressing annotation on the method com.hubspot.jinjava.lib.filter.AbstractFilter.filter(Object, JinjavaInterpreter, Object[], Map) is unnecessary [com.hubspot.jinjava.lib.filter.AbstractFilter] At AbstractFilter.java:[lines 83-126] US_USELESS_SUPPRESSION_ON_METHOD
[ERROR] Medium: Shared primitive variable "reconstructing" in one thread may not yield the value of the most recent write from another thread [com.hubspot.jinjava.lib.fn.eager.EagerMacroFunction, com.hubspot.jinjava.lib.fn.eager.EagerMacroFunction] At EagerMacroFunction.java:[line 269]Another occurrence at EagerMacroFunction.java:[line 287] AT_STALE_THREAD_WRITE_OF_PRIMITIVE
[ERROR] Medium: The method 'instance()' in class 'NonRevertingEagerExecutionMode' hides a method in class 'EagerExecutionMode'. Declare the respective methods non-static or private to eradicate the problem. [com.hubspot.jinjava.mode.NonRevertingEagerExecutionMode] At NonRevertingEagerExecutionMode.java:[line 10] HSM_HIDING_METHOD
```
