### PR TITLE
refactor: Don't require explicitly pushing JinjavaInterpreter when using it directly

### DIFF
--- a/src/main/java/com/hubspot/jinjava/Jinjava.java
+++ b/src/main/java/com/hubspot/jinjava/Jinjava.java
@@ -20,7 +20,6 @@ import com.hubspot.jinjava.doc.JinjavaDocFactory;
 import com.hubspot.jinjava.el.ExtendedSyntaxBuilder;
 import com.hubspot.jinjava.el.TruthyTypeConverter;
 import com.hubspot.jinjava.el.ext.eager.EagerExtendedSyntaxBuilder;
-import com.hubspot.jinjava.interpret.AutoCloseableSupplier.AutoCloseableImpl;
 import com.hubspot.jinjava.interpret.Context;
 import com.hubspot.jinjava.interpret.FatalTemplateErrorsException;
 import com.hubspot.jinjava.interpret.InterpretException;
@@ -246,14 +245,10 @@ public class Jinjava {
       context = new Context(copyGlobalContext(), bindings, renderConfig.getDisabled());
     }
 
-    try (
-      AutoCloseableImpl<JinjavaInterpreter> interpreterAutoCloseable = JinjavaInterpreter
-        .closeablePushCurrent(
-          globalConfig.getInterpreterFactory().newInstance(this, context, renderConfig)
-        )
-        .get()
-    ) {
-      JinjavaInterpreter interpreter = interpreterAutoCloseable.value();
+    try {
+      JinjavaInterpreter interpreter = globalConfig
+        .getInterpreterFactory()
+        .newInstance(this, context, renderConfig);
       try {
         String result = interpreter.render(template);
         return new RenderResult(

--- a/src/main/java/com/hubspot/jinjava/lib/tag/FromTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/FromTag.java
@@ -114,13 +114,7 @@ public class FromTag implements Tag {
                 .getInterpreterFactory()
                 .newInstance(interpreter);
               child.getContext().put(Context.IMPORT_RESOURCE_PATH_KEY, templateFile);
-              try (
-                AutoCloseableImpl<JinjavaInterpreter> a = JinjavaInterpreter
-                  .closeablePushCurrent(child)
-                  .get()
-              ) {
-                child.render(node);
-              }
+              child.render(node);
 
               interpreter.addAllChildErrors(templateFile, child.getErrorsCopy());
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/ImportTag.java
@@ -123,14 +123,7 @@ public class ImportTag implements Tag {
                 .getInterpreterFactory()
                 .newInstance(interpreter);
               child.getContext().put(Context.IMPORT_RESOURCE_PATH_KEY, templateFile);
-
-              try (
-                AutoCloseableImpl<JinjavaInterpreter> a = JinjavaInterpreter
-                  .closeablePushCurrent(child)
-                  .get()
-              ) {
-                child.render(node.value());
-              }
+              child.render(node.value());
 
               interpreter.addAllChildErrors(templateFile, child.getErrorsCopy());
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerFromTag.java
@@ -120,13 +120,7 @@ public class EagerFromTag extends EagerStateChangingTag<FromTag> {
                 .newInstance(interpreter);
               child.getContext().put(Context.IMPORT_RESOURCE_PATH_KEY, templateFile);
               String output;
-              try (
-                AutoCloseableImpl<JinjavaInterpreter> a = JinjavaInterpreter
-                  .closeablePushCurrent(child)
-                  .get()
-              ) {
-                output = child.render(node);
-              }
+              output = child.render(node);
 
               interpreter.addAllChildErrors(templateFile, child.getErrorsCopy());
 

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTag.java
@@ -85,14 +85,9 @@ public class EagerImportTag extends EagerStateChangingTag<ImportTag> {
                 .newInstance(interpreter);
               child.getContext().put(Context.IMPORT_RESOURCE_PATH_KEY, templateFile);
               String output;
-              try (
-                AutoCloseableImpl<JinjavaInterpreter> a = JinjavaInterpreter
-                  .closeablePushCurrent(child)
-                  .get()
-              ) {
-                eagerImportingStrategy.setup(child);
-                output = child.render(node.value());
-              }
+              eagerImportingStrategy.setup(child);
+              output = child.render(node.value());
+
               interpreter.addAllChildErrors(templateFile, child.getErrorsCopy());
               Map<String, Object> childBindings = child.getContext().getSessionBindings();
 

--- a/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/TreeParser.java
@@ -38,6 +38,7 @@ import com.hubspot.jinjava.tree.parse.Token;
 import com.hubspot.jinjava.tree.parse.TokenScanner;
 import com.hubspot.jinjava.tree.parse.TokenScannerSymbols;
 import com.hubspot.jinjava.tree.parse.UnclosedToken;
+import com.hubspot.jinjava.tree.parse.WhitespaceControlParser;
 import org.apache.commons.lang3.StringUtils;
 
 public class TreeParser {
@@ -45,6 +46,7 @@ public class TreeParser {
   private final PeekingIterator<Token> scanner;
   private final JinjavaInterpreter interpreter;
   private final TokenScannerSymbols symbols;
+  private final WhitespaceControlParser whitespaceControlParser;
 
   private Node parent;
 
@@ -53,6 +55,10 @@ public class TreeParser {
       Iterators.peekingIterator(new TokenScanner(input, interpreter.getConfig()));
     this.interpreter = interpreter;
     this.symbols = interpreter.getConfig().getTokenScannerSymbols();
+    this.whitespaceControlParser =
+      interpreter.getConfig().getLegacyOverrides().isParseWhitespaceControlStrictly()
+        ? WhitespaceControlParser.STRICT
+        : WhitespaceControlParser.LENIENT;
   }
 
   public Node buildTree() {
@@ -178,7 +184,8 @@ public class TreeParser {
               StringUtils.stripEnd(textToken.getImage(), "\t "),
               textToken.getLineNumber(),
               textToken.getStartPosition(),
-              symbols
+              symbols,
+              whitespaceControlParser
             );
         }
       }

--- a/src/main/java/com/hubspot/jinjava/tree/parse/ExpressionToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/ExpressionToken.java
@@ -29,7 +29,17 @@ public class ExpressionToken extends Token {
     int startPosition,
     TokenScannerSymbols symbols
   ) {
-    super(image, lineNumber, startPosition, symbols);
+    this(image, lineNumber, startPosition, symbols, WhitespaceControlParser.LENIENT);
+  }
+
+  public ExpressionToken(
+    String image,
+    int lineNumber,
+    int startPosition,
+    TokenScannerSymbols symbols,
+    WhitespaceControlParser whitespaceControlParser
+  ) {
+    super(image, lineNumber, startPosition, symbols, whitespaceControlParser);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/tree/parse/NoteToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/NoteToken.java
@@ -25,7 +25,17 @@ public class NoteToken extends Token {
     int startPosition,
     TokenScannerSymbols symbols
   ) {
-    super(image, lineNumber, startPosition, symbols);
+    this(image, lineNumber, startPosition, symbols, WhitespaceControlParser.LENIENT);
+  }
+
+  public NoteToken(
+    String image,
+    int lineNumber,
+    int startPosition,
+    TokenScannerSymbols symbols,
+    WhitespaceControlParser whitespaceControlParser
+  ) {
+    super(image, lineNumber, startPosition, symbols, whitespaceControlParser);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TagToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TagToken.java
@@ -31,7 +31,17 @@ public class TagToken extends Token {
     int startPosition,
     TokenScannerSymbols symbols
   ) {
-    super(image, lineNumber, startPosition, symbols);
+    this(image, lineNumber, startPosition, symbols, WhitespaceControlParser.LENIENT);
+  }
+
+  public TagToken(
+    String image,
+    int lineNumber,
+    int startPosition,
+    TokenScannerSymbols symbols,
+    WhitespaceControlParser whitespaceControlParser
+  ) {
+    super(image, lineNumber, startPosition, symbols, whitespaceControlParser);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/tree/parse/TextToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/TextToken.java
@@ -27,7 +27,17 @@ public class TextToken extends Token {
     int startPosition,
     TokenScannerSymbols symbols
   ) {
-    super(image, lineNumber, startPosition, symbols);
+    this(image, lineNumber, startPosition, symbols, WhitespaceControlParser.LENIENT);
+  }
+
+  public TextToken(
+    String image,
+    int lineNumber,
+    int startPosition,
+    TokenScannerSymbols symbols,
+    WhitespaceControlParser whitespaceControlParser
+  ) {
+    super(image, lineNumber, startPosition, symbols, whitespaceControlParser);
   }
 
   public void mergeImageAndContent(TextToken otherToken) {

--- a/src/main/java/com/hubspot/jinjava/tree/parse/UnclosedToken.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/UnclosedToken.java
@@ -8,6 +8,16 @@ public class UnclosedToken extends TextToken {
     int startPosition,
     TokenScannerSymbols symbols
   ) {
-    super(image, lineNumber, startPosition, symbols);
+    this(image, lineNumber, startPosition, symbols, WhitespaceControlParser.LENIENT);
+  }
+
+  public UnclosedToken(
+    String image,
+    int lineNumber,
+    int startPosition,
+    TokenScannerSymbols symbols,
+    WhitespaceControlParser whitespaceControlParser
+  ) {
+    super(image, lineNumber, startPosition, symbols, whitespaceControlParser);
   }
 }


### PR DESCRIPTION
Previously, anytime that you wanted to use `JinjavaInterpreter#render` or `JinjavaInterpreter#parse` directly, you'd need to push the interpreter onto the ThreadLocal stack.

This PR moves the logic that pushes the current interpreter to instead be done inside of `JinjavaInterpreter#render` rather than within `Jinjava#renderForResult`  to simplify the usage pattern.

As part of doing this, I'm removing the direct dependency on `JinjavaInterpreter.getCurrent()` from parsing by moving the `WhitespaceControlParser` to be injected in the constructor, similar to `TokenScannerSymbols`.

Part of the reason why I'm doing this is because I'm going to make JinjavaBeanELResolver require a current JinjavaInterpreter in a 3.0 release of Jinjava and by pushing automatically, I can help make that more seamless for anyone that may be using a `JinjavaInterpreter` directly as opposed to using a `Jinjava`