### PR TITLE
fix: reconstruct current_path when base template defers before blocks

### DIFF
--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -432,6 +432,7 @@ public class JinjavaInterpreter implements PyishSerializable {
       if (processExtendRoots) {
         Set<String> extendPaths = new HashSet<>();
         Optional<String> extendPath = context.getExtendPathStack().peek();
+        boolean processedExtendRoots = false;
         int numDeferredTokensBefore = 0;
         while (!extendParentRoots.isEmpty()) {
           if (extendPaths.contains(extendPath.orElse(""))) {
@@ -494,9 +495,12 @@ public class JinjavaInterpreter implements PyishSerializable {
             extendPath =
               hasNestedExtends ? currentExtendPath : context.getExtendPathStack().peek();
             basePath = Optional.of(currentPath);
+            processedExtendRoots = true;
           }
         }
-        preserveBlocks = (context.getDeferredTokens().size() > numDeferredTokensBefore);
+        preserveBlocks =
+          processedExtendRoots &&
+          (context.getDeferredTokens().size() > numDeferredTokensBefore);
       }
 
       int numDeferredTokensBefore = context.getDeferredTokens().size();

--- a/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
+++ b/src/main/java/com/hubspot/jinjava/interpret/JinjavaInterpreter.java
@@ -513,7 +513,9 @@ public class JinjavaInterpreter implements PyishSerializable {
           );
         }
       }
-      if (context.getDeferredTokens().size() > numDeferredTokensBefore) {
+      if (
+        preserveBlocks || context.getDeferredTokens().size() > numDeferredTokensBefore
+      ) {
         pathSetter.setValue(
           EagerReconstructionUtils.buildBlockOrInlineSetTag(
             RelativePathResolver.CURRENT_PATH_CONTEXT_KEY,

--- a/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerExtendsTagTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/tag/eager/EagerExtendsTagTest.java
@@ -125,6 +125,21 @@ public class EagerExtendsTagTest extends ExtendsTagTest {
   }
 
   @Test
+  public void itDefersSetInBaseBeforeBlock() {
+    expectedTemplateInterpreter.assertExpectedOutputNonIdempotent(
+      "defers-set-in-base-before-block"
+    );
+  }
+
+  @Test
+  public void itDefersSetInBaseBeforeBlockSecondPass() {
+    context.put("deferred", "Resolved now");
+    expectedTemplateInterpreter.assertExpectedOutput(
+      "defers-set-in-base-before-block.expected"
+    );
+  }
+
+  @Test
   public void itThrowsWhenDeferredExtendsTag() {
     interpreter.render(
       expectedTemplateInterpreter.getFixtureTemplate("throws-when-deferred-extends-tag")

--- a/src/test/resources/tags/eager/extendstag/base-with-deferred-before-block.html
+++ b/src/test/resources/tags/eager/extendstag/base-with-deferred-before-block.html
@@ -1,0 +1,4 @@
+{% set foo = deferred %}
+{{ foo }}
+{% block body %}
+{% endblock body %}

--- a/src/test/resources/tags/eager/extendstag/defers-set-in-base-before-block.expected.expected.jinja
+++ b/src/test/resources/tags/eager/extendstag/defers-set-in-base-before-block.expected.expected.jinja
@@ -1,0 +1,4 @@
+
+Resolved now
+
+Hi

--- a/src/test/resources/tags/eager/extendstag/defers-set-in-base-before-block.expected.jinja
+++ b/src/test/resources/tags/eager/extendstag/defers-set-in-base-before-block.expected.jinja
@@ -1,0 +1,6 @@
+{% set current_path = '../eager/extendstag/base-with-deferred-before-block.html' %}\
+{% set foo = deferred %}
+{{ foo }}
+{% block body %}
+Hi
+{% endblock body %}

--- a/src/test/resources/tags/eager/extendstag/defers-set-in-base-before-block.jinja
+++ b/src/test/resources/tags/eager/extendstag/defers-set-in-base-before-block.jinja
@@ -1,0 +1,4 @@
+{% extends "../eager/extendstag/base-with-deferred-before-block.html" %}
+{% block body %}
+Hi
+{% endblock body %}


### PR DESCRIPTION
## Description

_PR description authored by Claude Code._

Base templates that `extends` and `set` a deferred variable **before** their block
definitions were losing the `current_path` reference across eager passes. The eager
first pass emitted output without `{% set current_path = '...' %}`, so the second pass
had no base-template path to resolve relative includes against, breaking path-dependent
tags in any such base template.

The path setter was only written when `resolveBlockStubs()` added deferred tokens
(deferred content inside block bodies), not when the base template itself deferred
tokens before its blocks.

This PR contains two commits:

- **`reconstruct current_path when base template defers before blocks`** — widens the
  path-setter condition so it also fires when the base template defers before its blocks.
- **`only reconstruct current_path when an extends actually deferred`** — fixes a
  regression from the first commit. `preserveBlocks` was unsound outside the extends
  loop: `numDeferredTokensBefore` starts at `0` and is only advanced inside the
  `while (!extendParentRoots.isEmpty())` loop, so a template with **no** extend parents
  never entered the loop and `preserveBlocks` collapsed to `deferredTokens.size() > 0`.
  Any deferred template (`for`, `import`, `set`, `include`, ...) then injected a spurious
  `{% set current_path = null %}`. The fix gates `preserveBlocks` on an extends having
  actually been processed, so the path setter only fires in the intended
  base-template-defers-before-blocks case.

## BRAVE

#### Backwards Compatibility

- The no-extends path now falls back to the original `resolveBlockStubs` growth check, restoring pre-first-commit behavior.
- Only the extends + defer-before-blocks case changes: it now correctly emits the `current_path` setter.

#### Rollout and Rollback Plan

- Library change; rolls out with the next jinjava release. Revert the PR to roll back.

#### Automated Testing

- Added `itDefersSetInBaseBeforeBlock` / `itDefersSetInBaseBeforeBlockSecondPass` covering the base-defers-before-block case.
- Full suite green: 2130 run, 0 failures (was 279 failures after the first commit alone).

#### Verification

- Confirmed the spurious `{% set current_path = null %}` no longer appears in the previously-failing eager tag tests (`EagerForTag`, `EagerImportTag`, `EagerSetTag`, `EagerIncludeTag`, `EagerFromTag`, etc.).

#### Expect Dependencies to Fail

- None expected.

##### *REVIEWERS*: Please review both the code changes and the answers above, and validate that they match the expectations for BRAVE
