### PR TITLE
Bump SNAPSHOT to 2.8.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.hubspot.jinjava</groupId>
   <artifactId>jinjava</artifactId>
-  <version>2.8.3-SNAPSHOT</version>
+  <version>2.8.4-SNAPSHOT</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>Jinja templating engine implemented in Java</description>


### PR DESCRIPTION
This is usually handled by https://github.com/HubSpot/jinjava/pull/1277, but running both our 2.8.3 and 2.7.6 releases at the same time resulted in that PR and repo being deleted