### PR TITLE
fix: reconstruct current_path when base template defers before blocks

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -513,7 +513,9 @@ public class JinjavaInterpreter implements PyishSerializable {
           );
         }
       }
-      if (context.getDeferredTokens().size() > numDeferredTokensBefore) {
+      if (
+        preserveBlocks || context.getDeferredTokens().size() > numDeferredTokensBefore
+      ) {
         pathSetter.setValue(
           EagerReconstructionUtils.buildBlockOrInlineSetTag(
             RelativePathResolver.CURRENT_PATH_CONTEXT_KEY,

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerExtendsTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerExtendsTagTest.java
@@ -125,6 +125,21 @@ public class EagerExtendsTagTest extends ExtendsTagTest {
   }
 
   @Test
+  public void itDefersSetInBaseBeforeBlock() {
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
+      "defers-set-in-base-before-block"
+    );
+  }
+
+  @Test
+  public void itDefersSetInBaseBeforeBlockSecondPass() {
+    context.put("deferred", "Resolved now");
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "defers-set-in-base-before-block.expected"
+    );
+  }
+
+  @Test
   public void itThrowsWhenDeferredExtendsTag() {
     interpreter.render(
       expectedTemplateInterpreter.getFixtureTemplate("throws-when-deferred-extends-tag")

--- a/src/test/resources/tags/eager/extendstag/base-with-deferred-before-block.html
+++ b/src/test/resources/tags/eager/extendstag/base-with-deferred-before-block.html
@@ -1,0 +1,4 @@
+{% set foo = deferred %}
+{{ foo }}
+{% block body %}
+{% endblock body %}

--- a/src/test/resources/tags/eager/extendstag/defers-set-in-base-before-block.expected.expected.jinja
+++ b/src/test/resources/tags/eager/extendstag/defers-set-in-base-before-block.expected.expected.jinja
@@ -1,0 +1,4 @@
+
+Resolved now
+
+Hi

--- a/src/test/resources/tags/eager/extendstag/defers-set-in-base-before-block.expected.jinja
+++ b/src/test/resources/tags/eager/extendstag/defers-set-in-base-before-block.expected.jinja
@@ -1,0 +1,6 @@
+{% set current_path = '../eager/extendstag/base-with-deferred-before-block.html' %}\
+{% set foo = deferred %}
+{{ foo }}
+{% block body %}
+Hi
+{% endblock body %}

--- a/src/test/resources/tags/eager/extendstag/defers-set-in-base-before-block.jinja
+++ b/src/test/resources/tags/eager/extendstag/defers-set-in-base-before-block.jinja
@@ -1,0 +1,4 @@
+{% extends "../eager/extendstag/base-with-deferred-before-block.html" %}
+{% block body %}
+Hi
+{% endblock body %}


### PR DESCRIPTION
## Description

When a Jinja template extends a base that defers a variable **before** its block definitions, the eager first-pass output was missing the `{% set current_path = '...' %}` preamble that all other eager extends scenarios include. Without it, the second pass has no base-template path reference, which would break relative path resolution (e.g., `{% include %}` calls) inside any such base template.

The `pathSetter` node — responsible for emitting the `current_path` reconstruction — was only written when `resolveBlockStubs()` added deferred tokens (i.e., deferred content inside block bodies). It was not written when the base template itself produced deferred tokens before its blocks (`preserveBlocks = true`). The fix is a one-character condition change: also set `pathSetter` when `preserveBlocks` is true.

This is the root cause of internal HubL issue https://github.com/HubSpotProductSupport/ProductSupport/issues/146621.

## BRAVE

#### Backwards Compatibility

No API or behavioral change for non-deferred templates. The fix only applies when `preserveBlocks` is already true, which only happens in eager mode when the base template itself defers content.

#### Rollout and Rollback Plan

- Library change — consumers pick it up on their next version bump
- Rollback: revert the single condition change in `JinjavaInterpreter.java`

#### Automated Testing

- `itDefersSetInBaseBeforeBlock` — verifies first-pass output now includes `{% set current_path = '...' %}`
- `itDefersSetInBaseBeforeBlockSecondPass` — verifies the second pass renders correctly once the deferred value is resolved

#### Verification

- Run `EagerExtendsTagTest` locally; both new tests pass

#### Expect Dependencies to Fail

None expected.

---
*PR description authored by Claude Code*

##### *REVIEWERS*: Please review both the code changes and the answers above, and validate that they match the expectations for BRAVE