### PR TITLE
fix(eager execution): Fix bug from escaped slash right before quote character

### DIFF
--- a/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
+++ b/src/main/java/com/hubspot/jinjava/util/EagerExpressionResolver.java
@@ -175,7 +175,12 @@ public class EagerExpressionResolver {
           );
           prevQuotePos = curPos;
         }
-        prevChar = c;
+        if (prevChar == '\\') {
+          // Double escapes cancel out.
+          prevChar = 0;
+        } else {
+          prevChar = c;
+        }
         curPos++;
       }
       words.addAll(

--- a/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
@@ -358,6 +358,15 @@ public class EagerExpressionResolverTest {
   }
 
   @Test
+  public void itHandlesEscapedSlashBeforeQuoteProperly() {
+    EagerExpressionResult eagerExpressionResult = eagerResolveExpression(
+      "deferred|replace('\\\\', '.')"
+    );
+    assertThat(eagerExpressionResult.getDeferredWords())
+      .containsExactlyInAnyOrder("deferred", "replace.filter");
+  }
+
+  @Test
   public void itHandlesNewlines() {
     context.put("foo", "\n");
     context.put("bar", "\\" + "n"); // Jinja doesn't see this as a newline.


### PR DESCRIPTION
There's a bug in EagerExpressionResolver that an escaped `\`, which should make it innocuous is still being treated as an escape so `\\'` is being treated as an escaped quote, when it should be a real quote.

This is already handled in WhitespaceUtils, and I'm taking that logic of clearing the `prevChar` and applying it to the EagerExpressionResolver too