### PR TITLE
fix: Handle empty strings in StrictWhitespaceControlParser

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/parse/StrictWhitespaceControlParser.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/StrictWhitespaceControlParser.java
@@ -4,21 +4,23 @@ public class StrictWhitespaceControlParser implements WhitespaceControlParser {
 
   @Override
   public boolean hasLeftTrim(String unwrapped) {
-    return unwrapped.charAt(0) == '-';
+    return !unwrapped.isEmpty() && unwrapped.charAt(0) == '-';
   }
 
   @Override
   public String stripLeft(String unwrapped) {
-    return unwrapped.substring(1);
+    return unwrapped.isEmpty() ? unwrapped : unwrapped.substring(1);
   }
 
   @Override
   public boolean hasRightTrim(String unwrapped) {
-    return unwrapped.charAt(unwrapped.length() - 1) == '-';
+    return !unwrapped.isEmpty() && unwrapped.charAt(unwrapped.length() - 1) == '-';
   }
 
   @Override
   public String stripRight(String unwrapped) {
-    return unwrapped.substring(0, unwrapped.length() - 1);
+    return unwrapped.isEmpty()
+      ? unwrapped
+      : unwrapped.substring(0, unwrapped.length() - 1);
   }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/LegacyWhitespaceControlParsingTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/LegacyWhitespaceControlParsingTest.java
@@ -82,7 +82,6 @@ public class LegacyWhitespaceControlParsingTest {
       .isThrownBy(() -> modern.render(template, new HashMap<>()))
       .withMessageContaining("syntax error at position 9");
   }
-
   
   @Test
   public void itHandlesEmptyExpressionToken() {

--- a/src/test/java/com/hubspot/jinjava/interpret/LegacyWhitespaceControlParsingTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/LegacyWhitespaceControlParsingTest.java
@@ -82,4 +82,12 @@ public class LegacyWhitespaceControlParsingTest {
       .isThrownBy(() -> modern.render(template, new HashMap<>()))
       .withMessageContaining("syntax error at position 9");
   }
+
+  
+  @Test
+  public void itHandlesEmptyExpressionToken() {
+    String template = "{{}}";
+
+    assertThat(modern.render(template, new HashMap<>())).isEqualTo("");
+  }
 }

--- a/src/test/java/com/hubspot/jinjava/interpret/LegacyWhitespaceControlParsingTest.java
+++ b/src/test/java/com/hubspot/jinjava/interpret/LegacyWhitespaceControlParsingTest.java
@@ -82,7 +82,7 @@ public class LegacyWhitespaceControlParsingTest {
       .isThrownBy(() -> modern.render(template, new HashMap<>()))
       .withMessageContaining("syntax error at position 9");
   }
-  
+
   @Test
   public void itHandlesEmptyExpressionToken() {
     String template = "{{}}";

--- a/src/test/java/com/hubspot/jinjava/tree/parse/StrictWhitespaceControlParserTest
+++ b/src/test/java/com/hubspot/jinjava/tree/parse/StrictWhitespaceControlParserTest
@@ -1,0 +1,48 @@
+package com.hubspot.jinjava.tree.parse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class StrictWhitespaceControlParserTest {
+
+  StrictWhitespaceControlParser parser;
+
+  @Before
+  public void setUp() {
+    parser = new StrictWhitespaceControlParser();
+  }
+
+  @Test
+  public void itDoesNotTrimEmptyTokenOnLeft() {
+    assertThat(parser.hasLeftTrim("")).isFalse();
+  }
+
+  @Test
+  public void itDoesNotTrimEmptyTokenOnRight() {
+    assertThat(parser.hasRightTrim("")).isFalse();
+  }
+
+  @Test
+  public void itStripsLeftOfEmptyTokenWithoutThrowing() {
+    assertThat(parser.stripLeft("")).isEqualTo("");
+  }
+
+  @Test
+  public void itStripsRightOfEmptyTokenWithoutThrowing() {
+    assertThat(parser.stripRight("")).isEqualTo("");
+  }
+
+  @Test
+  public void itDetectsLeftTrim() {
+    assertThat(parser.hasLeftTrim("-foo")).isTrue();
+    assertThat(parser.stripLeft("-foo")).isEqualTo("foo");
+  }
+
+  @Test
+  public void itDetectsRightTrim() {
+    assertThat(parser.hasRightTrim("foo-")).isTrue();
+    assertThat(parser.stripRight("foo-")).isEqualTo("foo");
+  }
+}


### PR DESCRIPTION
## What

Add empty-string guards to `StrictWhitespaceControlParser` so `hasLeftTrim`,
`hasRightTrim`, `stripLeft`, and `stripRight` no longer index into an empty
token.

## Why

`hasLeftTrim` called `unwrapped.charAt(0)` and `hasRightTrim` called
`unwrapped.charAt(unwrapped.length() - 1)` with no empty-string guard. Any
template parsed with `withParseWhitespaceControlStrictly(true)` that produces
an empty unwrapped token (e.g. `{{}}`) threw `StringIndexOutOfBoundsException`
during parsing.

The lenient parser already handles this gracefully — `WhitespaceUtils.startsWith`
/ `endsWith` return `false` for null/empty input. This change gives the strict
parser the same defensive guarantee, so the two implementations behave
consistently on empty tokens.

Fixing it here protects every consumer of the strict parser rather than
sanitizing input in a single downstream call path.

## Behavior change

- `{{}}` now renders to an empty string instead of throwing.
- An empty tag token (`{%%}`) still errors, but with the expected `Unknown tag`
  error rather than a `StringIndexOutOfBoundsException` — correct downstream
  behavior, unchanged in intent.

## Tests

- `StrictWhitespaceControlParserTest`: empty token returns `false` from the
  `hasX` methods and is returned unchanged by the `stripX` methods; non-empty
  trim markers still detected and stripped.
- `LegacyWhitespaceControlParsingTest.itHandlesEmptyExpressionToken`: `{{}}`
  renders to `""` in strict mode.

---
PR description authored by Claude Code.