### PR TITLE
fix(eager): reconstruct deferred set tags before block content

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -39,6 +39,7 @@ import com.hubspot.jinjava.interpret.TemplateError.ErrorType;
 import com.hubspot.jinjava.interpret.errorcategory.BasicTemplateErrorCategory;
 import com.hubspot.jinjava.lib.tag.DoTag;
 import com.hubspot.jinjava.lib.tag.ExtendsTag;
+import com.hubspot.jinjava.lib.tag.eager.DeferredToken;
 import com.hubspot.jinjava.lib.tag.eager.EagerGenericTag;
 import com.hubspot.jinjava.loader.RelativePathResolver;
 import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
@@ -569,6 +570,9 @@ public class JinjavaInterpreter implements PyishSerializable {
           DynamicRenderedOutputNode prefix = new DynamicRenderedOutputNode();
           blockValueBuilder.addNode(prefix);
           int numDeferredTokensBefore = context.getDeferredTokens().size();
+          Set<DeferredToken> deferredTokensBefore = new HashSet<>(
+            context.getDeferredTokens()
+          );
 
           try (
             AutoCloseableImpl<Boolean> parentPathPush = conditionallyPushParentPath(block)
@@ -590,6 +594,7 @@ public class JinjavaInterpreter implements PyishSerializable {
                 blockValueBuilder,
                 this
               );
+              reconstructDeferredVariablesBeforeBlock(prefix, deferredTokensBefore);
             }
           }
           blockNames.push(blockPlaceholder.getBlockName());
@@ -606,6 +611,47 @@ public class JinjavaInterpreter implements PyishSerializable {
       if (!blockPlaceholder.isResolved()) {
         blockPlaceholder.resolve("");
       }
+    }
+  }
+
+  private void reconstructDeferredVariablesBeforeBlock(
+    DynamicRenderedOutputNode prefix,
+    Set<DeferredToken> deferredTokensBefore
+  ) {
+    Set<DeferredToken> newTokens = context
+      .getDeferredTokens()
+      .stream()
+      .filter(dt -> !deferredTokensBefore.contains(dt))
+      .collect(Collectors.toSet());
+    Set<String> wordsSetInBlock = newTokens
+      .stream()
+      .flatMap(dt -> dt.getSetDeferredWords().stream())
+      .collect(Collectors.toSet());
+    Set<String> deferredWordsUsedInBlock = newTokens
+      .stream()
+      .flatMap(dt -> dt.getUsedDeferredWords().stream())
+      .map(w -> w.split("\\.", 2)[0])
+      .filter(w -> context.get(w) instanceof DeferredValue)
+      .filter(w -> !wordsSetInBlock.contains(w))
+      .collect(Collectors.toSet());
+    if (deferredWordsUsedInBlock.isEmpty()) {
+      return;
+    }
+    StringBuilder setPrefix = new StringBuilder();
+    for (DeferredToken priorToken : deferredTokensBefore) {
+      if (priorToken.getUsedDeferredWords().isEmpty()) {
+        continue;
+      }
+      for (String setWord : priorToken.getSetDeferredWords()) {
+        if (deferredWordsUsedInBlock.contains(setWord)) {
+          setPrefix.append(priorToken.getToken().getImage());
+          break;
+        }
+      }
+    }
+    if (setPrefix.length() > 0) {
+      String existingPrefix = prefix.getValue() != null ? prefix.getValue() : "";
+      prefix.setValue(setPrefix.toString() + existingPrefix);
     }
   }
 

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerExtendsTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerExtendsTagTest.java
@@ -125,6 +125,29 @@ public class EagerExtendsTagTest extends ExtendsTagTest {
   }
 
   @Test
+  public void itReconstructsDeferredSetAfterBlock() {
+    String result = expectedTemplateInterpreter.getFixtureTemplate(
+      "reconstructs-deferred-set-after-block"
+    );
+    String output = interpreter.render(result);
+    context.put("deferred", "Jack");
+    String secondPass = jinjava.render(output, context);
+    assertThat(secondPass).contains("I am Jack");
+  }
+
+  @Test
+  public void itReconstructsDeferredSetAfterBlockSecondPass() {
+    context.put("deferred", "Jack");
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "reconstructs-deferred-set-after-block.expected"
+    );
+    context.remove(RelativePathResolver.CURRENT_PATH_CONTEXT_KEY);
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
+      "reconstructs-deferred-set-after-block.expected"
+    );
+  }
+
+  @Test
   public void itThrowsWhenDeferredExtendsTag() {
     interpreter.render(
       expectedTemplateInterpreter.getFixtureTemplate("throws-when-deferred-extends-tag")

--- a/src/test/resources/tags/eager/extendstag/base-with-deferred-after-block.html
+++ b/src/test/resources/tags/eager/extendstag/base-with-deferred-after-block.html
@@ -1,0 +1,13 @@
+<html>
+<body>
+<div class="content">
+{% block content %}
+<p>default content</p>
+{% endblock %}
+</div>
+<div class="footer">
+{% set first_name = deferred %}
+<p>Am I {{ first_name }}?</p>
+</div>
+</body>
+</html>

--- a/src/test/resources/tags/eager/extendstag/reconstructs-deferred-set-after-block.expected.expected.jinja
+++ b/src/test/resources/tags/eager/extendstag/reconstructs-deferred-set-after-block.expected.expected.jinja
@@ -1,0 +1,11 @@
+<html>
+<body>
+<div class="content">
+<h1>I am Jack</h1>
+</div>
+<div class="footer">
+
+<p>Am I Jack?</p>
+</div>
+</body>
+</html>

--- a/src/test/resources/tags/eager/extendstag/reconstructs-deferred-set-after-block.expected.jinja
+++ b/src/test/resources/tags/eager/extendstag/reconstructs-deferred-set-after-block.expected.jinja
@@ -1,0 +1,11 @@
+{% set current_path = '../eager/extendstag/base-with-deferred-after-block.html' %}<html>
+<body>
+<div class="content">
+{% set first_name = deferred %}{% set __temp_meta_current_path_704376120__,current_path = current_path,'' %}<h1>I am {{ first_name }}</h1>{% set current_path,__temp_meta_current_path_704376120__ = __temp_meta_current_path_704376120__,null %}
+</div>
+<div class="footer">
+{% set first_name = deferred %}
+<p>Am I {{ first_name }}?</p>
+</div>
+</body>
+</html>

--- a/src/test/resources/tags/eager/extendstag/reconstructs-deferred-set-after-block.jinja
+++ b/src/test/resources/tags/eager/extendstag/reconstructs-deferred-set-after-block.jinja
@@ -1,0 +1,4 @@
+{% extends "../eager/extendstag/base-with-deferred-after-block.html" %}
+{%- block content -%}
+<h1>I am {{ first_name }}</h1>
+{%- endblock -%}


### PR DESCRIPTION
When a parent template sets a deferred variable after a block placeholder (e.g. `{% set first_name = deferred %}`), child block content using that variable would fail to resolve on the second render pass. This happened because the `{% set %}` tag appeared after the block content in the output, so the second pass evaluated `{{ first_name }}` before it was defined.

The fix adds `reconstructDeferredVariablesBeforeBlock()` to `resolveBlockStubs()`, which identifies deferred variables used (but not set) within a block, finds prior DeferredTokens that define those variables, and prepends their set tag images before the block content.