### PR TITLE
fix(eager execution): Create DeferredNodes rather than NotInLoopException when trying to evaluate continue or break in a deferred for loop

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/BreakTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/BreakTag.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.lib.tag;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaTextMateSnippet;
+import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.NotInLoopException;
@@ -37,6 +38,8 @@ public class BreakTag implements Tag {
       }
       ForLoop forLoop = (ForLoop) loop;
       forLoop.doBreak();
+    } else if (loop instanceof DeferredValue) {
+      throw new DeferredValueException("Deferred break");
     } else {
       throw new NotInLoopException(TAG_NAME);
     }

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ContinueTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ContinueTag.java
@@ -2,6 +2,7 @@ package com.hubspot.jinjava.lib.tag;
 
 import com.hubspot.jinjava.doc.annotations.JinjavaDoc;
 import com.hubspot.jinjava.doc.annotations.JinjavaTextMateSnippet;
+import com.hubspot.jinjava.interpret.DeferredValue;
 import com.hubspot.jinjava.interpret.DeferredValueException;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.interpret.NotInLoopException;
@@ -35,6 +36,8 @@ public class ContinueTag implements Tag {
       }
       ForLoop forLoop = (ForLoop) loop;
       forLoop.doContinue();
+    } else if (loop instanceof DeferredValue) {
+      throw new DeferredValueException("Deferred continue");
     } else {
       throw new NotInLoopException(TAG_NAME);
     }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1656,9 +1656,29 @@ public class EagerTest {
   }
 
   @Test
+  public void itHandlesBreakInDeferredForLoop() {
+    String input = expectedTemplateInterpreter.getFixtureTemplate(
+      "handles-break-in-deferred-for-loop/test"
+    );
+    interpreter.render(input);
+    // We don't support this yet
+    assertThat(interpreter.getContext().getDeferredNodes()).isNotEmpty();
+  }
+
+  @Test
   public void itHandlesDeferredContinueInForLoop() {
     String input = expectedTemplateInterpreter.getFixtureTemplate(
       "handles-deferred-continue-in-for-loop/test"
+    );
+    interpreter.render(input);
+    // We don't support this yet
+    assertThat(interpreter.getContext().getDeferredNodes()).isNotEmpty();
+  }
+
+  @Test
+  public void itHandlesContinueInDeferredForLoop() {
+    String input = expectedTemplateInterpreter.getFixtureTemplate(
+      "handles-continue-in-deferred-for-loop/test"
     );
     interpreter.render(input);
     // We don't support this yet

--- a/src/test/resources/eager/handles-break-in-deferred-for-loop/test.jinja
+++ b/src/test/resources/eager/handles-break-in-deferred-for-loop/test.jinja
@@ -1,0 +1,8 @@
+Start loop
+{% for i in deferred %}
+  {% if i %}
+    {% break %}
+  {% endif %}
+  i is: {{ i }}
+{% endfor %}
+End loop

--- a/src/test/resources/eager/handles-continue-in-deferred-for-loop/test.jinja
+++ b/src/test/resources/eager/handles-continue-in-deferred-for-loop/test.jinja
@@ -1,0 +1,8 @@
+Start loop
+{% for i in deferred %}
+  {% if i %}
+    {% continue %}
+  {% endif %}
+  i is: {{ i }}
+{% endfor %}
+End loop


### PR DESCRIPTION
We [haven't implemented](https://github.com/HubSpot/jinjava/commit/9cf4ad630fbc22356348e837d4a9e2481eba14b7) handling of `{% break %}` or `{% continue %}` in eager execution fully so they must create deferred nodes rather than deferred tokens when used in deferred for loops or deferred if statements within for loops.

The latter was handled, but the former was not handled correctly as we'd end up throwing a `NotInLoopException` rather than a `DeferredValueException`: 

```
com.hubspot.jinjava.interpret.NotInLoopException: `continue` called while not in a for loop
```