### PR TITLE
fix error thrown for class cast

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/eager/EagerMacroFunction.java
@@ -237,9 +237,11 @@ public class EagerMacroFunction extends MacroFunction {
     String suffix = "";
     JinjavaInterpreter interpreter = JinjavaInterpreter.getCurrent();
 
-    Optional<String> importFile = Optional.ofNullable(
-      (String) localContextScope.get(Context.IMPORT_RESOURCE_PATH_KEY)
-    );
+    Optional<String> importFile = Optional.empty();
+    Object importFileObject = localContextScope.get(Context.IMPORT_RESOURCE_PATH_KEY);
+    if (!(importFileObject instanceof DeferredValue)) {
+      importFile = Optional.ofNullable((String) importFileObject);
+    }
     Object currentDeferredImportResource = null;
     if (importFile.isPresent()) {
       currentDeferredImportResource =


### PR DESCRIPTION
Since recent changes to the master branch for jinjava, running code has seen an increase in `ClassCastExceptions` which can be traced to the changed line in this PR 

java.lang.ClassCastException: class com.hubspot.jinjava.interpret.DeferredValueImpl cannot be cast to class java.lang.String

To address this and reduce exceptions, I added some code to check if the object is not a DeferredValue before trying to cast it as a string. 


