### PR TITLE
fix: default null TokenScannerSymbols to DefaultTokenScannerSymbols

### DIFF
--- a/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
+++ b/src/main/java/com/hubspot/jinjava/tree/parse/Token.java
@@ -45,7 +45,7 @@ public abstract class Token implements Serializable {
     this.image = image;
     this.lineNumber = lineNumber;
     this.startPosition = startPosition;
-    this.symbols = symbols;
+    this.symbols = symbols != null ? symbols : new DefaultTokenScannerSymbols();
     this.whitespaceControlParser = whitespaceControlParser;
     parse();
   }

--- a/src/test/java/com/hubspot/jinjava/tree/parse/TagTokenTest.java
+++ b/src/test/java/com/hubspot/jinjava/tree/parse/TagTokenTest.java
@@ -31,6 +31,13 @@ public class TagTokenTest {
   }
 
   @Test
+  public void itDefaultsNullSymbolsToDefaultTokenScannerSymbols() {
+    TagToken t = new TagToken("{% foo %}", 1, 2, null);
+    assertThat(t.getSymbols()).isInstanceOf(DefaultTokenScannerSymbols.class);
+    assertThat(t.getTagName()).isEqualTo("foo");
+  }
+
+  @Test
   public void itThrowsParseErrorWhenMalformed() {
     try {
       new TagToken("{% ", 1, 2, SYMBOLS);


### PR DESCRIPTION
## Description

Backport to `master-2.8.x`.

`Token` (and therefore `TagNode` via `master.getSymbols()`) treats its `TokenScannerSymbols` as required. When a `Token` is constructed with a `null` `TokenScannerSymbols`, `getSymbols()` returns `null`, which leads to `NullPointerException`s in `Token.parse()` and `TagNode.reconstructEnd()`.

This restores backwards compatibility for callers (e.g. downstream code that builds tokens/`TagNode`s directly and previously relied on default symbols) by defaulting a `null` `TokenScannerSymbols` to `DefaultTokenScannerSymbols` in the `Token` base constructor. This is the single point that feeds every `getSymbols()` call and `parse()`, so all `Node`/`Token` symbol access becomes null-safe.

## Testing

- Added `TagTokenTest.itDefaultsNullSymbolsToDefaultTokenScannerSymbols`, verifying a `TagToken` built with `null` symbols resolves to `DefaultTokenScannerSymbols` and parses correctly.
- `mvn -Dtest=TagTokenTest test` passes (5/5).

_This PR description was authored by Claude Code._