### PR TITLE
Retain both the original deferred words and their bases, and expose them with separate methods

### DIFF
--- a/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
+++ b/src/main/java/com/hubspot/jinjava/lib/fn/MacroFunction.java
@@ -237,11 +237,8 @@ public class MacroFunction extends AbstractCallableMethod {
           Objects.equals(importResourcePath, deferredToken.getImportResourcePath())
         )
         .anyMatch(deferredToken ->
-          deferredToken.getSetDeferredWords().contains(key) ||
-          deferredToken
-            .getUsedDeferredWords()
-            .stream()
-            .anyMatch(used -> key.equals(used.split("\\.", 2)[0]))
+          deferredToken.getSetDeferredBases().contains(key) ||
+          deferredToken.getUsedDeferredBases().contains(key)
         );
     }
     return false;

--- a/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerReconstructionUtils.java
@@ -795,13 +795,13 @@ public class EagerReconstructionUtils {
     deferredToken.addTo(interpreter.getContext());
     return reconstructDeferredReferences(
       interpreter,
-      deferredToken.getUsedDeferredWords()
+      deferredToken.getUsedDeferredBases()
     );
   }
 
   public static Map<String, String> reconstructDeferredReferences(
     JinjavaInterpreter interpreter,
-    Set<String> usedDeferredWords
+    Set<String> usedDeferredBases
   ) {
     return interpreter
       .getContext()
@@ -815,7 +815,7 @@ public class EagerReconstructionUtils {
       .filter(entry ->
         // Always reconstruct the DeferredLazyReferenceSource, but only reconstruct DeferredLazyReferences when they are used
         entry.getValue() instanceof DeferredLazyReferenceSource ||
-        usedDeferredWords.contains(entry.getKey())
+        usedDeferredBases.contains(entry.getKey())
       )
       .peek(entry -> ((OneTimeReconstructible) entry.getValue()).setReconstructed(true))
       .map(entry ->

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagTest.java
@@ -160,6 +160,14 @@ public class EagerSetTagTest extends SetTagTest {
         .flatMap(deferredToken -> deferredToken.getUsedDeferredWords().stream())
         .collect(Collectors.toSet())
     )
+      .containsExactlyInAnyOrder("deferred", "foo", "add.filter");
+    assertThat(
+      context
+        .getDeferredTokens()
+        .stream()
+        .flatMap(deferredToken -> deferredToken.getUsedDeferredBases().stream())
+        .collect(Collectors.toSet())
+    )
       .containsExactlyInAnyOrder("deferred", "foo", "add");
   }
 
@@ -210,6 +218,14 @@ public class EagerSetTagTest extends SetTagTest {
         .getDeferredTokens()
         .stream()
         .flatMap(deferredToken -> deferredToken.getUsedDeferredWords().stream())
+        .collect(Collectors.toSet())
+    )
+      .containsExactlyInAnyOrder("deferred", "foo", "add.filter");
+    assertThat(
+      context
+        .getDeferredTokens()
+        .stream()
+        .flatMap(deferredToken -> deferredToken.getUsedDeferredBases().stream())
         .collect(Collectors.toSet())
     )
       .containsExactlyInAnyOrder("deferred", "foo", "add");

--- a/src/test/java/com/hubspot/jinjava/util/DeferredValueUtilsTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/DeferredValueUtilsTest.java
@@ -256,9 +256,9 @@ public class DeferredValueUtilsTest {
       .addSetDeferredWords(ImmutableSet.of("deferred", ".attribute2"))
       .build();
 
-    assertThat(deferredToken.getUsedDeferredWords())
+    assertThat(deferredToken.getUsedDeferredBases())
       .isEqualTo(ImmutableSet.of("deferred", "attribute1"));
-    assertThat(deferredToken.getSetDeferredWords())
+    assertThat(deferredToken.getSetDeferredBases())
       .isEqualTo(ImmutableSet.of("deferred", "attribute2"));
   }
 
@@ -272,9 +272,9 @@ public class DeferredValueUtilsTest {
       .addSetDeferredWords(ImmutableSet.of("deferred", ".attribute2.ignoreme"))
       .build();
 
-    assertThat(deferredToken.getUsedDeferredWords())
+    assertThat(deferredToken.getUsedDeferredBases())
       .isEqualTo(ImmutableSet.of("deferred", "attribute1"));
-    assertThat(deferredToken.getSetDeferredWords())
+    assertThat(deferredToken.getSetDeferredBases())
       .isEqualTo(ImmutableSet.of("deferred", "attribute2"));
   }
 


### PR DESCRIPTION
When deferring an expression like `{{ deferred.bar }}` the `deferred.bar` is marked as a `usedDeferredWord` and in the current logic, it's distilled down to its base `deferred`, but it is helpful to retain the context that `deferred.bar` is the whole part that got deferred.

So I'm adding a `getUsedDeferredBases` and `getSetDeferredBases`, which do what `getUsedDeferredWords` and `getSetDeferredWords` did and moved the usages that look for the base to call the new methods instead.

This changes what those methods return for better consistency and this `DeferredToken` class _is_ marked with `@Beta`.