### PR TITLE
Enable break and continue tags to work in eager execution

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerContinueTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerContinueTag.java
@@ -1,0 +1,33 @@
+package com.hubspot.jinjava.lib.tag.eager;
+
+import com.google.common.annotations.Beta;
+import com.hubspot.jinjava.interpret.DeferredValue;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.lib.tag.ContinueTag;
+import com.hubspot.jinjava.lib.tag.ForTag;
+import com.hubspot.jinjava.tree.parse.TagToken;
+
+/**
+ * Eager decorator for the continue tag that handles reconstruction when the continue
+ * is inside a deferred context (e.g., when in deferred execution mode such as
+ * inside a deferred if condition within a for loop).
+ */
+@Beta
+public class EagerContinueTag extends EagerTagDecorator<ContinueTag> {
+
+  public EagerContinueTag() {
+    super(new ContinueTag());
+  }
+
+  public EagerContinueTag(ContinueTag continueTag) {
+    super(continueTag);
+  }
+
+  @Override
+  public String getEagerTagImage(TagToken tagToken, JinjavaInterpreter interpreter) {
+    if (!(interpreter.getContext().get(ForTag.LOOP) instanceof DeferredValue)) {
+      interpreter.getContext().replace(ForTag.LOOP, DeferredValue.instance());
+    }
+    return super.getEagerTagImage(tagToken, interpreter);
+  }
+}

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactory.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerTagFactory.java
@@ -5,7 +5,6 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.jinjava.lib.tag.BlockTag;
-import com.hubspot.jinjava.lib.tag.BreakTag;
 import com.hubspot.jinjava.lib.tag.CallTag;
 import com.hubspot.jinjava.lib.tag.ContinueTag;
 import com.hubspot.jinjava.lib.tag.CycleTag;
@@ -46,6 +45,7 @@ public class EagerTagFactory {
       .put(IfTag.class, EagerIfTag.class)
       .put(UnlessTag.class, EagerUnlessTag.class)
       .put(CallTag.class, EagerCallTag.class)
+      .put(ContinueTag.class, EagerContinueTag.class)
       .build();
   // These classes don't need an eager decorator.
   public static final Set<Class<? extends Tag>> TAG_CLASSES_TO_SKIP = ImmutableSet
@@ -56,8 +56,6 @@ public class EagerTagFactory {
     .add(ElseTag.class)
     .add(RawTag.class)
     .add(ExtendsTag.class) // TODO support reconstructing extends tags
-    .add(BreakTag.class) // TODO support eager break tag
-    .add(ContinueTag.class) // TODO support eager continue tag
     .build();
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -1647,42 +1648,74 @@ public class EagerTest {
 
   @Test
   public void itHandlesDeferredBreakInForLoop() {
-    String input = expectedTemplateInterpreter.getFixtureTemplate(
+    expectedTemplateInterpreter.assertExpectedOutput(
       "handles-deferred-break-in-for-loop/test"
     );
-    interpreter.render(input);
-    // We don't support this yet
-    assertThat(interpreter.getContext().getDeferredNodes()).isNotEmpty();
+  }
+
+  @Test
+  public void itHandlesDeferredBreakInForLoopSecondPass() {
+    localContext.put("deferred", 1);
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "handles-deferred-break-in-for-loop/test.expected"
+    );
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
+      "handles-deferred-break-in-for-loop/test.expected"
+    );
   }
 
   @Test
   public void itHandlesBreakInDeferredForLoop() {
-    String input = expectedTemplateInterpreter.getFixtureTemplate(
+    expectedTemplateInterpreter.assertExpectedOutput(
       "handles-break-in-deferred-for-loop/test"
     );
-    interpreter.render(input);
-    // We don't support this yet
-    assertThat(interpreter.getContext().getDeferredNodes()).isNotEmpty();
+  }
+
+  @Test
+  public void itHandlesBreakInDeferredForLoopSecondPass() {
+    localContext.put("deferred", List.of(0, 1, 2, 3, 4, 5));
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "handles-break-in-deferred-for-loop/test.expected"
+    );
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
+      "handles-break-in-deferred-for-loop/test.expected"
+    );
   }
 
   @Test
   public void itHandlesDeferredContinueInForLoop() {
-    String input = expectedTemplateInterpreter.getFixtureTemplate(
+    expectedTemplateInterpreter.assertExpectedOutput(
       "handles-deferred-continue-in-for-loop/test"
     );
-    interpreter.render(input);
-    // We don't support this yet
-    assertThat(interpreter.getContext().getDeferredNodes()).isNotEmpty();
+  }
+
+  @Test
+  public void itHandlesDeferredContinueInForLoopSecondPass() {
+    localContext.put("deferred", 2);
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "handles-deferred-continue-in-for-loop/test.expected"
+    );
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
+      "handles-deferred-continue-in-for-loop/test.expected"
+    );
   }
 
   @Test
   public void itHandlesContinueInDeferredForLoop() {
-    String input = expectedTemplateInterpreter.getFixtureTemplate(
+    expectedTemplateInterpreter.assertExpectedOutput(
       "handles-continue-in-deferred-for-loop/test"
     );
-    interpreter.render(input);
-    // We don't support this yet
-    assertThat(interpreter.getContext().getDeferredNodes()).isNotEmpty();
+  }
+
+  @Test
+  public void itHandlesContinueInDeferredForLoopSecondPass() {
+    localContext.put("deferred", List.of(0, 1, 2, 3, 4, 5));
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "handles-continue-in-deferred-for-loop/test.expected"
+    );
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
+      "handles-continue-in-deferred-for-loop/test.expected"
+    );
   }
 
   @Test

--- a/src/test/resources/eager/handles-break-in-deferred-for-loop/test.expected.expected.jinja
+++ b/src/test/resources/eager/handles-break-in-deferred-for-loop/test.expected.expected.jinja
@@ -1,0 +1,4 @@
+Start loop
+i is: 0
+i is: 1
+End loop

--- a/src/test/resources/eager/handles-break-in-deferred-for-loop/test.expected.jinja
+++ b/src/test/resources/eager/handles-break-in-deferred-for-loop/test.expected.jinja
@@ -1,0 +1,8 @@
+Start loop
+{% for i in deferred %}\
+  {% if i > 1 %}\
+    {% break '' %}\
+  {% endif %}\
+  i is: {{ i }}
+{% endfor %}\
+End loop

--- a/src/test/resources/eager/handles-break-in-deferred-for-loop/test.jinja
+++ b/src/test/resources/eager/handles-break-in-deferred-for-loop/test.jinja
@@ -1,8 +1,8 @@
 Start loop
-{% for i in deferred %}
-  {% if i %}
-    {% break %}
-  {% endif %}
+{% for i in deferred -%}
+  {% if i > 1 -%}
+    {% break -%}
+  {% endif -%}
   i is: {{ i }}
-{% endfor %}
+{% endfor -%}
 End loop

--- a/src/test/resources/eager/handles-continue-in-deferred-for-loop/test.expected.expected.jinja
+++ b/src/test/resources/eager/handles-continue-in-deferred-for-loop/test.expected.expected.jinja
@@ -1,0 +1,5 @@
+Start loop
+i is: 1
+i is: 3
+i is: 5
+End loop

--- a/src/test/resources/eager/handles-continue-in-deferred-for-loop/test.expected.jinja
+++ b/src/test/resources/eager/handles-continue-in-deferred-for-loop/test.expected.jinja
@@ -1,0 +1,8 @@
+Start loop
+{% for i in deferred %}\
+  {% if i % 2 == 0 %}\
+    {% continue '' %}\
+  {% endif %}\
+  i is: {{ i }}
+{% endfor %}\
+End loop

--- a/src/test/resources/eager/handles-continue-in-deferred-for-loop/test.jinja
+++ b/src/test/resources/eager/handles-continue-in-deferred-for-loop/test.jinja
@@ -1,8 +1,8 @@
 Start loop
-{% for i in deferred %}
-  {% if i %}
-    {% continue %}
-  {% endif %}
+{% for i in deferred -%}
+  {% if i % 2 == 0 -%}
+    {% continue -%}
+  {% endif -%}
   i is: {{ i }}
-{% endfor %}
+{% endfor -%}
 End loop

--- a/src/test/resources/eager/handles-deferred-break-in-for-loop/test.expected.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-break-in-for-loop/test.expected.expected.jinja
@@ -1,0 +1,4 @@
+Start loop
+i is: 0
+i is: 1
+End loop

--- a/src/test/resources/eager/handles-deferred-break-in-for-loop/test.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-break-in-for-loop/test.expected.jinja
@@ -1,0 +1,24 @@
+Start loop
+{% for __ignored__ in [0] %}\
+{% if 0 > deferred %}\
+  {% break '' %}\
+  {% endif %}\
+i is: 0
+{% if 1 > deferred %}\
+  {% break '' %}\
+  {% endif %}\
+i is: 1
+{% if 2 > deferred %}\
+  {% break '' %}\
+  {% endif %}\
+i is: 2
+{% if 3 > deferred %}\
+  {% break '' %}\
+  {% endif %}\
+i is: 3
+{% if 4 > deferred %}\
+  {% break '' %}\
+  {% endif %}\
+  i is: 4
+{% endfor %}\
+End loop

--- a/src/test/resources/eager/handles-deferred-break-in-for-loop/test.jinja
+++ b/src/test/resources/eager/handles-deferred-break-in-for-loop/test.jinja
@@ -1,8 +1,8 @@
 Start loop
-{% for i in range(5) %}
-  {% if deferred %}
-    {% break %}
-  {% endif %}
+{% for i in range(5) -%}
+  {% if i > deferred -%}
+    {% break -%}
+  {% endif -%}
   i is: {{ i }}
-{% endfor %}
+{% endfor -%}
 End loop

--- a/src/test/resources/eager/handles-deferred-continue-in-for-loop/test.expected.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-continue-in-for-loop/test.expected.expected.jinja
@@ -1,0 +1,4 @@
+Start loop
+i is: 1
+i is: 3
+End loop

--- a/src/test/resources/eager/handles-deferred-continue-in-for-loop/test.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-continue-in-for-loop/test.expected.jinja
@@ -1,0 +1,8 @@
+Start loop
+{% for i in [0, 1, 2, 3, 4] %}\
+  {% if i % deferred == 0 %}\
+    {% continue '' %}\
+  {% endif %}\
+  i is: {{ i }}
+{% endfor %}\
+End loop

--- a/src/test/resources/eager/handles-deferred-continue-in-for-loop/test.jinja
+++ b/src/test/resources/eager/handles-deferred-continue-in-for-loop/test.jinja
@@ -1,8 +1,8 @@
 Start loop
-{% for i in range(5) %}
-  {% if deferred %}
-    {% continue %}
-  {% endif %}
+{% for i in range(5) -%}
+  {% if i % deferred == 0 -%}
+    {% continue -%}
+  {% endif -%}
   i is: {{ i }}
-{% endfor %}
+{% endfor -%}
 End loop


### PR DESCRIPTION
Handles the `{% continue %}` and `{% break %}` tags in eager execution.

There are 4 situations considered, each of them tested via a separate test:
1. Continue tag is used in an already deferred for loop
2. Continue tag is used in a for loop that is being flattened, but is in deferred execution mode
3. Break tag is used in an already deferred for loop
4. Break tag is used in a for loop that is being flattened, but is in deferred execution mode

The break tag is easiest to handle. We can simply use the `EagerGenericTag` wrapper. If a `DeferredValueException` is thrown when evaluating the BreakTag, then it will be reconstructed. This works for both flattened for-loops (because a `{% for __ignored__ in [0] %}` wrapper is already added to preserve the scope, meaning when the break tag is hit, it will break out of the single-level for-loop) and for deferred for loops.

The continue tag is a bit trickier because it wouldn't work in a flattened for loop as it would effectively become a `{% break %}`:
```
{% for __ignored__ in [0] %}
  {% if deferred %}
    {% continue %} {# if we were to continue here, we'd just end up skipping the code that's from the subsequent iterations of the loop #}
  {% endif %}
  i is: 0
  {% if deferred %}
    {% continue %}
  {% endif %}
  i is: 1
{% endfor %}
```

Instead, when encountering a `{% continue %}` tag that must be deferred, we'll reconstruct it _and_ mark the for loop that it's currently in as deferred (as we don't know if it would continue or not after that). Omitting this step is basically an optimization for the `{% break %}` tag because it functions the same in a flattened or a deferred for-loop.