### PR TITLE
feat: allowlist enum method invocation and return types

### DIFF
--- a/src/main/java/com/hubspot/jinjava/el/ext/AllowlistMethodValidator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AllowlistMethodValidator.java
@@ -52,6 +52,12 @@ public final class AllowlistMethodValidator {
         Class<?> clazz = m1.getDeclaringClass();
         String canonicalClassName = clazz.getCanonicalName();
         if (canonicalClassName == null) {
+          Class<?> superclass = clazz.getSuperclass();
+          if (superclass != null && superclass.isEnum()) {
+            canonicalClassName = superclass.getCanonicalName();
+          }
+        }
+        if (canonicalClassName == null) {
           return false;
         }
         return (

--- a/src/main/java/com/hubspot/jinjava/el/ext/AllowlistReturnTypeValidator.java
+++ b/src/main/java/com/hubspot/jinjava/el/ext/AllowlistReturnTypeValidator.java
@@ -50,7 +50,7 @@ public final class AllowlistReturnTypeValidator {
     if (o instanceof String || o instanceof Number || o instanceof Boolean) {
       return o;
     }
-    Class<?> clazz = o.getClass();
+    Class<?> clazz = o instanceof Enum ? ((Enum<?>) o).getDeclaringClass() : o.getClass();
     if (clazz.isArray() && allowArrays) {
       return o;
     }

--- a/src/test/java/com/hubspot/jinjava/el/ext/AllowlistEnumTest.java
+++ b/src/test/java/com/hubspot/jinjava/el/ext/AllowlistEnumTest.java
@@ -1,0 +1,95 @@
+package com.hubspot.jinjava.el.ext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hubspot.jinjava.BaseJinjavaTest;
+import com.hubspot.jinjava.testobjects.OperationEnum;
+import com.hubspot.jinjava.testobjects.SimpleColorEnum;
+import java.lang.reflect.Method;
+import java.time.Month;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class AllowlistEnumTest extends BaseJinjavaTest {
+
+  private static final AllowlistReturnTypeValidator ENUM_RETURN_TYPE_VALIDATOR =
+    AllowlistReturnTypeValidator.create(
+      ReturnTypeValidatorConfig
+        .builder()
+        .addAllowedCanonicalClassNames(
+          SimpleColorEnum.class.getCanonicalName(),
+          OperationEnum.class.getCanonicalName()
+        )
+        .build()
+    );
+
+  private static final AllowlistMethodValidator ENUM_METHOD_VALIDATOR =
+    AllowlistMethodValidator.create(
+      MethodValidatorConfig
+        .builder()
+        .addAllowedDeclaredMethodsFromCanonicalClassNames(
+          SimpleColorEnum.class.getCanonicalName(),
+          OperationEnum.class.getCanonicalName()
+        )
+        .build()
+    );
+
+  @Test
+  public void itAllowsReturningSimpleEnumValue() {
+    assertThat(ENUM_RETURN_TYPE_VALIDATOR.validateReturnType(SimpleColorEnum.RED))
+      .isEqualTo(SimpleColorEnum.RED);
+  }
+
+  @Test
+  public void itAllowsReturningConstantSpecificBodyEnumValue() {
+    assertThat(ENUM_RETURN_TYPE_VALIDATOR.validateReturnType(OperationEnum.PLUS))
+      .isEqualTo(OperationEnum.PLUS);
+  }
+
+  @Test
+  public void itRejectsReturningNonAllowlistedEnumValue() {
+    assertThat(ENUM_RETURN_TYPE_VALIDATOR.validateReturnType(Month.JANUARY)).isNull();
+  }
+
+  @Test
+  public void itAllowsInvokingSimpleEnumGetter() throws NoSuchMethodException {
+    Method getLabel = SimpleColorEnum.class.getMethod("getLabel");
+    assertThat(ENUM_METHOD_VALIDATOR.validateMethod(getLabel)).isEqualTo(getLabel);
+  }
+
+  @Test
+  public void itAllowsInvokingConstantSpecificBodyEnumMethod()
+    throws NoSuchMethodException {
+    Method apply = OperationEnum.PLUS.getClass().getMethod("apply", int.class, int.class);
+    assertThat(apply.getDeclaringClass().getCanonicalName()).isNull();
+    assertThat(ENUM_METHOD_VALIDATOR.validateMethod(apply)).isEqualTo(apply);
+  }
+
+  @Test
+  public void itRejectsInvokingNonAllowlistedEnumMethod() throws NoSuchMethodException {
+    Method getValue = Month.class.getMethod("getValue");
+    assertThat(ENUM_METHOD_VALIDATOR.validateMethod(getValue)).isNull();
+  }
+
+  @Test
+  public void itRendersSimpleEnumGetter() {
+    Map<String, Object> context = new HashMap<>();
+    context.put("color", SimpleColorEnum.RED);
+    assertThat(jinjava.render("{{ color.label }}", context)).isEqualTo("red-label");
+  }
+
+  @Test
+  public void itRendersConstantSpecificBodyEnumMethodInvocation() {
+    Map<String, Object> context = new HashMap<>();
+    context.put("op", OperationEnum.PLUS);
+    assertThat(jinjava.render("{{ op.apply(2, 3) }}", context)).isEqualTo("5");
+  }
+
+  @Test
+  public void itRendersEnumValueAsName() {
+    Map<String, Object> context = new HashMap<>();
+    context.put("op", OperationEnum.TIMES);
+    assertThat(jinjava.render("{{ op }}", context)).isEqualTo("TIMES");
+  }
+}

--- a/src/test/java/com/hubspot/jinjava/testobjects/OperationEnum.java
+++ b/src/test/java/com/hubspot/jinjava/testobjects/OperationEnum.java
@@ -1,0 +1,18 @@
+package com.hubspot.jinjava.testobjects;
+
+public enum OperationEnum {
+  PLUS {
+    @Override
+    public int apply(int a, int b) {
+      return a + b;
+    }
+  },
+  TIMES {
+    @Override
+    public int apply(int a, int b) {
+      return a * b;
+    }
+  };
+
+  public abstract int apply(int a, int b);
+}

--- a/src/test/java/com/hubspot/jinjava/testobjects/SimpleColorEnum.java
+++ b/src/test/java/com/hubspot/jinjava/testobjects/SimpleColorEnum.java
@@ -1,0 +1,16 @@
+package com.hubspot.jinjava.testobjects;
+
+public enum SimpleColorEnum {
+  RED("red-label"),
+  GREEN("green-label");
+
+  private final String label;
+
+  SimpleColorEnum(String label) {
+    this.label = label;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+}


### PR DESCRIPTION
## Description

_This PR description was authored by Claude Code._

jinjava sandboxes template rendering with two allowlists — a method allowlist and a return-type allowlist — both of which match a value's **canonical class name** against configured names/prefixes.

A **simple** enum (`enum Color { RED, GREEN }`) could already be allowlisted by adding its canonical class name. But an enum with a **constant-specific class body** (`enum Op { PLUS { int apply(){...} } }`) is realized at runtime as an anonymous subclass (`Op$1`) whose `getCanonicalName()` returns `null`. Both validators bail on a `null` canonical name, so these enums — their values *and* their overridden methods — could never be allowlisted, even when the caller explicitly added the enum type.

This change resolves the runtime enum-constant class to its base enum type before the existing canonical-name check, so allowlisting a specific enum by class name works for its values and methods, including constant-specific bodies.

Scope is intentionally narrow: specific enums only. No blanket "allow all enums" toggle, no new builder helper, no new `AllowlistGroup` — just correct resolution of the value/method class back to the enum type the caller already allowlisted.

- `AllowlistReturnTypeValidator`: when the value is an enum, validate against `((Enum<?>) o).getDeclaringClass()` instead of the runtime class.
- `AllowlistMethodValidator`: when a method's declaring class has a `null` canonical name and its superclass is an enum, use the enum type's canonical name for the check.

Both are no-ops for simple enums and non-enum values.

## BRAVE

#### Backwards Compatibility

- Fully backwards compatible.
- No API changes; the two validators only change how they derive the class name used for the existing allowlist check.
- No-op for simple enums and all non-enum values — behavior only changes for enum values that were previously rejected due to a `null` canonical name.

#### Rollout and Rollback Plan

- Standard library release; no data migration or feature gate.
- Rollback is a straight revert of this commit.

#### Automated Testing

- New `AllowlistEnumTest` (9 tests): direct validator checks for a simple enum and a constant-specific-body enum, rejection of a non-allowlisted enum (`java.time.Month`), and end-to-end renders (`{{ op.apply(2, 3) }}` → `5`, `{{ color.label }}`, `{{ op }}` → name). The constant-body method test pins the regression by asserting the declaring class canonical name is `null`.
- New test enums `SimpleColorEnum` and `OperationEnum` under the already-allowlisted `testobjects` package.
- Full `com.hubspot.jinjava.el.**` suite (236 tests) passes; `spotless:check` clean.

#### Verification

- `mvn -Dtest=AllowlistEnumTest,AllowlistGroupTest,ValidatorConfigBannedConstructsTest test` — green.

#### Expect Dependencies to Fail

- None expected. The sandbox is only widened for enum types a caller has explicitly allowlisted; the `@Value.Check` guardrails still reject banned classes at config time, so resolution cannot expose anything not already permitted.

##### *REVIEWERS*: Please review both the code changes and the answers above, and validate that they match the expectations for BRAVE