### PR TITLE
fix: Backport block tag preservation fix to 2.8.x (#1312)

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -498,9 +498,7 @@ public class JinjavaInterpreter implements PyishSerializable {
             basePath = Optional.of(currentPath);
           }
         }
-        if (context.getDeferredTokens().size() > numDeferredTokensBefore) {
-          preserveBlocks = true;
-        }
+        preserveBlocks = (context.getDeferredTokens().size() > numDeferredTokensBefore);
       }
 
       int numDeferredTokensBefore = context.getDeferredTokens().size();

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -508,11 +508,12 @@ public class JinjavaInterpreter implements PyishSerializable {
       if (preserveBlocks) {
         for (BlockPlaceholderOutputNode blockPlaceholder : output.getBlocks()) {
           blockPlaceholder.resolve(
-            "{%% block %s %%}%s{%% endblock %s %%}".formatted(
-                blockPlaceholder.getBlockName(),
-                blockPlaceholder.getValue(),
-                blockPlaceholder.getBlockName()
-              )
+            EagerReconstructionUtils.wrapInTag(
+              blockPlaceholder.getValue(),
+              "block %s".formatted(blockPlaceholder.getBlockName()),
+              this,
+              false
+            )
           );
         }
       }

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -429,6 +429,7 @@ public class JinjavaInterpreter implements PyishSerializable {
       output.addNode(pathSetter);
       Optional<String> basePath = context.getCurrentPathStack().peek();
       StringBuilder ignoredOutput = new StringBuilder();
+      boolean preserveBlocks = false;
       // render all extend parents, keeping the last as the root output
       if (processExtendRoots) {
         Set<String> extendPaths = new HashSet<>();
@@ -497,10 +498,24 @@ public class JinjavaInterpreter implements PyishSerializable {
             basePath = Optional.of(currentPath);
           }
         }
+        if (context.getDeferredTokens().size() > numDeferredTokensBefore) {
+          preserveBlocks = true;
+        }
       }
 
       int numDeferredTokensBefore = context.getDeferredTokens().size();
       resolveBlockStubs(output);
+      if (preserveBlocks) {
+        for (BlockPlaceholderOutputNode blockPlaceholder : output.getBlocks()) {
+          blockPlaceholder.resolve(
+            "{%% block %s %%}%s{%% endblock %s %%}".formatted(
+                blockPlaceholder.getBlockName(),
+                blockPlaceholder.getValue(),
+                blockPlaceholder.getBlockName()
+              )
+          );
+        }
+      }
       if (context.getDeferredTokens().size() > numDeferredTokensBefore) {
         pathSetter.setValue(
           EagerReconstructionUtils.buildBlockOrInlineSetTag(

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1754,4 +1754,22 @@ public class EagerTest {
       "handles-deferred-value-in-render-filter/test"
     );
   }
+
+  @Test
+  public void itHandlesDeferredUsedInMultipleBlockLevels() {
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
+      "handles-deferred-used-in-multiple-block-levels/test"
+    );
+  }
+
+  @Test
+  public void itHandlesDeferredUsedInMultipleBlockLevelsSecondPass() {
+    localContext.put("deferred", "resolved");
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "handles-deferred-used-in-multiple-block-levels/test.expected"
+    );
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
+      "handles-deferred-used-in-multiple-block-levels/test.expected"
+    );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1772,4 +1772,22 @@ public class EagerTest {
       "handles-deferred-used-in-multiple-block-levels/test.expected"
     );
   }
+
+  @Test
+  public void itDoesNotDeferBlockWhenOnlyMiddleDefers() {
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
+      "does-not-defer-block-when-only-middle-defers/test"
+    );
+  }
+
+  @Test
+  public void itDoesNotDeferBlockWhenOnlyMiddleDefersSecondPass() {
+    localContext.put("deferred", "resolved");
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "does-not-defer-block-when-only-middle-defers/test.expected"
+    );
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
+      "does-not-defer-block-when-only-middle-defers/test.expected"
+    );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -1790,4 +1790,29 @@ public class EagerTest {
       "does-not-defer-block-when-only-middle-defers/test.expected"
     );
   }
+
+  @Test
+  public void itPreservesBlocksForReconstructionOrder() {
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
+      "preserves-blocks-for-reconstruction-order/test"
+    );
+  }
+
+  @Test
+  public void itPreservesBlocksForReconstructionOrderSecondPhase() {
+    localContext.put("deferred", "resolved");
+    String twoPhaseOutput = expectedTemplateInterpreter.assertExpectedOutput(
+      "preserves-blocks-for-reconstruction-order/test.expected"
+    );
+    expectedTemplateInterpreter.assertExpectedNonEagerOutput(
+      "preserves-blocks-for-reconstruction-order/test.expected"
+    );
+    // Sanity check
+    assertThat(twoPhaseOutput)
+      .isEqualToIgnoringWhitespace(
+        expectedTemplateInterpreter.renderTemplate(
+          "preserves-blocks-for-reconstruction-order/test"
+        )
+      );
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/ExpectedTemplateInterpreter.java
+++ b/src/test/java/com/hubspot/jinjava/ExpectedTemplateInterpreter.java
@@ -49,8 +49,7 @@ public class ExpectedTemplateInterpreter {
   }
 
   public String assertExpectedOutput(String name) {
-    String template = getFixtureTemplate(name);
-    String output = JinjavaInterpreter.getCurrent().render(template);
+    String output = renderTemplate(name);
     assertThat(JinjavaInterpreter.getCurrent().getContext().getDeferredNodes())
       .as("Ensure no deferred nodes were created")
       .isEmpty();
@@ -60,9 +59,13 @@ public class ExpectedTemplateInterpreter {
     return output;
   }
 
-  public String assertExpectedOutputNonIdempotent(String name) {
+  public String renderTemplate(String name) {
     String template = getFixtureTemplate(name);
-    String output = JinjavaInterpreter.getCurrent().render(template);
+    return JinjavaInterpreter.getCurrent().render(template);
+  }
+
+  public String assertExpectedOutputNonIdempotent(String name) {
+    String output = renderTemplate(name);
     assertThat(JinjavaInterpreter.getCurrent().getContext().getDeferredNodes())
       .as("Ensure no deferred nodes were created")
       .isEmpty();

--- a/src/test/resources/eager/does-not-defer-block-when-only-middle-defers/base.jinja
+++ b/src/test/resources/eager/does-not-defer-block-when-only-middle-defers/base.jinja
@@ -1,0 +1,12 @@
+{% set tracker_base = '1_base' %}
+
+
+-----Pre-First-----
+{% block first -%}
+{%- endblock %}
+-----Post-First-----
+-----Pre-Second-----
+{% block second -%}
+{%- endblock %}
+-----Post-Second-----
+We aren't deferring tracker base.{# This message WILL show up in final output #}

--- a/src/test/resources/eager/does-not-defer-block-when-only-middle-defers/middle.jinja
+++ b/src/test/resources/eager/does-not-defer-block-when-only-middle-defers/middle.jinja
@@ -1,0 +1,13 @@
+{% extends '../../eager/does-not-defer-block-when-only-middle-defers/base.jinja' %}
+{% set tracker_middle = '2_middle' %}
+{% block first %}
+I WON'T SHOW UP
+{% endblock %}
+
+{% block second %}
+tracker_base is: {{ tracker_base }}? {{ tracker_base == '1_base' }}
+tracker_middle is: {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
+tracker_test is: {{ tracker_test }}? {{ tracker_test == 'resolved' }}
+{% endblock %}
+Deferring tracker middle.{# This message will not show up in final output #}
+{% set tracker_middle = deferred %}

--- a/src/test/resources/eager/does-not-defer-block-when-only-middle-defers/middle.jinja
+++ b/src/test/resources/eager/does-not-defer-block-when-only-middle-defers/middle.jinja
@@ -5,9 +5,9 @@ I WON'T SHOW UP
 {% endblock %}
 
 {% block second %}
-tracker_base is: {{ tracker_base }}? {{ tracker_base == '1_base' }}
-tracker_middle is: {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
-tracker_test is: {{ tracker_test }}? {{ tracker_test == 'resolved' }}
+tracker_base is '1_base': {{ tracker_base }}? {{ tracker_base == '1_base' }}
+tracker_middle is 'resolved': {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
+tracker_test is 'resolved': {{ tracker_test }}? {{ tracker_test == 'resolved' }}
 {% endblock %}
 Deferring tracker middle.{# This message will not show up in final output #}
 {% set tracker_middle = deferred %}

--- a/src/test/resources/eager/does-not-defer-block-when-only-middle-defers/test.expected.expected.jinja
+++ b/src/test/resources/eager/does-not-defer-block-when-only-middle-defers/test.expected.expected.jinja
@@ -1,0 +1,15 @@
+-----Pre-First-----
+
+tracker_base is: 1_base? true
+tracker_middle is: resolved? true
+tracker_test is: resolved? true
+
+-----Post-First-----
+-----Pre-Second-----
+
+tracker_base is: 1_base? true
+tracker_middle is: resolved? true
+tracker_test is: resolved? true
+
+-----Post-Second-----
+We aren't deferring tracker base.

--- a/src/test/resources/eager/does-not-defer-block-when-only-middle-defers/test.expected.expected.jinja
+++ b/src/test/resources/eager/does-not-defer-block-when-only-middle-defers/test.expected.expected.jinja
@@ -1,15 +1,15 @@
 -----Pre-First-----
 
-tracker_base is: 1_base? true
-tracker_middle is: resolved? true
-tracker_test is: resolved? true
+tracker_base is '1_base': 1_base? true
+tracker_middle is 'resolved': resolved? true
+tracker_test is 'resolved': resolved? true
 
 -----Post-First-----
 -----Pre-Second-----
 
-tracker_base is: 1_base? true
-tracker_middle is: resolved? true
-tracker_test is: resolved? true
+tracker_base is '1_base': 1_base? true
+tracker_middle is 'resolved': resolved? true
+tracker_test is 'resolved': resolved? true
 
 -----Post-Second-----
 We aren't deferring tracker base.

--- a/src/test/resources/eager/does-not-defer-block-when-only-middle-defers/test.expected.jinja
+++ b/src/test/resources/eager/does-not-defer-block-when-only-middle-defers/test.expected.jinja
@@ -17,19 +17,19 @@ Deferring tracker middle.
 
 -----Pre-First-----
 {% set __temp_meta_current_path_1008935144__,current_path = current_path,'eager/does-not-defer-block-when-only-middle-defers/test.jinja' %}
-tracker_base is: 1_base? true
-tracker_middle is: {{ tracker_middle }}\
+tracker_base is '1_base': 1_base? true
+tracker_middle is 'resolved': {{ tracker_middle }}\
 ? {{ tracker_middle == 'resolved' }}
-tracker_test is: {{ tracker_test }}\
+tracker_test is 'resolved': {{ tracker_test }}\
 ? {{ tracker_test == 'resolved' }}
 {% set current_path,__temp_meta_current_path_1008935144__ = __temp_meta_current_path_1008935144__,null %}
 -----Post-First-----
 -----Pre-Second-----
 {% set __temp_meta_current_path_245328778__,current_path = current_path,'eager/does-not-defer-block-when-only-middle-defers/middle.jinja' %}
-tracker_base is: 1_base? true
-tracker_middle is: {{ tracker_middle }}\
+tracker_base is '1_base': 1_base? true
+tracker_middle is 'resolved': {{ tracker_middle }}\
 ? {{ tracker_middle == 'resolved' }}
-tracker_test is: {{ tracker_test }}\
+tracker_test is 'resolved': {{ tracker_test }}\
 ? {{ tracker_test == 'resolved' }}
 {% set current_path,__temp_meta_current_path_245328778__ = __temp_meta_current_path_245328778__,null %}
 -----Post-Second-----

--- a/src/test/resources/eager/does-not-defer-block-when-only-middle-defers/test.expected.jinja
+++ b/src/test/resources/eager/does-not-defer-block-when-only-middle-defers/test.expected.jinja
@@ -1,0 +1,36 @@
+{# Start Label:  ignored_output_from_extends #}{% do %}
+
+
+
+Deferring tracker test.
+{% set tracker_test = deferred %}
+
+
+
+
+
+Deferring tracker middle.
+{% set tracker_middle = deferred %}
+{% enddo %}\
+{# End Label:  ignored_output_from_extends #}{% set current_path = 'eager/does-not-defer-block-when-only-middle-defers/base.jinja' %}
+
+
+-----Pre-First-----
+{% set __temp_meta_current_path_1008935144__,current_path = current_path,'eager/does-not-defer-block-when-only-middle-defers/test.jinja' %}
+tracker_base is: 1_base? true
+tracker_middle is: {{ tracker_middle }}\
+? {{ tracker_middle == 'resolved' }}
+tracker_test is: {{ tracker_test }}\
+? {{ tracker_test == 'resolved' }}
+{% set current_path,__temp_meta_current_path_1008935144__ = __temp_meta_current_path_1008935144__,null %}
+-----Post-First-----
+-----Pre-Second-----
+{% set __temp_meta_current_path_245328778__,current_path = current_path,'eager/does-not-defer-block-when-only-middle-defers/middle.jinja' %}
+tracker_base is: 1_base? true
+tracker_middle is: {{ tracker_middle }}\
+? {{ tracker_middle == 'resolved' }}
+tracker_test is: {{ tracker_test }}\
+? {{ tracker_test == 'resolved' }}
+{% set current_path,__temp_meta_current_path_245328778__ = __temp_meta_current_path_245328778__,null %}
+-----Post-Second-----
+We aren't deferring tracker base.

--- a/src/test/resources/eager/does-not-defer-block-when-only-middle-defers/test.jinja
+++ b/src/test/resources/eager/does-not-defer-block-when-only-middle-defers/test.jinja
@@ -1,0 +1,10 @@
+{% extends '../../eager/does-not-defer-block-when-only-middle-defers/middle.jinja' %}
+
+{% set tracker_test = '3_test' %}
+{% block first %}
+tracker_base is: {{ tracker_base }}? {{ tracker_base == '1_base' }}
+tracker_middle is: {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
+tracker_test is: {{ tracker_test }}? {{ tracker_test == 'resolved' }}
+{% endblock %}
+Deferring tracker test.{# This message will not show up in final output #}
+{% set tracker_test = deferred %}

--- a/src/test/resources/eager/does-not-defer-block-when-only-middle-defers/test.jinja
+++ b/src/test/resources/eager/does-not-defer-block-when-only-middle-defers/test.jinja
@@ -2,9 +2,9 @@
 
 {% set tracker_test = '3_test' %}
 {% block first %}
-tracker_base is: {{ tracker_base }}? {{ tracker_base == '1_base' }}
-tracker_middle is: {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
-tracker_test is: {{ tracker_test }}? {{ tracker_test == 'resolved' }}
+tracker_base is '1_base': {{ tracker_base }}? {{ tracker_base == '1_base' }}
+tracker_middle is 'resolved': {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
+tracker_test is 'resolved': {{ tracker_test }}? {{ tracker_test == 'resolved' }}
 {% endblock %}
 Deferring tracker test.{# This message will not show up in final output #}
 {% set tracker_test = deferred %}

--- a/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/base.jinja
+++ b/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/base.jinja
@@ -1,0 +1,27 @@
+{% set tracker_base = '1_base' %}
+
+tracker_base is: {{ tracker_base }}? {{ tracker_base == '1_base' }}
+tracker_middle is: {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
+tracker_test is: {{ tracker_test }}? {{ tracker_test == 'resolved' }}
+-----Pre-First-----
+{% block first -%}
+tracker_base is: {{ tracker_base }}? {{ tracker_base == 'resolved' }}
+tracker_middle is: {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
+tracker_test is: {{ tracker_test }}? {{ tracker_test == 'resolved' }}
+{%- endblock %}
+-----Post-First-----
+tracker_base is: {{ tracker_base }}? {{ tracker_base == '1_base' }}
+tracker_middle is: {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
+tracker_test is: {{ tracker_test }}? {{ tracker_test == 'resolved' }}
+-----Pre-Second-----
+{% block second -%}
+tracker_base is: {{ tracker_base }}? {{ tracker_base == 'resolved' }}
+tracker_middle is: {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
+tracker_test is: {{ tracker_test }}? {{ tracker_test == 'resolved' }}
+{%- endblock %}
+-----Post-Second-----
+Deferring tracker base.{# This message WILL show up in final output #}
+{% set tracker_base = deferred %}
+tracker_base is: {{ tracker_base }}? {{ tracker_base == 'resolved' }}
+tracker_middle is: {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
+tracker_test is: {{ tracker_test }}? {{ tracker_test == 'resolved' }}

--- a/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/base.jinja
+++ b/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/base.jinja
@@ -1,27 +1,27 @@
 {% set tracker_base = '1_base' %}
 
-tracker_base is: {{ tracker_base }}? {{ tracker_base == '1_base' }}
-tracker_middle is: {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
-tracker_test is: {{ tracker_test }}? {{ tracker_test == 'resolved' }}
+tracker_base is '1_base': {{ tracker_base }}? {{ tracker_base == '1_base' }}
+tracker_middle is 'resolved': {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
+tracker_test is 'resolved': {{ tracker_test }}? {{ tracker_test == 'resolved' }}
 -----Pre-First-----
 {% block first -%}
-tracker_base is: {{ tracker_base }}? {{ tracker_base == 'resolved' }}
-tracker_middle is: {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
-tracker_test is: {{ tracker_test }}? {{ tracker_test == 'resolved' }}
+tracker_base is 'resolved': {{ tracker_base }}? {{ tracker_base == 'resolved' }}
+tracker_middle is 'resolved': {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
+tracker_test is 'resolved': {{ tracker_test }}? {{ tracker_test == 'resolved' }}
 {%- endblock %}
 -----Post-First-----
-tracker_base is: {{ tracker_base }}? {{ tracker_base == '1_base' }}
-tracker_middle is: {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
-tracker_test is: {{ tracker_test }}? {{ tracker_test == 'resolved' }}
+tracker_base is '1_base': {{ tracker_base }}? {{ tracker_base == '1_base' }}
+tracker_middle is 'resolved': {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
+tracker_test is 'resolved': {{ tracker_test }}? {{ tracker_test == 'resolved' }}
 -----Pre-Second-----
 {% block second -%}
-tracker_base is: {{ tracker_base }}? {{ tracker_base == 'resolved' }}
-tracker_middle is: {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
-tracker_test is: {{ tracker_test }}? {{ tracker_test == 'resolved' }}
+tracker_base is 'resolved': {{ tracker_base }}? {{ tracker_base == 'resolved' }}
+tracker_middle is 'resolved': {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
+tracker_test is 'resolved': {{ tracker_test }}? {{ tracker_test == 'resolved' }}
 {%- endblock %}
 -----Post-Second-----
 Deferring tracker base.{# This message WILL show up in final output #}
 {% set tracker_base = deferred %}
-tracker_base is: {{ tracker_base }}? {{ tracker_base == 'resolved' }}
-tracker_middle is: {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
-tracker_test is: {{ tracker_test }}? {{ tracker_test == 'resolved' }}
+tracker_base is 'resolved': {{ tracker_base }}? {{ tracker_base == 'resolved' }}
+tracker_middle is 'resolved': {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
+tracker_test is 'resolved': {{ tracker_test }}? {{ tracker_test == 'resolved' }}

--- a/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/middle.jinja
+++ b/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/middle.jinja
@@ -5,9 +5,9 @@ I WON'T SHOW UP
 {% endblock %}
 
 {% block second %}
-tracker_base is: {{ tracker_base }}? {{ tracker_base == 'resolved' }}
-tracker_middle is: {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
-tracker_test is: {{ tracker_test }}? {{ tracker_test == 'resolved' }}
+tracker_base is 'resolved': {{ tracker_base }}? {{ tracker_base == 'resolved' }}
+tracker_middle is 'resolved': {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
+tracker_test is 'resolved': {{ tracker_test }}? {{ tracker_test == 'resolved' }}
 {% endblock %}
 Deferring tracker middle.{# This message will not show up in final output #}
 {% set tracker_middle = deferred %}

--- a/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/middle.jinja
+++ b/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/middle.jinja
@@ -1,0 +1,13 @@
+{% extends '../../eager/handles-deferred-used-in-multiple-block-levels/base.jinja' %}
+{% set tracker_middle = '2_middle' %}
+{% block first %}
+I WON'T SHOW UP
+{% endblock %}
+
+{% block second %}
+tracker_base is: {{ tracker_base }}? {{ tracker_base == 'resolved' }}
+tracker_middle is: {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
+tracker_test is: {{ tracker_test }}? {{ tracker_test == 'resolved' }}
+{% endblock %}
+Deferring tracker middle.{# This message will not show up in final output #}
+{% set tracker_middle = deferred %}

--- a/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/test.expected.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/test.expected.expected.jinja
@@ -1,25 +1,25 @@
-tracker_base is: 1_base? true
-tracker_middle is: resolved? true
-tracker_test is: resolved? true
+tracker_base is '1_base': 1_base? true
+tracker_middle is 'resolved': resolved? true
+tracker_test is 'resolved': resolved? true
 -----Pre-First-----
 
-tracker_base is: resolved? true
-tracker_middle is: resolved? true
-tracker_test is: resolved? true
+tracker_base is 'resolved': resolved? true
+tracker_middle is 'resolved': resolved? true
+tracker_test is 'resolved': resolved? true
 
 -----Post-First-----
-tracker_base is: 1_base? true
-tracker_middle is: resolved? true
-tracker_test is: resolved? true
+tracker_base is '1_base': 1_base? true
+tracker_middle is 'resolved': resolved? true
+tracker_test is 'resolved': resolved? true
 -----Pre-Second-----
 
-tracker_base is: resolved? true
-tracker_middle is: resolved? true
-tracker_test is: resolved? true
+tracker_base is 'resolved': resolved? true
+tracker_middle is 'resolved': resolved? true
+tracker_test is 'resolved': resolved? true
 
 -----Post-Second-----
 Deferring tracker base.
 
-tracker_base is: resolved? true
-tracker_middle is: resolved? true
-tracker_test is: resolved? true
+tracker_base is 'resolved': resolved? true
+tracker_middle is 'resolved': resolved? true
+tracker_test is 'resolved': resolved? true

--- a/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/test.expected.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/test.expected.expected.jinja
@@ -1,0 +1,25 @@
+tracker_base is: 1_base? true
+tracker_middle is: resolved? true
+tracker_test is: resolved? true
+-----Pre-First-----
+
+tracker_base is: resolved? true
+tracker_middle is: resolved? true
+tracker_test is: resolved? true
+
+-----Post-First-----
+tracker_base is: 1_base? true
+tracker_middle is: resolved? true
+tracker_test is: resolved? true
+-----Pre-Second-----
+
+tracker_base is: resolved? true
+tracker_middle is: resolved? true
+tracker_test is: resolved? true
+
+-----Post-Second-----
+Deferring tracker base.
+
+tracker_base is: resolved? true
+tracker_middle is: resolved? true
+tracker_test is: resolved? true

--- a/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/test.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/test.expected.jinja
@@ -14,45 +14,45 @@ Deferring tracker middle.
 {% enddo %}\
 {# End Label:  ignored_output_from_extends #}{% set current_path = 'eager/handles-deferred-used-in-multiple-block-levels/base.jinja' %}
 
-tracker_base is: 1_base? true
-tracker_middle is: {{ tracker_middle }}\
+tracker_base is '1_base': 1_base? true
+tracker_middle is 'resolved': {{ tracker_middle }}\
 ? {{ tracker_middle == 'resolved' }}
-tracker_test is: {{ tracker_test }}\
+tracker_test is 'resolved': {{ tracker_test }}\
 ? {{ tracker_test == 'resolved' }}
 -----Pre-First-----
 {% block first %}\
 {% set __temp_meta_current_path_1057627035__,current_path = current_path,'eager/handles-deferred-used-in-multiple-block-levels/test.jinja' %}
-tracker_base is: {{ tracker_base }}\
+tracker_base is 'resolved': {{ tracker_base }}\
 ? {{ tracker_base == 'resolved' }}
-tracker_middle is: {{ tracker_middle }}\
+tracker_middle is 'resolved': {{ tracker_middle }}\
 ? {{ tracker_middle == 'resolved' }}
-tracker_test is: {{ tracker_test }}\
+tracker_test is 'resolved': {{ tracker_test }}\
 ? {{ tracker_test == 'resolved' }}
 {% set current_path,__temp_meta_current_path_1057627035__ = __temp_meta_current_path_1057627035__,null %}\
 {% endblock first %}
 -----Post-First-----
-tracker_base is: 1_base? true
-tracker_middle is: {{ tracker_middle }}\
+tracker_base is '1_base': 1_base? true
+tracker_middle is 'resolved': {{ tracker_middle }}\
 ? {{ tracker_middle == 'resolved' }}
-tracker_test is: {{ tracker_test }}\
+tracker_test is 'resolved': {{ tracker_test }}\
 ? {{ tracker_test == 'resolved' }}
 -----Pre-Second-----
 {% block second %}\
 {% set __temp_meta_current_path_697061783__,current_path = current_path,'eager/handles-deferred-used-in-multiple-block-levels/middle.jinja' %}
-tracker_base is: {{ tracker_base }}\
+tracker_base is 'resolved': {{ tracker_base }}\
 ? {{ tracker_base == 'resolved' }}
-tracker_middle is: {{ tracker_middle }}\
+tracker_middle is 'resolved': {{ tracker_middle }}\
 ? {{ tracker_middle == 'resolved' }}
-tracker_test is: {{ tracker_test }}\
+tracker_test is 'resolved': {{ tracker_test }}\
 ? {{ tracker_test == 'resolved' }}
 {% set current_path,__temp_meta_current_path_697061783__ = __temp_meta_current_path_697061783__,null %}\
 {% endblock second %}
 -----Post-Second-----
 Deferring tracker base.
 {% set tracker_base = deferred %}
-tracker_base is: {{ tracker_base }}\
+tracker_base is 'resolved': {{ tracker_base }}\
 ? {{ tracker_base == 'resolved' }}
-tracker_middle is: {{ tracker_middle }}\
+tracker_middle is 'resolved': {{ tracker_middle }}\
 ? {{ tracker_middle == 'resolved' }}
-tracker_test is: {{ tracker_test }}\
+tracker_test is 'resolved': {{ tracker_test }}\
 ? {{ tracker_test == 'resolved' }}

--- a/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/test.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/test.expected.jinja
@@ -20,6 +20,7 @@ tracker_middle is: {{ tracker_middle }}\
 tracker_test is: {{ tracker_test }}\
 ? {{ tracker_test == 'resolved' }}
 -----Pre-First-----
+{% block first %}\
 {% set __temp_meta_current_path_1057627035__,current_path = current_path,'eager/handles-deferred-used-in-multiple-block-levels/test.jinja' %}
 tracker_base is: {{ tracker_base }}\
 ? {{ tracker_base == 'resolved' }}
@@ -27,7 +28,8 @@ tracker_middle is: {{ tracker_middle }}\
 ? {{ tracker_middle == 'resolved' }}
 tracker_test is: {{ tracker_test }}\
 ? {{ tracker_test == 'resolved' }}
-{% set current_path,__temp_meta_current_path_1057627035__ = __temp_meta_current_path_1057627035__,null %}
+{% set current_path,__temp_meta_current_path_1057627035__ = __temp_meta_current_path_1057627035__,null %}\
+{% endblock first %}
 -----Post-First-----
 tracker_base is: 1_base? true
 tracker_middle is: {{ tracker_middle }}\
@@ -35,6 +37,7 @@ tracker_middle is: {{ tracker_middle }}\
 tracker_test is: {{ tracker_test }}\
 ? {{ tracker_test == 'resolved' }}
 -----Pre-Second-----
+{% block second %}\
 {% set __temp_meta_current_path_697061783__,current_path = current_path,'eager/handles-deferred-used-in-multiple-block-levels/middle.jinja' %}
 tracker_base is: {{ tracker_base }}\
 ? {{ tracker_base == 'resolved' }}
@@ -42,7 +45,8 @@ tracker_middle is: {{ tracker_middle }}\
 ? {{ tracker_middle == 'resolved' }}
 tracker_test is: {{ tracker_test }}\
 ? {{ tracker_test == 'resolved' }}
-{% set current_path,__temp_meta_current_path_697061783__ = __temp_meta_current_path_697061783__,null %}
+{% set current_path,__temp_meta_current_path_697061783__ = __temp_meta_current_path_697061783__,null %}\
+{% endblock second %}
 -----Post-Second-----
 Deferring tracker base.
 {% set tracker_base = deferred %}

--- a/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/test.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/test.expected.jinja
@@ -1,0 +1,54 @@
+{# Start Label:  ignored_output_from_extends #}{% do %}
+
+
+
+Deferring tracker test.
+{% set tracker_test = deferred %}
+
+
+
+
+
+Deferring tracker middle.
+{% set tracker_middle = deferred %}
+{% enddo %}\
+{# End Label:  ignored_output_from_extends #}{% set current_path = 'eager/handles-deferred-used-in-multiple-block-levels/base.jinja' %}
+
+tracker_base is: 1_base? true
+tracker_middle is: {{ tracker_middle }}\
+? {{ tracker_middle == 'resolved' }}
+tracker_test is: {{ tracker_test }}\
+? {{ tracker_test == 'resolved' }}
+-----Pre-First-----
+{% set __temp_meta_current_path_1057627035__,current_path = current_path,'eager/handles-deferred-used-in-multiple-block-levels/test.jinja' %}
+tracker_base is: {{ tracker_base }}\
+? {{ tracker_base == 'resolved' }}
+tracker_middle is: {{ tracker_middle }}\
+? {{ tracker_middle == 'resolved' }}
+tracker_test is: {{ tracker_test }}\
+? {{ tracker_test == 'resolved' }}
+{% set current_path,__temp_meta_current_path_1057627035__ = __temp_meta_current_path_1057627035__,null %}
+-----Post-First-----
+tracker_base is: 1_base? true
+tracker_middle is: {{ tracker_middle }}\
+? {{ tracker_middle == 'resolved' }}
+tracker_test is: {{ tracker_test }}\
+? {{ tracker_test == 'resolved' }}
+-----Pre-Second-----
+{% set __temp_meta_current_path_697061783__,current_path = current_path,'eager/handles-deferred-used-in-multiple-block-levels/middle.jinja' %}
+tracker_base is: {{ tracker_base }}\
+? {{ tracker_base == 'resolved' }}
+tracker_middle is: {{ tracker_middle }}\
+? {{ tracker_middle == 'resolved' }}
+tracker_test is: {{ tracker_test }}\
+? {{ tracker_test == 'resolved' }}
+{% set current_path,__temp_meta_current_path_697061783__ = __temp_meta_current_path_697061783__,null %}
+-----Post-Second-----
+Deferring tracker base.
+{% set tracker_base = deferred %}
+tracker_base is: {{ tracker_base }}\
+? {{ tracker_base == 'resolved' }}
+tracker_middle is: {{ tracker_middle }}\
+? {{ tracker_middle == 'resolved' }}
+tracker_test is: {{ tracker_test }}\
+? {{ tracker_test == 'resolved' }}

--- a/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/test.jinja
+++ b/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/test.jinja
@@ -2,9 +2,9 @@
 
 {% set tracker_test = '3_test' %}
 {% block first %}
-tracker_base is: {{ tracker_base }}? {{ tracker_base == 'resolved' }}
-tracker_middle is: {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
-tracker_test is: {{ tracker_test }}? {{ tracker_test == 'resolved' }}
+tracker_base is 'resolved': {{ tracker_base }}? {{ tracker_base == 'resolved' }}
+tracker_middle is 'resolved': {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
+tracker_test is 'resolved': {{ tracker_test }}? {{ tracker_test == 'resolved' }}
 {% endblock %}
 Deferring tracker test.{# This message will not show up in final output #}
 {% set tracker_test = deferred %}

--- a/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/test.jinja
+++ b/src/test/resources/eager/handles-deferred-used-in-multiple-block-levels/test.jinja
@@ -1,0 +1,10 @@
+{% extends '../../eager/handles-deferred-used-in-multiple-block-levels/middle.jinja' %}
+
+{% set tracker_test = '3_test' %}
+{% block first %}
+tracker_base is: {{ tracker_base }}? {{ tracker_base == 'resolved' }}
+tracker_middle is: {{ tracker_middle }}? {{ tracker_middle == 'resolved' }}
+tracker_test is: {{ tracker_test }}? {{ tracker_test == 'resolved' }}
+{% endblock %}
+Deferring tracker test.{# This message will not show up in final output #}
+{% set tracker_test = deferred %}

--- a/src/test/resources/eager/preserves-blocks-for-reconstruction-order/base.jinja
+++ b/src/test/resources/eager/preserves-blocks-for-reconstruction-order/base.jinja
@@ -1,0 +1,13 @@
+{% if deferred %}
+{% set deferred_list = [] %}
+{% endif %}
+{% do deferred_list.append('Before block') %}
+Deferred list after block is: {{ deferred_list }}
+Deferred list after block should be: ['Before block']
+-----Pre-First-----
+{% block first -%}
+{%- endblock %}
+-----Post-First-----
+{% do deferred_list.append('After block') %}
+Deferred list after block is: {{ deferred_list }}
+Deferred list after block should be: ['Before block', 'After block']

--- a/src/test/resources/eager/preserves-blocks-for-reconstruction-order/test.expected.expected.jinja
+++ b/src/test/resources/eager/preserves-blocks-for-reconstruction-order/test.expected.expected.jinja
@@ -1,0 +1,12 @@
+Deferred list after block is: ['Before block']
+Deferred list after block should be: ['Before block']
+-----Pre-First-----
+
+
+Deferred list inside of block is: ['Before block', 'After block', 'In child block']
+Deferred list inside of block should be: ['Before block', 'After block', 'In child block']
+
+-----Post-First-----
+
+Deferred list after block is: ['Before block', 'After block']
+Deferred list after block should be: ['Before block', 'After block']

--- a/src/test/resources/eager/preserves-blocks-for-reconstruction-order/test.expected.jinja
+++ b/src/test/resources/eager/preserves-blocks-for-reconstruction-order/test.expected.jinja
@@ -1,0 +1,19 @@
+{% set current_path = 'eager/preserves-blocks-for-reconstruction-order/base.jinja' %}\
+{% if deferred %}
+{% set deferred_list = [] %}
+{% endif %}
+{% do deferred_list.append('Before block') %}
+Deferred list after block is: {{ deferred_list }}
+Deferred list after block should be: ['Before block']
+-----Pre-First-----
+{% block first %}\
+{% set __temp_meta_current_path_1012932725__,current_path = current_path,'eager/preserves-blocks-for-reconstruction-order/test.jinja' %}
+{% do deferred_list.append('In child block') %}
+Deferred list inside of block is: {{ deferred_list }}
+Deferred list inside of block should be: ['Before block', 'After block', 'In child block']
+{% set current_path,__temp_meta_current_path_1012932725__ = __temp_meta_current_path_1012932725__,null %}\
+{% endblock first %}
+-----Post-First-----
+{% do deferred_list.append('After block') %}
+Deferred list after block is: {{ deferred_list }}
+Deferred list after block should be: ['Before block', 'After block']

--- a/src/test/resources/eager/preserves-blocks-for-reconstruction-order/test.jinja
+++ b/src/test/resources/eager/preserves-blocks-for-reconstruction-order/test.jinja
@@ -1,0 +1,7 @@
+{% extends '../../eager/preserves-blocks-for-reconstruction-order/base.jinja' %}
+
+{% block first %}
+{% do deferred_list.append('In child block') %}
+Deferred list inside of block is: {{ deferred_list }}
+Deferred list inside of block should be: ['Before block', 'After block', 'In child block']
+{% endblock %}

--- a/src/test/resources/eager/reconstructs-block-path-when-deferred-nested/test.expected.jinja
+++ b/src/test/resources/eager/reconstructs-block-path-when-deferred-nested/test.expected.jinja
@@ -3,18 +3,22 @@
 Parent's current path is: {{ '{{' + prefix + '_path }}\
 ' }}
 -----Pre-First-----
+{% block first %}\
 {% set __temp_meta_current_path_389897147__,current_path = current_path,'eager/reconstructs-block-path-when-deferred-nested/test.jinja' %}\
 {% set prefix = deferred ? 'current' : 'current' %}\
 Child's first current path is: {{ '{{' + prefix + '_path }}\
 ' }}
-{% set current_path,__temp_meta_current_path_389897147__ = __temp_meta_current_path_389897147__,null %}
+{% set current_path,__temp_meta_current_path_389897147__ = __temp_meta_current_path_389897147__,null %}\
+{% endblock first %}
 -----Post-First-----
 -----Pre-Second-----
+{% block second %}\
 {% set __temp_meta_current_path_198396781__,current_path = current_path,'eager/reconstructs-block-path-when-deferred-nested/middle.jinja' %}\
 {% set prefix = deferred ? 'current' : 'current' %}\
 Middle's second current path is: {{ '{{' + prefix + '_path }}\
 ' }}
-{% set current_path,__temp_meta_current_path_198396781__ = __temp_meta_current_path_198396781__,null %}
+{% set current_path,__temp_meta_current_path_198396781__ = __temp_meta_current_path_198396781__,null %}\
+{% endblock second %}
 -----Post-Second-----
 Parent's current path is: {{ '{{' + prefix + '_path }}\
 ' }}

--- a/src/test/resources/eager/reconstructs-block-path-when-deferred/test.expected.jinja
+++ b/src/test/resources/eager/reconstructs-block-path-when-deferred/test.expected.jinja
@@ -3,11 +3,13 @@
 Parent's current path is: {{ '{{' + prefix + '_path }}\
 ' }}
 -----Pre-Block-----
+{% block body %}\
 {% set __temp_meta_current_path_329664044__,current_path = current_path,'eager/reconstructs-block-path-when-deferred/test.jinja' %}\
 {% set prefix = deferred ? 'current' : 'current' %}\
 Block's current path is: {{ '{{' + prefix + '_path }}\
 ' }}
-{% set current_path,__temp_meta_current_path_329664044__ = __temp_meta_current_path_329664044__,null %}
+{% set current_path,__temp_meta_current_path_329664044__ = __temp_meta_current_path_329664044__,null %}\
+{% endblock body %}
 -----Post-Block-----
 Parent's current path is: {{ '{{' + prefix + '_path }}\
 ' }}


### PR DESCRIPTION
## Description

Backport of #1312 to `master-2.8.x` so the block reconstruction/execution order fix is available in jinjava 2.8.4. The original fix addressed values not being resolved properly when used in blocks that have been deferred in their extends roots. Cherry-picked cleanly with no conflicts; all tests pass.

*Authored by Claude Code*

## BRAVE
#### Backwards Compatibility
This is a direct backport of an already-merged fix from master. No new API changes.

#### Rollout and Rollback Plan
Standard library release. Rollback by reverting this PR or not publishing the 2.8.4 release.

#### Automated Testing
Tests added in the original PR are included in the cherry-pick: block reconstruction order tests, deferred block resolution tests, and multi-level block inheritance tests.

#### Verification
All 184 EagerTest tests pass locally with 0 failures.

#### Expect Dependencies to Fail
No expected downstream failures — this is a bug fix.

##### *REVIEWERS*: Please review both the code changes and the answers above, and validate that they match the expectations for BRAVE