### PR TITLE
Fix NPE when calling macros inside ternary with variable condition

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -281,7 +281,7 @@ public class ExtendedParser extends Parser {
     switch (getToken().getSymbol()) {
       case IDENTIFIER:
         String name = consumeToken().getImage();
-        if (getToken().getSymbol() == COLON) {
+        if (getToken().getSymbol() == COLON && getToken().getImage().equals(":")) {
           Symbol lookahead = lookahead(0).getSymbol();
           if (
             isPossibleExpTest(lookahead) &&

--- a/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
@@ -386,6 +386,19 @@ public class MacroTagTest extends BaseInterpretingTest {
     assertThat(jinjava.render(template, context).trim()).isEqualTo("Hello nobody");
   }
 
+  @Test
+  public void itCallsMacroInStandardTernaryWithVariableCondition() {
+    String template =
+      "{% macro greet(name) %}Hello {{ name }}{% endmacro %}" +
+      "{{ myVar ? greet('world') : greet('nobody') }}";
+
+    context.put("myVar", true);
+    assertThat(jinjava.render(template, context).trim()).isEqualTo("Hello world");
+
+    context.put("myVar", false);
+    assertThat(jinjava.render(template, context).trim()).isEqualTo("Hello nobody");
+  }
+
   private Node snippet(String jinja) {
     return new TreeParser(interpreter, jinja).buildTree().getChildren().getFirst();
   }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/MacroTagTest.java
@@ -373,6 +373,19 @@ public class MacroTagTest extends BaseInterpretingTest {
     }
   }
 
+  @Test
+  public void itCallsMacroInTernaryWithVariableCondition() {
+    String template =
+      "{% macro greet(name) %}Hello {{ name }}{% endmacro %}" +
+      "{{ greet('world') if myVar else greet('nobody') }}";
+
+    context.put("myVar", true);
+    assertThat(jinjava.render(template, context).trim()).isEqualTo("Hello world");
+
+    context.put("myVar", false);
+    assertThat(jinjava.render(template, context).trim()).isEqualTo("Hello nobody");
+  }
+
   private Node snippet(String jinja) {
     return new TreeParser(interpreter, jinja).buildTree().getChildren().getFirst();
   }


### PR DESCRIPTION
Using a macro in a ternary would lead to the macro name failing to parse correctly and throw an NPE.

For ternary like:

```
{{ greet('world') if myVar else greet('nobody') }}
```

The `else` keyword in a ternary is registered with `Symbol.COLON`, causing `nonliteral()` to greedily interpret `myVar else greet('nobody') ` as the namespace-prefixed function `myVar:greet` instead of `greet`.

The fix adds an image check (`getImage().equals(":")`) so the parser only enters namespace-prefix logic for a literal colon token, not `else`.