### PR TITLE
Jinjava 3.0: Roll back some of the unnecessary breaking changes

### DIFF
--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -54,6 +54,12 @@ import org.immutables.value.Value;
 
 @Value.Immutable(singleton = true)
 @JinjavaImmutableStyle.WithStyle
+@Value.Style(
+  init = "with*",
+  get = { "is*", "get*" }, // Detect 'get' and 'is' prefixes in accessor methods
+  build = "buildImpl", // This is an alias for keeping binary compatibility on the "build" method.
+  visibility = Value.Style.ImplementationVisibility.PACKAGE
+)
 public class JinjavaConfig {
 
   public JinjavaConfig() {}
@@ -249,7 +255,12 @@ public class JinjavaConfig {
     return getLegacyOverrides().isIterateOverMapKeys();
   }
 
-  public static class Builder extends ImmutableJinjavaConfig.Builder {}
+  public static class Builder extends ImmutableJinjavaConfig.Builder {
+
+    public JinjavaConfig build() {
+      return super.buildImpl();
+    }
+  }
 
   public static Builder builder() {
     return new Builder();

--- a/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
+++ b/src/main/java/com/hubspot/jinjava/JinjavaConfig.java
@@ -20,6 +20,7 @@ import static com.hubspot.jinjava.lib.fn.Functions.DEFAULT_RANGE_LIMIT;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.google.common.collect.ImmutableMap;
 import com.hubspot.jinjava.el.JinjavaInterpreterResolver;
 import com.hubspot.jinjava.el.JinjavaObjectUnwrapper;
 import com.hubspot.jinjava.el.JinjavaProcessors;
@@ -53,158 +54,164 @@ import org.immutables.value.Value;
 
 @Value.Immutable(singleton = true)
 @JinjavaImmutableStyle.WithStyle
-public interface JinjavaConfig {
+public class JinjavaConfig {
+
+  public JinjavaConfig() {}
+
   @Value.Default
-  default Charset getCharset() {
+  public Charset getCharset() {
     return StandardCharsets.UTF_8;
   }
 
   @Value.Default
-  default Locale getLocale() {
+  public Locale getLocale() {
     return Locale.ENGLISH;
   }
 
   @Value.Default
-  default ZoneId getTimeZone() {
+  public ZoneId getTimeZone() {
     return ZoneOffset.UTC;
   }
 
   @Value.Default
-  default int getMaxRenderDepth() {
+  public int getMaxRenderDepth() {
     return 10;
   }
 
   @Value.Default
-  default long getMaxOutputSize() {
+  public long getMaxOutputSize() {
     return 0;
   }
 
   @Value.Default
-  default boolean isTrimBlocks() {
+  public boolean isTrimBlocks() {
     return false;
   }
 
   @Value.Default
-  default boolean isLstripBlocks() {
+  public boolean isLstripBlocks() {
     return false;
   }
 
   @Value.Default
-  default boolean isEnableRecursiveMacroCalls() {
+  public boolean isEnableRecursiveMacroCalls() {
     return false;
   }
 
   @Value.Default
-  default int getMaxMacroRecursionDepth() {
+  public int getMaxMacroRecursionDepth() {
     return 0;
   }
 
-  Map<Library, Set<String>> getDisabled();
+  @Value.Default
+  public Map<Library, Set<String>> getDisabled() {
+    return ImmutableMap.of();
+  }
 
   @Value.Default
-  default boolean isFailOnUnknownTokens() {
+  public boolean isFailOnUnknownTokens() {
     return false;
   }
 
   @Value.Default
-  default boolean isNestedInterpretationEnabled() {
+  public boolean isNestedInterpretationEnabled() {
     return false; // Default changed to false in 3.0
   }
 
   @Value.Default
-  default RandomNumberGeneratorStrategy getRandomNumberGeneratorStrategy() {
+  public RandomNumberGeneratorStrategy getRandomNumberGeneratorStrategy() {
     return RandomNumberGeneratorStrategy.THREAD_LOCAL;
   }
 
   @Value.Default
-  default boolean isValidationMode() {
+  public boolean isValidationMode() {
     return false;
   }
 
   @Value.Default
-  default long getMaxStringLength() {
+  public long getMaxStringLength() {
     return getMaxOutputSize();
   }
 
   @Value.Default
-  default int getMaxListSize() {
+  public int getMaxListSize() {
     return Integer.MAX_VALUE;
   }
 
   @Value.Default
-  default int getMaxMapSize() {
+  public int getMaxMapSize() {
     return Integer.MAX_VALUE;
   }
 
   @Value.Default
-  default int getRangeLimit() {
+  public int getRangeLimit() {
     return DEFAULT_RANGE_LIMIT;
   }
 
   @Value.Default
-  default int getMaxNumDeferredTokens() {
+  public int getMaxNumDeferredTokens() {
     return 1000;
   }
 
   @Value.Default
-  default InterpreterFactory getInterpreterFactory() {
+  public InterpreterFactory getInterpreterFactory() {
     return new JinjavaInterpreterFactory();
   }
 
   @Value.Default
-  default DateTimeProvider getDateTimeProvider() {
+  public DateTimeProvider getDateTimeProvider() {
     return new CurrentDateTimeProvider();
   }
 
   @Value.Default
-  default TokenScannerSymbols getTokenScannerSymbols() {
+  public TokenScannerSymbols getTokenScannerSymbols() {
     return new DefaultTokenScannerSymbols();
   }
 
   @Value.Default
-  default AllowlistMethodValidator getMethodValidator() {
+  public AllowlistMethodValidator getMethodValidator() {
     return AllowlistMethodValidator.DEFAULT;
   }
 
   @Value.Default
-  default AllowlistReturnTypeValidator getReturnTypeValidator() {
+  public AllowlistReturnTypeValidator getReturnTypeValidator() {
     return AllowlistReturnTypeValidator.DEFAULT;
   }
 
   @Value.Default
-  default ELResolver getElResolver() {
+  public ELResolver getElResolver() {
     return isDefaultReadOnlyResolver()
       ? JinjavaInterpreterResolver.DEFAULT_RESOLVER_READ_ONLY
       : JinjavaInterpreterResolver.DEFAULT_RESOLVER_READ_WRITE;
   }
 
   @Value.Default
-  default boolean isDefaultReadOnlyResolver() {
+  public boolean isDefaultReadOnlyResolver() {
     return true;
   }
 
   @Value.Default
-  default ExecutionMode getExecutionMode() {
+  public ExecutionMode getExecutionMode() {
     return DefaultExecutionMode.instance();
   }
 
   @Value.Default
-  default LegacyOverrides getLegacyOverrides() {
+  public LegacyOverrides getLegacyOverrides() {
     return LegacyOverrides.THREE_POINT_0;
   }
 
   @Value.Default
-  default boolean getEnablePreciseDivideFilter() {
+  public boolean getEnablePreciseDivideFilter() {
     return false;
   }
 
   @Value.Default
-  default boolean isEnableFilterChainOptimization() {
+  public boolean isEnableFilterChainOptimization() {
     return false;
   }
 
   @Value.Default
-  default ObjectMapper getObjectMapper() {
+  public ObjectMapper getObjectMapper() {
     ObjectMapper objectMapper = new ObjectMapper().registerModule(new Jdk8Module());
     if (getLegacyOverrides().isUseSnakeCasePropertyNaming()) {
       objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
@@ -213,42 +220,42 @@ public interface JinjavaConfig {
   }
 
   @Value.Default
-  default ObjectUnwrapper getObjectUnwrapper() {
+  public ObjectUnwrapper getObjectUnwrapper() {
     return new JinjavaObjectUnwrapper();
   }
 
   @Value.Derived
-  default Features getFeatures() {
+  public Features getFeatures() {
     return new Features(getFeatureConfig());
   }
 
   @Value.Default
-  default FeatureConfig getFeatureConfig() {
+  public FeatureConfig getFeatureConfig() {
     return FeatureConfig.newBuilder().build();
   }
 
   @Value.Default
-  default JinjavaProcessors getProcessors() {
+  public JinjavaProcessors getProcessors() {
     return JinjavaProcessors.newBuilder().build();
   }
 
   @Deprecated
-  default BiConsumer<Node, JinjavaInterpreter> getNodePreProcessor() {
+  public BiConsumer<Node, JinjavaInterpreter> getNodePreProcessor() {
     return getProcessors().getNodePreProcessor();
   }
 
   @Deprecated
-  default boolean isIterateOverMapKeys() {
+  public boolean isIterateOverMapKeys() {
     return getLegacyOverrides().isIterateOverMapKeys();
   }
 
-  class Builder extends ImmutableJinjavaConfig.Builder {}
+  public static class Builder extends ImmutableJinjavaConfig.Builder {}
 
-  static Builder builder() {
+  public static Builder builder() {
     return new Builder();
   }
 
-  static Builder newBuilder() {
+  public static Builder newBuilder() {
     return builder();
   }
 }

--- a/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
+++ b/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
@@ -1,17 +1,14 @@
 package com.hubspot.jinjava;
 
-import org.immutables.value.Value;
-
 /**
  * This class allows Jinjava to be configured to override legacy behaviour.
  * LegacyOverrides.NONE signifies that none of the legacy functionality will be overridden.
  * LegacyOverrides.ALL signifies that all new functionality will be used; avoid legacy "bugs".
  */
-@Value.Immutable(singleton = true)
-@JinjavaImmutableStyle.WithStyle
-public interface LegacyOverrides extends WithLegacyOverrides {
-  LegacyOverrides NONE = new Builder().build();
-  LegacyOverrides THREE_POINT_0 = new Builder()
+public class LegacyOverrides {
+
+  public static final LegacyOverrides NONE = new LegacyOverrides.Builder().build();
+  public static final LegacyOverrides THREE_POINT_0 = new Builder()
     .withEvaluateMapKeys(true)
     .withIterateOverMapKeys(true)
     .withUsePyishObjectMapper(true)
@@ -22,7 +19,7 @@ public interface LegacyOverrides extends WithLegacyOverrides {
     .withUseTrimmingForNotesAndExpressions(true)
     .withKeepNullableLoopValues(true)
     .build();
-  LegacyOverrides ALL = new Builder()
+  public static final LegacyOverrides ALL = new LegacyOverrides.Builder()
     .withEvaluateMapKeys(true)
     .withIterateOverMapKeys(true)
     .withUsePyishObjectMapper(true)
@@ -33,59 +30,151 @@ public interface LegacyOverrides extends WithLegacyOverrides {
     .withUseTrimmingForNotesAndExpressions(true)
     .withKeepNullableLoopValues(true)
     .build();
+  private final boolean evaluateMapKeys;
+  private final boolean iterateOverMapKeys;
+  private final boolean usePyishObjectMapper;
+  private final boolean useSnakeCasePropertyNaming;
+  private final boolean useNaturalOperatorPrecedence;
+  private final boolean parseWhitespaceControlStrictly;
+  private final boolean allowAdjacentTextNodes;
+  private final boolean useTrimmingForNotesAndExpressions;
+  private final boolean keepNullableLoopValues;
 
-  @Value.Default
-  default boolean isEvaluateMapKeys() {
-    return false;
+  private LegacyOverrides(Builder builder) {
+    evaluateMapKeys = builder.evaluateMapKeys;
+    iterateOverMapKeys = builder.iterateOverMapKeys;
+    usePyishObjectMapper = builder.usePyishObjectMapper;
+    useSnakeCasePropertyNaming = builder.useSnakeCasePropertyNaming;
+    useNaturalOperatorPrecedence = builder.useNaturalOperatorPrecedence;
+    parseWhitespaceControlStrictly = builder.parseWhitespaceControlStrictly;
+    allowAdjacentTextNodes = builder.allowAdjacentTextNodes;
+    useTrimmingForNotesAndExpressions = builder.useTrimmingForNotesAndExpressions;
+    keepNullableLoopValues = builder.keepNullableLoopValues;
   }
 
-  @Value.Default
-  default boolean isIterateOverMapKeys() {
-    return false;
-  }
-
-  @Value.Default
-  default boolean isUsePyishObjectMapper() {
-    return false;
-  }
-
-  @Value.Default
-  default boolean isUseSnakeCasePropertyNaming() {
-    return false;
-  }
-
-  @Value.Default
-  default boolean isUseNaturalOperatorPrecedence() {
-    return false;
-  }
-
-  @Value.Default
-  default boolean isParseWhitespaceControlStrictly() {
-    return false;
-  }
-
-  @Value.Default
-  default boolean isAllowAdjacentTextNodes() {
-    return false;
-  }
-
-  @Value.Default
-  default boolean isUseTrimmingForNotesAndExpressions() {
-    return false;
-  }
-
-  @Value.Default
-  default boolean isKeepNullableLoopValues() {
-    return false;
-  }
-
-  class Builder extends ImmutableLegacyOverrides.Builder {}
-
-  static Builder newBuilder() {
-    return builder();
-  }
-
-  static Builder builder() {
+  public static Builder newBuilder() {
     return new Builder();
+  }
+
+  public boolean isEvaluateMapKeys() {
+    return evaluateMapKeys;
+  }
+
+  public boolean isIterateOverMapKeys() {
+    return iterateOverMapKeys;
+  }
+
+  public boolean isUsePyishObjectMapper() {
+    return usePyishObjectMapper;
+  }
+
+  public boolean isUseSnakeCasePropertyNaming() {
+    return useSnakeCasePropertyNaming;
+  }
+
+  public boolean isUseNaturalOperatorPrecedence() {
+    return useNaturalOperatorPrecedence;
+  }
+
+  public boolean isParseWhitespaceControlStrictly() {
+    return parseWhitespaceControlStrictly;
+  }
+
+  public boolean isAllowAdjacentTextNodes() {
+    return allowAdjacentTextNodes;
+  }
+
+  public boolean isUseTrimmingForNotesAndExpressions() {
+    return useTrimmingForNotesAndExpressions;
+  }
+
+  public boolean isKeepNullableLoopValues() {
+    return keepNullableLoopValues;
+  }
+
+  public static class Builder {
+
+    private boolean evaluateMapKeys = false;
+    private boolean iterateOverMapKeys = false;
+    private boolean usePyishObjectMapper = false;
+    private boolean useSnakeCasePropertyNaming = false;
+    private boolean useNaturalOperatorPrecedence = false;
+    private boolean parseWhitespaceControlStrictly = false;
+    private boolean allowAdjacentTextNodes = false;
+    private boolean useTrimmingForNotesAndExpressions = false;
+    private boolean keepNullableLoopValues = false;
+
+    private Builder() {}
+
+    public LegacyOverrides build() {
+      return new LegacyOverrides(this);
+    }
+
+    public static Builder from(LegacyOverrides legacyOverrides) {
+      return new Builder()
+        .withEvaluateMapKeys(legacyOverrides.evaluateMapKeys)
+        .withIterateOverMapKeys(legacyOverrides.iterateOverMapKeys)
+        .withUsePyishObjectMapper(legacyOverrides.usePyishObjectMapper)
+        .withUseSnakeCasePropertyNaming(legacyOverrides.useSnakeCasePropertyNaming)
+        .withUseNaturalOperatorPrecedence(legacyOverrides.useNaturalOperatorPrecedence)
+        .withParseWhitespaceControlStrictly(
+          legacyOverrides.parseWhitespaceControlStrictly
+        )
+        .withAllowAdjacentTextNodes(legacyOverrides.allowAdjacentTextNodes)
+        .withUseTrimmingForNotesAndExpressions(
+          legacyOverrides.useTrimmingForNotesAndExpressions
+        );
+    }
+
+    public Builder withEvaluateMapKeys(boolean evaluateMapKeys) {
+      this.evaluateMapKeys = evaluateMapKeys;
+      return this;
+    }
+
+    public Builder withIterateOverMapKeys(boolean iterateOverMapKeys) {
+      this.iterateOverMapKeys = iterateOverMapKeys;
+      return this;
+    }
+
+    public Builder withUsePyishObjectMapper(boolean usePyishObjectMapper) {
+      this.usePyishObjectMapper = usePyishObjectMapper;
+      return this;
+    }
+
+    public Builder withUseSnakeCasePropertyNaming(boolean useSnakeCasePropertyNaming) {
+      this.useSnakeCasePropertyNaming = useSnakeCasePropertyNaming;
+      return this;
+    }
+
+    public Builder withUseNaturalOperatorPrecedence(
+      boolean useNaturalOperatorPrecedence
+    ) {
+      this.useNaturalOperatorPrecedence = useNaturalOperatorPrecedence;
+      return this;
+    }
+
+    public Builder withParseWhitespaceControlStrictly(
+      boolean parseWhitespaceControlStrictly
+    ) {
+      this.parseWhitespaceControlStrictly = parseWhitespaceControlStrictly;
+      return this;
+    }
+
+    public Builder withAllowAdjacentTextNodes(boolean allowAdjacentTextNodes) {
+      this.allowAdjacentTextNodes = allowAdjacentTextNodes;
+      return this;
+    }
+
+    public Builder withUseTrimmingForNotesAndExpressions(
+      boolean useTrimmingForNotesAndExpressions
+    ) {
+      this.useTrimmingForNotesAndExpressions = useTrimmingForNotesAndExpressions;
+      return this;
+    }
+
+    public Builder withKeepNullableLoopValues(boolean keepNullableLoopValues) {
+      this.keepNullableLoopValues = keepNullableLoopValues;
+      return this;
+    }
   }
 }

--- a/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
+++ b/src/main/java/com/hubspot/jinjava/LegacyOverrides.java
@@ -18,6 +18,7 @@ public class LegacyOverrides {
     .withAllowAdjacentTextNodes(true)
     .withUseTrimmingForNotesAndExpressions(true)
     .withKeepNullableLoopValues(true)
+    .withIteratorOnlyReverseFilter(true)
     .build();
   public static final LegacyOverrides ALL = new LegacyOverrides.Builder()
     .withEvaluateMapKeys(true)
@@ -29,6 +30,7 @@ public class LegacyOverrides {
     .withAllowAdjacentTextNodes(true)
     .withUseTrimmingForNotesAndExpressions(true)
     .withKeepNullableLoopValues(true)
+    .withIteratorOnlyReverseFilter(true)
     .build();
   private final boolean evaluateMapKeys;
   private final boolean iterateOverMapKeys;
@@ -39,6 +41,7 @@ public class LegacyOverrides {
   private final boolean allowAdjacentTextNodes;
   private final boolean useTrimmingForNotesAndExpressions;
   private final boolean keepNullableLoopValues;
+  private final boolean iteratorOnlyReverseFilter;
 
   private LegacyOverrides(Builder builder) {
     evaluateMapKeys = builder.evaluateMapKeys;
@@ -50,6 +53,7 @@ public class LegacyOverrides {
     allowAdjacentTextNodes = builder.allowAdjacentTextNodes;
     useTrimmingForNotesAndExpressions = builder.useTrimmingForNotesAndExpressions;
     keepNullableLoopValues = builder.keepNullableLoopValues;
+    iteratorOnlyReverseFilter = builder.iteratorOnlyReverseFilter;
   }
 
   public static Builder newBuilder() {
@@ -92,6 +96,10 @@ public class LegacyOverrides {
     return keepNullableLoopValues;
   }
 
+  public boolean isIteratorOnlyReverseFilter() {
+    return iteratorOnlyReverseFilter;
+  }
+
   public static class Builder {
 
     private boolean evaluateMapKeys = false;
@@ -103,6 +111,7 @@ public class LegacyOverrides {
     private boolean allowAdjacentTextNodes = false;
     private boolean useTrimmingForNotesAndExpressions = false;
     private boolean keepNullableLoopValues = false;
+    private boolean iteratorOnlyReverseFilter = false;
 
     private Builder() {}
 
@@ -123,7 +132,9 @@ public class LegacyOverrides {
         .withAllowAdjacentTextNodes(legacyOverrides.allowAdjacentTextNodes)
         .withUseTrimmingForNotesAndExpressions(
           legacyOverrides.useTrimmingForNotesAndExpressions
-        );
+        )
+        .withKeepNullableLoopValues(legacyOverrides.keepNullableLoopValues)
+        .withIteratorOnlyReverseFilter(legacyOverrides.iteratorOnlyReverseFilter);
     }
 
     public Builder withEvaluateMapKeys(boolean evaluateMapKeys) {
@@ -174,6 +185,11 @@ public class LegacyOverrides {
 
     public Builder withKeepNullableLoopValues(boolean keepNullableLoopValues) {
       this.keepNullableLoopValues = keepNullableLoopValues;
+      return this;
+    }
+
+    public Builder withIteratorOnlyReverseFilter(boolean iteratorOnlyReverseFilter) {
+      this.iteratorOnlyReverseFilter = iteratorOnlyReverseFilter;
       return this;
     }
   }

--- a/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/ExtendedParser.java
@@ -129,7 +129,7 @@ public class ExtendedParser extends Parser {
   }
 
   protected AstNode interpreter() {
-    return new AstNull();
+    return identifier(INTERPRETER);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/eager/EvalResultHolder.java
@@ -76,12 +76,14 @@ public interface EvalResultHolder {
     if (astNode == null) {
       return "";
     }
+    if (
+      astNode instanceof AstIdentifier &&
+      ExtendedParser.INTERPRETER.equals(((AstIdentifier) astNode).getName())
+    ) {
+      return ExtendedParser.INTERPRETER;
+    }
     preserveIdentifier =
-      IdentifierPreservationStrategy.preserving(
-        preserveIdentifier.isPreserving() ||
-        (astNode instanceof AstIdentifier &&
-          ExtendedParser.INTERPRETER.equals(((AstIdentifier) astNode).getName()))
-      );
+      IdentifierPreservationStrategy.preserving(preserveIdentifier.isPreserving());
     if (
       preserveIdentifier.isPreserving() &&
       !astNode.hasEvalResult() &&

--- a/src/main/java/com/hubspot/jinjava/lib/filter/ReverseFilter.java
+++ b/src/main/java/com/hubspot/jinjava/lib/filter/ReverseFilter.java
@@ -21,8 +21,10 @@ import com.hubspot.jinjava.doc.annotations.JinjavaSnippet;
 import com.hubspot.jinjava.interpret.JinjavaInterpreter;
 import com.hubspot.jinjava.objects.collections.ArrayBacked;
 import java.lang.reflect.Array;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 
 @JinjavaDoc(
@@ -51,11 +53,14 @@ public class ReverseFilter implements Filter {
     }
     // collection
     if (object instanceof Collection) {
-      return ReverseArrayIterator.create(((Collection<?>) object).toArray());
+      return maybeCollectToList(
+        ReverseArrayIterator.create(((Collection<?>) object).toArray()),
+        interpreter
+      );
     }
     // array
     if (object.getClass().isArray()) {
-      return ReverseArrayIterator.create(object);
+      return maybeCollectToList(ReverseArrayIterator.create(object), interpreter);
     }
     // string
     if (object instanceof String) {
@@ -70,6 +75,20 @@ public class ReverseFilter implements Filter {
     }
 
     return object;
+  }
+
+  private Object maybeCollectToList(
+    ReverseArrayIterator iterator,
+    JinjavaInterpreter interpreter
+  ) {
+    if (interpreter.getConfig().getLegacyOverrides().isIteratorOnlyReverseFilter()) {
+      return iterator;
+    }
+    List<Object> result = new ArrayList<>();
+    while (iterator.hasNext()) {
+      result.add(iterator.next());
+    }
+    return result;
   }
 
   @Override

--- a/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
+++ b/src/main/java/com/hubspot/jinjava/lib/tag/eager/EagerCycleTag.java
@@ -245,7 +245,7 @@ public class EagerCycleTag extends EagerStateChangingTag<CycleTag> {
       ) +
       // modulo indexing
       String.format(
-        "{{ %s[%d %% filter:length.filter(%s, null)] }}",
+        "{{ %s[%d %% filter:length.filter(%s, ____int3rpr3t3r____)] }}",
         var,
         forIndex,
         var

--- a/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
+++ b/src/main/java/com/hubspot/jinjava/objects/date/PyishDate.java
@@ -7,10 +7,24 @@ import com.hubspot.jinjava.objects.serialization.PyishObjectMapper;
 import com.hubspot.jinjava.objects.serialization.PyishSerializable;
 import java.io.IOException;
 import java.io.Serializable;
+import java.time.DayOfWeek;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAdjuster;
+import java.time.temporal.TemporalAmount;
+import java.time.temporal.TemporalField;
+import java.time.temporal.TemporalQuery;
+import java.time.temporal.TemporalUnit;
+import java.time.temporal.ValueRange;
 import java.util.Date;
 import java.util.Objects;
 import java.util.Optional;
@@ -113,6 +127,237 @@ public final class PyishDate
 
   public int getMicrosecond() {
     return date.get(ChronoField.MILLI_OF_SECOND);
+  }
+
+  // ZonedDateTime delegate methods
+
+  public ZoneId getZone() {
+    return date.getZone();
+  }
+
+  public ZoneOffset getOffset() {
+    return date.getOffset();
+  }
+
+  public ZonedDateTime withZoneSameLocal(ZoneId zone) {
+    return date.withZoneSameLocal(zone);
+  }
+
+  public ZonedDateTime withZoneSameInstant(ZoneId zone) {
+    return date.withZoneSameInstant(zone);
+  }
+
+  public ZonedDateTime withFixedOffsetZone() {
+    return date.withFixedOffsetZone();
+  }
+
+  public ZonedDateTime withEarlierOffsetAtOverlap() {
+    return date.withEarlierOffsetAtOverlap();
+  }
+
+  public ZonedDateTime withLaterOffsetAtOverlap() {
+    return date.withLaterOffsetAtOverlap();
+  }
+
+  public LocalDateTime toLocalDateTime() {
+    return date.toLocalDateTime();
+  }
+
+  public LocalDate toLocalDate() {
+    return date.toLocalDate();
+  }
+
+  public LocalTime toLocalTime() {
+    return date.toLocalTime();
+  }
+
+  public OffsetDateTime toOffsetDateTime() {
+    return date.toOffsetDateTime();
+  }
+
+  @Override
+  public Instant toInstant() {
+    return date.toInstant();
+  }
+
+  public boolean isSupported(TemporalField field) {
+    return date.isSupported(field);
+  }
+
+  public boolean isSupported(TemporalUnit unit) {
+    return date.isSupported(unit);
+  }
+
+  public ValueRange range(TemporalField field) {
+    return date.range(field);
+  }
+
+  public int get(TemporalField field) {
+    return date.get(field);
+  }
+
+  public long getLong(TemporalField field) {
+    return date.getLong(field);
+  }
+
+  public int getMonthValue() {
+    return date.getMonthValue();
+  }
+
+  public int getDayOfMonth() {
+    return date.getDayOfMonth();
+  }
+
+  public int getDayOfYear() {
+    return date.getDayOfYear();
+  }
+
+  public DayOfWeek getDayOfWeek() {
+    return date.getDayOfWeek();
+  }
+
+  public int getNano() {
+    return date.getNano();
+  }
+
+  public ZonedDateTime with(TemporalAdjuster adjuster) {
+    return date.with(adjuster);
+  }
+
+  public ZonedDateTime with(TemporalField field, long newValue) {
+    return date.with(field, newValue);
+  }
+
+  public ZonedDateTime withYear(int year) {
+    return date.withYear(year);
+  }
+
+  public ZonedDateTime withMonth(int month) {
+    return date.withMonth(month);
+  }
+
+  public ZonedDateTime withDayOfMonth(int dayOfMonth) {
+    return date.withDayOfMonth(dayOfMonth);
+  }
+
+  public ZonedDateTime withDayOfYear(int dayOfYear) {
+    return date.withDayOfYear(dayOfYear);
+  }
+
+  public ZonedDateTime withHour(int hour) {
+    return date.withHour(hour);
+  }
+
+  public ZonedDateTime withMinute(int minute) {
+    return date.withMinute(minute);
+  }
+
+  public ZonedDateTime withSecond(int second) {
+    return date.withSecond(second);
+  }
+
+  public ZonedDateTime withNano(int nanoOfSecond) {
+    return date.withNano(nanoOfSecond);
+  }
+
+  public ZonedDateTime truncatedTo(TemporalUnit unit) {
+    return date.truncatedTo(unit);
+  }
+
+  public ZonedDateTime plus(TemporalAmount amountToAdd) {
+    return date.plus(amountToAdd);
+  }
+
+  public ZonedDateTime plus(long amountToAdd, TemporalUnit unit) {
+    return date.plus(amountToAdd, unit);
+  }
+
+  public ZonedDateTime plusYears(long years) {
+    return date.plusYears(years);
+  }
+
+  public ZonedDateTime plusMonths(long months) {
+    return date.plusMonths(months);
+  }
+
+  public ZonedDateTime plusWeeks(long weeks) {
+    return date.plusWeeks(weeks);
+  }
+
+  public ZonedDateTime plusDays(long days) {
+    return date.plusDays(days);
+  }
+
+  public ZonedDateTime plusHours(long hours) {
+    return date.plusHours(hours);
+  }
+
+  public ZonedDateTime plusMinutes(long minutes) {
+    return date.plusMinutes(minutes);
+  }
+
+  public ZonedDateTime plusSeconds(long seconds) {
+    return date.plusSeconds(seconds);
+  }
+
+  public ZonedDateTime plusNanos(long nanos) {
+    return date.plusNanos(nanos);
+  }
+
+  public ZonedDateTime minus(TemporalAmount amountToSubtract) {
+    return date.minus(amountToSubtract);
+  }
+
+  public ZonedDateTime minus(long amountToSubtract, TemporalUnit unit) {
+    return date.minus(amountToSubtract, unit);
+  }
+
+  public ZonedDateTime minusYears(long years) {
+    return date.minusYears(years);
+  }
+
+  public ZonedDateTime minusMonths(long months) {
+    return date.minusMonths(months);
+  }
+
+  public ZonedDateTime minusWeeks(long weeks) {
+    return date.minusWeeks(weeks);
+  }
+
+  public ZonedDateTime minusDays(long days) {
+    return date.minusDays(days);
+  }
+
+  public ZonedDateTime minusHours(long hours) {
+    return date.minusHours(hours);
+  }
+
+  public ZonedDateTime minusMinutes(long minutes) {
+    return date.minusMinutes(minutes);
+  }
+
+  public ZonedDateTime minusSeconds(long seconds) {
+    return date.minusSeconds(seconds);
+  }
+
+  public ZonedDateTime minusNanos(long nanos) {
+    return date.minusNanos(nanos);
+  }
+
+  public <R> R query(TemporalQuery<R> query) {
+    return date.query(query);
+  }
+
+  public long until(Temporal endExclusive, TemporalUnit unit) {
+    return date.until(endExclusive, unit);
+  }
+
+  public String format(DateTimeFormatter formatter) {
+    return date.format(formatter);
+  }
+
+  public long toEpochSecond() {
+    return date.toEpochSecond();
   }
 
   public String getDateFormat() {

--- a/src/test/java/com/hubspot/jinjava/EagerTest.java
+++ b/src/test/java/com/hubspot/jinjava/EagerTest.java
@@ -216,7 +216,7 @@ public class EagerTest {
 
     assertThat(output)
       .isEqualTo(
-        "{% if false || exptest:equalto.evaluate('a', null, deferred) %}preserved{% endif %}"
+        "{% if false || exptest:equalto.evaluate('a', ____int3rpr3t3r____, deferred) %}preserved{% endif %}"
       );
     assertThat(interpreter.getErrors()).isEmpty();
     localContext.put("deferred", "a");
@@ -307,7 +307,8 @@ public class EagerTest {
   @Test
   public void itPreservesFilters() {
     String output = interpreter.render("{{ deferred|capitalize }}");
-    assertThat(output).isEqualTo("{{ filter:capitalize.filter(deferred, null) }}");
+    assertThat(output)
+      .isEqualTo("{{ filter:capitalize.filter(deferred, ____int3rpr3t3r____) }}");
     assertThat(interpreter.getErrors()).isEmpty();
     localContext.put("deferred", "foo");
     assertThat(interpreter.render(output)).isEqualTo("Foo");
@@ -317,14 +318,17 @@ public class EagerTest {
   public void itPreservesFunctions() {
     String output = interpreter.render("{{ deferred|datetimeformat('%B %e, %Y') }}");
     assertThat(output)
-      .isEqualTo("{{ filter:datetimeformat.filter(deferred, null, '%B %e, %Y') }}");
+      .isEqualTo(
+        "{{ filter:datetimeformat.filter(deferred, ____int3rpr3t3r____, '%B %e, %Y') }}"
+      );
     assertThat(interpreter.getErrors()).isEmpty();
   }
 
   @Test
   public void itPreservesRandomness() {
     String output = interpreter.render("{{ [1, 2, 3]|shuffle }}");
-    assertThat(output).isEqualTo("{{ filter:shuffle.filter([1, 2, 3], null) }}");
+    assertThat(output)
+      .isEqualTo("{{ filter:shuffle.filter([1, 2, 3], ____int3rpr3t3r____) }}");
     assertThat(interpreter.getErrors()).isEmpty();
   }
 

--- a/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ExtendedSyntaxBuilderTest.java
@@ -196,7 +196,12 @@ public class ExtendedSyntaxBuilderTest {
         BaseJinjavaTest
           .newConfigBuilder()
           .withMaxOutputSize(MAX_STRING_LENGTH)
-          .withLegacyOverrides(LegacyOverrides.THREE_POINT_0.withEvaluateMapKeys(false))
+          .withLegacyOverrides(
+            LegacyOverrides.Builder
+              .from(LegacyOverrides.THREE_POINT_0)
+              .withEvaluateMapKeys(false)
+              .build()
+          )
           .build()
       )
         .newInterpreter();

--- a/src/test/java/com/hubspot/jinjava/el/ext/ExtendedParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/ExtendedParserTest.java
@@ -11,7 +11,6 @@ import de.odysseus.el.tree.impl.ast.AstIdentifier;
 import de.odysseus.el.tree.impl.ast.AstMethod;
 import de.odysseus.el.tree.impl.ast.AstNested;
 import de.odysseus.el.tree.impl.ast.AstNode;
-import de.odysseus.el.tree.impl.ast.AstNull;
 import de.odysseus.el.tree.impl.ast.AstParameters;
 import de.odysseus.el.tree.impl.ast.AstString;
 import org.assertj.core.api.Assertions;
@@ -176,10 +175,12 @@ public class ExtendedParserTest {
 
     AstParameters astParameters = (AstParameters) astNode.getChild(1);
     assertThat(astParameters.getChild(0)).isInstanceOf(AstString.class);
-    assertThat(astParameters.getChild(1)).isInstanceOf(AstNull.class);
+    assertThat(astParameters.getChild(1)).isInstanceOf(AstIdentifier.class);
     assertThat(astParameters.getChild(2)).isInstanceOf(AstString.class);
 
     assertThat(astParameters.getChild(0).eval(null, null)).isEqualTo(leftExpected);
+    assertThat(((AstIdentifier) astParameters.getChild(1)).getName())
+      .isEqualTo("____int3rpr3t3r____");
     assertThat(astParameters.getChild(2).eval(null, null)).isEqualTo(rightExpected);
   }
 

--- a/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethodTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/eager/EagerAstMethodTest.java
@@ -235,7 +235,7 @@ public class EagerAstMethodTest extends BaseInterpretingTest {
       fail("Should throw DeferredParsingException");
     } catch (DeferredParsingException e) {
       assertThat(e.getDeferredEvalResult())
-        .isEqualTo("filter:upper.filter(foo_object.deferred, null)");
+        .isEqualTo("filter:upper.filter(foo_object.deferred, ____int3rpr3t3r____)");
     }
   }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/JinjavaInterpreterTest.java
@@ -387,7 +387,10 @@ public class JinjavaInterpreterTest {
           .newConfigBuilder()
           .withTimeZone(ZoneId.of("America/New_York"))
           .withLegacyOverrides(
-            LegacyOverrides.THREE_POINT_0.withParseWhitespaceControlStrictly(false)
+            LegacyOverrides.Builder
+              .from(LegacyOverrides.THREE_POINT_0)
+              .withParseWhitespaceControlStrictly(false)
+              .build()
           )
           .build()
       );

--- a/src/test/java/com/hubspot/jinjava/lib/filter/ReverseFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/ReverseFilterTest.java
@@ -3,6 +3,8 @@ package com.hubspot.jinjava.lib.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hubspot.jinjava.BaseJinjavaTest;
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.LegacyOverrides;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
@@ -27,5 +29,23 @@ public class ReverseFilterTest extends BaseJinjavaTest {
       jinjava.render("{% for item in arr|reverse %}{{ item }}{% endfor %}", context)
     )
       .isEqualTo("cba");
+  }
+
+  @Test
+  public void itAllowsIndexingWhenLegacyOverrideIsDisabled() {
+    Jinjava legacyJinjava = new Jinjava(
+      BaseJinjavaTest
+        .newConfigBuilder()
+        .withLegacyOverrides(
+          LegacyOverrides.Builder
+            .from(LegacyOverrides.THREE_POINT_0)
+            .withIteratorOnlyReverseFilter(false)
+            .build()
+        )
+        .build()
+    );
+    Map<String, Object> context = new HashMap<>();
+    context.put("arr", new String[] { "a", "b", "c" });
+    assertThat(legacyJinjava.render("{{ (arr|reverse)[0] }}", context)).isEqualTo("c");
   }
 }

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerImportTagTest.java
@@ -423,7 +423,7 @@ public class EagerImportTagTest extends ImportTagTest {
     assertThat(firstPassResult)
       .isEqualTo(
         "{% set deferred_import_resource_path = 'import-macro.jinja' %}{% macro m.print_path_macro(var) %}\n" +
-        "{{ filter:print_path.filter(var, null) }}\n" +
+        "{{ filter:print_path.filter(var, ____int3rpr3t3r____) }}\n" +
         "{{ var }}\n" +
         "{% endmacro %}{% set deferred_import_resource_path = null %}{{ m.print_path_macro(foo) }}"
       );
@@ -442,7 +442,7 @@ public class EagerImportTagTest extends ImportTagTest {
     assertThat(firstPassResult)
       .isEqualTo(
         "{% set deferred_import_resource_path = 'import-macro.jinja' %}{% macro print_path_macro(var) %}\n" +
-        "{{ filter:print_path.filter(var, null) }}\n" +
+        "{{ filter:print_path.filter(var, ____int3rpr3t3r____) }}\n" +
         "{{ var }}\n" +
         "{% endmacro %}{% set deferred_import_resource_path = null %}{{ print_path_macro(foo) }}"
       );
@@ -460,9 +460,9 @@ public class EagerImportTagTest extends ImportTagTest {
     );
     assertThat(firstPassResult)
       .isEqualTo(
-        "{% set deferred_import_resource_path = 'double-import-macro.jinja' %}{% macro print_path_macro2(var) %}{{ filter:print_path.filter(var, null) }}\n" +
+        "{% set deferred_import_resource_path = 'double-import-macro.jinja' %}{% macro print_path_macro2(var) %}{{ filter:print_path.filter(var, ____int3rpr3t3r____) }}\n" +
         "{% set deferred_import_resource_path = 'import-macro.jinja' %}{% macro print_path_macro(var) %}\n" +
-        "{{ filter:print_path.filter(var, null) }}\n" +
+        "{{ filter:print_path.filter(var, ____int3rpr3t3r____) }}\n" +
         "{{ var }}\n" +
         "{% endmacro %}{% set deferred_import_resource_path = 'double-import-macro.jinja' %}{{ print_path_macro(var) }}{% endmacro %}{% set deferred_import_resource_path = null %}{{ print_path_macro2(foo) }}"
       );

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerSetTagTest.java
@@ -142,7 +142,9 @@ public class EagerSetTagTest extends SetTagTest {
     final String result = interpreter.render(template);
 
     assertThat(result)
-      .isEqualTo("{% set foo = filter:add.filter(2, null, deferred) %}{{ foo }}");
+      .isEqualTo(
+        "{% set foo = filter:add.filter(2, ____int3rpr3t3r____, deferred) %}{{ foo }}"
+      );
     assertThat(
       context
         .getDeferredTokens()
@@ -177,7 +179,7 @@ public class EagerSetTagTest extends SetTagTest {
 
     assertThat(result)
       .isEqualTo(
-        "{% set foo %}{{ 1 + deferred }}{% endset %}{% set foo = filter:add.filter(foo, null, filter:int.filter(deferred, null)) %}{{ foo }}"
+        "{% set foo %}{{ 1 + deferred }}{% endset %}{% set foo = filter:add.filter(foo, ____int3rpr3t3r____, filter:int.filter(deferred, ____int3rpr3t3r____)) %}{{ foo }}"
       );
     context.remove("foo");
     context.put("deferred", 2);
@@ -201,7 +203,7 @@ public class EagerSetTagTest extends SetTagTest {
 
     assertThat(result)
       .isEqualTo(
-        "{% set foo %}1{% endset %}{% set foo = filter:add.filter(1, null, deferred) %}{{ foo }}"
+        "{% set foo %}1{% endset %}{% set foo = filter:add.filter(1, ____int3rpr3t3r____, deferred) %}{{ foo }}"
       );
     assertThat(
       context

--- a/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
+++ b/src/test/java/com/hubspot/jinjava/objects/collections/PyMapTest.java
@@ -359,7 +359,12 @@ public class PyMapTest extends BaseJinjavaTest {
       new Jinjava(
         BaseJinjavaTest
           .newConfigBuilder()
-          .withLegacyOverrides(LegacyOverrides.THREE_POINT_0.withEvaluateMapKeys(false))
+          .withLegacyOverrides(
+            LegacyOverrides.Builder
+              .from(LegacyOverrides.THREE_POINT_0)
+              .withEvaluateMapKeys(false)
+              .build()
+          )
           .build()
       );
     assertThat(

--- a/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/TreeParserTest.java
@@ -257,7 +257,10 @@ public class TreeParserTest extends BaseInterpretingTest {
         BaseJinjavaTest
           .newConfigBuilder()
           .withLegacyOverrides(
-            LegacyOverrides.THREE_POINT_0.withUseTrimmingForNotesAndExpressions(false)
+            LegacyOverrides.Builder
+              .from(LegacyOverrides.THREE_POINT_0)
+              .withUseTrimmingForNotesAndExpressions(false)
+              .build()
           )
           .build()
       )
@@ -349,7 +352,10 @@ public class TreeParserTest extends BaseInterpretingTest {
         BaseJinjavaTest
           .newConfigBuilder()
           .withLegacyOverrides(
-            LegacyOverrides.THREE_POINT_0.withUseTrimmingForNotesAndExpressions(false)
+            LegacyOverrides.Builder
+              .from(LegacyOverrides.THREE_POINT_0)
+              .withUseTrimmingForNotesAndExpressions(false)
+              .build()
           )
           .build()
       )
@@ -368,7 +374,10 @@ public class TreeParserTest extends BaseInterpretingTest {
         BaseJinjavaTest
           .newConfigBuilder()
           .withLegacyOverrides(
-            LegacyOverrides.THREE_POINT_0.withAllowAdjacentTextNodes(false)
+            LegacyOverrides.Builder
+              .from(LegacyOverrides.THREE_POINT_0)
+              .withAllowAdjacentTextNodes(false)
+              .build()
           )
           .build()
       )

--- a/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/EagerExpressionResolverTest.java
@@ -641,7 +641,7 @@ public class EagerExpressionResolverTest {
     interpreter.getContext().setThrowInterpreterErrors(true);
     String partiallyResolved = eagerExpressionResult.toString();
     assertThat(partiallyResolved)
-      .isEqualTo("exptest:equalto.evaluateNegated(4, null, deferred)");
+      .isEqualTo("exptest:equalto.evaluateNegated(4, ____int3rpr3t3r____, deferred)");
     assertThat(eagerExpressionResult.getDeferredWords())
       .containsExactlyInAnyOrder("deferred", "equalto.evaluateNegated");
     context.put("deferred", 4);
@@ -756,7 +756,7 @@ public class EagerExpressionResolverTest {
     assertThat(eagerResolveExpression("deferred.append(foo)").toString())
       .isEqualTo("deferred.append('foo')");
     assertThat(eagerResolveExpression("deferred[1 + 1] | length").toString())
-      .isEqualTo("filter:length.filter(deferred[2], null)");
+      .isEqualTo("filter:length.filter(deferred[2], ____int3rpr3t3r____)");
   }
 
   @Test
@@ -823,7 +823,7 @@ public class EagerExpressionResolverTest {
   @Test
   public void itHandlesRandom() {
     assertThat(eagerResolveExpression("range(1)|random").toString())
-      .isEqualTo("filter:random.filter(range(1), null)");
+      .isEqualTo("filter:random.filter(range(1), ____int3rpr3t3r____)");
   }
 
   @Test

--- a/src/test/java/com/hubspot/jinjava/util/ObjectIteratorTest.java
+++ b/src/test/java/com/hubspot/jinjava/util/ObjectIteratorTest.java
@@ -103,7 +103,9 @@ public class ObjectIteratorTest {
   public void testItIteratesOverKeys() throws Exception {
     JinjavaConfig config = BaseJinjavaTest
       .newConfigBuilder()
-      .withLegacyOverrides(LegacyOverrides.builder().withIterateOverMapKeys(true).build())
+      .withLegacyOverrides(
+        LegacyOverrides.newBuilder().withIterateOverMapKeys(true).build()
+      )
       .build();
     JinjavaInterpreter.pushCurrent(
       new JinjavaInterpreter(new Jinjava(), new Context(), config)

--- a/src/test/resources/eager/defers-macro-in-expression/test.expected.jinja
+++ b/src/test/resources/eager/defers-macro-in-expression/test.expected.jinja
@@ -1,10 +1,10 @@
 2
 {% macro plus(foo, add) %}\
-{{ foo + (filter:int.filter(add, null)) }}\
+{{ foo + (filter:int.filter(add, ____int3rpr3t3r____)) }}\
 {% endmacro %}\
 {{ plus(deferred, 1.1) }}\
 {% set deferred = deferred + 2 %}
 {% macro plus(foo, add) %}\
-{{ foo + (filter:int.filter(add, null)) }}\
+{{ foo + (filter:int.filter(add, ____int3rpr3t3r____)) }}\
 {% endmacro %}\
 {{ plus(deferred, 3.1) }}

--- a/src/test/resources/eager/defers-macro-in-for/test.expected.jinja
+++ b/src/test/resources/eager/defers-macro-in-for/test.expected.jinja
@@ -3,6 +3,6 @@
 {% do my_list.append(num) %}\
 {{ my_list }}\
 {% endmacro %}\
-{% for item in filter:split.filter(macro_append(deferred), null, ',', 2) %}
+{% for item in filter:split.filter(macro_append(deferred), ____int3rpr3t3r____, ',', 2) %}
 {{ item }}
 {% endfor %}

--- a/src/test/resources/eager/defers-macro-in-if/test.expected.jinja
+++ b/src/test/resources/eager/defers-macro-in-if/test.expected.jinja
@@ -3,6 +3,6 @@
 {% do my_list.append(num) %}\
 {{ my_list }}\
 {% endmacro %}\
-{% if [] == filter:split.filter(macro_append(deferred), null, ',', 2) %}
+{% if [] == filter:split.filter(macro_append(deferred), ____int3rpr3t3r____, ',', 2) %}
 {{ my_list }}
 {% endif %}

--- a/src/test/resources/eager/does-not-override-import-modification-in-for/test.expected.jinja
+++ b/src/test/resources/eager/does-not-override-import-modification-in-for/test.expected.jinja
@@ -11,7 +11,7 @@
 
 {% endif %}
 
-{% set foo = filter:join.filter([foo, 'b'], null, '') %}\
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}\
 {% do __temp_meta_import_alias_3016318__.update({'foo': foo}) %}
 {% do __temp_meta_import_alias_3016318__.update({'foo': foo,'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
 {% endfor %}\
@@ -25,12 +25,12 @@
 {% for __ignored__ in [0] %}\
 {% if deferred %}
 
-{% set foo = filter:join.filter([foo, 'a'], null, '') %}\
+{% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}\
 {% do __temp_meta_import_alias_3016319__.update({'foo': foo}) %}
 
 {% endif %}
 
-{% set foo = filter:join.filter([foo, 'b'], null, '') %}\
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}\
 {% do __temp_meta_import_alias_3016319__.update({'foo': foo}) %}
 {% do __temp_meta_import_alias_3016319__.update({'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
 {% endfor %}\
@@ -45,12 +45,12 @@
 {% for __ignored__ in [0] %}\
 {% if deferred %}
 
-{% set foo = filter:join.filter([foo, 'a'], null, '') %}\
+{% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}\
 {% do __temp_meta_import_alias_3016318__.update({'foo': foo}) %}
 
 {% endif %}
 
-{% set foo = filter:join.filter([foo, 'b'], null, '') %}\
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}\
 {% do __temp_meta_import_alias_3016318__.update({'foo': foo}) %}
 {% do __temp_meta_import_alias_3016318__.update({'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
 {% endfor %}\
@@ -64,12 +64,12 @@
 {% for __ignored__ in [0] %}\
 {% if deferred %}
 
-{% set foo = filter:join.filter([foo, 'a'], null, '') %}\
+{% set foo = filter:join.filter([foo, 'a'], ____int3rpr3t3r____, '') %}\
 {% do __temp_meta_import_alias_3016319__.update({'foo': foo}) %}
 
 {% endif %}
 
-{% set foo = filter:join.filter([foo, 'b'], null, '') %}\
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}\
 {% do __temp_meta_import_alias_3016319__.update({'foo': foo}) %}
 {% do __temp_meta_import_alias_3016319__.update({'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
 {% endfor %}\

--- a/src/test/resources/eager/fully-defers-filtered-macro/test.expected.jinja
+++ b/src/test/resources/eager/fully-defers-filtered-macro/test.expected.jinja
@@ -1,5 +1,5 @@
 {% macro flashy(foo) %}\
-{{ filter:upper.filter(foo, null) }}
+{{ filter:upper.filter(foo, ____int3rpr3t3r____) }}
   A flashy {{ deferred }}\
 .{% endmacro %}\
 {% set __macro_flashy_1625622909_temp_variable_0__ %}\
@@ -12,4 +12,4 @@ BAR
 {% set __macro_silly_2092874071_temp_variable_0__ %}\
 A silly {{ deferred }}\
 .{% endset %}\
-{{ filter:upper.filter(__macro_silly_2092874071_temp_variable_0__, null) }}
+{{ filter:upper.filter(__macro_silly_2092874071_temp_variable_0__, ____int3rpr3t3r____) }}

--- a/src/test/resources/eager/handles-deferred-cycle-as/test.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-cycle-as/test.expected.jinja
@@ -1,19 +1,19 @@
 {% for __ignored__ in [0] %}
 {% set c = [1, deferred] %}
 {% if exptest:iterable.evaluate(c, null) %}\
-{{ c[0 % filter:length.filter(c, null)] }}\
+{{ c[0 % filter:length.filter(c, ____int3rpr3t3r____)] }}\
 {% else %}\
 {{ c }}\
 {% endif %}
 {% set c = [2, deferred] %}
 {% if exptest:iterable.evaluate(c, null) %}\
-{{ c[1 % filter:length.filter(c, null)] }}\
+{{ c[1 % filter:length.filter(c, ____int3rpr3t3r____)] }}\
 {% else %}\
 {{ c }}\
 {% endif %}
 {% set c = [3, deferred] %}
 {% if exptest:iterable.evaluate(c, null) %}\
-{{ c[2 % filter:length.filter(c, null)] }}\
+{{ c[2 % filter:length.filter(c, ____int3rpr3t3r____)] }}\
 {% else %}\
 {{ c }}\
 {% endif %}\

--- a/src/test/resources/eager/handles-deferred-for-loop-var-from-macro/test.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-for-loop-var-from-macro/test.expected.jinja
@@ -5,12 +5,12 @@
 {% set __macro_doIt_1327224118_temp_variable_0__ %}
 {{ deferred ~ '{\"a\":\"a\"}' }}
 {% endset %}\
-{{ filter:upper.filter(__macro_doIt_1327224118_temp_variable_0__, null) }}
+{{ filter:upper.filter(__macro_doIt_1327224118_temp_variable_0__, ____int3rpr3t3r____) }}
 
 {% set __macro_doIt_1327224118_temp_variable_1__ %}
 {{ deferred ~ '{\"b\":\"b\"}' }}
 {% endset %}\
-{{ filter:upper.filter(__macro_doIt_1327224118_temp_variable_1__, null) }}
+{{ filter:upper.filter(__macro_doIt_1327224118_temp_variable_1__, ____int3rpr3t3r____) }}
 {% endfor %}
 {% endset %}\
-{{ filter:upper.filter(__macro_getData_357124436_temp_variable_0__, null) }}
+{{ filter:upper.filter(__macro_getData_357124436_temp_variable_0__, ____int3rpr3t3r____) }}

--- a/src/test/resources/eager/handles-deferred-value-in-render-filter/test.expected.jinja
+++ b/src/test/resources/eager/handles-deferred-value-in-render-filter/test.expected.jinja
@@ -1,9 +1,9 @@
-{% set __render_572171194_temp_variable__ %}\
-Hi {{ filter:escape.filter(deferred, null) }}\
+{% set __render_524436216_temp_variable__ %}\
+Hi {{ filter:escape.filter(deferred, ____int3rpr3t3r____) }}\
 {% endset %}\
-{{ filter:escape_jinjava.filter(__render_572171194_temp_variable__, null) }}
+{{ filter:escape_jinjava.filter(__render_524436216_temp_variable__, ____int3rpr3t3r____) }}
 
-{% set __render_572171194_temp_variable__ %}\
-Hi {{ filter:escape.filter(deferred, null) }}\
+{% set __render_524436216_temp_variable__ %}\
+Hi {{ filter:escape.filter(deferred, ____int3rpr3t3r____) }}\
 {% endset %}\
-{{ __render_572171194_temp_variable__ }}
+{{ __render_524436216_temp_variable__ }}

--- a/src/test/resources/eager/handles-double-import-modification/test.expected.jinja
+++ b/src/test/resources/eager/handles-double-import-modification/test.expected.jinja
@@ -9,7 +9,7 @@
 
 {% endif %}
 
-{% set foo = filter:join.filter([foo, 'b'], null, '') %}\
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}\
 {% do __temp_meta_import_alias_3016318__.update({'foo': foo}) %}
 {% do __temp_meta_import_alias_3016318__.update({'foo': foo,'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
 {% endfor %}\
@@ -28,7 +28,7 @@
 
 {% endif %}
 
-{% set foo = filter:join.filter([foo, 'b'], null, '') %}\
+{% set foo = filter:join.filter([foo, 'b'], ____int3rpr3t3r____, '') %}\
 {% do __temp_meta_import_alias_3016319__.update({'foo': foo}) %}
 {% do __temp_meta_import_alias_3016319__.update({'foo': foo,'import_resource_path': 'eager/supplements/deferred-modification.jinja'}) %}\
 {% endfor %}\

--- a/src/test/resources/eager/handles-same-name-import-var/test.expected.jinja
+++ b/src/test/resources/eager/handles-same-name-import-var/test.expected.jinja
@@ -35,5 +35,5 @@
 {% set my_var = __temp_meta_import_alias_1059697132__ %}\
 {% set current_path,__temp_meta_current_path_944750549__ = __temp_meta_current_path_944750549__,null %}\
 {% enddo %}
-{{ filter:dictsort.filter(my_var, null, false, 'key') }}
+{{ filter:dictsort.filter(my_var, ____int3rpr3t3r____, false, 'key') }}
 {% endif %}

--- a/src/test/resources/eager/reconstructs-block-set-variables-in-for-loop/test.expected.jinja
+++ b/src/test/resources/eager/reconstructs-block-set-variables-in-for-loop/test.expected.jinja
@@ -2,5 +2,5 @@
 {% set __macro_foo_97643642_temp_variable_0__ %}
 {{ deferred }}
 {% endset %}\
-{{ filter:int.filter(__macro_foo_97643642_temp_variable_0__, null) + 3 }}
+{{ filter:int.filter(__macro_foo_97643642_temp_variable_0__, ____int3rpr3t3r____) + 3 }}
 {% endfor %}

--- a/src/test/resources/eager/reconstructs-fromed-macro/test.expected.jinja
+++ b/src/test/resources/eager/reconstructs-fromed-macro/test.expected.jinja
@@ -1,6 +1,6 @@
 {% set deferred_import_resource_path = 'eager/reconstructs-fromed-macro/has-macro.jinja' %}\
 {% macro to_upper(param) %}
- {{ filter:upper.filter(param, null) }}
+ {{ filter:upper.filter(param, ____int3rpr3t3r____) }}
 {% endmacro %}\
 {% set deferred_import_resource_path = null %}\
 {{ to_upper(deferred) }}

--- a/src/test/resources/eager/uses-unique-macro-names/test.expected.jinja
+++ b/src/test/resources/eager/uses-unique-macro-names/test.expected.jinja
@@ -3,13 +3,13 @@
 {% set __macro_foo_97643642_temp_variable_0__ %}
 Goodbye {{ myname }}
 {% endset %}\
-{% set a = filter:upper.filter(__macro_foo_97643642_temp_variable_0__, null) %}
+{% set a = filter:upper.filter(__macro_foo_97643642_temp_variable_0__, ____int3rpr3t3r____) %}
 {% do %}\
 {% set __temp_meta_current_path_203114534__,current_path = current_path,'eager/uses-unique-macro-names/macro-with-filter.jinja' %}
 {% set __macro_foo_1717337666_temp_variable_0__ %}\
 Hello {{ myname }}\
 {% endset %}\
-{% set b = filter:upper.filter(__macro_foo_1717337666_temp_variable_0__, null) %}
+{% set b = filter:upper.filter(__macro_foo_1717337666_temp_variable_0__, ____int3rpr3t3r____) %}
 {% set current_path,__temp_meta_current_path_203114534__ = __temp_meta_current_path_203114534__,null %}\
 {% enddo %}
 {{ a }}


### PR DESCRIPTION
There can be some binary incompatibility issues with how I migrated JinjavaConfig to an immutable and LegacyOverrides to an Immutable.

- The JinjavaConfig migration binary incompatibility can be solved by having JinjavaConfig remain a class so that the reference to `JinjavaConfig#newBuilder` remains a class method reference rather than an interface method reference.

- I could not keep LegacyOverrides as an immutable, and had to revert it back to being a POJO. Trying to solve the interface method reference backwards incompatibility issue by making it a class could introduce a static class initialization deadlock due to the static members like `LegacyOverrides.NONE` referencing a subclass of `LegacyOverrides` (`ImmutableLegacyOverrides`)
- I kept it so that eager execution will continue to reconstruct the `JinjavaInterpreter` arguments as `____int3rpr3t3r____` rather than `null` so that if needing to revert an upgrade to Jinjava 3.0, there won't have been any first-phase eager execution outputs that are backwards incompatible (as resolving `null` for exptests and filters in Jinjava 2.8.X would break them). This does not decrease the security of Jinjava 3.0 because I'm still not resolving the `____int3rpr3t3r____` variable ever, it is still resolved to `null`

