### PR TITLE
Add license info to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <dep.plugin.jacoco.version>0.8.3</dep.plugin.jacoco.version>
     <dep.plugin.javadoc.version>3.0.1</dep.plugin.javadoc.version>
-    <dep.hubspot-immutables.version>1.9</dep.hubspot-immutables.version>
+    <dep.hubspot-immutables.version>1.11.2</dep.hubspot-immutables.version>
 
 
     <basepom.test.add.opens>
@@ -328,6 +328,13 @@
   </build>
 
   <url>https://github.com/HubSpot/jinjava</url>
+
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
 
   <developers>
     <developer>


### PR DESCRIPTION
Some projects have license checking stages that need the project's dependencies to advertise their license type. One way to do this is by adding a `licenses` section to file `pom.xml`. Jinjava at the moment fails to advertise its license in this way. This PR aims to fill this gap.

Jinjava dependencies should also do the same and project [hubspot-immutables](https://github.com/HubSpot/hubspot-immutables/tree/master) has recently added the `licenses` section to its `pom.xml`. For this reason it is being bumped to version `1.11.2` in this PR.