### PR TITLE
Add NamedParameter to JinjavaFunctions allowlist group

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/AllowlistGroup.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AllowlistGroup.java
@@ -156,7 +156,10 @@ public enum AllowlistGroup {
     }
   },
   JinjavaFunctions {
-    private static final String[] ARRAY = { ZonedDateTime.class.getCanonicalName() };
+    private static final String[] ARRAY = {
+      ZonedDateTime.class.getCanonicalName(),
+      NamedParameter.class.getCanonicalName(),
+    };
 
     @Override
     String[] allowedDeclaredMethodsFromClasses() {

--- a/src/test/java/com/hubspot/jinjava/el/ext/AllowlistGroupTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/AllowlistGroupTest.java
@@ -1,0 +1,27 @@
+package com.hubspot.jinjava.el.ext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hubspot.jinjava.BaseJinjavaTest;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class AllowlistGroupTest extends BaseJinjavaTest {
+
+  @Test
+  public void itResolvesNamedParameterNameThroughAllowlist() {
+    Map<String, Object> context = new HashMap<>();
+    context.put("np", new NamedParameter("greeting", "hello"));
+    String result = jinjava.render("{{ np.name }}", context);
+    assertThat(result).isEqualTo("greeting");
+  }
+
+  @Test
+  public void itResolvesNamedParameterValueThroughAllowlist() {
+    Map<String, Object> context = new HashMap<>();
+    context.put("np", new NamedParameter("greeting", "hello"));
+    String result = jinjava.render("{{ np.value }}", context);
+    assertThat(result).isEqualTo("hello");
+  }
+}


### PR DESCRIPTION
## Description

Adds `NamedParameter` to the `JinjavaFunctions` allowlist group so that NamedParameter objects are accepted by both the return type and method validators when accessed through the EL resolver. Without this, a NamedParameter looked up from context would be rejected by the allowlist validators, preventing property access like `.name` and `.value`.

*Authored by Claude Code*

## BRAVE
#### Backwards Compatibility
Additive-only change — adds a new class to an existing allowlist. No existing behavior is modified.

#### Rollout and Rollback Plan
Standard deploy. Rollback by reverting the commit.

#### Automated Testing
Tests added:
- `itResolvesNamedParameterNameThroughAllowlist` — verifies `{{ np.name }}` resolves through the allowlist
- `itResolvesNamedParameterValueThroughAllowlist` — verifies `{{ np.value }}` resolves through the allowlist

#### Verification
Unit tests pass locally. Both tests exercise the full rendering path with allowlist validators enabled via `BaseJinjavaTest`.

#### Expect Dependencies to Fail
No downstream breakage expected — this is purely additive.

##### *REVIEWERS*: Please review both the code changes and the answers above, and validate that they match the expectations for BRAVE