### PR TITLE
feat: add boolean parameter to withUnwrapRawOverride (2.8.x)

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -2,4 +2,4 @@ buildResources:
   memoryMb: 10240
 
 env:
-  SKIP_VERSION_OVERRIDE: true
+  SKIP_VERSION_OVERRIDE_ON_BRANCH: master-2.8.x

--- a/src/main/java/com/hubspot/jinjava/interpret/Context.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/Context.java
@@ -884,11 +884,15 @@ public class Context extends ScopeMap<String, Object> {
   }
 
   public TemporaryValueClosable<Boolean> withUnwrapRawOverride() {
+    return withUnwrapRawOverride(true);
+  }
+
+  public TemporaryValueClosable<Boolean> withUnwrapRawOverride(boolean value) {
     TemporaryValueClosable<Boolean> temporaryValueClosable = new TemporaryValueClosable<>(
       isUnwrapRawOverride(),
       this::setUnwrapRawOverride
     );
-    setUnwrapRawOverride(true);
+    setUnwrapRawOverride(value);
     return temporaryValueClosable;
   }
 


### PR DESCRIPTION
## Description

Cherry-pick of #1313 onto `master-2.8.x` so the feature is available in both jinjava 2.8.4 and 3.0.0.

`withUnwrapRawOverride()` always sets the override to `true`. Callers that need to temporarily force the override to `false` had no clean way to do so. This adds a `withUnwrapRawOverride(boolean)` overload so the value can be specified, while keeping the existing no-arg method as a convenience that delegates with `true`.

## BRAVE
#### Backwards Compatibility
Fully backwards compatible — the existing no-arg method is unchanged and delegates to the new overload.

#### Rollout and Rollback Plan
Library change; rolls out when consumers upgrade. Rollback by reverting the version bump.

#### Automated Testing
Existing tests continue to pass. The no-arg method behavior is unchanged.

#### Verification
Local build passes.

#### Expect Dependencies to Fail
No expected failures.

##### *REVIEWERS*: Please review both the code changes and the answers above, and validate that they match the expectations for BRAVE

*Authored by Claude Code*