### PR TITLE
docs: prepare changelog for jinjava 2.8.4 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,16 @@
 # Jinjava Releases #
+### 2026-07-23 Version 2.8.4 ([Maven Central](https://search.maven.org/artifact/com.hubspot.jinjava/jinjava/2.8.4/jar)) ###
+* [Add support for configurable multi-character delimiters](https://github.com/HubSpot/jinjava/pull/1305)
+* [Treat backslash as an escape character only inside quoted strings, matching Jinja2](https://github.com/HubSpot/jinjava/pull/1306)
+* [Add `keepTrailingNewline` option to match Python Jinja2's default of stripping a single trailing newline](https://github.com/HubSpot/jinjava/pull/1311)
+* [Auto-convert `Integer` to `Long` in set filters when the feature is enabled](https://github.com/HubSpot/jinjava/pull/1308)
+* [Add a boolean parameter to `withUnwrapRawOverride`](https://github.com/HubSpot/jinjava/pull/1313)
+* [Introduce `BuiltinFeatures`](https://github.com/HubSpot/jinjava/pull/1289)
+* [Preserve block tags to maintain reconstruction and execution order](https://github.com/HubSpot/jinjava/pull/1312)
+* [Fix `RenderFilter`'s handling of deferred values](https://github.com/HubSpot/jinjava/pull/1258)
+* [Use `isResolvableObject` before building a hashcode in eager execution](https://github.com/HubSpot/jinjava/pull/1286)
+* [Don't require explicitly pushing the `JinjavaInterpreter` when using it directly](https://github.com/HubSpot/jinjava/pull/1285)
+
 ### 2026-02-02 Version 2.8.3 ([Maven Central](https://search.maven.org/artifact/com.hubspot.jinjava/jinjava/2.8.3/jar)) ###
 * Disallow accessing properties on restricted classes while rendering through ForTag
 * Upgrade jackson to version 2.20

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 # Jinjava Releases #
-### 2026-07-23 Version 2.8.4 ([Maven Central](https://search.maven.org/artifact/com.hubspot.jinjava/jinjava/2.8.4/jar)) ###
+### 2026-07-24 Version 2.8.4 ([Maven Central](https://search.maven.org/artifact/com.hubspot.jinjava/jinjava/2.8.4/jar)) ###
 * [Add support for configurable multi-character delimiters](https://github.com/HubSpot/jinjava/pull/1305)
 * [Treat backslash as an escape character only inside quoted strings, matching Jinja2](https://github.com/HubSpot/jinjava/pull/1306)
 * [Add `keepTrailingNewline` option to match Python Jinja2's default of stripping a single trailing newline](https://github.com/HubSpot/jinjava/pull/1311)


### PR DESCRIPTION
## Description

Adds the `2.8.4` release notes (dated 2026-07-23) to the top of `CHANGES.md`, following the existing entry format. This changelog is authored by Claude Code.

The 2.8.4 release is cut from the `master-2.8.x` maintenance line (currently `2.8.4-SNAPSHOT`). The entries cover every user-facing PR merged into `master-2.8.x` since 2.8.3 shipped on 2026-02-02 — largely backports of 3.0-line fixes/features that consumers still pinned to the 2.8.x line need:

- Configurable multi-character delimiters (#1305)
- Backslash as an escape character only inside quoted strings, matching Jinja2 (#1306)
- `keepTrailingNewline` option matching Python Jinja2's default (#1311)
- Auto-convert `Integer` to `Long` in set filters (#1308)
- Boolean parameter on `withUnwrapRawOverride` (#1313)
- `BuiltinFeatures` (#1289)
- Preserve block tags for reconstruction/execution order (#1312)
- Fix `RenderFilter` handling of deferred values (#1258)
- Eager: use `isResolvableObject` before building hashcode (#1286)
- Don't require explicitly pushing the `JinjavaInterpreter` (#1285)

A pom publish-location revert (#1283) was excluded as non-user-facing.

## Notes

- Bundled backports #1305/#1306/#1311 (landed on 2.8.x via #1325) are linked to their originating PRs for the clearest descriptions; #1308/#1312/#1313 likewise link to the originating PRs rather than their 2.8.x backports (#1309/#1315/#1314).

_This PR description was authored by Claude Code._